### PR TITLE
feat(runner-v2): implement brief artifact tools

### DIFF
--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -1,0 +1,21 @@
+"""Runner v2 tool implementations."""
+
+from reporter_v2.runner.tools.brief_tools import (
+    read_brief,
+    save_fact,
+    save_storyline,
+    set_bias,
+    set_outline,
+    set_style,
+)
+from reporter_v2.runner.tools.context import ToolContext
+
+__all__ = [
+    "ToolContext",
+    "read_brief",
+    "save_fact",
+    "save_storyline",
+    "set_bias",
+    "set_outline",
+    "set_style",
+]

--- a/reporter_v2/runner/tools/brief_tools.py
+++ b/reporter_v2/runner/tools/brief_tools.py
@@ -1,0 +1,205 @@
+"""Brief artifact tools for runner v2."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import ValidationError
+
+from reporter_v2.runner.schemas import (
+    Fact,
+    Outline,
+    ResolvedBias,
+    ResolvedStyle,
+    Storyline,
+)
+from reporter_v2.runner.tools.context import ToolContext
+
+
+def save_fact(
+    ctx: ToolContext,
+    *,
+    id: str,
+    claim_text: str,
+    data_refs: list[str],
+    numbers: dict[str, Any] | None = None,
+    category: str = "general",
+) -> str:
+    """Add or update a verified fact in the brief."""
+    if not claim_text.strip():
+        return _error("claim_text must be non-empty")
+    if not data_refs:
+        return _error("data_refs must contain at least one reference")
+
+    fact = Fact(
+        id=id,
+        claim_text=claim_text,
+        data_refs=data_refs,
+        numbers=numbers or {},
+        category=category,
+    )
+    brief = ctx.artifacts.brief
+    operation = "update_fact" if brief.get_fact(id) is not None else "save_fact"
+    _upsert_by_id(brief.facts, fact)
+    revision = brief.bump_revision()
+    ctx.log.add_artifact_write("brief", operation, id, revision, turn=ctx.turn)
+    return _success({"fact_id": id, "brief_revision": revision})
+
+
+def save_storyline(
+    ctx: ToolContext,
+    *,
+    id: str,
+    headline: str,
+    summary: str,
+    supporting_fact_ids: list[str],
+    priority: int = 2,
+    tags: list[str] | None = None,
+) -> str:
+    """Add or update a storyline in the brief."""
+    brief = ctx.artifacts.brief
+    fact_ids = {fact.id for fact in brief.facts}
+    missing_fact_ids = [
+        fact_id for fact_id in supporting_fact_ids if fact_id not in fact_ids
+    ]
+    if missing_fact_ids:
+        return _error(
+            "supporting_fact_ids contains unknown fact ids",
+            {"missing_fact_ids": missing_fact_ids},
+        )
+
+    revision = brief.bump_revision()
+    try:
+        storyline = Storyline(
+            id=id,
+            headline=headline,
+            summary=summary,
+            supporting_fact_ids=supporting_fact_ids,
+            priority=priority,
+            tags=tags or [],
+            revision_at_set=revision,
+        )
+    except ValidationError as exc:
+        brief.revision -= 1
+        return _error("invalid storyline", {"details": _validation_details(exc)})
+
+    operation = (
+        "update_storyline"
+        if any(existing.id == id for existing in brief.storylines)
+        else "save_storyline"
+    )
+    _upsert_by_id(brief.storylines, storyline)
+    ctx.log.add_artifact_write("brief", operation, id, revision, turn=ctx.turn)
+    return _success({"storyline_id": id, "brief_revision": revision})
+
+
+def set_outline(ctx: ToolContext, *, sections: list[dict[str, Any]]) -> str:
+    """Replace the article outline."""
+    brief = ctx.artifacts.brief
+    revision = brief.bump_revision()
+    try:
+        brief.outline = Outline(sections=sections, revision_at_set=revision)
+    except ValidationError as exc:
+        brief.revision -= 1
+        return _error("invalid outline", {"details": _validation_details(exc)})
+
+    ctx.log.add_artifact_write(
+        "brief", "set_outline", "outline", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def set_style(
+    ctx: ToolContext,
+    *,
+    voice: str = "sports columnist",
+    pacing: str = "moderate",
+    humor_level: int = 1,
+    formality: str = "casual",
+) -> str:
+    """Set resolved article style."""
+    try:
+        style = ResolvedStyle(
+            voice=voice,
+            pacing=pacing,
+            humor_level=humor_level,
+            formality=formality,
+        )
+    except ValidationError as exc:
+        return _error("invalid style", {"details": _validation_details(exc)})
+
+    ctx.artifacts.brief.style = style
+    revision = ctx.artifacts.brief.bump_revision()
+    ctx.log.add_artifact_write(
+        "brief", "set_style", "style", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def set_bias(
+    ctx: ToolContext,
+    *,
+    favored_teams: list[str] | None = None,
+    disfavored_teams: list[str] | None = None,
+    intensity: int = 0,
+    framing_rules: list[str] | None = None,
+) -> str:
+    """Set resolved article bias."""
+    try:
+        bias = ResolvedBias(
+            favored_teams=favored_teams or [],
+            disfavored_teams=disfavored_teams or [],
+            intensity=intensity,
+            framing_rules=framing_rules or [],
+        )
+    except ValidationError as exc:
+        return _error("invalid bias", {"details": _validation_details(exc)})
+
+    ctx.artifacts.brief.bias = bias
+    revision = ctx.artifacts.brief.bump_revision()
+    ctx.log.add_artifact_write(
+        "brief", "set_bias", "bias", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def read_brief(ctx: ToolContext) -> str:
+    """Return the current brief and staleness metadata."""
+    brief_dict = ctx.artifacts.brief.model_dump()
+    brief_dict["staleness_info"] = ctx.artifacts.brief.staleness_info()
+    return _json(brief_dict)
+
+
+def _upsert_by_id(items: list[Any], item: Any) -> None:
+    for index, existing in enumerate(items):
+        if existing.id == item.id:
+            items[index] = item
+            return
+    items.append(item)
+
+
+def _success(data: dict[str, Any]) -> str:
+    return _json({"ok": True, **data})
+
+
+def _error(message: str, extra: dict[str, Any] | None = None) -> str:
+    payload = {"ok": False, "error": message}
+    if extra:
+        payload.update(extra)
+    return _json(payload)
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True)
+
+
+def _validation_details(exc: ValidationError) -> list[dict[str, Any]]:
+    return [
+        {
+            "loc": list(error["loc"]),
+            "msg": error["msg"],
+            "type": error["type"],
+        }
+        for error in exc.errors()
+    ]

--- a/reporter_v2/runner/tools/context.py
+++ b/reporter_v2/runner/tools/context.py
@@ -1,0 +1,16 @@
+"""Context object injected into runner v2 tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from reporter_v2.runner.run_log import RunLog
+from reporter_v2.runner.state import ArtifactStore, ProcedureState
+
+
+@dataclass
+class ToolContext:
+    artifacts: ArtifactStore
+    procedures: ProcedureState
+    log: RunLog
+    turn: int = 0

--- a/reporter_v2/tests/test_brief_tools.py
+++ b/reporter_v2/tests/test_brief_tools.py
@@ -1,0 +1,220 @@
+"""Tests for runner v2 brief artifact tools."""
+
+import json
+
+from reporter_v2.runner.run_log import RunLog
+from reporter_v2.runner.state import ArtifactStore, ProcedureState
+from reporter_v2.runner.tools import (
+    ToolContext,
+    read_brief,
+    save_fact,
+    save_storyline,
+    set_bias,
+    set_outline,
+    set_style,
+)
+
+
+def make_ctx() -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=3,
+    )
+
+
+def parse_result(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_save_fact_valid():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(
+            ctx,
+            id="fact_001",
+            claim_text="Team Taco scored 142.3 points.",
+            data_refs=["week_games:week=8"],
+            numbers={"points": 142.3},
+            category="score",
+        )
+    )
+
+    assert result == {"ok": True, "fact_id": "fact_001", "brief_revision": 1}
+    assert ctx.artifacts.brief.revision == 1
+    assert ctx.artifacts.brief.facts[0].id == "fact_001"
+    assert ctx.artifacts.brief.facts[0].numbers == {"points": 142.3}
+    assert ctx.log.entries[-1].event_type == "artifact_write"
+    assert ctx.log.entries[-1].data["key"] == "fact_001"
+
+
+def test_save_fact_empty_data_refs():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=[])
+    )
+
+    assert result["ok"] is False
+    assert "data_refs" in result["error"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.facts == []
+    assert ctx.log.entries == []
+
+
+def test_save_fact_empty_claim():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(ctx, id="fact_001", claim_text="  ", data_refs=["source"])
+    )
+
+    assert result["ok"] is False
+    assert "claim_text" in result["error"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.facts == []
+
+
+def test_save_fact_upsert():
+    ctx = make_ctx()
+    save_fact(
+        ctx,
+        id="fact_001",
+        claim_text="Original claim.",
+        data_refs=["source:old"],
+    )
+
+    result = parse_result(
+        save_fact(
+            ctx,
+            id="fact_001",
+            claim_text="Replacement claim.",
+            data_refs=["source:new"],
+            category="updated",
+        )
+    )
+
+    assert result["brief_revision"] == 2
+    assert len(ctx.artifacts.brief.facts) == 1
+    assert ctx.artifacts.brief.facts[0].claim_text == "Replacement claim."
+    assert ctx.artifacts.brief.facts[0].data_refs == ["source:new"]
+    assert ctx.log.entries[-1].data["operation"] == "update_fact"
+
+
+def test_save_storyline_valid():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=["source"])
+
+    result = parse_result(
+        save_storyline(
+            ctx,
+            id="story_001",
+            headline="Big Swing",
+            summary="A major matchup changed the standings.",
+            supporting_fact_ids=["fact_001"],
+            priority=1,
+            tags=["standings"],
+        )
+    )
+
+    assert result == {"ok": True, "storyline_id": "story_001", "brief_revision": 2}
+    assert len(ctx.artifacts.brief.storylines) == 1
+    assert ctx.artifacts.brief.storylines[0].revision_at_set == 2
+    assert ctx.artifacts.brief.storylines[0].tags == ["standings"]
+
+
+def test_save_storyline_invalid_fact_ids():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_storyline(
+            ctx,
+            id="story_001",
+            headline="Unsupported",
+            summary="This has no facts.",
+            supporting_fact_ids=["missing_fact"],
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["missing_fact_ids"] == ["missing_fact"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.storylines == []
+
+
+def test_set_outline():
+    ctx = make_ctx()
+
+    result = parse_result(
+        set_outline(
+            ctx,
+            sections=[
+                {
+                    "title": "Lead",
+                    "bullet_points": ["Open with Team Taco."],
+                    "required_fact_ids": ["fact_001"],
+                    "storyline_ids": ["story_001"],
+                }
+            ],
+        )
+    )
+
+    assert result == {"ok": True, "brief_revision": 1}
+    assert ctx.artifacts.brief.outline.revision_at_set == 1
+    assert ctx.artifacts.brief.outline.sections[0].title == "Lead"
+    assert ctx.log.entries[-1].data["operation"] == "set_outline"
+
+
+def test_set_style_and_bias():
+    ctx = make_ctx()
+
+    style_result = parse_result(
+        set_style(
+            ctx,
+            voice="beat reporter",
+            pacing="fast",
+            humor_level=2,
+            formality="sharp casual",
+        )
+    )
+    bias_result = parse_result(
+        set_bias(
+            ctx,
+            favored_teams=["Team Taco"],
+            disfavored_teams=["Waiver Wire"],
+            intensity=2,
+            framing_rules=["Praise decisive wins."],
+        )
+    )
+
+    assert style_result == {"ok": True, "brief_revision": 1}
+    assert bias_result == {"ok": True, "brief_revision": 2}
+    assert ctx.artifacts.brief.style.voice == "beat reporter"
+    assert ctx.artifacts.brief.bias.favored_teams == ["Team Taco"]
+
+
+def test_read_brief_staleness():
+    ctx = make_ctx()
+    set_outline(ctx, sections=[{"title": "Lead"}])
+    save_fact(ctx, id="fact_001", claim_text="A later claim.", data_refs=["source"])
+
+    result = parse_result(read_brief(ctx))
+
+    assert result["revision"] == 2
+    assert result["staleness_info"] == {
+        "outline_stale": True,
+        "outline_gap": "1 mutation(s) since outline was set",
+    }
+
+
+def test_read_brief_no_staleness():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=["source"])
+    set_outline(ctx, sections=[{"title": "Lead", "required_fact_ids": ["fact_001"]}])
+
+    result = parse_result(read_brief(ctx))
+
+    assert result["revision"] == 2
+    assert result["staleness_info"] == {}


### PR DESCRIPTION
## Description

Implements phase 3 of the runner v2 plan: brief artifact tools and their required run log support.

- Adds `RunLog` with typed entries, artifact-write logging, streaming output, and derived procedure/tool-call metadata.
- Adds `ToolContext` and exports the runner v2 tool surface.
- Adds brief tools for saving facts/storylines, setting outline/style/bias, reading the brief, validating inputs, bumping revisions, and reporting stale outline/storyline metadata.
- Adds focused tests for brief tool behavior and run log behavior.

## Testing

- `PYENV_VERSION=aidamshefter-v2 PYTHONPATH=. pyenv exec python -m pytest reporter_v2/tests`

## Risks

- Low risk; this is additive runner v2 functionality behind new modules and tests.

## Notes

- Graphite submission was attempted first, but Graphite could not verify access to this repo, so this PR is being created with GitHub CLI.
