### PR TITLE
feat(ai-gateway): add anthropic provider routing

### DIFF
--- a/ai_gateway/README.md
+++ b/ai_gateway/README.md
@@ -24,7 +24,10 @@ from ai_gateway import (
     ToolSpec,
     ToolCall,
     ToolResultMessage,
-    OpenAIGateway,
+    MODEL_REGISTRY,
+    ModelRoutingGateway,
+    OpenAIProvider,
+    AnthropicProvider,
     create_gateway,
 )
 ```
@@ -92,6 +95,42 @@ response = await gateway.get_response(
 print(response.text)
 ```
 
+By default, `create_gateway()` builds a `ModelRoutingGateway`. The router selects a provider from the requested model, configured provider, and available API keys:
+
+- `OPENAI_API_KEY` enables OpenAI models.
+- `ANTHROPIC_API_KEY` enables Claude models through the Anthropic SDK.
+- `AI_GATEWAY_PROVIDER` can be `auto`, `openai`, or `anthropic`. `gpt`, `chatgpt`, and `claude` are accepted as convenience aliases.
+- `AI_GATEWAY_MODEL` can set the default model directly.
+- `OPENAI_MODEL` sets the OpenAI fallback default, otherwise `REPORTER_MODEL` is used, otherwise `gpt-5o`.
+- `ANTHROPIC_MODEL` sets the Claude fallback default, otherwise `claude-sonnet-4-6`.
+
+When `provider="auto"`, known models are looked up in `MODEL_REGISTRY`; the router does not guess providers from model-name prefixes. If a requested provider is not configured, the router falls back to the first configured provider. For example, `AiGatewayConfig(provider="anthropic")` with no `ANTHROPIC_API_KEY` but with `OPENAI_API_KEY` falls back to OpenAI using `gpt-5o` unless overridden by `OPENAI_MODEL` or `REPORTER_MODEL`.
+
+```python
+from ai_gateway import AiGatewayConfig, AiRequest, ChatMessage, create_gateway
+
+gateway = create_gateway(AiGatewayConfig(provider="auto"))
+
+claude_response = await gateway.get_response(
+    AiRequest(
+        messages=[ChatMessage(role="user", content="Write a headline.")],
+        model="claude-sonnet-4-6",
+    )
+)
+
+openai_response = await gateway.get_response(
+    AiRequest(
+        messages=[ChatMessage(role="user", content="Write a headline.")],
+        model="gpt-5o",
+    )
+)
+```
+
+The built-in model registry includes the common chat/reasoning models used by this project:
+
+- OpenAI: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5o`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o3`, `o3-pro`, `o4-mini`.
+- Anthropic: `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-opus-4-1-20250805`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`.
+
 ## Tool Calling
 
 Tools are passed in as `ToolSpec` objects. Existing OpenAI-style tool JSON can be adapted directly:
@@ -121,7 +160,7 @@ print(final_response.text)
 
 ## Structured Output
 
-Pass a Pydantic model class as `structured_output_schema`. The OpenAI adapter sends it as a JSON Schema response format and validates the returned text into that model.
+Pass a Pydantic model class as `structured_output_schema`. Provider adapters send the schema using their provider-specific JSON Schema mechanism and validate the returned text into that model.
 
 ```python
 from pydantic import BaseModel
@@ -148,13 +187,13 @@ Invalid structured output raises `StructuredOutputValidationError`.
 
 ## OpenAI Provider
 
-`OpenAIGateway` uses the official OpenAI Python SDK and the Responses API.
+`OpenAIProvider` uses the official OpenAI Python SDK and the Responses API.
 
 Configuration defaults:
 
 - `provider="openai"`
 - `api_key` from `OPENAI_API_KEY`
-- `model` from `REPORTER_MODEL`, falling back to `gpt-5-mini`
+- `model` from `OPENAI_MODEL`, then `REPORTER_MODEL`, falling back to `gpt-5o`
 
 ```python
 from ai_gateway import AiGatewayConfig, create_gateway
@@ -181,6 +220,30 @@ response = await gateway.get_response(
 
 `provider_context` supports provider metadata needed across calls, such as `previous_response_id` for OpenAI Responses API continuation.
 
+## Anthropic Provider
+
+`AnthropicProvider` uses the official Anthropic Python SDK and the Messages API.
+
+Configuration defaults:
+
+- `provider="anthropic"`
+- `api_key` from `ANTHROPIC_API_KEY`
+- `model` from `ANTHROPIC_MODEL`, falling back to `claude-sonnet-4-6`
+
+```python
+from ai_gateway import AiGatewayConfig, create_gateway
+
+gateway = create_gateway(
+    AiGatewayConfig(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        timeout=30,
+    )
+)
+```
+
+Anthropic tool definitions are translated from `ToolSpec` into Messages API tools with `input_schema`. Structured output schemas are sent using `output_config.format` with `type="json_schema"` and are validated into the requested Pydantic model after the response is returned.
+
 ## Errors
 
 - `UnsupportedProviderError`: Raised by `create_gateway` for unknown providers.
@@ -195,4 +258,4 @@ pytest ai_gateway/tests reporter/tests
 pytest
 ```
 
-The gateway tests use a fake OpenAI client, so they do not require network access or an API key.
+The gateway tests use fake provider clients, so they do not require network access or API keys.

--- a/ai_gateway/README.md
+++ b/ai_gateway/README.md
@@ -128,7 +128,7 @@ openai_response = await gateway.get_response(
 
 The built-in model registry includes the common chat/reasoning models used by this project:
 
-- OpenAI: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5o`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `gpt-4o`, `gpt-4o-mini`, `o3`, `o3-pro`, `o4-mini`.
+- OpenAI: `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.1`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5o`, `gpt-4.1`, `gpt-4.1-mini`.
 - Anthropic: `claude-opus-4-7`, `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-opus-4-1-20250805`, `claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001`.
 
 ## Tool Calling

--- a/ai_gateway/__init__.py
+++ b/ai_gateway/__init__.py
@@ -1,5 +1,6 @@
 """Lightweight AI gateway public interface."""
 
+from ai_gateway.anthropic_provider import AnthropicProvider
 from ai_gateway.errors import (
     AiGatewayError,
     GatewayToolArgumentError,
@@ -18,7 +19,9 @@ from ai_gateway.models import (
     ToolResultMessage,
     ToolSpec,
 )
-from ai_gateway.openai_gateway import OpenAIGateway
+from ai_gateway.model_registry import MODEL_REGISTRY, available_providers
+from ai_gateway.openai_provider import OpenAIProvider
+from ai_gateway.routing_gateway import ModelRoutingGateway
 
 __all__ = [
     "AiGateway",
@@ -27,13 +30,17 @@ __all__ = [
     "AiRequest",
     "AiResponse",
     "AiUsage",
+    "AnthropicProvider",
     "ChatMessage",
     "GatewayToolArgumentError",
-    "OpenAIGateway",
+    "MODEL_REGISTRY",
+    "ModelRoutingGateway",
+    "OpenAIProvider",
     "StructuredOutputValidationError",
     "ToolCall",
     "ToolResultMessage",
     "ToolSpec",
     "UnsupportedProviderError",
+    "available_providers",
     "create_gateway",
 ]

--- a/ai_gateway/anthropic_provider.py
+++ b/ai_gateway/anthropic_provider.py
@@ -1,0 +1,269 @@
+"""Anthropic Messages API provider adapter for the AI gateway."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from ai_gateway.errors import GatewayToolArgumentError, StructuredOutputValidationError
+from ai_gateway.models import (
+    AiGateway,
+    AiGatewayConfig,
+    AiMessage,
+    AiRequest,
+    AiResponse,
+    AiUsage,
+    ChatMessage,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+
+
+class AnthropicProvider(AiGateway):
+    """Provider adapter backed by Anthropic's Messages API."""
+
+    def __init__(self, config: AiGatewayConfig | None = None, client: Any | None = None) -> None:
+        self.config = config or AiGatewayConfig(provider="anthropic")
+        self.client = client or self._create_client()
+        self._tool_use_cache: dict[str, dict[str, Any]] = {}
+
+    def _create_client(self) -> Any:
+        try:
+            from anthropic import AsyncAnthropic
+        except ImportError as exc:
+            raise RuntimeError("The anthropic package is required to use AnthropicProvider.") from exc
+
+        kwargs: dict[str, Any] = {}
+        if self.config.api_key:
+            kwargs["api_key"] = self.config.api_key
+        if self.config.base_url:
+            kwargs["base_url"] = self.config.base_url
+        if self.config.timeout is not None:
+            kwargs["timeout"] = self.config.timeout
+        return AsyncAnthropic(**kwargs)
+
+    async def get_response(self, request: AiRequest) -> AiResponse:
+        messages, system = self._serialize_messages(request.messages, request.provider_context)
+        kwargs: dict[str, Any] = {
+            "model": request.model or self.config.model,
+            "max_tokens": 4096,
+            "messages": messages,
+        }
+        if system:
+            kwargs["system"] = system
+        if request.tools:
+            kwargs["tools"] = [self._serialize_tool(tool) for tool in request.tools]
+        if request.structured_output_schema is not None:
+            kwargs["output_config"] = {
+                "format": self._serialize_structured_output(request.structured_output_schema)
+            }
+        kwargs.update(request.options)
+
+        response = await self.client.messages.create(**kwargs)
+        normalized = self._normalize_response(response, request.structured_output_schema, request.mode)
+        self._cache_tool_use_blocks(normalized.tool_calls)
+        return normalized
+
+    def _serialize_messages(
+        self,
+        messages: list[AiMessage],
+        provider_context: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], str | list[dict[str, Any]] | None]:
+        serialized: list[dict[str, Any]] = []
+        system_parts: list[str] = []
+        system_blocks: list[dict[str, Any]] = []
+        pending_tool_results: list[ToolResultMessage] = []
+
+        def flush_tool_results() -> None:
+            nonlocal pending_tool_results
+            if not pending_tool_results:
+                return
+            if not self._last_message_has_tool_use(serialized):
+                tool_use_blocks = self._tool_use_blocks_for_results(pending_tool_results, provider_context)
+                if tool_use_blocks:
+                    serialized.append({"role": "assistant", "content": tool_use_blocks})
+            serialized.append(
+                {
+                    "role": "user",
+                    "content": [self._serialize_tool_result(message) for message in pending_tool_results],
+                }
+            )
+            pending_tool_results = []
+
+        for message in messages:
+            if isinstance(message, ToolResultMessage):
+                pending_tool_results.append(message)
+                continue
+            flush_tool_results()
+            if message.role == "system":
+                if isinstance(message.content, str):
+                    system_parts.append(message.content)
+                else:
+                    system_blocks.extend(message.content)
+                continue
+            serialized.append({"role": message.role, "content": message.content})
+
+        flush_tool_results()
+
+        system: str | list[dict[str, Any]] | None = None
+        if system_blocks:
+            if system_parts:
+                system_blocks.insert(0, {"type": "text", "text": "\n\n".join(system_parts)})
+            system = system_blocks
+        elif system_parts:
+            system = "\n\n".join(system_parts)
+        return serialized, system
+
+    def _serialize_tool_result(self, message: ToolResultMessage) -> dict[str, Any]:
+        return {
+            "type": "tool_result",
+            "tool_use_id": message.tool_call_id,
+            "content": message.content,
+        }
+
+    def _last_message_has_tool_use(self, messages: list[dict[str, Any]]) -> bool:
+        if not messages or messages[-1].get("role") != "assistant":
+            return False
+        content = messages[-1].get("content")
+        if not isinstance(content, list):
+            return False
+        return any(self._read_attr(block, "type") == "tool_use" for block in content)
+
+    def _tool_use_blocks_for_results(
+        self,
+        results: list[ToolResultMessage],
+        provider_context: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        context_blocks = provider_context.get("anthropic_tool_use_blocks", [])
+        block_by_id = {self._read_attr(block, "id"): self._to_content_block(block) for block in context_blocks}
+        blocks: list[dict[str, Any]] = []
+        for result in results:
+            block = block_by_id.get(result.tool_call_id) or self._tool_use_cache.get(result.tool_call_id)
+            if block:
+                blocks.append(block)
+        return blocks
+
+    def _serialize_tool(self, tool: ToolSpec) -> dict[str, Any]:
+        serialized: dict[str, Any] = {
+            "name": tool.name,
+            "description": tool.description,
+            "input_schema": tool.parameters,
+        }
+        if tool.strict is not None:
+            serialized["strict"] = tool.strict
+        return serialized
+
+    def _serialize_structured_output(self, schema: type[BaseModel]) -> dict[str, Any]:
+        return {
+            "type": "json_schema",
+            "schema": schema.model_json_schema(),
+        }
+
+    def _normalize_response(
+        self,
+        response: Any,
+        structured_output_schema: type[BaseModel] | None,
+        mode: str | None,
+    ) -> AiResponse:
+        text = self._extract_text(response)
+        structured_output = self._extract_structured_output(response, text, structured_output_schema)
+        tool_calls = self._extract_tool_calls(response)
+        return AiResponse(
+            text=text,
+            structured_output=structured_output,
+            tool_calls=tool_calls,
+            finish_reason=self._read_attr(response, "stop_reason"),
+            usage=self._extract_usage(response),
+            mode=mode,
+            provider_metadata={
+                "provider": "anthropic",
+                "response_id": self._read_attr(response, "id"),
+                "model": self._read_attr(response, "model"),
+                "tool_use_blocks": [self._to_content_block(call.raw) for call in tool_calls],
+            },
+        )
+
+    def _extract_text(self, response: Any) -> str | None:
+        chunks: list[str] = []
+        for block in self._read_attr(response, "content", []) or []:
+            if self._read_attr(block, "type") == "text":
+                text = self._read_attr(block, "text")
+                if text:
+                    chunks.append(text)
+        return "\n".join(chunks) if chunks else None
+
+    def _extract_structured_output(
+        self,
+        response: Any,
+        text: str | None,
+        schema: type[BaseModel] | None,
+    ) -> BaseModel | None:
+        if schema is None:
+            return None
+        parsed = self._read_attr(response, "parsed")
+        if parsed is not None:
+            try:
+                return parsed if isinstance(parsed, schema) else schema.model_validate(parsed)
+            except ValidationError as exc:
+                raise StructuredOutputValidationError(str(exc)) from exc
+        if not text:
+            return None
+        try:
+            return schema.model_validate_json(text)
+        except (ValueError, ValidationError) as exc:
+            raise StructuredOutputValidationError(str(exc)) from exc
+
+    def _extract_tool_calls(self, response: Any) -> list[ToolCall]:
+        calls: list[ToolCall] = []
+        for block in self._read_attr(response, "content", []) or []:
+            if self._read_attr(block, "type") != "tool_use":
+                continue
+            raw_input = self._read_attr(block, "input", {})
+            if raw_input in (None, ""):
+                arguments = {}
+            elif isinstance(raw_input, dict):
+                arguments = raw_input
+            else:
+                raise GatewayToolArgumentError(f"Tool input must be JSON object data: {block!r}")
+            calls.append(
+                ToolCall(
+                    id=self._read_attr(block, "id"),
+                    name=self._read_attr(block, "name"),
+                    arguments=arguments,
+                    raw=block,
+                )
+            )
+        return calls
+
+    def _extract_usage(self, response: Any) -> AiUsage | None:
+        usage = self._read_attr(response, "usage")
+        if usage is None:
+            return None
+        input_tokens = self._read_attr(usage, "input_tokens")
+        output_tokens = self._read_attr(usage, "output_tokens")
+        total_tokens = self._read_attr(usage, "total_tokens")
+        if total_tokens is None and input_tokens is not None and output_tokens is not None:
+            total_tokens = input_tokens + output_tokens
+        return AiUsage(input_tokens=input_tokens, output_tokens=output_tokens, total_tokens=total_tokens)
+
+    def _cache_tool_use_blocks(self, calls: list[ToolCall]) -> None:
+        for call in calls:
+            self._tool_use_cache[call.id] = self._to_content_block(call.raw)
+
+    def _to_content_block(self, block: Any) -> dict[str, Any]:
+        if isinstance(block, dict):
+            return block
+        return {
+            "type": self._read_attr(block, "type"),
+            "id": self._read_attr(block, "id"),
+            "name": self._read_attr(block, "name"),
+            "input": self._read_attr(block, "input"),
+        }
+
+    def _read_attr(self, value: Any, name: str, default: Any = None) -> Any:
+        if isinstance(value, dict):
+            return value.get(name, default)
+        return getattr(value, name, default)
+

--- a/ai_gateway/factory.py
+++ b/ai_gateway/factory.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 from typing import Any
 
+from ai_gateway.anthropic_provider import AnthropicProvider
 from ai_gateway.errors import UnsupportedProviderError
-from ai_gateway.models import AiGatewayConfig
-from ai_gateway.openai_gateway import OpenAIGateway
+from ai_gateway.model_registry import normalize_provider
+from ai_gateway.models import AiGateway, AiGatewayConfig
+from ai_gateway.openai_provider import OpenAIProvider
+from ai_gateway.routing_gateway import ModelRoutingGateway
 
 
-def create_gateway(config: AiGatewayConfig | None = None, client: Any | None = None) -> OpenAIGateway:
+def create_gateway(config: AiGatewayConfig | None = None, client: Any | None = None) -> AiGateway:
     """Create a gateway implementation for the configured provider."""
     gateway_config = config or AiGatewayConfig()
-    if gateway_config.provider == "openai":
-        return OpenAIGateway(gateway_config, client=client)
+    provider = normalize_provider(gateway_config.provider)
+    if provider == "auto":
+        return ModelRoutingGateway(gateway_config)
+    if provider == "openai":
+        if client is None:
+            return ModelRoutingGateway(gateway_config)
+        return OpenAIProvider(gateway_config, client=client)
+    if provider == "anthropic":
+        if client is None:
+            return ModelRoutingGateway(gateway_config)
+        return AnthropicProvider(gateway_config, client=client)
     raise UnsupportedProviderError(f"Unsupported AI provider: {gateway_config.provider}")

--- a/ai_gateway/factory.py
+++ b/ai_gateway/factory.py
@@ -17,7 +17,8 @@ def create_gateway(config: AiGatewayConfig | None = None, client: Any | None = N
     gateway_config = config or AiGatewayConfig()
     provider = normalize_provider(gateway_config.provider)
     if provider == "auto":
-        return ModelRoutingGateway(gateway_config)
+        clients = {"openai": client} if client is not None else None
+        return ModelRoutingGateway(gateway_config, clients=clients)
     if provider == "openai":
         if client is None:
             return ModelRoutingGateway(gateway_config)

--- a/ai_gateway/model_registry.py
+++ b/ai_gateway/model_registry.py
@@ -1,0 +1,128 @@
+"""Hard-coded AI gateway model registry."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ai_gateway.errors import UnsupportedProviderError
+
+ProviderName = str
+
+OPENAI_PROVIDER = "openai"
+ANTHROPIC_PROVIDER = "anthropic"
+AUTO_PROVIDER = "auto"
+
+PROVIDER_ALIASES: dict[str, ProviderName] = {
+    "auto": AUTO_PROVIDER,
+    "openai": OPENAI_PROVIDER,
+    "gpt": OPENAI_PROVIDER,
+    "chatgpt": OPENAI_PROVIDER,
+    "anthropic": ANTHROPIC_PROVIDER,
+    "claude": ANTHROPIC_PROVIDER,
+}
+
+DEFAULT_PROVIDER_ORDER: tuple[ProviderName, ...] = (OPENAI_PROVIDER, ANTHROPIC_PROVIDER)
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A known model and the provider that serves it."""
+
+    name: str
+    provider: ProviderName
+
+
+MODEL_REGISTRY: dict[str, ModelSpec] = {
+    "gpt-5.2": ModelSpec("gpt-5.2", OPENAI_PROVIDER),
+    "gpt-5.2-pro": ModelSpec("gpt-5.2-pro", OPENAI_PROVIDER),
+    "gpt-5.1": ModelSpec("gpt-5.1", OPENAI_PROVIDER),
+    "gpt-5": ModelSpec("gpt-5", OPENAI_PROVIDER),
+    "gpt-5-pro": ModelSpec("gpt-5-pro", OPENAI_PROVIDER),
+    "gpt-5-mini": ModelSpec("gpt-5-mini", OPENAI_PROVIDER),
+    "gpt-5o": ModelSpec("gpt-5o", OPENAI_PROVIDER),
+    "gpt-4.1": ModelSpec("gpt-4.1", OPENAI_PROVIDER),
+    "gpt-4.1-mini": ModelSpec("gpt-4.1-mini", OPENAI_PROVIDER),
+    "claude-opus-4-7": ModelSpec("claude-opus-4-7", ANTHROPIC_PROVIDER),
+    "claude-opus-4-6": ModelSpec("claude-opus-4-6", ANTHROPIC_PROVIDER),
+    "claude-opus-4-5-20251101": ModelSpec("claude-opus-4-5-20251101", ANTHROPIC_PROVIDER),
+    "claude-opus-4-1-20250805": ModelSpec("claude-opus-4-1-20250805", ANTHROPIC_PROVIDER),
+    "claude-sonnet-4-6": ModelSpec("claude-sonnet-4-6", ANTHROPIC_PROVIDER),
+    "claude-sonnet-4-5-20250929": ModelSpec("claude-sonnet-4-5-20250929", ANTHROPIC_PROVIDER),
+    "claude-haiku-4-5-20251001": ModelSpec("claude-haiku-4-5-20251001", ANTHROPIC_PROVIDER),
+}
+
+MODEL_ALIASES: dict[str, str] = {
+    "openai": "gpt-5o",
+    "gpt": "gpt-5o",
+    "gpt-default": "gpt-5o",
+    "claude": "claude-sonnet-4-6",
+    "anthropic": "claude-sonnet-4-6",
+    "claude-sonnet": "claude-sonnet-4-6",
+    "claude-sonnet-4-6": "claude-sonnet-4-6",
+    "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
+    "claude-haiku": "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5": "claude-haiku-4-5-20251001",
+    "claude-opus": "claude-opus-4-7",
+    "claude-opus-4-7": "claude-opus-4-7",
+    "claude-opus-4-6": "claude-opus-4-6",
+    "claude-opus-4-5": "claude-opus-4-5-20251101",
+    "claude-opus-4.1": "claude-opus-4-1-20250805",
+    "claude-opus-4-1": "claude-opus-4-1-20250805",
+}
+
+
+def normalize_provider(provider: str | None) -> ProviderName:
+    """Normalize provider aliases used by CLI/config callers."""
+    if not provider:
+        return AUTO_PROVIDER
+    normalized = PROVIDER_ALIASES.get(provider.lower())
+    if normalized is None:
+        raise UnsupportedProviderError(f"Unsupported AI provider: {provider}")
+    return normalized
+
+
+def normalize_model_name(model: str | None) -> str | None:
+    """Resolve model aliases without guessing provider from prefixes."""
+    if not model:
+        return None
+    model_name = model.lower()
+    if model_name in MODEL_ALIASES:
+        return MODEL_ALIASES[model_name]
+    if model_name in MODEL_REGISTRY:
+        return model_name
+    return model
+
+
+def provider_for_model(model: str | None) -> ProviderName | None:
+    """Return the registered provider for a known model."""
+    normalized = normalize_model_name(model)
+    if not normalized:
+        return None
+    spec = MODEL_REGISTRY.get(normalized)
+    return spec.provider if spec else None
+
+
+def default_model_for_provider(provider: ProviderName) -> str:
+    """Return the configured default model for a provider."""
+    normalized = normalize_provider(provider)
+    if normalized == ANTHROPIC_PROVIDER:
+        return os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+    if normalized == OPENAI_PROVIDER:
+        return os.getenv("OPENAI_MODEL") or os.getenv("REPORTER_MODEL", "gpt-5o")
+    raise UnsupportedProviderError(f"Unsupported AI provider: {provider}")
+
+
+def api_key_for_provider(provider: ProviderName) -> str | None:
+    """Return the API key env var for a provider."""
+    normalized = normalize_provider(provider)
+    if normalized == ANTHROPIC_PROVIDER:
+        return os.getenv("ANTHROPIC_API_KEY")
+    if normalized == OPENAI_PROVIDER:
+        return os.getenv("OPENAI_API_KEY")
+    return None
+
+
+def available_providers() -> list[ProviderName]:
+    """List providers configured with API keys in fallback order."""
+    return [provider for provider in DEFAULT_PROVIDER_ORDER if api_key_for_provider(provider)]

--- a/ai_gateway/models.py
+++ b/ai_gateway/models.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ai_gateway.model_registry import default_model_for_provider, normalize_provider
+
 
 class ChatMessage(BaseModel):
     """A normal conversation message."""
@@ -85,11 +87,22 @@ class AiUsage(BaseModel):
 class AiGatewayConfig(BaseModel):
     """Configuration for a gateway provider."""
 
-    provider: str = "openai"
-    api_key: str | None = Field(default_factory=lambda: os.getenv("OPENAI_API_KEY"))
-    model: str = Field(default_factory=lambda: os.getenv("REPORTER_MODEL", "gpt-5-mini"))
+    provider: str = Field(default_factory=lambda: os.getenv("AI_GATEWAY_PROVIDER", "auto"))
+    api_key: str | None = None
+    model: str | None = Field(default_factory=lambda: os.getenv("AI_GATEWAY_MODEL"))
     base_url: str | None = None
     timeout: float | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        provider = normalize_provider(self.provider)
+        if self.api_key is None:
+            if provider == "anthropic":
+                self.api_key = os.getenv("ANTHROPIC_API_KEY")
+            elif provider == "openai":
+                self.api_key = os.getenv("OPENAI_API_KEY")
+        if self.model is None:
+            if provider in {"anthropic", "openai"}:
+                self.model = default_model_for_provider(provider)
 
 
 class AiRequest(BaseModel):

--- a/ai_gateway/openai_provider.py
+++ b/ai_gateway/openai_provider.py
@@ -1,4 +1,4 @@
-"""OpenAI Responses API adapter for the AI gateway."""
+"""OpenAI Responses API provider adapter for the AI gateway."""
 
 from __future__ import annotations
 
@@ -21,18 +21,18 @@ from ai_gateway.models import (
 )
 
 
-class OpenAIGateway(AiGateway):
-    """AI gateway implementation backed by OpenAI's Responses API."""
+class OpenAIProvider(AiGateway):
+    """Provider adapter backed by OpenAI's Responses API."""
 
     def __init__(self, config: AiGatewayConfig | None = None, client: Any | None = None) -> None:
-        self.config = config or AiGatewayConfig()
+        self.config = config or AiGatewayConfig(provider="openai")
         self.client = client or self._create_client()
 
     def _create_client(self) -> Any:
         try:
             from openai import AsyncOpenAI
         except ImportError as exc:
-            raise RuntimeError("The openai package is required to use OpenAIGateway.") from exc
+            raise RuntimeError("The openai package is required to use OpenAIProvider.") from exc
 
         kwargs: dict[str, Any] = {}
         if self.config.api_key:
@@ -210,3 +210,4 @@ class OpenAIGateway(AiGateway):
         if isinstance(value, dict):
             return value.get(name, default)
         return getattr(value, name, default)
+

--- a/ai_gateway/routing_gateway.py
+++ b/ai_gateway/routing_gateway.py
@@ -1,0 +1,120 @@
+"""Model-aware gateway router."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ai_gateway.anthropic_provider import AnthropicProvider
+from ai_gateway.errors import UnsupportedProviderError
+from ai_gateway.model_registry import (
+    ANTHROPIC_PROVIDER,
+    AUTO_PROVIDER,
+    DEFAULT_PROVIDER_ORDER,
+    OPENAI_PROVIDER,
+    ProviderName,
+    api_key_for_provider,
+    default_model_for_provider,
+    normalize_model_name,
+    normalize_provider,
+    provider_for_model,
+)
+from ai_gateway.models import AiGateway, AiGatewayConfig, AiRequest, AiResponse
+from ai_gateway.openai_provider import OpenAIProvider
+
+
+class ModelRoutingGateway(AiGateway):
+    """Route each AI request to a configured provider based on model/provider hints."""
+
+    def __init__(
+        self,
+        config: AiGatewayConfig | None = None,
+        clients: dict[ProviderName, Any] | None = None,
+    ) -> None:
+        self.config = config or AiGatewayConfig()
+        self.clients = clients or {}
+        self._gateways: dict[ProviderName, AiGateway] = {}
+
+    async def get_response(self, request: AiRequest) -> AiResponse:
+        requested_provider, requested_model, routed_provider, routed_model = self._resolve_route(request)
+        gateway = self._get_gateway(routed_provider)
+        routed_request = request.model_copy(update={"model": routed_model})
+        response = await gateway.get_response(routed_request)
+        response.provider_metadata.update(
+            {
+                "requested_provider": requested_provider,
+                "requested_model": requested_model,
+                "routed_provider": routed_provider,
+                "routed_model": routed_model,
+            }
+        )
+        return response
+
+    def _resolve_route(self, request: AiRequest) -> tuple[ProviderName, str | None, ProviderName, str]:
+        requested_model = normalize_model_name(request.model or self.config.model)
+        configured_provider = normalize_provider(self.config.provider)
+        requested_provider = configured_provider
+
+        model_provider = provider_for_model(requested_model)
+        if configured_provider == AUTO_PROVIDER:
+            requested_provider = model_provider or self._first_available_provider()
+
+        if requested_provider == AUTO_PROVIDER:
+            requested_provider = self._first_available_provider()
+
+        if self._provider_is_available(requested_provider):
+            return (
+                requested_provider,
+                requested_model,
+                requested_provider,
+                requested_model or default_model_for_provider(requested_provider),
+            )
+
+        fallback_provider = self._first_available_provider(excluding={requested_provider})
+        fallback_model = requested_model if model_provider == fallback_provider else None
+        return (
+            requested_provider,
+            requested_model,
+            fallback_provider,
+            fallback_model or default_model_for_provider(fallback_provider),
+        )
+
+    def _first_available_provider(self, excluding: set[ProviderName] | None = None) -> ProviderName:
+        excluded = excluding or set()
+        for provider in DEFAULT_PROVIDER_ORDER:
+            if provider not in excluded and self._provider_is_available(provider):
+                return provider
+        raise UnsupportedProviderError(
+            "No configured AI provider API keys found. Set OPENAI_API_KEY or ANTHROPIC_API_KEY."
+        )
+
+    def _provider_is_available(self, provider: ProviderName) -> bool:
+        normalized = normalize_provider(provider)
+        return normalized in self.clients or self._api_key_for_provider(normalized) is not None
+
+    def _get_gateway(self, provider: ProviderName) -> AiGateway:
+        normalized = normalize_provider(provider)
+        if normalized in self._gateways:
+            return self._gateways[normalized]
+
+        provider_config = AiGatewayConfig(
+            provider=normalized,
+            api_key=self._api_key_for_provider(normalized),
+            model=default_model_for_provider(normalized),
+            base_url=self.config.base_url,
+            timeout=self.config.timeout,
+        )
+        client = self.clients.get(normalized)
+        if normalized == OPENAI_PROVIDER:
+            gateway: AiGateway = OpenAIProvider(provider_config, client=client)
+        elif normalized == ANTHROPIC_PROVIDER:
+            gateway = AnthropicProvider(provider_config, client=client)
+        else:
+            raise UnsupportedProviderError(f"Unsupported AI provider: {provider}")
+        self._gateways[normalized] = gateway
+        return gateway
+
+    def _api_key_for_provider(self, provider: ProviderName) -> str | None:
+        configured_provider = normalize_provider(self.config.provider)
+        if configured_provider == provider and self.config.api_key:
+            return self.config.api_key
+        return api_key_for_provider(provider)

--- a/ai_gateway/tests/test_anthropic_provider.py
+++ b/ai_gateway/tests/test_anthropic_provider.py
@@ -1,0 +1,234 @@
+"""Tests for the Anthropic provider adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from ai_gateway import (
+    AiGatewayConfig,
+    AiRequest,
+    AnthropicProvider,
+    ChatMessage,
+    GatewayToolArgumentError,
+    StructuredOutputValidationError,
+    ToolCall,
+    ToolResultMessage,
+    ToolSpec,
+)
+
+
+class FakeMessages:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.kwargs = kwargs
+        return self.response
+
+
+class FakeClient:
+    def __init__(self, response: Any) -> None:
+        self.messages = FakeMessages(response)
+
+
+class ArticleShape(BaseModel):
+    title: str
+    score: int
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def test_plain_text_response_normalizes_and_system_message_serializes():
+    client = FakeClient(
+        {
+            "id": "msg_123",
+            "model": "claude-test",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Week recap"}],
+            "usage": {"input_tokens": 10, "output_tokens": 4},
+        }
+    )
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    response = run(
+        gateway.get_response(
+            AiRequest(
+                messages=[
+                    ChatMessage(role="system", content="You are a fantasy analyst."),
+                    ChatMessage(role="user", content="recap"),
+                ]
+            )
+        )
+    )
+
+    assert response.text == "Week recap"
+    assert response.finish_reason == "end_turn"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 14
+    assert response.provider_metadata["provider"] == "anthropic"
+    assert client.messages.kwargs is not None
+    assert client.messages.kwargs["system"] == "You are a fantasy analyst."
+    assert client.messages.kwargs["messages"] == [{"role": "user", "content": "recap"}]
+
+
+def test_maps_tools_into_anthropic_request():
+    client = FakeClient({"stop_reason": "end_turn", "content": [{"type": "text", "text": "ok"}]})
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    run(
+        gateway.get_response(
+            AiRequest(
+                messages=[ChatMessage(role="user", content="look up standings")],
+                tools=[
+                    ToolSpec(
+                        name="standings",
+                        description="Get standings",
+                        parameters={"type": "object", "properties": {"week": {"type": "integer"}}},
+                        strict=True,
+                    )
+                ],
+                options={"temperature": 0.2},
+            )
+        )
+    )
+
+    assert client.messages.kwargs is not None
+    assert client.messages.kwargs["model"] == "claude-test"
+    assert client.messages.kwargs["temperature"] == 0.2
+    assert client.messages.kwargs["tools"] == [
+        {
+            "name": "standings",
+            "description": "Get standings",
+            "input_schema": {"type": "object", "properties": {"week": {"type": "integer"}}},
+            "strict": True,
+        }
+    ]
+
+
+def test_tool_call_response_normalizes_arguments():
+    client = FakeClient(
+        {
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_123",
+                    "name": "team_game",
+                    "input": {"roster_key": "Schefter", "week": 8},
+                }
+            ],
+        }
+    )
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
+
+    assert response.tool_calls == [
+        ToolCall(id="toolu_123", name="team_game", arguments={"roster_key": "Schefter", "week": 8}, raw=response.tool_calls[0].raw)
+    ]
+    assert response.provider_metadata["tool_use_blocks"] == [
+        {
+            "type": "tool_use",
+            "id": "toolu_123",
+            "name": "team_game",
+            "input": {"roster_key": "Schefter", "week": 8},
+        }
+    ]
+
+
+def test_malformed_tool_arguments_raise_gateway_error():
+    client = FakeClient(
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_123",
+                    "name": "team_game",
+                    "input": "broken",
+                }
+            ],
+        }
+    )
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    with pytest.raises(GatewayToolArgumentError):
+        run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
+
+
+def test_tool_result_message_serializes_for_next_request():
+    client = FakeClient({"stop_reason": "end_turn", "content": [{"type": "text", "text": "thanks"}]})
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+    gateway._tool_use_cache["toolu_123"] = {
+        "type": "tool_use",
+        "id": "toolu_123",
+        "name": "standings",
+        "input": {"week": 8},
+    }
+
+    run(
+        gateway.get_response(
+            AiRequest(
+                messages=[
+                    ChatMessage(role="user", content="recap"),
+                    ToolResultMessage(tool_call_id="toolu_123", name="standings", content='{"rank": 1}'),
+                ]
+            )
+        )
+    )
+
+    assert client.messages.kwargs is not None
+    assert client.messages.kwargs["messages"][1] == {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "standings",
+                "input": {"week": 8},
+            }
+        ],
+    }
+    assert client.messages.kwargs["messages"][2] == {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "toolu_123", "content": '{"rank": 1}'}],
+    }
+
+
+def test_structured_output_schema_is_sent_and_validated():
+    client = FakeClient({"stop_reason": "end_turn", "content": [{"type": "text", "text": '{"title": "Recap", "score": 98}'}]})
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    response = run(
+        gateway.get_response(
+            AiRequest(
+                messages=[ChatMessage(role="user", content="json")],
+                structured_output_schema=ArticleShape,
+            )
+        )
+    )
+
+    assert client.messages.kwargs is not None
+    assert client.messages.kwargs["output_config"]["format"]["type"] == "json_schema"
+    assert response.structured_output == ArticleShape(title="Recap", score=98)
+
+
+def test_invalid_structured_output_raises_gateway_error():
+    client = FakeClient({"stop_reason": "end_turn", "content": [{"type": "text", "text": '{"title": "Recap"}'}]})
+    gateway = AnthropicProvider(AiGatewayConfig(provider="anthropic", model="claude-test"), client=client)
+
+    with pytest.raises(StructuredOutputValidationError):
+        run(
+            gateway.get_response(
+                AiRequest(
+                    messages=[ChatMessage(role="user", content="json")],
+                    structured_output_schema=ArticleShape,
+                )
+            )
+        )

--- a/ai_gateway/tests/test_factory.py
+++ b/ai_gateway/tests/test_factory.py
@@ -1,15 +1,82 @@
 """Tests for gateway factory behavior."""
 
+import asyncio
+from typing import Any
+
 import pytest
 
-from ai_gateway import AiGatewayConfig, OpenAIGateway, UnsupportedProviderError, create_gateway
+from ai_gateway import (
+    AiGatewayConfig,
+    AnthropicProvider,
+    ChatMessage,
+    MODEL_REGISTRY,
+    ModelRoutingGateway,
+    OpenAIProvider,
+    UnsupportedProviderError,
+    create_gateway,
+)
+from ai_gateway.model_registry import normalize_model_name, provider_for_model
+from ai_gateway.models import AiRequest
 
 
-def test_config_defaults_to_openai_provider():
+class FakeResponses:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.kwargs = kwargs
+        return self.response
+
+
+class FakeOpenAIClient:
+    def __init__(self, response: Any) -> None:
+        self.responses = FakeResponses(response)
+
+
+class FakeMessages:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.kwargs = kwargs
+        return self.response
+
+
+class FakeAnthropicClient:
+    def __init__(self, response: Any) -> None:
+        self.messages = FakeMessages(response)
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def test_config_defaults_to_auto_provider(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("AI_GATEWAY_PROVIDER", raising=False)
+    monkeypatch.delenv("AI_GATEWAY_MODEL", raising=False)
+
     config = AiGatewayConfig()
 
-    assert config.provider == "openai"
-    assert config.model
+    assert config.provider == "auto"
+    assert config.model is None
+
+
+def test_model_registry_contains_common_provider_models():
+    assert MODEL_REGISTRY["gpt-5o"].provider == "openai"
+    assert MODEL_REGISTRY["gpt-5-mini"].provider == "openai"
+    assert MODEL_REGISTRY["claude-opus-4-7"].provider == "anthropic"
+    assert MODEL_REGISTRY["claude-opus-4-6"].provider == "anthropic"
+    assert MODEL_REGISTRY["claude-sonnet-4-6"].provider == "anthropic"
+    assert MODEL_REGISTRY["claude-haiku-4-5-20251001"].provider == "anthropic"
+    assert normalize_model_name("Claude-Sonnet-4-6") == "claude-sonnet-4-6"
+    assert normalize_model_name("GPT-5O") == "gpt-5o"
+
+
+def test_unknown_model_does_not_infer_provider_from_prefix():
+    assert provider_for_model("claude-test") is None
+    assert provider_for_model("gpt-test") is None
 
 
 def test_create_gateway_supports_openai_with_injected_client():
@@ -17,8 +84,94 @@ def test_create_gateway_supports_openai_with_injected_client():
 
     gateway = create_gateway(AiGatewayConfig(provider="openai"), client=client)
 
-    assert isinstance(gateway, OpenAIGateway)
+    assert isinstance(gateway, OpenAIProvider)
     assert gateway.client is client
+
+
+def test_create_gateway_supports_anthropic_with_injected_client():
+    client = object()
+
+    gateway = create_gateway(AiGatewayConfig(provider="claude"), client=client)
+
+    assert isinstance(gateway, AnthropicProvider)
+    assert gateway.client is client
+
+
+def test_create_gateway_uses_router_without_injected_client():
+    gateway = create_gateway(AiGatewayConfig(provider="openai"))
+
+    assert isinstance(gateway, ModelRoutingGateway)
+
+
+def test_router_uses_requested_claude_model_when_anthropic_key_exists(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    anthropic_client = FakeAnthropicClient(
+        {
+            "id": "msg_123",
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Claude response"}],
+        }
+    )
+    gateway = ModelRoutingGateway(
+        AiGatewayConfig(provider="auto"),
+        clients={"anthropic": anthropic_client},
+    )
+
+    response = run(
+        gateway.get_response(
+            AiRequest(messages=[ChatMessage(role="user", content="recap")], model="claude-sonnet-4-6")
+        )
+    )
+
+    assert response.text == "Claude response"
+    assert response.provider_metadata["provider"] == "anthropic"
+    assert response.provider_metadata["routed_provider"] == "anthropic"
+    assert anthropic_client.messages.kwargs is not None
+    assert anthropic_client.messages.kwargs["model"] == "claude-sonnet-4-6"
+
+
+def test_router_falls_back_from_claude_to_openai_default_when_anthropic_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    openai_client = FakeOpenAIClient({"status": "completed", "output_text": "OpenAI fallback"})
+    gateway = ModelRoutingGateway(
+        AiGatewayConfig(provider="claude"),
+        clients={"openai": openai_client},
+    )
+
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="recap")])))
+
+    assert response.text == "OpenAI fallback"
+    assert response.provider_metadata["provider"] == "openai"
+    assert response.provider_metadata["requested_provider"] == "anthropic"
+    assert response.provider_metadata["routed_provider"] == "openai"
+    assert response.provider_metadata["routed_model"] == "gpt-5o"
+    assert openai_client.responses.kwargs is not None
+    assert openai_client.responses.kwargs["model"] == "gpt-5o"
+
+
+def test_router_treats_explicit_config_api_key_as_available(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert ModelRoutingGateway(AiGatewayConfig(provider="openai", api_key="config-key"))._provider_is_available("openai")
+
+    openai_client = FakeOpenAIClient({"status": "completed", "output_text": "Configured key"})
+    gateway = ModelRoutingGateway(
+        AiGatewayConfig(provider="openai", api_key="config-key", model="gpt-configured"),
+        clients={"openai": openai_client},
+    )
+
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="recap")])))
+
+    assert response.text == "Configured key"
+    assert response.provider_metadata["routed_provider"] == "openai"
+    assert openai_client.responses.kwargs is not None
+    assert openai_client.responses.kwargs["model"] == "gpt-configured"
 
 
 def test_create_gateway_rejects_unknown_provider():

--- a/ai_gateway/tests/test_factory.py
+++ b/ai_gateway/tests/test_factory.py
@@ -103,6 +103,21 @@ def test_create_gateway_uses_router_without_injected_client():
     assert isinstance(gateway, ModelRoutingGateway)
 
 
+def test_create_gateway_wires_default_injected_client_into_auto_router(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    openai_client = FakeOpenAIClient({"status": "completed", "output_text": "Injected OpenAI"})
+
+    gateway = create_gateway(client=openai_client)
+
+    assert isinstance(gateway, ModelRoutingGateway)
+    response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="recap")])))
+
+    assert response.text == "Injected OpenAI"
+    assert response.provider_metadata["routed_provider"] == "openai"
+    assert openai_client.responses.kwargs is not None
+
+
 def test_router_uses_requested_claude_model_when_anthropic_key_exists(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/ai_gateway/tests/test_openai_provider.py
+++ b/ai_gateway/tests/test_openai_provider.py
@@ -1,4 +1,4 @@
-"""Tests for the OpenAI gateway adapter."""
+"""Tests for the OpenAI provider adapter."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from ai_gateway import (
     AiRequest,
     ChatMessage,
     GatewayToolArgumentError,
-    OpenAIGateway,
+    OpenAIProvider,
     StructuredOutputValidationError,
     ToolCall,
     ToolResultMessage,
@@ -55,7 +55,7 @@ def test_plain_text_response_normalizes():
             "usage": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14},
         }
     )
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="recap")])))
 
@@ -70,7 +70,7 @@ def test_plain_text_response_normalizes():
 
 def test_maps_tools_into_responses_request():
     client = FakeClient({"status": "completed", "output_text": "ok"})
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     run(
         gateway.get_response(
@@ -116,7 +116,7 @@ def test_tool_call_response_normalizes_arguments():
             ],
         }
     )
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     response = run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
 
@@ -138,7 +138,7 @@ def test_malformed_tool_arguments_raise_gateway_error():
             ],
         }
     )
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     with pytest.raises(GatewayToolArgumentError):
         run(gateway.get_response(AiRequest(messages=[ChatMessage(role="user", content="team game")])))
@@ -146,7 +146,7 @@ def test_malformed_tool_arguments_raise_gateway_error():
 
 def test_tool_result_message_serializes_for_next_request():
     client = FakeClient({"status": "completed", "output_text": "thanks"})
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     run(
         gateway.get_response(
@@ -171,7 +171,7 @@ def test_tool_result_message_serializes_for_next_request():
 
 def test_structured_output_schema_is_sent_and_validated():
     client = FakeClient({"status": "completed", "output_text": '{"title": "Recap", "score": 98}'})
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     response = run(
         gateway.get_response(
@@ -189,7 +189,7 @@ def test_structured_output_schema_is_sent_and_validated():
 
 def test_invalid_structured_output_raises_gateway_error():
     client = FakeClient({"status": "completed", "output_text": '{"title": "Recap"}'})
-    gateway = OpenAIGateway(AiGatewayConfig(model="gpt-test"), client=client)
+    gateway = OpenAIProvider(AiGatewayConfig(model="gpt-test"), client=client)
 
     with pytest.raises(StructuredOutputValidationError):
         run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "python-dotenv",
     "pydantic>=2.0",
     "openai>=2.26.0",
+    "anthropic>=0.66.0",
     "openai-agents>=0.1.0",
     "sqlalchemy>=2.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ requests
 python-dotenv
 pydantic>=2.0
 openai>=2.26.0
+anthropic>=0.66.0
 openai-agents>=0.1.0
 pytest>=7.0
 pytest-asyncio>=0.21


### PR DESCRIPTION
Adds Anthropic support to `ai_gateway` with canonical `OpenAIProvider` and `AnthropicProvider` adapters behind a model-routing gateway. Introduces a hard-coded model registry for OpenAI and Claude 4.x models, env-aware provider/model defaults, and fallback routing when a requested provider lacks an API key. Renames the old OpenAI gateway implementation to provider terminology, adds Anthropic request/response normalization, and documents the new routing behavior.

Testing: `./.context/ai_gateway_venv313/bin/python -m pytest` passed with 215 tests and 12 existing warnings.
