### PR TITLE
Add structured roster output by role and position

### DIFF
--- a/tests/datalayer/integration/test_sleeper_league_data_load.py
+++ b/tests/datalayer/integration/test_sleeper_league_data_load.py
@@ -20,4 +20,6 @@ def test_load_pipeline_and_queries(monkeypatch_sleeper_api, sleeper_config):
 
     roster = data.get_roster_current("Alpha")
     assert roster["found"] is True
-    assert roster["players"]
+    assert "roster" in roster
+    assert "starters" in roster["roster"]
+    assert "bench" in roster["roster"]


### PR DESCRIPTION
Organize players into a nested structure for easier position-by-position comparison: {starters: {qb: [], rb: [], ...}, bench: {qb: [], rb: [], ...}}

closes #12