### PR TITLE
feat(ai-gateway): add lightweight OpenAI gateway

### DIFF
--- a/ai_gateway/README.md
+++ b/ai_gateway/README.md
@@ -1,0 +1,198 @@
+# AI Gateway
+
+`ai_gateway` is a lightweight model I/O layer for chat-style AI calls. It is independent from `reporter/` and `datalayer/`: callers provide messages, optional tool definitions, and optional structured output schemas, then receive normalized text, structured output, and tool-call requests.
+
+The gateway does not execute tools. Application code owns the loop that runs datalayer or app tools and sends tool results back to the model.
+
+## Goals
+
+- Provide one stable interface for model calls.
+- Keep provider-specific SDK shapes out of application code.
+- Support assistant text, structured output, and tool calls.
+- Reuse existing OpenAI function-calling tool JSON schemas through `ToolSpec`.
+- Avoid orchestration dependencies such as LangChain, LiteLLM, or the OpenAI Agents SDK inside this package.
+
+## Public Interface
+
+```python
+from ai_gateway import (
+    AiGateway,
+    AiGatewayConfig,
+    AiRequest,
+    AiResponse,
+    ChatMessage,
+    ToolSpec,
+    ToolCall,
+    ToolResultMessage,
+    OpenAIGateway,
+    create_gateway,
+)
+```
+
+### Core Types
+
+- `ChatMessage`: A normal `system`, `user`, or `assistant` message.
+- `ToolSpec`: A provider-neutral function definition with `name`, `description`, and JSON Schema `parameters`.
+- `ToolCall`: A model-requested tool call with parsed JSON `arguments`.
+- `ToolResultMessage`: A tool result tied to a previous `tool_call_id`.
+- `AiRequest`: Messages plus optional tools, model options, mode metadata, and structured output schema.
+- `AiResponse`: Normalized assistant text, structured output, tool calls, finish reason, usage, and provider metadata.
+- `AiGatewayConfig`: Provider, API key, model, base URL, and timeout.
+- `AiGateway`: Abstract interface implemented by concrete providers.
+
+## Architecture
+
+```text
+Application
+  |
+  | AiRequest(messages, tools, schema, options)
+  v
+ai_gateway
+  |
+  | provider-specific SDK request
+  v
+Model Provider
+  |
+  | provider-specific response
+  v
+ai_gateway
+  |
+  | AiResponse(text, structured_output, tool_calls)
+  v
+Application
+```
+
+The application is responsible for any higher-level workflow:
+
+1. Build messages and tool specs.
+2. Call `gateway.get_response(...)`.
+3. If the response contains tool calls, execute those calls with app-owned handlers.
+4. Append `ToolResultMessage` entries.
+5. Call the gateway again.
+
+This keeps orchestration, mode switching, authorization, and datalayer access outside the gateway.
+
+## Basic Usage
+
+```python
+from ai_gateway import AiRequest, ChatMessage, create_gateway
+
+gateway = create_gateway()
+
+response = await gateway.get_response(
+    AiRequest(
+        messages=[
+            ChatMessage(role="system", content="You are a fantasy football analyst."),
+            ChatMessage(role="user", content="Summarize week 8."),
+        ],
+        model="gpt-5-mini",
+    )
+)
+
+print(response.text)
+```
+
+## Tool Calling
+
+Tools are passed in as `ToolSpec` objects. Existing OpenAI-style tool JSON can be adapted directly:
+
+```python
+from ai_gateway import AiRequest, ChatMessage, ToolResultMessage, ToolSpec
+from datalayer.tools import SLEEPER_TOOLS, create_tool_handlers
+
+tools = ToolSpec.from_openai_tools(SLEEPER_TOOLS)
+handlers = create_tool_handlers(data)
+
+messages = [
+    ChatMessage(role="user", content="Who had the best week 8 performance?")
+]
+
+response = await gateway.get_response(AiRequest(messages=messages, tools=tools))
+
+for call in response.tool_calls:
+    result = handlers[call.name](**call.arguments)
+    messages.append(ToolResultMessage.from_call(call, result))
+
+final_response = await gateway.get_response(AiRequest(messages=messages, tools=tools))
+print(final_response.text)
+```
+
+`ToolResultMessage.from_call(...)` serializes non-string results as JSON. Tool execution errors should be handled by the application, which can choose whether to raise, retry, or send an error result back to the model.
+
+## Structured Output
+
+Pass a Pydantic model class as `structured_output_schema`. The OpenAI adapter sends it as a JSON Schema response format and validates the returned text into that model.
+
+```python
+from pydantic import BaseModel
+
+from ai_gateway import AiRequest, ChatMessage
+
+
+class Storyline(BaseModel):
+    headline: str
+    summary: str
+
+
+response = await gateway.get_response(
+    AiRequest(
+        messages=[ChatMessage(role="user", content="Find the lead storyline.")],
+        structured_output_schema=Storyline,
+    )
+)
+
+storyline = response.structured_output
+```
+
+Invalid structured output raises `StructuredOutputValidationError`.
+
+## OpenAI Provider
+
+`OpenAIGateway` uses the official OpenAI Python SDK and the Responses API.
+
+Configuration defaults:
+
+- `provider="openai"`
+- `api_key` from `OPENAI_API_KEY`
+- `model` from `REPORTER_MODEL`, falling back to `gpt-5-mini`
+
+```python
+from ai_gateway import AiGatewayConfig, create_gateway
+
+gateway = create_gateway(
+    AiGatewayConfig(
+        provider="openai",
+        model="gpt-5-mini",
+        timeout=30,
+    )
+)
+```
+
+Provider-specific request options can be passed through `AiRequest.options`:
+
+```python
+response = await gateway.get_response(
+    AiRequest(
+        messages=messages,
+        options={"temperature": 0.2, "max_output_tokens": 1000},
+    )
+)
+```
+
+`provider_context` supports provider metadata needed across calls, such as `previous_response_id` for OpenAI Responses API continuation.
+
+## Errors
+
+- `UnsupportedProviderError`: Raised by `create_gateway` for unknown providers.
+- `GatewayToolArgumentError`: Raised when a provider returns malformed tool-call arguments.
+- `StructuredOutputValidationError`: Raised when structured output cannot be validated into the requested Pydantic model.
+
+## Tests
+
+```bash
+pytest ai_gateway/tests/
+pytest ai_gateway/tests reporter/tests
+pytest
+```
+
+The gateway tests use a fake OpenAI client, so they do not require network access or an API key.

--- a/ai_gateway/__init__.py
+++ b/ai_gateway/__init__.py
@@ -1,0 +1,39 @@
+"""Lightweight AI gateway public interface."""
+
+from ai_gateway.errors import (
+    AiGatewayError,
+    GatewayToolArgumentError,
+    StructuredOutputValidationError,
+    UnsupportedProviderError,
+)
+from ai_gateway.factory import create_gateway
+from ai_gateway.models import (
+    AiGateway,
+    AiGatewayConfig,
+    AiRequest,
+    AiResponse,
+    AiUsage,
+    ChatMessage,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+from ai_gateway.openai_gateway import OpenAIGateway
+
+__all__ = [
+    "AiGateway",
+    "AiGatewayConfig",
+    "AiGatewayError",
+    "AiRequest",
+    "AiResponse",
+    "AiUsage",
+    "ChatMessage",
+    "GatewayToolArgumentError",
+    "OpenAIGateway",
+    "StructuredOutputValidationError",
+    "ToolCall",
+    "ToolResultMessage",
+    "ToolSpec",
+    "UnsupportedProviderError",
+    "create_gateway",
+]

--- a/ai_gateway/errors.py
+++ b/ai_gateway/errors.py
@@ -1,0 +1,17 @@
+"""Gateway-specific exceptions."""
+
+
+class AiGatewayError(Exception):
+    """Base exception for AI gateway failures."""
+
+
+class UnsupportedProviderError(AiGatewayError):
+    """Raised when a gateway provider is not supported."""
+
+
+class GatewayToolArgumentError(AiGatewayError):
+    """Raised when a provider returns malformed tool arguments."""
+
+
+class StructuredOutputValidationError(AiGatewayError):
+    """Raised when structured model output cannot be validated."""

--- a/ai_gateway/factory.py
+++ b/ai_gateway/factory.py
@@ -1,0 +1,17 @@
+"""Gateway factory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ai_gateway.errors import UnsupportedProviderError
+from ai_gateway.models import AiGatewayConfig
+from ai_gateway.openai_gateway import OpenAIGateway
+
+
+def create_gateway(config: AiGatewayConfig | None = None, client: Any | None = None) -> OpenAIGateway:
+    """Create a gateway implementation for the configured provider."""
+    gateway_config = config or AiGatewayConfig()
+    if gateway_config.provider == "openai":
+        return OpenAIGateway(gateway_config, client=client)
+    raise UnsupportedProviderError(f"Unsupported AI provider: {gateway_config.provider}")

--- a/ai_gateway/models.py
+++ b/ai_gateway/models.py
@@ -1,0 +1,128 @@
+"""Provider-neutral request and response models for AI chat calls."""
+
+from __future__ import annotations
+
+import json
+import os
+from abc import ABC, abstractmethod
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ChatMessage(BaseModel):
+    """A normal conversation message."""
+
+    role: Literal["system", "user", "assistant"]
+    content: str | list[dict[str, Any]]
+
+
+class ToolSpec(BaseModel):
+    """Provider-neutral function/tool definition."""
+
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=lambda: {"type": "object", "properties": {}})
+    strict: bool | None = None
+
+    @classmethod
+    def from_openai_tool(cls, tool: dict[str, Any]) -> "ToolSpec":
+        """Create a tool spec from OpenAI function-calling JSON."""
+        function = tool.get("function", tool)
+        return cls(
+            name=function["name"],
+            description=function.get("description", ""),
+            parameters=function.get("parameters", {"type": "object", "properties": {}}),
+            strict=function.get("strict"),
+        )
+
+    @classmethod
+    def from_openai_tools(cls, tools: list[dict[str, Any]]) -> list["ToolSpec"]:
+        """Create tool specs from OpenAI function-calling JSON tools."""
+        return [cls.from_openai_tool(tool) for tool in tools]
+
+
+class ToolCall(BaseModel):
+    """A model-requested tool call with parsed JSON arguments."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+    raw: Any = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ToolResultMessage(BaseModel):
+    """A tool execution result tied to a previous tool call."""
+
+    role: Literal["tool"] = "tool"
+    tool_call_id: str
+    content: str
+    name: str | None = None
+
+    @classmethod
+    def from_call(cls, call: ToolCall, result: Any) -> "ToolResultMessage":
+        """Create a tool result message from a tool call and arbitrary result."""
+        if isinstance(result, str):
+            content = result
+        else:
+            content = json.dumps(result, default=str)
+        return cls(tool_call_id=call.id, name=call.name, content=content)
+
+
+AiMessage = ChatMessage | ToolResultMessage
+
+
+class AiUsage(BaseModel):
+    """Token usage normalized across providers."""
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+class AiGatewayConfig(BaseModel):
+    """Configuration for a gateway provider."""
+
+    provider: str = "openai"
+    api_key: str | None = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
+    model: str = Field(default_factory=lambda: os.getenv("REPORTER_MODEL", "gpt-5-mini"))
+    base_url: str | None = None
+    timeout: float | None = None
+
+
+class AiRequest(BaseModel):
+    """Provider-neutral model request."""
+
+    messages: list[AiMessage]
+    tools: list[ToolSpec] = Field(default_factory=list)
+    model: str | None = None
+    options: dict[str, Any] = Field(default_factory=dict)
+    structured_output_schema: type[BaseModel] | None = Field(default=None, exclude=True)
+    mode: str | None = None
+    provider_context: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AiResponse(BaseModel):
+    """Provider-neutral model response."""
+
+    text: str | None = None
+    structured_output: BaseModel | None = None
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    finish_reason: str | None = None
+    usage: AiUsage | None = None
+    mode: str | None = None
+    provider_metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AiGateway(ABC):
+    """Abstract gateway interface."""
+
+    @abstractmethod
+    async def get_response(self, request: AiRequest) -> AiResponse:
+        """Send a request to a model provider and return normalized output."""

--- a/ai_gateway/openai_gateway.py
+++ b/ai_gateway/openai_gateway.py
@@ -1,0 +1,212 @@
+"""OpenAI Responses API adapter for the AI gateway."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from ai_gateway.errors import GatewayToolArgumentError, StructuredOutputValidationError
+from ai_gateway.models import (
+    AiGateway,
+    AiGatewayConfig,
+    AiRequest,
+    AiResponse,
+    AiUsage,
+    ChatMessage,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+
+
+class OpenAIGateway(AiGateway):
+    """AI gateway implementation backed by OpenAI's Responses API."""
+
+    def __init__(self, config: AiGatewayConfig | None = None, client: Any | None = None) -> None:
+        self.config = config or AiGatewayConfig()
+        self.client = client or self._create_client()
+
+    def _create_client(self) -> Any:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise RuntimeError("The openai package is required to use OpenAIGateway.") from exc
+
+        kwargs: dict[str, Any] = {}
+        if self.config.api_key:
+            kwargs["api_key"] = self.config.api_key
+        if self.config.base_url:
+            kwargs["base_url"] = self.config.base_url
+        if self.config.timeout is not None:
+            kwargs["timeout"] = self.config.timeout
+        return AsyncOpenAI(**kwargs)
+
+    async def get_response(self, request: AiRequest) -> AiResponse:
+        kwargs: dict[str, Any] = {
+            "model": request.model or self.config.model,
+            "input": [self._serialize_message(message) for message in request.messages],
+        }
+        if request.tools:
+            kwargs["tools"] = [self._serialize_tool(tool) for tool in request.tools]
+        if request.structured_output_schema is not None:
+            kwargs["text"] = {"format": self._serialize_structured_output(request.structured_output_schema)}
+        if "previous_response_id" in request.provider_context:
+            kwargs["previous_response_id"] = request.provider_context["previous_response_id"]
+        kwargs.update(request.options)
+
+        response = await self.client.responses.create(**kwargs)
+        return self._normalize_response(response, request.structured_output_schema, request.mode)
+
+    def _serialize_message(self, message: ChatMessage | ToolResultMessage) -> dict[str, Any]:
+        if isinstance(message, ToolResultMessage):
+            return {
+                "type": "function_call_output",
+                "call_id": message.tool_call_id,
+                "output": message.content,
+            }
+        return {"role": message.role, "content": message.content}
+
+    def _serialize_tool(self, tool: ToolSpec) -> dict[str, Any]:
+        serialized: dict[str, Any] = {
+            "type": "function",
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters,
+            "strict": tool.strict,
+        }
+        return serialized
+
+    def _serialize_structured_output(self, schema: type[BaseModel]) -> dict[str, Any]:
+        return {
+            "type": "json_schema",
+            "name": schema.__name__,
+            "schema": schema.model_json_schema(),
+            "strict": True,
+        }
+
+    def _normalize_response(
+        self,
+        response: Any,
+        structured_output_schema: type[BaseModel] | None,
+        mode: str | None,
+    ) -> AiResponse:
+        text = self._extract_text(response)
+        structured_output = self._extract_structured_output(response, text, structured_output_schema)
+        return AiResponse(
+            text=text,
+            structured_output=structured_output,
+            tool_calls=self._extract_tool_calls(response),
+            finish_reason=self._extract_finish_reason(response),
+            usage=self._extract_usage(response),
+            mode=mode,
+            provider_metadata={
+                "provider": "openai",
+                "response_id": self._read_attr(response, "id"),
+                "model": self._read_attr(response, "model"),
+            },
+        )
+
+    def _extract_text(self, response: Any) -> str | None:
+        output_text = self._read_attr(response, "output_text")
+        if output_text:
+            return output_text
+
+        chunks: list[str] = []
+        for item in self._iter_output_items(response):
+            item_type = self._read_attr(item, "type")
+            if item_type != "message":
+                continue
+            for content in self._read_attr(item, "content", []) or []:
+                content_type = self._read_attr(content, "type")
+                if content_type in {"output_text", "text"}:
+                    text = self._read_attr(content, "text")
+                    if text:
+                        chunks.append(text)
+        return "\n".join(chunks) if chunks else None
+
+    def _extract_structured_output(
+        self,
+        response: Any,
+        text: str | None,
+        schema: type[BaseModel] | None,
+    ) -> BaseModel | None:
+        if schema is None:
+            return None
+
+        parsed = self._read_attr(response, "output_parsed")
+        if parsed is not None:
+            try:
+                return parsed if isinstance(parsed, schema) else schema.model_validate(parsed)
+            except ValidationError as exc:
+                raise StructuredOutputValidationError(str(exc)) from exc
+
+        if not text:
+            return None
+
+        try:
+            return schema.model_validate_json(text)
+        except (ValueError, ValidationError) as exc:
+            raise StructuredOutputValidationError(str(exc)) from exc
+
+    def _extract_tool_calls(self, response: Any) -> list[ToolCall]:
+        calls: list[ToolCall] = []
+        for item in self._iter_output_items(response):
+            item_type = self._read_attr(item, "type")
+            if item_type not in {"function_call", "tool_call"}:
+                continue
+
+            raw_arguments = self._read_attr(item, "arguments", "{}")
+            arguments = self._parse_arguments(raw_arguments, item)
+            call_id = self._read_attr(item, "call_id") or self._read_attr(item, "id")
+            name = self._read_attr(item, "name")
+            calls.append(ToolCall(id=call_id, name=name, arguments=arguments, raw=item))
+        return calls
+
+    def _parse_arguments(self, raw_arguments: Any, raw_item: Any) -> dict[str, Any]:
+        if raw_arguments in (None, ""):
+            return {}
+        if isinstance(raw_arguments, dict):
+            return raw_arguments
+        if not isinstance(raw_arguments, str):
+            raise GatewayToolArgumentError(f"Tool arguments must be JSON object data: {raw_item!r}")
+
+        try:
+            parsed = json.loads(raw_arguments)
+        except json.JSONDecodeError as exc:
+            raise GatewayToolArgumentError(f"Malformed tool arguments: {raw_arguments}") from exc
+        if not isinstance(parsed, dict):
+            raise GatewayToolArgumentError(f"Tool arguments must decode to an object: {raw_arguments}")
+        return parsed
+
+    def _extract_finish_reason(self, response: Any) -> str | None:
+        status = self._read_attr(response, "status")
+        if status:
+            return status
+        for item in self._iter_output_items(response):
+            finish_reason = self._read_attr(item, "finish_reason")
+            if finish_reason:
+                return finish_reason
+        return None
+
+    def _extract_usage(self, response: Any) -> AiUsage | None:
+        usage = self._read_attr(response, "usage")
+        if usage is None:
+            return None
+        input_tokens = self._read_attr(usage, "input_tokens")
+        output_tokens = self._read_attr(usage, "output_tokens")
+        total_tokens = self._read_attr(usage, "total_tokens")
+        if input_tokens is None:
+            input_tokens = self._read_attr(usage, "prompt_tokens")
+        if output_tokens is None:
+            output_tokens = self._read_attr(usage, "completion_tokens")
+        return AiUsage(input_tokens=input_tokens, output_tokens=output_tokens, total_tokens=total_tokens)
+
+    def _iter_output_items(self, response: Any) -> list[Any]:
+        return self._read_attr(response, "output", []) or []
+
+    def _read_attr(self, value: Any, name: str, default: Any = None) -> Any:
+        if isinstance(value, dict):
+            return value.get(name, default)
+        return getattr(value, name, default)

--- a/ai_gateway/tests/test_factory.py
+++ b/ai_gateway/tests/test_factory.py
@@ -1,0 +1,26 @@
+"""Tests for gateway factory behavior."""
+
+import pytest
+
+from ai_gateway import AiGatewayConfig, OpenAIGateway, UnsupportedProviderError, create_gateway
+
+
+def test_config_defaults_to_openai_provider():
+    config = AiGatewayConfig()
+
+    assert config.provider == "openai"
+    assert config.model
+
+
+def test_create_gateway_supports_openai_with_injected_client():
+    client = object()
+
+    gateway = create_gateway(AiGatewayConfig(provider="openai"), client=client)
+
+    assert isinstance(gateway, OpenAIGateway)
+    assert gateway.client is client
+
+
+def test_create_gateway_rejects_unknown_provider():
+    with pytest.raises(UnsupportedProviderError):
+        create_gateway(AiGatewayConfig(provider="unknown"), client=object())

--- a/ai_gateway/tests/test_models.py
+++ b/ai_gateway/tests/test_models.py
@@ -1,0 +1,35 @@
+"""Tests for provider-neutral AI gateway models."""
+
+from ai_gateway import ToolCall, ToolResultMessage, ToolSpec
+
+
+def test_tool_spec_from_openai_tool():
+    spec = ToolSpec.from_openai_tool(
+        {
+            "type": "function",
+            "function": {
+                "name": "league_snapshot",
+                "description": "Get league data",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"week": {"type": "integer"}},
+                    "required": [],
+                },
+            },
+        }
+    )
+
+    assert spec.name == "league_snapshot"
+    assert spec.description == "Get league data"
+    assert spec.parameters["properties"]["week"]["type"] == "integer"
+
+
+def test_tool_result_message_from_call_serializes_result():
+    call = ToolCall(id="call_123", name="league_snapshot", arguments={"week": 1})
+
+    message = ToolResultMessage.from_call(call, {"standings": []})
+
+    assert message.role == "tool"
+    assert message.tool_call_id == "call_123"
+    assert message.name == "league_snapshot"
+    assert message.content == '{"standings": []}'

--- a/ai_gateway/tests/test_openai_gateway.py
+++ b/ai_gateway/tests/test_openai_gateway.py
@@ -1,0 +1,202 @@
+"""Tests for the OpenAI gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from ai_gateway import (
+    AiGatewayConfig,
+    AiRequest,
+    ChatMessage,
+    GatewayToolArgumentError,
+    OpenAIGateway,
+    StructuredOutputValidationError,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+
+
+class FakeResponses:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.kwargs = kwargs
+        return self.response
+
+
+class FakeClient:
+    def __init__(self, response: Any) -> None:
+        self.responses = FakeResponses(response)
+
+
+class ArticleShape(BaseModel):
+    title: str
+    score: int
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def test_plain_text_response_normalizes():
+    client = FakeClient(
+        {
+            "id": "resp_123",
+            "model": "gpt-test",
+            "status": "completed",
+            "output_text": "Week recap",
+            "usage": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14},
+        }
+    )
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="recap")])))
+
+    assert response.text == "Week recap"
+    assert response.finish_reason == "completed"
+    assert response.usage is not None
+    assert response.usage.input_tokens == 10
+    assert response.provider_metadata["response_id"] == "resp_123"
+    assert client.responses.kwargs is not None
+    assert client.responses.kwargs["input"] == [{"role": "user", "content": "recap"}]
+
+
+def test_maps_tools_into_responses_request():
+    client = FakeClient({"status": "completed", "output_text": "ok"})
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    run(
+        gateway.get_response(
+            AiRequest(
+                messages=[ChatMessage(role="user", content="look up standings")],
+                tools=[
+                    ToolSpec(
+                        name="standings",
+                        description="Get standings",
+                        parameters={"type": "object", "properties": {"week": {"type": "integer"}}},
+                    )
+                ],
+                options={"temperature": 0.2},
+            )
+        )
+    )
+
+    assert client.responses.kwargs is not None
+    assert client.responses.kwargs["model"] == "gpt-test"
+    assert client.responses.kwargs["temperature"] == 0.2
+    assert client.responses.kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "standings",
+            "description": "Get standings",
+            "parameters": {"type": "object", "properties": {"week": {"type": "integer"}}},
+            "strict": None,
+        }
+    ]
+
+
+def test_tool_call_response_normalizes_arguments():
+    client = FakeClient(
+        {
+            "status": "requires_action",
+            "output": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_abc",
+                    "name": "team_game",
+                    "arguments": '{"roster_key": "Schefter", "week": 8}',
+                }
+            ],
+        }
+    )
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
+
+    assert response.tool_calls == [
+        ToolCall(id="call_abc", name="team_game", arguments={"roster_key": "Schefter", "week": 8}, raw=response.tool_calls[0].raw)
+    ]
+
+
+def test_malformed_tool_arguments_raise_gateway_error():
+    client = FakeClient(
+        {
+            "output": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_abc",
+                    "name": "team_game",
+                    "arguments": "{broken",
+                }
+            ],
+        }
+    )
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    with pytest.raises(GatewayToolArgumentError):
+        run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
+
+
+def test_tool_result_message_serializes_for_next_request():
+    client = FakeClient({"status": "completed", "output_text": "thanks"})
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    run(
+        gateway.get_response(
+            AiRequest(
+                messages=[
+                    ChatMessage(role="user", content="recap"),
+                    ToolResultMessage(tool_call_id="call_abc", name="standings", content='{"rank": 1}'),
+                ],
+                provider_context={"previous_response_id": "resp_prev"},
+            )
+        )
+    )
+
+    assert client.responses.kwargs is not None
+    assert client.responses.kwargs["previous_response_id"] == "resp_prev"
+    assert client.responses.kwargs["input"][1] == {
+        "type": "function_call_output",
+        "call_id": "call_abc",
+        "output": '{"rank": 1}',
+    }
+
+
+def test_structured_output_schema_is_sent_and_validated():
+    client = FakeClient({"status": "completed", "output_text": '{"title": "Recap", "score": 98}'})
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    response = run(
+        gateway.get_response(
+            AiRequest(
+                messages=[ChatMessage(role="user", content="json")],
+                structured_output_schema=ArticleShape,
+            )
+        )
+    )
+
+    assert client.responses.kwargs is not None
+    assert client.responses.kwargs["text"]["format"]["name"] == "ArticleShape"
+    assert response.structured_output == ArticleShape(title="Recap", score=98)
+
+
+def test_invalid_structured_output_raises_gateway_error():
+    client = FakeClient({"status": "completed", "output_text": '{"title": "Recap"}'})
+    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+
+    with pytest.raises(StructuredOutputValidationError):
+        run(
+            gateway.get_response(
+                AiRequest(
+                    messages=[ChatMessage(role="user", content="json")],
+                    structured_output_schema=ArticleShape,
+                )
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests",
     "python-dotenv",
     "pydantic>=2.0",
+    "openai>=2.26.0",
     "openai-agents>=0.1.0",
     "sqlalchemy>=2.0",
 ]
@@ -28,9 +29,9 @@ reporter = "reporter.app.runner:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["datalayer*", "reporter*"]
+include = ["datalayer*", "reporter*", "ai_gateway*"]
 
 [tool.pytest.ini_options]
-testpaths = ["datalayer/tests", "reporter/tests"]
+testpaths = ["datalayer/tests", "reporter/tests", "ai_gateway/tests"]
 addopts = "-ra"
 pythonpath = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 python-dotenv
 pydantic>=2.0
+openai>=2.26.0
 openai-agents>=0.1.0
 pytest>=7.0
 pytest-asyncio>=0.21


### PR DESCRIPTION
## Description
Adds a standalone `ai_gateway` package that normalizes model I/O behind provider-neutral request and response types. The package includes an OpenAI Responses API adapter, a provider factory, public exports, gateway-specific errors, and README documentation for the architecture and interface.

The gateway intentionally does not execute tools. Applications pass tool specs in, receive normalized tool-call requests, execute handlers themselves, append `ToolResultMessage` results, and call the gateway again.

## Testing
- `.venv/bin/python -m pytest`

## Notes
- Adds `openai>=2.26.0` as a direct dependency because the new gateway uses the official OpenAI SDK directly.
- The reporter implementation is unchanged.