### PR TITLE
feat(reporter-v2): add run log

### DIFF
--- a/reporter_v2/runner/run_log.py
+++ b/reporter_v2/runner/run_log.py
@@ -1,0 +1,208 @@
+"""Run log for tracking all events during a runner session."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, TextIO
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, PrivateAttr
+
+
+class ProcedureSwitch(BaseModel):
+    from_procedure: str | None
+    to_procedure: str
+    turn: int
+
+
+class RunLogEntry(BaseModel):
+    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
+    turn: int = 0
+    event_type: str
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunLog(BaseModel):
+    session_id: str = Field(default_factory=lambda: str(uuid4())[:8])
+    started_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    entries: list[RunLogEntry] = Field(default_factory=list)
+
+    _stream_file: TextIO | None = PrivateAttr(default=None)
+    _start_time: datetime = PrivateAttr(default_factory=datetime.now)
+
+    def _add(self, entry: RunLogEntry) -> None:
+        self.entries.append(entry)
+        self._stream_entry(entry)
+
+    def add_tool_call(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+        result_summary: str,
+        duration_ms: int,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="tool_call",
+                data={
+                    "tool_name": tool_name,
+                    "params": params,
+                    "result_summary": result_summary,
+                    "duration_ms": duration_ms,
+                },
+            )
+        )
+
+    def add_procedure_switch(
+        self,
+        from_proc: str | None,
+        to_proc: str,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="procedure_switch",
+                data={"from_procedure": from_proc, "to_procedure": to_proc},
+            )
+        )
+
+    def add_artifact_write(
+        self,
+        artifact: str,
+        operation: str,
+        key: str,
+        revision: int | None = None,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="artifact_write",
+                data={
+                    "artifact": artifact,
+                    "operation": operation,
+                    "key": key,
+                    "brief_revision": revision,
+                },
+            )
+        )
+
+    def add_model_text(self, text_preview: str, *, turn: int) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="model_text",
+                data={"text_preview": text_preview[:200]},
+            )
+        )
+
+    def add_guardrail(
+        self,
+        guardrail_type: str,
+        current: int,
+        limit: int,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="guardrail",
+                data={
+                    "guardrail_type": guardrail_type,
+                    "current_count": current,
+                    "limit": limit,
+                },
+            )
+        )
+
+    def add_completion(self, stats: dict[str, Any], *, turn: int) -> None:
+        self._add(RunLogEntry(turn=turn, event_type="completion", data=stats))
+
+    @property
+    def tool_call_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.event_type == "tool_call")
+
+    @property
+    def procedure_history(self) -> list[ProcedureSwitch]:
+        switches: list[ProcedureSwitch] = []
+        for entry in self.entries:
+            if entry.event_type == "procedure_switch":
+                switches.append(
+                    ProcedureSwitch(
+                        from_procedure=entry.data.get("from_procedure"),
+                        to_procedure=entry.data["to_procedure"],
+                        turn=entry.turn,
+                    )
+                )
+        return switches
+
+    def start_streaming(self, path: Path) -> None:
+        self._stream_file = open(path, "w", encoding="utf-8")
+        self._stream_file.write(f"# Run Log: {self.session_id}\n")
+        self._stream_file.write(f"Started: {self.started_at}\n\n")
+        self._stream_file.flush()
+
+    def stop_streaming(self) -> None:
+        if self._stream_file is None:
+            return
+
+        self._stream_file.write(f"\nCompleted: {datetime.now().isoformat()}\n")
+        self._stream_file.write(f"Total tool calls: {self.tool_call_count}\n")
+        self._stream_file.close()
+        self._stream_file = None
+
+    def _stream_entry(self, entry: RunLogEntry) -> None:
+        if self._stream_file is None:
+            return
+
+        elapsed = self._format_elapsed(entry)
+        line = self._format_entry(entry, elapsed)
+        self._stream_file.write(line + "\n")
+        self._stream_file.flush()
+
+    def _format_elapsed(self, entry: RunLogEntry) -> str:
+        delta = datetime.fromisoformat(entry.timestamp) - self._start_time
+        minutes, seconds = divmod(int(delta.total_seconds()), 60)
+        return f"[{minutes:02d}:{seconds:02d}]"
+
+    def _format_entry(self, entry: RunLogEntry, elapsed: str) -> str:
+        data = entry.data
+        if entry.event_type == "procedure_switch":
+            previous = (
+                f" (was: {data['from_procedure']})"
+                if data.get("from_procedure")
+                else ""
+            )
+            return f"{elapsed} Loaded procedure: {data['to_procedure']}{previous}"
+        if entry.event_type == "tool_call":
+            duration_ms = data.get("duration_ms", 0)
+            return (
+                f"{elapsed} {data['tool_name']}() -> "
+                f"{data['result_summary']} [{duration_ms}ms]"
+            )
+        if entry.event_type == "artifact_write":
+            revision = (
+                f" -> brief rev {data['brief_revision']}"
+                if data.get("brief_revision")
+                else ""
+            )
+            return f"{elapsed} {data['operation']}({data['key']}){revision}"
+        if entry.event_type == "model_text":
+            return f"{elapsed} Model: {data['text_preview'][:80]}"
+        if entry.event_type == "guardrail":
+            return (
+                f"{elapsed} GUARDRAIL: {data['guardrail_type']} "
+                f"({data['current_count']}/{data['limit']})"
+            )
+        if entry.event_type == "completion":
+            return f"{elapsed} COMPLETE: {json.dumps(data)}"
+        return f"{elapsed} {entry.event_type}: {data}"

--- a/reporter_v2/tests/test_run_log.py
+++ b/reporter_v2/tests/test_run_log.py
@@ -1,0 +1,107 @@
+"""Tests for reporter_v2 runner run logs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from reporter_v2.runner.run_log import RunLog, RunLogEntry, ProcedureSwitch
+
+
+def test_add_tool_call() -> None:
+    log = RunLog(session_id="test1234")
+
+    log.add_tool_call(
+        "standings",
+        {"week": 8},
+        "12 teams in standings",
+        42,
+        turn=3,
+    )
+
+    assert log.tool_call_count == 1
+    assert len(log.entries) == 1
+
+    entry = log.entries[0]
+    assert entry.event_type == "tool_call"
+    assert entry.turn == 3
+    assert entry.data == {
+        "tool_name": "standings",
+        "params": {"week": 8},
+        "result_summary": "12 teams in standings",
+        "duration_ms": 42,
+    }
+
+
+def test_procedure_history() -> None:
+    log = RunLog()
+
+    log.add_procedure_switch(None, "research", turn=1)
+    log.add_tool_call("league_snapshot", {}, "snapshot loaded", 10, turn=2)
+    log.add_procedure_switch("research", "drafting", turn=5)
+
+    assert log.procedure_history == [
+        ProcedureSwitch(from_procedure=None, to_procedure="research", turn=1),
+        ProcedureSwitch(from_procedure="research", to_procedure="drafting", turn=5),
+    ]
+
+
+def test_streaming(tmp_path) -> None:
+    path = tmp_path / "run-log.md"
+    log = RunLog(session_id="stream01", started_at="2026-05-18T10:00:00")
+
+    log.start_streaming(path)
+    log.add_procedure_switch(None, "research", turn=1)
+    log.add_tool_call("standings", {}, "12 teams", 25, turn=2)
+    log.add_artifact_write("brief", "save_fact", "fact_001", revision=1, turn=3)
+    log.add_model_text("Drafting a lead from the standings.", turn=4)
+    log.add_guardrail("tool_limit", 40, 50, turn=5)
+    log.add_completion({"status": "done"}, turn=6)
+    log.stop_streaming()
+
+    content = path.read_text(encoding="utf-8")
+    assert content.startswith("# Run Log: stream01\nStarted: 2026-05-18T10:00:00")
+    assert "Loaded procedure: research" in content
+    assert "standings() -> 12 teams [25ms]" in content
+    assert "save_fact(fact_001) -> brief rev 1" in content
+    assert "Model: Drafting a lead from the standings." in content
+    assert "GUARDRAIL: tool_limit (40/50)" in content
+    assert 'COMPLETE: {"status": "done"}' in content
+    assert "Completed:" in content
+    assert "Total tool calls: 1" in content
+    assert log._stream_file is None
+
+
+def test_format_elapsed() -> None:
+    log = RunLog()
+    log._start_time = datetime(2026, 5, 18, 10, 0, 0)
+    entry = RunLogEntry(
+        timestamp=(log._start_time + timedelta(minutes=2, seconds=7)).isoformat(),
+        event_type="model_text",
+        data={"text_preview": "hello"},
+    )
+
+    assert log._format_elapsed(entry) == "[02:07]"
+
+
+def test_model_text_truncates_to_200_chars() -> None:
+    log = RunLog()
+
+    log.add_model_text("x" * 250, turn=1)
+
+    assert len(log.entries[0].data["text_preview"]) == 200
+
+
+def test_artifact_write_metadata_with_optional_revision() -> None:
+    log = RunLog()
+
+    log.add_artifact_write("brief", "set_outline", "outline", turn=7)
+
+    entry = log.entries[0]
+    assert entry.event_type == "artifact_write"
+    assert entry.turn == 7
+    assert entry.data == {
+        "artifact": "brief",
+        "operation": "set_outline",
+        "key": "outline",
+        "brief_revision": None,
+    }


### PR DESCRIPTION
## Description
- Add the standalone reporter_v2 RunLog implementation for Phase 2.
- Track typed runner events, derived tool/procedure history, and optional markdown streaming.
- Add unit coverage for event storage, streaming output, elapsed formatting, truncation, and artifact metadata.

## Testing
- `pyenv exec python -m pytest reporter_v2/tests/test_run_log.py`

## Notes
- Graphite submit was attempted first, but Graphite could not verify access to `maxwn04/AIdamShefter-v2`, so this PR was created with GitHub CLI.
- Per plan, this does not modify `pyproject.toml` or add Phase 1 package scaffolding.