### PR TITLE
feat(runner-v2): implement runner loop

### DIFF
--- a/reporter_v2/runner/__init__.py
+++ b/reporter_v2/runner/__init__.py
@@ -1,1 +1,8 @@
+"""Reporter v2 runner package."""
 
+from __future__ import annotations
+
+from reporter_v2.runner.runner import Runner
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+__all__ = ["Runner", "ToolRegistry"]

--- a/reporter_v2/runner/runner.py
+++ b/reporter_v2/runner/runner.py
@@ -57,25 +57,28 @@ class Runner:
             ChatMessage(role="user", content=user_message),
         ]
         turn = 0
+        previous_response_id: str | None = None
 
         try:
             while turn < self.config.max_turns and not self._submitted:
                 turn += 1
+                provider_context = {}
+                if previous_response_id is not None:
+                    provider_context["previous_response_id"] = previous_response_id
                 request = AiRequest(
                     messages=list(messages),
                     tools=self.registry.tool_specs,
                     model=self.config.model,
+                    provider_context=provider_context,
                 )
                 response = await self.gateway.get_response(request)
+                response_id = response.provider_metadata.get("response_id")
+                if response_id is not None:
+                    previous_response_id = str(response_id)
 
                 if response.tool_calls:
                     self.registry.set_turn(turn)
-                    results = await asyncio.gather(
-                        *[
-                            self._execute_tool(tool_call, turn)
-                            for tool_call in response.tool_calls
-                        ]
-                    )
+                    results = await self._execute_tool_batch(response.tool_calls, turn)
                     for call, result_content in zip(response.tool_calls, results):
                         if call.name == "load_procedure":
                             self._replace_procedure_message(messages, call, result_content)
@@ -117,6 +120,34 @@ class Runner:
         finally:
             self.log.stop_streaming()
 
+    async def _execute_tool_batch(
+        self,
+        calls: list[ToolCall],
+        turn: int,
+    ) -> list[str]:
+        results: list[str | None] = [None] * len(calls)
+        scheduled: list[tuple[int, ToolCall]] = []
+        remaining_tool_slots = max(
+            self.config.hard_tool_limit - self.log.tool_call_count,
+            0,
+        )
+
+        for index, call in enumerate(calls):
+            if call.name == "submit_article" or remaining_tool_slots > 0:
+                scheduled.append((index, call))
+                if call.name != "submit_article":
+                    remaining_tool_slots -= 1
+            else:
+                results[index] = self._hard_limit_tool_result(turn)
+
+        executed = await asyncio.gather(
+            *[self._execute_tool(call, turn) for _, call in scheduled]
+        )
+        for (index, _), result in zip(scheduled, executed):
+            results[index] = result
+
+        return [result or "" for result in results]
+
     async def _execute_tool(self, call: ToolCall, turn: int) -> str:
         handler = self.registry.get_handler(call.name)
         if handler is None:
@@ -143,10 +174,26 @@ class Runner:
             turn=turn,
         )
 
-        if call.name == "submit_article":
+        if call.name == "submit_article" and self._is_successful_submit(result_content):
             self._submitted = True
 
         return result_content
+
+    def _hard_limit_tool_result(self, turn: int) -> str:
+        self.log.add_guardrail(
+            "hard_tool_limit_blocked",
+            self.log.tool_call_count,
+            self.config.hard_tool_limit,
+            turn=turn,
+        )
+        return self._as_tool_result_content(
+            {
+                "ok": False,
+                "error": (
+                    "Hard tool limit reached. Only submit_article may be called."
+                ),
+            }
+        )
 
     def _replace_procedure_message(
         self,
@@ -207,6 +254,14 @@ class Runner:
         if isinstance(result, str):
             return result
         return json.dumps(result, default=str)
+
+    @staticmethod
+    def _is_successful_submit(result: str) -> bool:
+        try:
+            data = json.loads(result)
+        except json.JSONDecodeError:
+            return False
+        return isinstance(data, dict) and data.get("ok") is True
 
     @staticmethod
     def _summarize_result(result: str) -> str:

--- a/reporter_v2/runner/runner.py
+++ b/reporter_v2/runner/runner.py
@@ -1,0 +1,227 @@
+"""Core v2 runner loop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from ai_gateway import (
+    AiGateway,
+    AiRequest,
+    ChatMessage,
+    ToolCall,
+    ToolResultMessage,
+)
+from reporter_v2.runner.run_log import RunLog
+from reporter_v2.runner.schemas import ArticleOutput
+from reporter_v2.runner.state import ArtifactStore, ProcedureState, RunnerConfig
+from reporter_v2.runner.tools.context import ToolContext
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+
+class Runner:
+    """Single-loop runner that drives research, drafting, and verification."""
+
+    def __init__(
+        self,
+        gateway: AiGateway,
+        registry: ToolRegistry,
+        *,
+        config: RunnerConfig | None = None,
+        log_path: Path | None = None,
+    ) -> None:
+        self.gateway = gateway
+        self.registry = registry
+        self.config = config or RunnerConfig()
+        self.artifacts = ArtifactStore()
+        self.procedures = ProcedureState()
+        self.log = RunLog()
+        self.tool_context = ToolContext(
+            artifacts=self.artifacts,
+            procedures=self.procedures,
+            log=self.log,
+        )
+        self.registry.set_context(self.tool_context)
+        self._procedure_message_idx: int | None = None
+        self._submitted = False
+
+        if log_path is not None:
+            self.log.start_streaming(log_path)
+
+    async def run(self, system_prompt: str, user_message: str) -> ArticleOutput:
+        messages: list[ChatMessage | ToolResultMessage] = [
+            ChatMessage(role="system", content=system_prompt),
+            ChatMessage(role="user", content=user_message),
+        ]
+        turn = 0
+
+        try:
+            while turn < self.config.max_turns and not self._submitted:
+                turn += 1
+                request = AiRequest(
+                    messages=list(messages),
+                    tools=self.registry.tool_specs,
+                    model=self.config.model,
+                )
+                response = await self.gateway.get_response(request)
+
+                if response.tool_calls:
+                    self.registry.set_turn(turn)
+                    results = await asyncio.gather(
+                        *[
+                            self._execute_tool(tool_call, turn)
+                            for tool_call in response.tool_calls
+                        ]
+                    )
+                    for call, result_content in zip(response.tool_calls, results):
+                        if call.name == "load_procedure":
+                            self._replace_procedure_message(messages, call, result_content)
+                        else:
+                            messages.append(ToolResultMessage.from_call(call, result_content))
+
+                    self._check_guardrails(messages, turn)
+                    continue
+
+                if response.text:
+                    self.log.add_model_text(response.text, turn=turn)
+                    messages.append(ChatMessage(role="assistant", content=response.text))
+                    break
+
+                break
+
+            self.log.add_completion(
+                {
+                    "total_turns": turn,
+                    "total_tool_calls": self.log.tool_call_count,
+                    "submitted": self._submitted,
+                },
+                turn=turn,
+            )
+            return ArticleOutput(
+                article=self.artifacts.article.to_markdown(),
+                brief=self.artifacts.brief,
+                run_log_summary={
+                    "session_id": self.log.session_id,
+                    "total_tool_calls": self.log.tool_call_count,
+                    "total_turns": turn,
+                    "procedures_loaded": [
+                        procedure.to_procedure
+                        for procedure in self.log.procedure_history
+                    ],
+                    "submitted": self._submitted,
+                },
+            )
+        finally:
+            self.log.stop_streaming()
+
+    async def _execute_tool(self, call: ToolCall, turn: int) -> str:
+        handler = self.registry.get_handler(call.name)
+        if handler is None:
+            result: Any = {"error": f"Unknown tool: {call.name}"}
+            result_content = self._as_tool_result_content(result)
+            self.log.add_tool_call(call.name, call.arguments, result_content, 0, turn=turn)
+            return result_content
+
+        start = time.time()
+        try:
+            result = handler(**call.arguments)
+            if asyncio.iscoroutine(result):
+                result = await result
+        except Exception as exc:
+            result = {"error": str(exc)}
+
+        duration_ms = int((time.time() - start) * 1000)
+        result_content = self._as_tool_result_content(result)
+        self.log.add_tool_call(
+            call.name,
+            call.arguments,
+            self._summarize_result(result_content),
+            duration_ms,
+            turn=turn,
+        )
+
+        if call.name == "submit_article":
+            self._submitted = True
+
+        return result_content
+
+    def _replace_procedure_message(
+        self,
+        messages: list[ChatMessage | ToolResultMessage],
+        call: ToolCall,
+        content: str,
+    ) -> None:
+        """Remove the previous procedure message and append the new one."""
+        if self._procedure_message_idx is not None:
+            messages.pop(self._procedure_message_idx)
+
+        messages.append(ToolResultMessage.from_call(call, content))
+        self._procedure_message_idx = len(messages) - 1
+
+    def _check_guardrails(
+        self,
+        messages: list[ChatMessage | ToolResultMessage],
+        turn: int,
+    ) -> None:
+        tool_count = self.log.tool_call_count
+        if tool_count >= self.config.hard_tool_limit:
+            self.log.add_guardrail(
+                "hard_tool_limit",
+                tool_count,
+                self.config.hard_tool_limit,
+                turn=turn,
+            )
+            messages.append(
+                ChatMessage(
+                    role="system",
+                    content=(
+                        "HARD LIMIT REACHED. You must call submit_article() now. "
+                        "Do not make any more research or data tool calls."
+                    ),
+                )
+            )
+            return
+
+        if tool_count >= self.config.soft_tool_limit:
+            self.log.add_guardrail(
+                "soft_tool_limit",
+                tool_count,
+                self.config.soft_tool_limit,
+                turn=turn,
+            )
+            messages.append(
+                ChatMessage(
+                    role="system",
+                    content=(
+                        f"You have used {tool_count} tool calls. Start wrapping up: "
+                        "finalize your brief and move to drafting."
+                    ),
+                )
+            )
+
+    @staticmethod
+    def _as_tool_result_content(result: Any) -> str:
+        if isinstance(result, str):
+            return result
+        return json.dumps(result, default=str)
+
+    @staticmethod
+    def _summarize_result(result: str) -> str:
+        if len(result) <= 100:
+            return result
+
+        try:
+            data = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return result[:80] + "..."
+
+        if isinstance(data, dict):
+            if "error" in data:
+                return f"error: {str(data['error'])[:80]}"
+            return f"dict with {len(data)} keys"
+        if isinstance(data, list):
+            return f"{len(data)} items"
+        return result[:80] + "..."

--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -18,9 +18,11 @@ from reporter_v2.runner.tools.brief_tools import (
 )
 from reporter_v2.runner.tools.context import ToolContext
 from reporter_v2.runner.tools.procedure_tools import load_procedure
+from reporter_v2.runner.tools.registry import ToolRegistry
 
 __all__ = [
     "ToolContext",
+    "ToolRegistry",
     "load_procedure",
     "read_article",
     "read_brief",

--- a/reporter_v2/runner/tools/registry.py
+++ b/reporter_v2/runner/tools/registry.py
@@ -1,0 +1,58 @@
+"""Tool registry for the v2 runner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ai_gateway import ToolSpec
+from reporter_v2.runner.tools.context import ToolContext
+
+
+class ToolRegistry:
+    """Maps tool names to handlers and exposes gateway tool specs."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, Callable[..., Any]] = {}
+        self._specs: dict[str, ToolSpec] = {}
+        self._context: ToolContext | None = None
+
+    def set_context(self, context: ToolContext) -> None:
+        self._context = context
+
+    def register(
+        self,
+        name: str,
+        handler: Callable[..., Any],
+        spec: ToolSpec,
+    ) -> None:
+        self._handlers[name] = handler
+        self._specs[name] = spec
+
+    def register_context_tool(
+        self,
+        name: str,
+        handler: Callable[..., Any],
+        spec: ToolSpec,
+    ) -> None:
+        def bound_handler(**kwargs: Any) -> Any:
+            if self._context is None:
+                raise RuntimeError("ToolRegistry context has not been set.")
+            return handler(self._context, **kwargs)
+
+        self.register(name, bound_handler, spec)
+
+    def get_handler(self, name: str) -> Callable[..., Any] | None:
+        return self._handlers.get(name)
+
+    def set_turn(self, turn: int) -> None:
+        if self._context is not None:
+            self._context.turn = turn
+
+    @property
+    def tool_specs(self) -> list[ToolSpec]:
+        return list(self._specs.values())
+
+    @property
+    def tool_names(self) -> list[str]:
+        return list(self._handlers.keys())

--- a/reporter_v2/tests/test_runner.py
+++ b/reporter_v2/tests/test_runner.py
@@ -147,6 +147,26 @@ def test_runner_tool_call_dispatch() -> None:
     assert result_message.content == '{"ok": true, "value": 7}'
 
 
+def test_runner_passes_previous_response_id_after_tool_call() -> None:
+    gateway = FakeGateway(
+        [
+            AiResponse(
+                tool_calls=[tool_call("lookup")],
+                provider_metadata={"response_id": "resp_123"},
+            ),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(gateway, registry_with("lookup", lambda: "{}"))
+
+    run(runner.run("system", "user"))
+
+    assert gateway.requests[0].provider_context == {}
+    assert gateway.requests[1].provider_context == {
+        "previous_response_id": "resp_123"
+    }
+
+
 def test_runner_submit_article_breaks_loop() -> None:
     def submit_article() -> str:
         return '{"ok": true}'
@@ -164,6 +184,25 @@ def test_runner_submit_article_breaks_loop() -> None:
     assert output.run_log_summary["submitted"] is True
     assert output.run_log_summary["total_turns"] == 1
     assert len(gateway.requests) == 1
+
+
+def test_runner_failed_submit_article_does_not_break_loop() -> None:
+    def submit_article() -> str:
+        return '{"ok": false, "error": "Cannot submit an empty article."}'
+
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("submit_article")]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(gateway, registry_with("submit_article", submit_article))
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["submitted"] is False
+    assert output.run_log_summary["total_turns"] == 2
+    assert len(gateway.requests) == 2
 
 
 def test_runner_soft_guardrail() -> None:
@@ -214,6 +253,40 @@ def test_runner_hard_guardrail() -> None:
     guardrail_message = gateway.requests[1].messages[-1]
     assert guardrail_message.role == "system"
     assert "HARD LIMIT REACHED" in guardrail_message.content
+
+
+def test_runner_blocks_non_submit_tools_after_hard_limit() -> None:
+    calls: list[str] = []
+
+    def lookup() -> str:
+        calls.append("lookup")
+        return "{}"
+
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("lookup", call_id="call_1")]),
+            AiResponse(tool_calls=[tool_call("lookup", call_id="call_2")]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(
+        gateway,
+        registry_with("lookup", lookup),
+        config=RunnerConfig(soft_tool_limit=1, hard_tool_limit=1, max_turns=5),
+    )
+
+    output = run(runner.run("system", "user"))
+
+    assert calls == ["lookup"]
+    assert output.run_log_summary["total_tool_calls"] == 1
+    blocked_messages = [
+        message
+        for message in gateway.requests[2].messages
+        if isinstance(message, ToolResultMessage)
+        and message.tool_call_id == "call_2"
+    ]
+    assert len(blocked_messages) == 1
+    assert "Only submit_article may be called" in blocked_messages[0].content
 
 
 def test_runner_procedure_replacement() -> None:

--- a/reporter_v2/tests/test_runner.py
+++ b/reporter_v2/tests/test_runner.py
@@ -1,0 +1,272 @@
+"""Tests for the reporter v2 runner loop."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from ai_gateway import (
+    AiGateway,
+    AiRequest,
+    AiResponse,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+from reporter_v2.runner.runner import Runner
+from reporter_v2.runner.state import RunnerConfig
+from reporter_v2.runner.tools.context import ToolContext
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+
+class FakeGateway(AiGateway):
+    def __init__(self, responses: list[AiResponse]) -> None:
+        self.responses = responses
+        self.requests: list[AiRequest] = []
+
+    async def get_response(self, request: AiRequest) -> AiResponse:
+        self.requests.append(request)
+        if not self.responses:
+            return AiResponse()
+        return self.responses.pop(0)
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def registry_with(
+    name: str,
+    handler: Callable[..., Any],
+    *,
+    description: str = "Test tool",
+) -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(
+        name,
+        handler,
+        ToolSpec(
+            name=name,
+            description=description,
+            parameters={"type": "object", "properties": {}},
+        ),
+    )
+    return registry
+
+
+def tool_call(
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    call_id: str = "call_1",
+) -> ToolCall:
+    return ToolCall(id=call_id, name=name, arguments=arguments or {})
+
+
+def test_tool_registry_exposes_specs_and_names() -> None:
+    registry = registry_with("lookup", lambda: "{}")
+
+    assert registry.tool_names == ["lookup"]
+    assert registry.tool_specs == [
+        ToolSpec(
+            name="lookup",
+            description="Test tool",
+            parameters={"type": "object", "properties": {}},
+        )
+    ]
+    assert registry.get_handler("lookup") is not None
+    assert registry.get_handler("missing") is None
+
+
+def test_runner_context_tool_dispatch_updates_turn() -> None:
+    seen_turns: list[int] = []
+
+    def context_tool(ctx: ToolContext) -> str:
+        seen_turns.append(ctx.turn)
+        return "{}"
+
+    registry = ToolRegistry()
+    registry.register_context_tool(
+        "context_tool",
+        context_tool,
+        ToolSpec(name="context_tool", parameters={"type": "object", "properties": {}}),
+    )
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("context_tool")]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(gateway, registry)
+
+    run(runner.run("system", "user"))
+
+    assert seen_turns == [1]
+    assert runner.tool_context.artifacts is runner.artifacts
+    assert runner.tool_context.procedures is runner.procedures
+    assert runner.tool_context.log is runner.log
+
+
+def test_runner_simple_text_response() -> None:
+    gateway = FakeGateway([AiResponse(text="Done.")])
+    runner = Runner(gateway, ToolRegistry())
+
+    output = run(runner.run("system", "user"))
+
+    assert output.article == ""
+    assert output.run_log_summary["total_turns"] == 1
+    assert output.run_log_summary["total_tool_calls"] == 0
+    assert runner.log.entries[0].event_type == "model_text"
+    assert gateway.requests[0].messages[0].role == "system"
+    assert gateway.requests[0].messages[1].role == "user"
+
+
+def test_runner_tool_call_dispatch() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def handler(*, value: int) -> dict[str, Any]:
+        calls.append({"value": value})
+        return {"ok": True, "value": value}
+
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("lookup", {"value": 7})]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(gateway, registry_with("lookup", handler))
+
+    output = run(runner.run("system", "user"))
+
+    assert calls == [{"value": 7}]
+    assert output.run_log_summary["total_tool_calls"] == 1
+    assert len(gateway.requests) == 2
+    result_message = gateway.requests[1].messages[-1]
+    assert isinstance(result_message, ToolResultMessage)
+    assert result_message.tool_call_id == "call_1"
+    assert result_message.content == '{"ok": true, "value": 7}'
+
+
+def test_runner_submit_article_breaks_loop() -> None:
+    def submit_article() -> str:
+        return '{"ok": true}'
+
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("submit_article")]),
+            AiResponse(text="Should not be requested."),
+        ]
+    )
+    runner = Runner(gateway, registry_with("submit_article", submit_article))
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["submitted"] is True
+    assert output.run_log_summary["total_turns"] == 1
+    assert len(gateway.requests) == 1
+
+
+def test_runner_soft_guardrail() -> None:
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("lookup")]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(
+        gateway,
+        registry_with("lookup", lambda: "{}"),
+        config=RunnerConfig(soft_tool_limit=1, hard_tool_limit=10, max_turns=5),
+    )
+
+    run(runner.run("system", "user"))
+
+    assert any(
+        entry.event_type == "guardrail"
+        and entry.data["guardrail_type"] == "soft_tool_limit"
+        for entry in runner.log.entries
+    )
+    guardrail_message = gateway.requests[1].messages[-1]
+    assert guardrail_message.role == "system"
+    assert "Start wrapping up" in guardrail_message.content
+
+
+def test_runner_hard_guardrail() -> None:
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("lookup")]),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(
+        gateway,
+        registry_with("lookup", lambda: "{}"),
+        config=RunnerConfig(soft_tool_limit=1, hard_tool_limit=1, max_turns=5),
+    )
+
+    run(runner.run("system", "user"))
+
+    assert any(
+        entry.event_type == "guardrail"
+        and entry.data["guardrail_type"] == "hard_tool_limit"
+        for entry in runner.log.entries
+    )
+    guardrail_message = gateway.requests[1].messages[-1]
+    assert guardrail_message.role == "system"
+    assert "HARD LIMIT REACHED" in guardrail_message.content
+
+
+def test_runner_procedure_replacement() -> None:
+    gateway = FakeGateway(
+        [
+            AiResponse(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "research"}, "call_1")
+                ]
+            ),
+            AiResponse(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "drafting"}, "call_2")
+                ]
+            ),
+            AiResponse(text="Done."),
+        ]
+    )
+    runner = Runner(
+        gateway,
+        registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
+    )
+
+    run(runner.run("system", "user"))
+
+    third_request_messages = gateway.requests[2].messages
+    procedure_messages = [
+        message
+        for message in third_request_messages
+        if isinstance(message, ToolResultMessage)
+        and message.name == "load_procedure"
+    ]
+    assert len(procedure_messages) == 1
+    assert procedure_messages[0].tool_call_id == "call_2"
+    assert procedure_messages[0].content == "# Drafting"
+
+
+def test_runner_max_turns() -> None:
+    gateway = FakeGateway(
+        [
+            AiResponse(tool_calls=[tool_call("lookup", call_id="call_1")]),
+            AiResponse(tool_calls=[tool_call("lookup", call_id="call_2")]),
+            AiResponse(tool_calls=[tool_call("lookup", call_id="call_3")]),
+        ]
+    )
+    runner = Runner(
+        gateway,
+        registry_with("lookup", lambda: "{}"),
+        config=RunnerConfig(max_turns=2),
+    )
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["total_turns"] == 2
+    assert output.run_log_summary["total_tool_calls"] == 2
+    assert len(gateway.requests) == 2


### PR DESCRIPTION
Adds the reporter v2 phase 6 runner loop and tool registry on top of the existing brief, article, and procedure tools.
The runner now drives gateway turns, dispatches tool calls, injects bound `ToolContext`, replaces loaded procedure messages, enforces soft and hard tool limits, stops on `submit_article`, and returns `ArticleOutput`.
This also exports the runner/registry and adds runner tests for registry behavior, context binding, tool dispatch, guardrails, procedure replacement, submit handling, and max turns.

Testing: `.venv/bin/python -m pytest -q` (`210 passed, 3 warnings`).
