### PR TITLE
docs(aida): improve report writer storylines

### DIFF
--- a/.agents/skills/aida-report-writer/SKILL.md
+++ b/.agents/skills/aida-report-writer/SKILL.md
@@ -8,6 +8,8 @@ argument-hint: "<article request>"
 
 You are the fantasy football reporter. Your job is not to fill a template; your job is to discover the strongest article angle available in the data, build on existing league narratives, and write the best piece.
 
+The output should read like a real article, not a tool transcript, not a dutiful checklist, and not a single wall of text. Use editorial freedom inside a clear reader-friendly structure.
+
 ## Core Principles
 
 - Refresh Sleeper data once per run, then query the same snapshot for every factual claim.
@@ -15,6 +17,8 @@ You are the fantasy football reporter. Your job is not to fill a template; your 
 - Use freedom of form: recap, column, power rankings, trade fallout, playoff race, team deep dive, awards, or roast are all valid if the data supports them.
 - Facts are sacred. Scores, records, ranks, player points, margins, and transactions must come from `sleeperdl`.
 - Storyline context is interpretive memory, not factual truth. Confirm current facts against the snapshot before writing.
+- Structure is part of quality. Unless the user explicitly asks for a very short blurb, every article needs a headline, a strong lead, and multiple named sections.
+- Continuity must be explicit. When prior context exists, decide what changed this week and make that visible in the article or intentionally leave the stale arc out.
 
 ## Setup
 
@@ -68,6 +72,24 @@ Use enriched context to see storyline history and persisted facts. Persisted fac
 
 For broad requests, consider most active priority-1 storylines. For narrow requests, include only directly relevant storylines. Stale storylines should only appear when they directly matter to the requested article.
 
+Before researching the article, make a compact continuity map in your notes:
+
+```text
+Storyline ID:
+Remembered arc:
+Current verification needed:
+Current-week result:
+Treatment: continue | escalate | complicate | resolve | ignore
+Article placement:
+```
+
+Use this map to avoid two common failures:
+
+- Dropping existing storylines after reading them.
+- Repeating old context as if nothing new happened this week.
+
+For broad weekly articles, if persistent context exists, carry at least two relevant prior arcs into the finished piece unless the data clearly makes them irrelevant. For focused articles, carry the relevant team or topic arc forward even if it only earns one paragraph.
+
 ## Investigate Freely
 
 Discover available tools:
@@ -114,6 +136,23 @@ Good article angles include:
 - awards, villains, heroes, fraud watch, panic meter
 - a focused roast when the data supports it
 
+Good durable storylines are usually about tension, payoff, reversal, rivalry, or consequences over time. Examples:
+
+- **Repeated close matchups:** Two teams keep playing one-score games, trading heartbreaking wins, or producing recurring Monday-night sweat finishes.
+- **Trades that echo later:** A major traded player swings a matchup weeks later, the team that sold looks exposed, or both sides of the deal keep changing the playoff race.
+- **Waiver pickup payoff:** A desperation add becomes a weekly starter, wins a matchup, or outperforms the player they replaced.
+- **Bench regret as a pattern:** A manager repeatedly leaves enough points on the bench to flip losses, turning bad luck into a recurring identity.
+- **High scorer with bad luck:** A team keeps scoring well but runs into opponents' season-best weeks, creating a "dangerous losing record" arc.
+- **Paper tiger contender:** A team has a strong record but weak points-for, lucky opponent timing, or repeated narrow escapes.
+- **Sleeping giant:** A talented roster starts slow, then surges after lineup changes, injury returns, or a trade.
+- **Rivalry escalation:** Trash talk, prior matchups, playoff history, or repeated close results make a normal game feel like a chapter in a larger feud.
+- **Playoff gatekeeper:** A middling team keeps damaging contenders, spoiling streaks, or controlling seeding despite not looking like a title favorite.
+- **Injury survival or collapse:** A team either survives a stretch without a star or finally breaks under missing production.
+- **Rookie or breakout arrival:** A player goes from stash to weekly difference-maker and changes a team's outlook.
+- **Transaction identity:** A manager's aggressive trade or waiver style becomes part of their team story, for better or worse.
+
+Do not persist every interesting event as a storyline. Prefer arcs that can plausibly matter again in future weeks, can be verified with current and past facts, and give the next article something specific to continue, complicate, or resolve.
+
 The user’s request matters, but if the data clearly points to a stronger adjacent story, use editorial judgment and explain that choice briefly in the final response.
 
 When choosing the angle, explicitly consider:
@@ -122,6 +161,25 @@ When choosing the angle, explicitly consider:
 - enriched history/facts for those storylines
 - 1-3 new storyline hypotheses suggested by the week’s data
 - which storylines should be continued, resolved, or newly created after publication
+
+## Build A Brief Before Drafting
+
+Before writing the article, create a compact brief at:
+
+```text
+$run_dir/brief.md
+```
+
+The brief is the contract between research and drafting. Keep it concise but include:
+
+- **Angle:** the chosen article thesis in one sentence.
+- **Reader promise:** what the reader will understand by the end.
+- **Continuity plan:** the selected old storylines and their treatment this week.
+- **Verified facts:** only claims already supported by `sleeperdl` outputs, with source query names.
+- **Outline:** section headings in planned order, with 1-3 facts or storyline beats under each.
+- **Context updates to make:** storylines, team notes, league notes, and persisted facts you expect to save after drafting.
+
+The outline must have enough shape to prevent wall-of-text output, but it should not force a generic template. Name sections like a columnist would, not like process labels. Good section names are specific to the week: `The Upset That Changed The Bracket`, `Panic Meter`, `The Bench Points Crime Scene`, `Fraud Watch Survives Another Hearing`.
 
 ## Write The Article
 
@@ -135,14 +193,34 @@ Rules:
 
 - Use Markdown.
 - Lead with the strongest story.
+- Start with one `#` headline.
+- Use `##` section headers for the body.
+- For normal-length articles, write at least three `##` sections after the headline. For short articles under roughly 500 words, use at least two.
+- Keep paragraphs short enough to scan, usually 2-4 sentences.
+- Do not use only bullets. Bullets are allowed for quick-hit sections, but the article still needs prose and sections.
+- Do not reuse the same section template every run. Match the section structure to the evidence: recap, column, rankings, awards, panic meter, fraud watch, deep dive, or roast.
 - Use specific data, not generic commentary.
-- Bring forward previous memory only when it still fits the current data.
+- Bring forward previous memory only when it still fits the current data, and connect it to what changed in the current snapshot.
 - Do not invent stats.
 - Bias and snark affect framing only, never facts.
+
+When connecting past and present, use one of these moves:
+
+- **Continue:** prior arc is reinforced by current data.
+- **Escalate:** current data makes the old arc more urgent or dramatic.
+- **Complicate:** current data cuts against the old arc, creating tension.
+- **Resolve:** current data closes the old arc.
+- **Callback:** old fact becomes context for a new, different main story.
+
+Avoid generic continuity phrases like "as previously noted" unless you also state the concrete old fact and the new result that changes its meaning.
 
 ## Update Context After Writing
 
 After the article, update persistent context with the storylines, facts, and team state that should carry forward.
+
+When updating an existing storyline, use the existing storyline ID. The new summary should state both the remembered arc and what the current week changed. Do not replace a multi-week arc with a one-week recap.
+
+When creating a new storyline, only persist it if it has future value. A single weird box score can be a section in the article without becoming durable memory.
 
 Save or extend major arcs:
 
@@ -195,6 +273,9 @@ Before finishing:
 - Re-scan `article.md` for every number.
 - Confirm each score, record, rank, player total, margin, and transaction claim appears in your tool outputs.
 - If a claim is unsupported, remove it or re-query the snapshot.
+- Confirm `article.md` has one `#` headline and enough `##` sections for the length.
+- If persistent context existed, confirm the article either carries relevant arcs forward or the context-update notes explain why they were ignored/resolved.
+- Confirm each selected continued/resolved storyline has a corresponding save or resolve operation.
 - Optionally write a short `$run_dir/sources.md` with the key tool calls used.
 
 ## Final Response
@@ -202,6 +283,7 @@ Before finishing:
 Return:
 
 - the run directory
+- the brief path
 - the article path
 - a brief note on the chosen angle
 - any context updates made

--- a/.agents/skills/aida-season-simulator/SKILL.md
+++ b/.agents/skills/aida-season-simulator/SKILL.md
@@ -17,10 +17,13 @@ Each week must be handled by a subagent, and weeks must run sequentially. Do not
 - Use `SLEEPER_WEEK_OVERRIDE=<week>` when creating each week’s snapshot.
 - Each weekly report must use `aida-report-writer`.
 - Each weekly report should be a weekly summary that ties the week into the larger state of the league.
+- Each weekly report must produce a compact brief and a sectioned Markdown article, not an unstructured recap.
 - Vary the editorial focus across weeks: rivalries, best teams, worst teams, standings movement, fraud watch, contender watch, collapse watch, waiver/trade fallout.
 - Vary the tone across weeks: hype, snarky, informative, measured, playful.
 - Wait for each subagent to finish before starting the next week.
 - The context database is the main audit trail. Reports should update storylines, team context, league notes, and persisted facts.
+- The simulation should make continuity stronger over time: each week should continue, complicate, resolve, or intentionally ignore prior arcs based on that week's verified data.
+- Good recurring arcs include repeated close matchups, rivalry chapters, trades or waiver moves that affect later matchups, bench-regret patterns, unlucky high scorers, paper tiger contenders, sleeping giants, playoff spoilers, injury survival stories, and breakout players changing a team's outlook.
 
 ## Setup
 
@@ -65,10 +68,14 @@ This is part of a sequential season simulation. Use:
 
 Important:
 - Read persistent context first.
+- Build a brief before drafting with an outline, verified facts, and a continuity plan.
 - Use current-week snapshot facts for all numbers.
 - Treat context as continuity, not factual proof.
+- In the article, use a headline plus multiple `##` sections. Avoid wall-of-text recaps.
+- If prior context exists, explicitly connect at least two relevant prior arcs to this week's current facts unless the data makes them irrelevant.
+- Look for durable storylines such as repeated close matchups, trade/waiver payoff, rivalry escalation, bench-regret patterns, playoff spoilers, unlucky high scorers, paper tigers, sleeping giants, injury survival, and breakout arrivals.
 - Update storylines/team context/league notes/persisted facts before finishing.
-- Return the article path and a concise list of context updates.
+- Return the brief path, article path, and a concise list of context updates.
 ```
 
 ## Focus And Tone Rotation
@@ -93,7 +100,7 @@ For each week:
 1. Compute the week focus and tone.
 2. Spawn one subagent with the weekly prompt.
 3. Wait for that subagent to finish.
-4. Record its article path and context-update summary in a season index file.
+4. Record its brief path, article path, and context-update summary in a season index file.
 5. Only then move to the next week.
 
 Write a season index:
@@ -107,6 +114,7 @@ Include:
 - week number
 - focus
 - tone
+- brief path
 - article path
 - reported context updates
 - any failures or follow-up notes
@@ -126,7 +134,7 @@ Return:
 
 - season run directory
 - weeks completed
+- brief paths
 - article paths
 - a short summary of how the context database evolved
 - any failed week, if applicable
-


### PR DESCRIPTION
## Summary

Updates the AIda report writer skill so generated articles must use a brief, a headline, sectioned Markdown, and explicit continuity mapping from persistent storylines to current-week facts. It also adds concrete examples of durable fantasy storylines, and updates the season simulator prompts so weekly simulations look for those arcs over time.

## Testing

Ran `git diff --check`.
