### PR TITLE
feat(reporter_v2): add persistent context tools

### DIFF
--- a/reporter_v2/docs/impl/phase-1-core-data-models.md
+++ b/reporter_v2/docs/impl/phase-1-core-data-models.md
@@ -190,7 +190,7 @@ class RunnerConfig(BaseModel):
     soft_tool_limit: int = 40
     hard_tool_limit: int = 50
     max_turns: int = 60
-    model: str = "gpt-5-mini"
+    model: str | None = None
 ```
 
 ## Tests

--- a/reporter_v2/docs/impl/phase-9-integration-cli.md
+++ b/reporter_v2/docs/impl/phase-9-integration-cli.md
@@ -26,8 +26,8 @@ async def generate_article(
 ) -> ArticleOutput:
     """Main entry point for generating an article with the v2 runner."""
 
-    gw = gateway or create_gateway(AiGatewayConfig(model=model or "gpt-5-mini"))
-    runner_config = RunnerConfig(model=model or "gpt-5-mini")
+    gw = gateway or create_gateway(AiGatewayConfig(model=model))
+    runner_config = RunnerConfig(model=model)
 
     artifacts = ArtifactStore()
     procedures = ProcedureState()

--- a/reporter_v2/runner/state.py
+++ b/reporter_v2/runner/state.py
@@ -20,4 +20,4 @@ class RunnerConfig(BaseModel):
     soft_tool_limit: int = 40
     hard_tool_limit: int = 50
     max_turns: int = 60
-    model: str = "gpt-5-mini"
+    model: str | None = None

--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -21,11 +21,16 @@ from reporter_v2.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_SPECS,
     register_datalayer_tools,
 )
+from reporter_v2.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS,
+    register_persistent_tools,
+)
 from reporter_v2.runner.tools.procedure_tools import load_procedure
 from reporter_v2.runner.tools.registry import ToolRegistry
 
 __all__ = [
     "DATALAYER_TOOL_SPECS",
+    "PERSISTENT_TOOL_SPECS",
     "ToolContext",
     "ToolRegistry",
     "load_procedure",
@@ -34,6 +39,7 @@ __all__ = [
     "read_section",
     "rewrite_section",
     "register_datalayer_tools",
+    "register_persistent_tools",
     "save_fact",
     "save_storyline",
     "set_section_order",

--- a/reporter_v2/runner/tools/persistent_tools.py
+++ b/reporter_v2/runner/tools/persistent_tools.py
@@ -1,0 +1,281 @@
+"""Persistent context tools for reporter v2."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from ai_gateway import ToolSpec
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from datalayer.context_store import ContextStore
+
+
+PERSISTENT_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_persistent_storyline",
+            "description": (
+                "Create or update a persistent storyline that carries across weeks. "
+                "Use this for multi-week narrative arcs likely to matter in future "
+                "articles."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": (
+                            "Stable storyline ID. Use an existing ID to update, or "
+                            "a new ID like 'story_2024_w8_001' to create."
+                        ),
+                    },
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "stale", "resolved"],
+                    },
+                    "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "team_keys": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Team names or roster IDs involved in the arc.",
+                    },
+                },
+                "required": ["id", "headline", "summary", "status"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_team_context",
+            "description": (
+                "Save or update persistent narrative context for one team. This "
+                "replaces that team's previous note."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "roster_key": {
+                        "type": "string",
+                        "description": "Team name or roster ID.",
+                    },
+                    "narrative": {
+                        "type": "string",
+                        "description": "Summary of the team's current situation.",
+                    },
+                    "outlook": {
+                        "type": "string",
+                        "enum": [
+                            "rebuilding",
+                            "contending",
+                            "middling",
+                            "surging",
+                            "fading",
+                        ],
+                    },
+                },
+                "required": ["roster_key", "narrative"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_league_note",
+            "description": (
+                "Save or update a league-wide persistent note. Uses key-value pairs; "
+                "the same key overwrites the previous value."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": (
+                            "Note key such as 'season_theme', 'trade_activity', "
+                            "'rivalry_notes', or custom."
+                        ),
+                    },
+                    "value": {"type": "string"},
+                },
+                "required": ["key", "value"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_persistent_storylines",
+            "description": (
+                "Load active and stale persistent storylines, including available "
+                "history and persisted supporting facts."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_team_context",
+            "description": "Load all persistent team context notes.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_league_notes",
+            "description": "Load all persistent league context notes.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+PERSISTENT_TOOL_SPECS: list[ToolSpec] = ToolSpec.from_openai_tools(PERSISTENT_TOOLS)
+
+
+def register_persistent_tools(
+    registry: ToolRegistry,
+    context_store: ContextStore,
+    week: int,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+) -> None:
+    """Register persistent context tools against a ContextStore."""
+
+    def save_persistent_storyline(
+        *,
+        id: str,
+        headline: str,
+        summary: str,
+        status: str,
+        priority: int = 2,
+        tags: list[str] | None = None,
+        team_keys: list[str] | None = None,
+    ) -> str:
+        team_ids, unresolved_team_keys = _resolve_team_keys(
+            team_keys or [], resolve_roster_fn
+        )
+        context_store.upsert_storyline(
+            {
+                "id": id,
+                "headline": headline,
+                "summary": summary,
+                "status": status,
+                "priority": priority,
+                "tags": tags or [],
+                "team_ids": team_ids,
+            },
+            week=week,
+        )
+        payload: dict[str, Any] = {
+            "ok": True,
+            "saved": True,
+            "id": id,
+            "status": status,
+            "team_ids": team_ids,
+        }
+        if unresolved_team_keys:
+            payload["unresolved_team_keys"] = unresolved_team_keys
+        return _json(payload)
+
+    def save_team_context(
+        *,
+        roster_key: str,
+        narrative: str,
+        outlook: str | None = None,
+    ) -> str:
+        roster_id = _resolve_roster_id(roster_key, resolve_roster_fn)
+        if roster_id is None:
+            return _json(
+                {
+                    "ok": False,
+                    "saved": False,
+                    "error": f"Could not resolve team: {roster_key}",
+                }
+            )
+
+        context_store.upsert_team_context(
+            roster_id,
+            narrative,
+            outlook,
+            week=week,
+        )
+        return _json(
+            {
+                "ok": True,
+                "saved": True,
+                "roster_id": roster_id,
+                "roster_key": roster_key,
+            }
+        )
+
+    def save_league_note(*, key: str, value: str) -> str:
+        context_store.upsert_league_context(key, value, week=week)
+        return _json({"ok": True, "saved": True, "key": key})
+
+    def load_persistent_storylines() -> str:
+        storylines = context_store.get_storylines()
+        enriched = context_store.get_enriched_storylines(
+            [storyline["id"] for storyline in storylines]
+        )
+        return _json(enriched)
+
+    def load_team_context() -> str:
+        return _json(context_store.get_all_team_context())
+
+    def load_league_notes() -> str:
+        return _json(context_store.get_league_context())
+
+    handlers = {
+        "save_persistent_storyline": save_persistent_storyline,
+        "save_team_context": save_team_context,
+        "save_league_note": save_league_note,
+        "load_persistent_storylines": load_persistent_storylines,
+        "load_team_context": load_team_context,
+        "load_league_notes": load_league_notes,
+    }
+    for spec in PERSISTENT_TOOL_SPECS:
+        registry.register(spec.name, handlers[spec.name], spec)
+
+
+def _resolve_team_keys(
+    team_keys: list[str],
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> tuple[list[int], list[str]]:
+    team_ids: list[int] = []
+    unresolved_team_keys: list[str] = []
+    for key in team_keys:
+        roster_id = _resolve_roster_id(key, resolve_roster_fn)
+        if roster_id is None:
+            unresolved_team_keys.append(key)
+        else:
+            team_ids.append(roster_id)
+    return team_ids, unresolved_team_keys
+
+
+def _resolve_roster_id(
+    roster_key: str,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> int | None:
+    if resolve_roster_fn is not None:
+        result = resolve_roster_fn(roster_key)
+        if result.get("found"):
+            return int(result["roster_id"])
+        return None
+
+    try:
+        return int(roster_key)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, default=str)

--- a/reporter_v2/tests/test_persistent_tools.py
+++ b/reporter_v2/tests/test_persistent_tools.py
@@ -1,0 +1,181 @@
+"""Tests for reporter v2 persistent context tools."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from datalayer.context_store import ContextStore
+from reporter_v2.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS,
+    register_persistent_tools,
+)
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+def store() -> ContextStore:
+    context_store = ContextStore(
+        ":memory:",
+        league_id="league_123",
+        season="2024",
+    )
+    yield context_store
+    context_store.close()
+
+
+def registered_registry(
+    store: ContextStore,
+    *,
+    week: int = 8,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+) -> ToolRegistry:
+    registry = ToolRegistry()
+    register_persistent_tools(
+        registry,
+        store,
+        week=week,
+        resolve_roster_fn=resolve_roster_fn,
+    )
+    return registry
+
+
+def decode(result: str) -> Any:
+    return json.loads(result)
+
+
+def test_registers_persistent_tools(store: ContextStore) -> None:
+    registry = registered_registry(store)
+
+    assert registry.tool_names == [
+        "save_persistent_storyline",
+        "save_team_context",
+        "save_league_note",
+        "load_persistent_storylines",
+        "load_team_context",
+        "load_league_notes",
+    ]
+    assert registry.tool_specs == PERSISTENT_TOOL_SPECS
+
+
+def test_save_and_load_storyline(store: ContextStore) -> None:
+    def resolve_roster(roster_key: str) -> dict[str, Any]:
+        return {"found": roster_key == "Team Taco", "roster_id": 3}
+
+    registry = registered_registry(store, week=8, resolve_roster_fn=resolve_roster)
+    save_handler = registry.get_handler("save_persistent_storyline")
+    load_handler = registry.get_handler("load_persistent_storylines")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(
+            id="story_2024_w8_001",
+            headline="Taco Surges",
+            summary="Team Taco's playoff push is getting loud.",
+            status="active",
+            priority=1,
+            tags=["playoffs", "streak"],
+            team_keys=["Team Taco", "Unknown Team"],
+        )
+    )
+    storylines = decode(load_handler())
+
+    assert save_result == {
+        "ok": True,
+        "saved": True,
+        "id": "story_2024_w8_001",
+        "status": "active",
+        "team_ids": [3],
+        "unresolved_team_keys": ["Unknown Team"],
+    }
+    assert len(storylines) == 1
+    assert storylines[0]["id"] == "story_2024_w8_001"
+    assert storylines[0]["headline"] == "Taco Surges"
+    assert storylines[0]["summary"] == "Team Taco's playoff push is getting loud."
+    assert storylines[0]["priority"] == 1
+    assert storylines[0]["tags"] == ["playoffs", "streak"]
+    assert storylines[0]["team_ids"] == [3]
+    assert storylines[0]["week_created"] == 8
+    assert storylines[0]["history"] == []
+    assert storylines[0]["facts"] == []
+
+
+def test_save_team_context(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_handler = registry.get_handler("save_team_context")
+    load_handler = registry.get_handler("load_team_context")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(
+            roster_key="7",
+            narrative="A strong contender with a fragile running back room.",
+            outlook="contending",
+        )
+    )
+    team_context = decode(load_handler())
+
+    assert save_result == {
+        "ok": True,
+        "saved": True,
+        "roster_id": 7,
+        "roster_key": "7",
+    }
+    assert len(team_context) == 1
+    assert team_context[0]["roster_id"] == 7
+    assert team_context[0]["narrative"] == (
+        "A strong contender with a fragile running back room."
+    )
+    assert team_context[0]["outlook"] == "contending"
+    assert team_context[0]["week_last_updated"] == 9
+
+
+def test_save_team_context_unresolved_team(store: ContextStore) -> None:
+    registry = registered_registry(store)
+    handler = registry.get_handler("save_team_context")
+
+    assert handler is not None
+    result = decode(handler(roster_key="Team Taco", narrative="Unresolved."))
+
+    assert result == {
+        "ok": False,
+        "saved": False,
+        "error": "Could not resolve team: Team Taco",
+    }
+    assert store.get_all_team_context() == []
+
+
+def test_save_and_load_league_note(store: ContextStore) -> None:
+    registry = registered_registry(store, week=10)
+    save_handler = registry.get_handler("save_league_note")
+    load_handler = registry.get_handler("load_league_notes")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(key="season_theme", value="Every contender has a flaw.")
+    )
+    notes = decode(load_handler())
+
+    assert save_result == {"ok": True, "saved": True, "key": "season_theme"}
+    assert notes == {"season_theme": "Every contender has a flaw."}
+
+
+def test_load_empty_context(store: ContextStore) -> None:
+    registry = registered_registry(store)
+
+    load_storylines = registry.get_handler("load_persistent_storylines")
+    load_team_context = registry.get_handler("load_team_context")
+    load_league_notes = registry.get_handler("load_league_notes")
+
+    assert load_storylines is not None
+    assert load_team_context is not None
+    assert load_league_notes is not None
+    assert decode(load_storylines()) == []
+    assert decode(load_team_context()) == []
+    assert decode(load_league_notes()) == {}

--- a/reporter_v2/tests/test_runner.py
+++ b/reporter_v2/tests/test_runner.py
@@ -119,6 +119,20 @@ def test_runner_simple_text_response() -> None:
     assert runner.log.entries[0].event_type == "model_text"
     assert gateway.requests[0].messages[0].role == "system"
     assert gateway.requests[0].messages[1].role == "user"
+    assert gateway.requests[0].model is None
+
+
+def test_runner_passes_explicit_model_override() -> None:
+    gateway = FakeGateway([AiResponse(text="Done.")])
+    runner = Runner(
+        gateway,
+        ToolRegistry(),
+        config=RunnerConfig(model="claude-sonnet-4-6"),
+    )
+
+    run(runner.run("system", "user"))
+
+    assert gateway.requests[0].model == "claude-sonnet-4-6"
 
 
 def test_runner_tool_call_dispatch() -> None:

--- a/reporter_v2/tests/test_schemas.py
+++ b/reporter_v2/tests/test_schemas.py
@@ -186,4 +186,4 @@ class TestRunnerState:
         assert config.soft_tool_limit == 40
         assert config.hard_tool_limit == 50
         assert config.max_turns == 60
-        assert config.model == "gpt-5-mini"
+        assert config.model is None


### PR DESCRIPTION
## Description

Implements reporter_v2 phase 8 by adding persistent context tools backed by `ContextStore`.
This registers save/load handlers for persistent storylines, team context, and league notes, and exports the registration helper for later integration.
It also adds focused tests covering tool registration, save/load round trips, unresolved team handling, league notes, and empty context loads.

## Testing

`pyenv exec python -m pytest reporter_v2/tests/test_persistent_tools.py`

`pyenv exec python -m pytest reporter_v2/tests`
