### PR TITLE
Implement reporter v2 article tools

### DIFF
--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -1,5 +1,13 @@
 """Runner v2 tool implementations."""
 
+from reporter_v2.runner.tools.article_tools import (
+    read_article,
+    read_section,
+    rewrite_section,
+    set_section_order,
+    submit_article,
+    write_section,
+)
 from reporter_v2.runner.tools.brief_tools import (
     read_brief,
     save_fact,
@@ -12,10 +20,16 @@ from reporter_v2.runner.tools.context import ToolContext
 
 __all__ = [
     "ToolContext",
+    "read_article",
     "read_brief",
+    "read_section",
+    "rewrite_section",
     "save_fact",
     "save_storyline",
+    "set_section_order",
     "set_bias",
     "set_outline",
     "set_style",
+    "submit_article",
+    "write_section",
 ]

--- a/reporter_v2/runner/tools/article_tools.py
+++ b/reporter_v2/runner/tools/article_tools.py
@@ -1,0 +1,163 @@
+"""Article artifact tools for reporter v2."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from reporter_v2.runner.schemas import ArticleSection
+from reporter_v2.runner.tools.context import ToolContext
+
+
+def write_section(ctx: ToolContext, *, name: str, content: str) -> str:
+    """Create or overwrite a named article section."""
+    ctx.artifacts.article.set_section(name, content)
+    ctx.log.add_artifact_write(
+        "article",
+        "write_section",
+        name,
+        turn=ctx.turn,
+    )
+    return _json(
+        {
+            "ok": True,
+            "section_count": len(ctx.artifacts.article.sections),
+            "section_order": ctx.artifacts.article.section_order,
+        }
+    )
+
+
+def read_article(ctx: ToolContext) -> str:
+    """Return all article sections in display order."""
+    sections = _ordered_sections(
+        ctx.artifacts.article.sections,
+        ctx.artifacts.article.section_order,
+    )
+    markdown = ctx.artifacts.article.to_markdown()
+    return _json(
+        {
+            "ok": True,
+            "sections": [_section_payload(section) for section in sections],
+            "section_count": len(ctx.artifacts.article.sections),
+            "total_word_count": _word_count(markdown),
+        }
+    )
+
+
+def read_section(ctx: ToolContext, *, name: str) -> str:
+    """Return a single article section by name."""
+    section = ctx.artifacts.article.get_section(name)
+    if section is None:
+        return _error(f"Section not found: {name}", name=name)
+
+    return _json({"ok": True, "section": _section_payload(section)})
+
+
+def rewrite_section(ctx: ToolContext, *, name: str, content: str) -> str:
+    """Replace an existing section."""
+    section = ctx.artifacts.article.get_section(name)
+    if section is None:
+        return _error(f"Section not found: {name}", name=name)
+
+    section.content = content
+    ctx.log.add_artifact_write(
+        "article",
+        "rewrite_section",
+        name,
+        turn=ctx.turn,
+    )
+    return _json(
+        {
+            "ok": True,
+            "section": _section_payload(section),
+            "section_count": len(ctx.artifacts.article.sections),
+        }
+    )
+
+
+def set_section_order(ctx: ToolContext, *, names: list[str]) -> str:
+    """Set the display order of article sections."""
+    existing_names = [section.name for section in ctx.artifacts.article.sections]
+    unknown_names = [name for name in names if name not in existing_names]
+    missing_names = [name for name in existing_names if name not in names]
+    duplicate_names = _duplicate_names(names)
+
+    if unknown_names or missing_names or duplicate_names:
+        return _json(
+            {
+                "ok": False,
+                "error": "Section order must include each existing section exactly once.",
+                "unknown_names": unknown_names,
+                "missing_names": missing_names,
+                "duplicate_names": duplicate_names,
+            }
+        )
+
+    ctx.artifacts.article.section_order = list(names)
+    ctx.log.add_artifact_write(
+        "article",
+        "set_section_order",
+        "section_order",
+        turn=ctx.turn,
+    )
+    return _json({"ok": True, "section_order": ctx.artifacts.article.section_order})
+
+
+def submit_article(ctx: ToolContext) -> str:
+    """Signal article completion and return the final article."""
+    article = ctx.artifacts.article
+    if not article.sections:
+        return _error("Cannot submit an empty article.")
+
+    markdown = article.to_markdown()
+    stats = {
+        "section_count": len(article.sections),
+        "total_word_count": _word_count(markdown),
+        "total_char_count": len(markdown),
+    }
+    ctx.log.add_completion(stats, turn=ctx.turn)
+    return _json({"ok": True, "article": markdown, "stats": stats})
+
+
+def _ordered_sections(
+    sections: list[ArticleSection],
+    section_order: list[str],
+) -> list[ArticleSection]:
+    if not section_order:
+        return sections
+
+    by_name = {section.name: section for section in sections}
+    ordered = [by_name[name] for name in section_order if name in by_name]
+    unordered = [section for section in sections if section.name not in section_order]
+    return ordered + unordered
+
+
+def _section_payload(section: ArticleSection) -> dict[str, Any]:
+    return {
+        "name": section.name,
+        "content": section.content,
+        "word_count": _word_count(section.content),
+    }
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"[A-Za-z0-9]+(?:[.'-][A-Za-z0-9]+)*", text))
+
+
+def _duplicate_names(names: list[str]) -> list[str]:
+    seen = set()
+    duplicates = []
+    for name in names:
+        if name in seen and name not in duplicates:
+            duplicates.append(name)
+        seen.add(name)
+    return duplicates
+
+
+def _error(message: str, **extra: Any) -> str:
+    return _json({"ok": False, "error": message, **extra})
+
+
+def _json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload)

--- a/reporter_v2/tests/test_article_tools.py
+++ b/reporter_v2/tests/test_article_tools.py
@@ -1,0 +1,196 @@
+"""Tests for reporter v2 article artifact tools."""
+
+from __future__ import annotations
+
+import json
+
+from reporter_v2.runner.run_log import RunLog
+from reporter_v2.runner.state import ArtifactStore, ProcedureState
+from reporter_v2.runner.tools.article_tools import (
+    read_article,
+    read_section,
+    rewrite_section,
+    set_section_order,
+    submit_article,
+    write_section,
+)
+from reporter_v2.runner.tools.context import ToolContext
+
+
+def make_ctx() -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(session_id="testlog"),
+        turn=3,
+    )
+
+
+def decode(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_write_section() -> None:
+    ctx = make_ctx()
+
+    first = decode(write_section(ctx, name="opening", content="# Opening\n\nHello."))
+    second = decode(write_section(ctx, name="closing", content="# Closing\n\nBye."))
+
+    assert first["ok"] is True
+    assert second["section_count"] == 2
+    assert ctx.artifacts.article.section_order == ["opening", "closing"]
+    assert ctx.artifacts.article.to_markdown() == "# Opening\n\nHello.\n\n# Closing\n\nBye."
+    assert [entry.data["operation"] for entry in ctx.log.entries] == [
+        "write_section",
+        "write_section",
+    ]
+
+
+def test_write_section_overwrite() -> None:
+    ctx = make_ctx()
+
+    write_section(ctx, name="opening", content="First draft")
+    result = decode(write_section(ctx, name="opening", content="Second draft"))
+
+    assert result["section_count"] == 1
+    assert ctx.artifacts.article.get_section("opening").content == "Second draft"
+    assert ctx.artifacts.article.section_order == ["opening"]
+
+
+def test_read_article() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello league.")
+    write_section(ctx, name="closing", content="# Closing\n\nGood night.")
+
+    result = decode(read_article(ctx))
+
+    assert result["ok"] is True
+    assert result["section_count"] == 2
+    assert result["total_word_count"] == 6
+    assert [section["name"] for section in result["sections"]] == ["opening", "closing"]
+    assert result["sections"][0]["content"] == "# Opening\n\nHello league."
+
+
+def test_read_section() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello.")
+
+    result = decode(read_section(ctx, name="opening"))
+
+    assert result == {
+        "ok": True,
+        "section": {
+            "name": "opening",
+            "content": "# Opening\n\nHello.",
+            "word_count": 2,
+        },
+    }
+
+
+def test_read_section_missing() -> None:
+    ctx = make_ctx()
+
+    result = decode(read_section(ctx, name="missing"))
+
+    assert result["ok"] is False
+    assert result["name"] == "missing"
+    assert "not found" in result["error"]
+
+
+def test_rewrite_section_exists() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="First draft")
+
+    result = decode(rewrite_section(ctx, name="opening", content="Final draft"))
+
+    assert result["ok"] is True
+    assert result["section"]["content"] == "Final draft"
+    assert ctx.artifacts.article.get_section("opening").content == "Final draft"
+    assert ctx.log.entries[-1].data == {
+        "artifact": "article",
+        "operation": "rewrite_section",
+        "key": "opening",
+        "brief_revision": None,
+    }
+
+
+def test_rewrite_section_missing() -> None:
+    ctx = make_ctx()
+
+    result = decode(rewrite_section(ctx, name="missing", content="Nope."))
+
+    assert result["ok"] is False
+    assert result["name"] == "missing"
+    assert ctx.log.entries == []
+
+
+def test_set_section_order() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+    write_section(ctx, name="c", content="# C")
+
+    result = decode(set_section_order(ctx, names=["c", "a", "b"]))
+    article = decode(read_article(ctx))
+
+    assert result == {"ok": True, "section_order": ["c", "a", "b"]}
+    assert [section["name"] for section in article["sections"]] == ["c", "a", "b"]
+    assert ctx.artifacts.article.to_markdown() == "# C\n\n# A\n\n# B"
+
+
+def test_set_section_order_rejects_unknown_or_missing_names() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+
+    result = decode(set_section_order(ctx, names=["b", "c"]))
+
+    assert result["ok"] is False
+    assert result["unknown_names"] == ["c"]
+    assert result["missing_names"] == ["a"]
+    assert result["duplicate_names"] == []
+    assert ctx.artifacts.article.section_order == ["a", "b"]
+
+
+def test_set_section_order_rejects_duplicate_names() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+
+    result = decode(set_section_order(ctx, names=["a", "a", "b"]))
+
+    assert result["ok"] is False
+    assert result["unknown_names"] == []
+    assert result["missing_names"] == []
+    assert result["duplicate_names"] == ["a"]
+    assert ctx.artifacts.article.section_order == ["a", "b"]
+
+
+def test_submit_article_empty() -> None:
+    ctx = make_ctx()
+
+    result = decode(submit_article(ctx))
+
+    assert result["ok"] is False
+    assert "empty article" in result["error"]
+    assert ctx.log.entries == []
+
+
+def test_submit_article() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello league.")
+    write_section(ctx, name="closing", content="# Closing\n\nGood night.")
+
+    result = decode(submit_article(ctx))
+
+    assert result == {
+        "ok": True,
+        "article": "# Opening\n\nHello league.\n\n# Closing\n\nGood night.",
+        "stats": {
+            "section_count": 2,
+            "total_word_count": 6,
+            "total_char_count": 48,
+        },
+    }
+    assert ctx.log.entries[-1].event_type == "completion"
+    assert ctx.log.entries[-1].data == result["stats"]


### PR DESCRIPTION
## Summary
- Add reporter v2 ToolContext and tools package scaffold
- Implement article artifact tools for writing, reading, rewriting, ordering, and submitting sections
- Add phase 4 article tool tests covering success and error paths

## Tests
- /opt/homebrew/bin/pyenv exec python -m pytest reporter_v2/tests