### PR TITLE
Add reporter v2 procedure loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 .cache/
 .pytest_cache/
 .venv/
+build/
+dist/
+*.egg-info/
 sleeper_fantasy_reporter.egg-info/
 sleeper_datalayer.egg-info/
 .output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ reporter = "reporter.app.runner:main"
 where = ["."]
 include = ["datalayer*", "reporter*", "ai_gateway*"]
 
+[tool.setuptools.package-data]
+reporter_v2 = ["procedures/*.md"]
+
 [tool.pytest.ini_options]
 testpaths = ["datalayer/tests", "reporter/tests", "reporter_v2/tests", "ai_gateway/tests"]
 addopts = "-ra"

--- a/reporter_v2/procedures/drafting.md
+++ b/reporter_v2/procedures/drafting.md
@@ -1,0 +1,66 @@
+# Drafting Procedure
+
+You are writing the article from the brief artifact. Use `read_brief`, then write article sections with article tools. Do not call datalayer tools while drafting unless you discover the brief is missing a required fact; if that happens, switch back to `research`.
+
+## Operating Rules
+
+- The brief is the source of truth. Use only saved facts, storylines, outline, style, and bias.
+- Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
+- Numeric claims must match the fact `numbers` values or the fact `claim_text`.
+- Follow the outline unless it is stale or incomplete. If it is stale, switch to `storyline` to refresh it.
+- Write in sections with `write_section`. Do not submit the article from this procedure unless verification is explicitly skipped by the user or guardrails force wrap-up.
+
+## Drafting Flow
+
+1. Call `read_brief`.
+2. Check staleness information. If the outline or storylines are stale, switch to `storyline` before writing.
+3. Identify the lead storyline and section order from the outline.
+4. Write one focused section at a time with `write_section(name, content)`.
+5. Use `read_article` after major sections to inspect flow and coverage.
+6. Use `rewrite_section` for local improvements instead of rewriting the full article.
+7. Switch to `verification` when the draft is complete.
+
+## Writing Standards
+
+- Open with the best material, not a generic recap sentence.
+- Use concrete details from facts rather than vague claims.
+- Prioritize priority-1 storylines, then priority-2 storylines, then quick hits.
+- Keep paragraphs focused. Standard sections should usually be 2-5 paragraphs.
+- Use Markdown:
+  - `#` for the headline if the opening section includes one.
+  - `##` for major section headings.
+  - `**bold**` for emphasis when useful.
+- Match the requested target length. As a practical guide:
+  - 500 words: 1-2 storylines.
+  - 1000 words: 3-4 storylines.
+  - 1500+ words: broader weekly coverage or deeper analysis.
+
+## Voice And Bias
+
+Apply `style` consistently:
+
+- Sports columnist: informed, sharp, and personable.
+- Snarky columnist: witty and irreverent, with playful jabs.
+- Hype broadcaster: high energy, dramatic, and celebratory.
+- Beat reporter: factual, measured, and analysis-heavy.
+- Custom voices: satisfy the user's request while preserving factual grounding.
+
+Apply `bias` as framing only:
+
+- Favored teams can get more enthusiastic language, more prominent placement, and more charitable framing.
+- Disfavored teams can get skepticism or playful roasting.
+- The score, record, ranking, transaction, and player points must remain exactly what the facts say.
+
+## Section Naming
+
+Use stable, descriptive section names for article tools, such as:
+
+- `headline_and_lead`
+- `lead_story`
+- `standings_shift`
+- `quick_hits`
+- `transactions`
+- `playoff_picture`
+- `closing`
+
+Before switching to verification, make sure each required outline fact appears in an article section and the article has a coherent opening, body, and close.

--- a/reporter_v2/procedures/research.md
+++ b/reporter_v2/procedures/research.md
@@ -1,0 +1,72 @@
+# Research Procedure
+
+You are gathering verified fantasy football facts for the article brief. Use datalayer tools to inspect the league, then save only confirmed claims with `save_fact`. Do not draft article prose in this procedure.
+
+## Operating Rules
+
+- If you are returning to research after another procedure has run, call `read_brief` first so you know which facts already exist and what is stale.
+- Start broad, then drill down. Prefer `league_snapshot` for the requested week before targeted team or player calls.
+- Every saved fact must be traceable to one or more tool calls through `data_refs`.
+- Save specific, reusable facts rather than commentary. The article voice comes later.
+- Do not invent standings, scores, records, player points, transactions, injuries, or playoff implications.
+- Bias can guide what you investigate, but it must not change which facts you save.
+- If persistent context tools are available and the request may depend on league history, load relevant storylines, team context, and league notes before deciding what to investigate.
+- If the runner announces the hard tool limit, stop researching and move directly toward submitting the best article possible with the artifacts already available.
+
+## Default Research Flow
+
+1. Establish the request scope: week or week range, focus teams, focus topics, article type, target tone, and any teams to favor or roast.
+2. Call `league_snapshot(week=N)` for a single-week article, or use the available week and standings tools for a multi-week request.
+3. Inspect the main scoreboard and standings movement. Look for upsets, blowouts, close games, streaks, playoff movement, and season-best or season-worst performances.
+4. Call targeted tools for the strongest leads:
+   - `team_game(roster_key, week=N)` for player-level detail in a specific matchup.
+   - `team_dossier(roster_key, week=N)` for recent form, record, and broader context.
+   - `week_player_leaderboard(week=N, limit=10)` for top performers.
+   - `transactions(week_from=N, week_to=N)` or `team_transactions(...)` for trade, waiver, or roster-move angles.
+   - `player_weekly_log(...)` or `player_summary(...)` for trend checks on a featured player.
+   - `playoff_bracket(...)` and `team_playoff_path(...)` when the article has playoff stakes.
+5. Save the strongest facts with `save_fact`. Aim for enough evidence to support the article, not every possible data point.
+6. When the evidence base is ready, switch to `storyline` to organize facts into narrative threads and an outline.
+
+## Fact Quality
+
+Good facts are precise, sourced, and useful in more than one sentence. Include the exact numbers the writer will need.
+
+```json
+{
+  "id": "fact_week8_taco_win",
+  "claim_text": "Team Taco defeated The Waiver Wire 142.3-98.7 in Week 8.",
+  "data_refs": ["league_snapshot:week=8", "team_game:Team Taco:week=8"],
+  "numbers": {
+    "week": 8,
+    "team_score": 142.3,
+    "opponent_score": 98.7,
+    "margin": 43.6
+  },
+  "category": "score"
+}
+```
+
+Use stable IDs that describe the fact. Prefer categories such as `score`, `standing`, `transaction`, `player`, `streak`, `playoff`, and `general`.
+
+## What To Look For
+
+- Upsets: lower-ranked or struggling teams beating favorites.
+- Blowouts: dominant wins, especially margins around 30 points or more.
+- Nail-biters: games decided by fewer than 5 points.
+- Streaks: winning or losing runs, especially 3 or more games.
+- Breakouts: player or team performances that stand out from recent history.
+- Collapses: favorites or strong teams missing expectations.
+- Transactions: trades, waivers, and roster moves that affected the week.
+- Continuing arcs: previous storylines that changed, intensified, or resolved.
+- Playoff pressure: seed movement, elimination risk, byes, and bracket paths.
+
+## Stopping Criteria
+
+Move to `storyline` when you have enough verified facts to support the requested article:
+
+- Short focused article: 5-8 strong facts.
+- Standard weekly recap: 10-20 strong facts.
+- Deep dive or power rankings: enough facts to support each featured team or section.
+
+If tool limits are approaching, stop researching, save the best facts you already have, and switch to `storyline`. If the hard limit has already been reached, do not make more research calls.

--- a/reporter_v2/procedures/storyline.md
+++ b/reporter_v2/procedures/storyline.md
@@ -1,0 +1,81 @@
+# Storyline Procedure
+
+You are turning verified facts into a usable article plan. Read the current brief, create storylines from saved facts, set style and bias, and build an outline. Do not draft final article prose here.
+
+## Operating Rules
+
+- Use `read_brief` first unless you just saved all relevant facts in the immediately preceding turn.
+- Every storyline must be supported by existing fact IDs. If a needed fact is missing, switch back to `research` and get it.
+- Storyline summaries may interpret the data, but they must not add new factual claims.
+- Set the outline after the main storylines are saved. If `read_brief` reports stale outline or storyline IDs later, refresh the affected plan.
+- Bias is framing only. Use `set_bias` to preserve the user's framing preferences without altering scores, records, or outcomes.
+
+## Storyline Creation
+
+Create 3-6 storylines for a standard weekly recap and fewer for narrow requests. Use `save_storyline` for each narrative thread.
+
+Priority guidance:
+
+- `1`: lead story. Major upset, playoff swing, dominant performance, season-defining trend, or request-specific focus.
+- `2`: secondary story. Close game, important streak, notable breakout, trade fallout, or standings movement.
+- `3`: useful color. Routine wins, smaller stat nuggets, or supporting angles.
+- `4-5`: minor mentions that should only appear if space allows.
+
+Good storyline:
+
+```json
+{
+  "id": "story_taco_statement_win",
+  "headline": "Team Taco Turns A Win Into A Warning Shot",
+  "summary": "Team Taco's 142.3-98.7 Week 8 win was more than a comfortable result. The margin and player-level production make it a lead candidate for the week's biggest statement.",
+  "supporting_fact_ids": ["fact_week8_taco_win", "fact_week8_taco_top_players"],
+  "priority": 1,
+  "tags": ["blowout", "contender", "week_8"]
+}
+```
+
+## Style And Bias
+
+Use `set_style` to translate the request into writing controls:
+
+- `voice`: examples include `sports columnist`, `snarky columnist`, `hype broadcaster`, `beat reporter`, or a custom voice from the user.
+- `pacing`: `fast`, `moderate`, or `deliberate`.
+- `humor_level`: 0 for none, 1 for light, 2 for moderate, 3 for heavy.
+- `formality`: `formal`, `casual`, or `irreverent`.
+
+Use `set_bias` if the user asked to favor or roast teams:
+
+- `favored_teams`: teams to frame positively.
+- `disfavored_teams`: teams to frame skeptically or mockingly.
+- `intensity`: 0-3.
+- `framing_rules`: short reminders such as "celebrate wins, downplay losses" or "roast missed expectations, but keep all numbers exact".
+
+## Outline Creation
+
+Use `set_outline` to create the writing plan. Each section should include:
+
+- `title`: concise section heading.
+- `bullet_points`: what the section must accomplish.
+- `required_fact_ids`: exact facts the writer must use.
+- `storyline_ids`: storylines that belong in the section.
+
+Default weekly recap structure:
+
+1. Opening hook: lead with the priority-1 storyline and set the week's theme.
+2. Lead story: give the strongest matchup or narrative enough room.
+3. Supporting storylines: cover the next 2-3 important arcs.
+4. Quick hits: short notes for lower-priority items, top performers, or transactions.
+5. Standings or outlook: playoff implications, next-week stakes, or season trajectory.
+6. Closing: resolve the article with the strongest takeaway.
+
+For power rankings, build one section per rank or rank tier. For team deep dives, build sections around record, recent games, roster strengths or weaknesses, transactions, and outlook.
+
+## Persistent Context
+
+If persistent context tools are available, save narrative state before drafting:
+
+- Use `save_persistent_storyline` for arcs likely to matter in future weeks.
+- Use `save_team_context` for researched teams whose trajectory changed.
+- Use `save_league_note` for league-wide context such as season themes, trade activity, or rivalries.
+
+When the brief has facts, storylines, outline, style, and bias ready, switch to `drafting`.

--- a/reporter_v2/procedures/verification.md
+++ b/reporter_v2/procedures/verification.md
@@ -1,0 +1,61 @@
+# Verification Procedure
+
+You are checking the drafted article against the brief artifact. Your job is to find unsupported or incorrect claims, correct them with `rewrite_section`, and submit only when the article is grounded.
+
+## Operating Rules
+
+- Call both `read_article` and `read_brief` before judging the draft.
+- Verify every numeric or factual claim against saved facts.
+- Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
+- If the brief is missing evidence for a necessary claim, switch to `research` instead of guessing.
+- If the outline or storylines are stale, switch to `storyline` before final verification.
+
+## Claims To Check
+
+Check all claims involving:
+
+- Scores and matchup winners.
+- Team records, standings ranks, playoff seeds, and playoff paths.
+- Player fantasy points and leaderboard placement.
+- Transaction counts, trade participants, waiver adds, and dropped players.
+- Margins of victory or defeat.
+- Streak lengths and week ranges.
+- Any superlative such as "highest", "first", "best", "worst", or "season high".
+
+Flavor claims can be looser, but they must not imply unsupported facts.
+
+## Verification Flow
+
+1. Call `read_article`.
+2. Call `read_brief`.
+3. Extract each factual claim from the article section by section.
+4. Match each claim to a fact ID. Use exact numbers from `numbers` when available.
+5. Classify issues:
+   - `error`: wrong score, winner, record, player points, transaction, or other critical fact.
+   - `warning`: unsupported superlative, ambiguous rounding, or overstatement.
+   - `info`: stylistic claim that is not directly factual but may be too strong.
+6. Correct `error` issues with `rewrite_section`.
+7. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
+8. Call `read_article` again after corrections.
+9. Call `submit_article` only after the draft passes verification.
+
+## Correction Policy
+
+When rewriting a section:
+
+- Preserve the section's purpose and voice.
+- Change only the unsupported or incorrect parts unless the whole section depends on bad information.
+- Replace unsupported numbers with sourced numbers, or remove the claim.
+- Replace unsupported superlatives with grounded phrasing, such as "one of the week's strongest performances" if the brief supports it.
+- Keep bias within the allowed framing rules. Roasting is allowed only when the factual premise is true.
+
+## Final Checklist
+
+Before `submit_article`, confirm:
+
+- The article has at least one section and a clear Markdown structure.
+- All required outline facts are represented or intentionally omitted for a defensible reason.
+- All scores, records, rankings, and player points match the brief.
+- No datalayer-only facts appear in the article unless they were saved in the brief.
+- Bias changes word choice and emphasis only, never facts.
+- The article is readable and close to the target length.

--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -17,9 +17,11 @@ from reporter_v2.runner.tools.brief_tools import (
     set_style,
 )
 from reporter_v2.runner.tools.context import ToolContext
+from reporter_v2.runner.tools.procedure_tools import load_procedure
 
 __all__ = [
     "ToolContext",
+    "load_procedure",
     "read_article",
     "read_brief",
     "read_section",

--- a/reporter_v2/runner/tools/procedure_tools.py
+++ b/reporter_v2/runner/tools/procedure_tools.py
@@ -1,0 +1,36 @@
+"""Procedure-loading tools for the reporter v2 runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from reporter_v2.runner.tools.context import ToolContext
+
+
+PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
+VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
+
+
+def load_procedure(ctx: ToolContext, *, name: str) -> str:
+    """Load a procedure by name and return its markdown text."""
+    if name not in VALID_PROCEDURES:
+        return json.dumps(
+            {
+                "error": (
+                    f"Unknown procedure: {name}. "
+                    f"Valid: {sorted(VALID_PROCEDURES)}"
+                )
+            }
+        )
+
+    path = PROCEDURE_DIR / f"{name}.md"
+    if not path.exists():
+        return json.dumps({"error": f"Procedure file not found: {path}"})
+
+    previous = ctx.procedures.active
+    ctx.procedures.active = name
+    ctx.log.add_procedure_switch(previous, name, turn=ctx.turn)
+
+    return path.read_text(encoding="utf-8")
+

--- a/reporter_v2/tests/test_procedure_tools.py
+++ b/reporter_v2/tests/test_procedure_tools.py
@@ -1,0 +1,88 @@
+"""Tests for reporter_v2 procedure-loading tools."""
+
+from __future__ import annotations
+
+import json
+
+from reporter_v2.runner.run_log import RunLog, ProcedureSwitch
+from reporter_v2.runner.state import ArtifactStore, ProcedureState
+from reporter_v2.runner.tools.context import ToolContext
+from reporter_v2.runner.tools import procedure_tools
+from reporter_v2.runner.tools.procedure_tools import load_procedure
+
+
+def make_context(*, turn: int = 0) -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=turn,
+    )
+
+
+def test_load_valid_procedure(tmp_path, monkeypatch) -> None:
+    procedure_text = "# Research\n\nGather the facts first.\n"
+    (tmp_path / "research.md").write_text(procedure_text, encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context(turn=2)
+
+    result = load_procedure(ctx, name="research")
+
+    assert result == procedure_text
+    assert ctx.procedures.active == "research"
+
+
+def test_load_invalid_procedure() -> None:
+    ctx = make_context()
+
+    result = json.loads(load_procedure(ctx, name="bogus"))
+
+    assert result == {
+        "error": (
+            "Unknown procedure: bogus. "
+            "Valid: ['drafting', 'research', 'storyline', 'verification']"
+        )
+    }
+    assert ctx.procedures.active is None
+    assert ctx.log.procedure_history == []
+
+
+def test_load_missing_procedure_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context()
+
+    result = json.loads(load_procedure(ctx, name="research"))
+
+    assert result == {"error": f"Procedure file not found: {tmp_path / 'research.md'}"}
+    assert ctx.procedures.active is None
+    assert ctx.log.procedure_history == []
+
+
+def test_procedure_switch_logged(tmp_path, monkeypatch) -> None:
+    (tmp_path / "research.md").write_text("research text", encoding="utf-8")
+    (tmp_path / "drafting.md").write_text("drafting text", encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context(turn=4)
+
+    load_procedure(ctx, name="research")
+    ctx.turn = 7
+    load_procedure(ctx, name="drafting")
+
+    assert ctx.log.procedure_history == [
+        ProcedureSwitch(from_procedure=None, to_procedure="research", turn=4),
+        ProcedureSwitch(from_procedure="research", to_procedure="drafting", turn=7),
+    ]
+
+
+def test_procedure_state_updated(tmp_path, monkeypatch) -> None:
+    (tmp_path / "storyline.md").write_text("storyline text", encoding="utf-8")
+    (tmp_path / "verification.md").write_text("verification text", encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context()
+
+    load_procedure(ctx, name="storyline")
+    assert ctx.procedures.active == "storyline"
+
+    load_procedure(ctx, name="verification")
+    assert ctx.procedures.active == "verification"
+


### PR DESCRIPTION
## Description

Adds reporter v2 procedure loading with markdown procedures for research, storyline planning, drafting, and verification. The new `load_procedure` tool updates procedure state, logs switches, and returns the selected procedure text. This also packages procedure markdown into wheels and ignores standard local build artifacts.

## Testing

`PYENV_VERSION=aidamshefter-v2 pyenv exec python -m pytest reporter_v2/tests -q`
