### PR TITLE
Add reporter v2 run controls

### DIFF
--- a/reporter_v2/README.md
+++ b/reporter_v2/README.md
@@ -31,6 +31,7 @@ REPORTER_V2_MODEL=gpt-5-mini
 REPORTER_OUTPUT_DIR=.output
 REPORTER_DATA_DIR=.data
 REPORTER_V2_MAX_TURNS=60
+REPORTER_V2_PROCEDURE_MODE=replace
 ```
 
 `reporter-v2` uses LiteLLM model IDs, so provider-specific API keys should be
@@ -100,6 +101,8 @@ reporter-v2 "weekly recap" --week 8 --output-dir .output/v2-runs
 
 - `--week`: single week to cover
 - `--week-start` / `--week-end`: range of weeks to cover
+- `--week-override`: pin the Sleeper effective week during data load; overrides
+  `SLEEPER_WEEK_OVERRIDE`
 - `--league`: override `SLEEPER_LEAGUE_ID`
 - `--model`: LiteLLM model ID
 - `--voice`: writing persona
@@ -113,6 +116,8 @@ reporter-v2 "weekly recap" --week 8 --output-dir .output/v2-runs
 - `--bias-intensity`: framing intensity from `0` to `3`
 - `--evidence-policy`: `strict`, `standard`, or `relaxed`
 - `--max-turns`: maximum model turns before stopping; defaults to `60`
+- `--procedure-mode`: `replace` keeps only the latest full procedure in
+  conversation history; `append` keeps every loaded procedure result
 - `--no-context`: skip persistent context reads/writes
 
 ## Outputs

--- a/reporter_v2/__init__.py
+++ b/reporter_v2/__init__.py
@@ -6,14 +6,17 @@ from reporter_v2.config import BiasProfile, ReportConfig, TimeRange, ToneControl
 from reporter_v2.runner.entrypoint import generate_article
 from reporter_v2.runner.runner import Runner
 from reporter_v2.runner.schemas import ArticleOutput
+from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
 from reporter_v2.runner.tools.registry import ToolRegistry
 from reporter_v2.workflows import generate_report, generate_with_config
 
 __all__ = [
     "ArticleOutput",
     "BiasProfile",
+    "ProcedureHistoryMode",
     "ReportConfig",
     "Runner",
+    "RunnerConfig",
     "TimeRange",
     "ToolRegistry",
     "ToneControls",

--- a/reporter_v2/app/runner.py
+++ b/reporter_v2/app/runner.py
@@ -13,9 +13,10 @@ from dotenv import load_dotenv
 from sqlalchemy import text
 
 from datalayer.context_store import ContextStore
-from datalayer.sleeper_data import SleeperLeagueData
+from datalayer.sleeper_data import SleeperConfig, SleeperLeagueData
 from reporter_v2.config import BiasProfile, ReportConfig, TimeRange, ToneControls
 from reporter_v2.runner.entrypoint import generate_article
+from reporter_v2.runner.state import ProcedureHistoryMode
 
 
 def parse_args() -> argparse.Namespace:
@@ -38,6 +39,15 @@ Examples:
     parser.add_argument("--week", "-w", type=int, help="Single week to cover.")
     parser.add_argument("--week-start", type=int, help="Start week for a range.")
     parser.add_argument("--week-end", type=int, help="End week for a range.")
+    parser.add_argument(
+        "--week-override",
+        type=int,
+        default=None,
+        help=(
+            "Pin the Sleeper effective week during data load. "
+            "Overrides SLEEPER_WEEK_OVERRIDE."
+        ),
+    )
     parser.add_argument(
         "--league",
         "-l",
@@ -126,6 +136,15 @@ Examples:
         default=None,
         help="Maximum model turns before stopping. Defaults to REPORTER_V2_MAX_TURNS or 60.",
     )
+    parser.add_argument(
+        "--procedure-mode",
+        choices=[mode.value for mode in ProcedureHistoryMode],
+        default=None,
+        help=(
+            "How to retain loaded procedure tool results: replace or append. "
+            "Defaults to REPORTER_V2_PROCEDURE_MODE or replace."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -135,6 +154,9 @@ async def run(args: argparse.Namespace) -> None:
     prompt = args.prompt or _prompt_for_request()
     selected_model = _resolve_model(args.model)
     max_turns = _resolve_max_turns(args.max_turns)
+    procedure_history_mode = _resolve_procedure_history_mode(
+        getattr(args, "procedure_mode", None)
+    )
     output_dir = args.output_dir or Path(os.getenv("REPORTER_OUTPUT_DIR", ".output"))
     data_dir = args.data_dir or Path(os.getenv("REPORTER_DATA_DIR", ".data"))
 
@@ -145,7 +167,7 @@ async def run(args: argparse.Namespace) -> None:
     print()
     print("Loading league data...")
 
-    data = SleeperLeagueData(league_id=args.league)
+    data = _make_sleeper_data(args.league, getattr(args, "week_override", None))
     data.load()
 
     time_range = _resolve_time_range(args, data)
@@ -168,8 +190,11 @@ async def run(args: argparse.Namespace) -> None:
     print(f"League: {data.league_id}")
     print(f"Season: {season}")
     print(f"Weeks: {time_range.week_start}-{time_range.week_end}")
+    if data.week_override is not None:
+        print(f"Sleeper week override: {data.week_override}")
     print(f"Model: {selected_model}")
     print(f"Max turns: {max_turns}")
+    print(f"Procedure mode: {procedure_history_mode.value}")
     if context_store is not None:
         print(f"Context DB: {data_dir / 'context.db'}")
     print(f"Stream log: {log_path}")
@@ -183,6 +208,7 @@ async def run(args: argparse.Namespace) -> None:
         context_store=context_store,
         model=selected_model,
         max_turns=max_turns,
+        procedure_history_mode=procedure_history_mode,
         log_path=log_path,
     )
 
@@ -265,6 +291,47 @@ def _resolve_max_turns(max_turns_arg: int | None) -> int:
     if max_turns < 1:
         raise ValueError("REPORTER_V2_MAX_TURNS must be at least 1.")
     return max_turns
+
+
+def _make_sleeper_data(
+    league_arg: str | None,
+    week_override_arg: int | None,
+) -> SleeperLeagueData:
+    if week_override_arg is None:
+        return SleeperLeagueData(league_id=league_arg)
+
+    league_id = league_arg or os.getenv("SLEEPER_LEAGUE_ID")
+    if not league_id:
+        raise ValueError(
+            "SLEEPER_LEAGUE_ID must be set or --league must be provided "
+            "when using --week-override."
+        )
+
+    return SleeperLeagueData(
+        config=SleeperConfig(
+            league_id=str(league_id),
+            week_override=week_override_arg,
+        )
+    )
+
+
+def _resolve_procedure_history_mode(
+    procedure_mode_arg: str | None,
+) -> ProcedureHistoryMode:
+    raw_value = procedure_mode_arg or os.getenv("REPORTER_V2_PROCEDURE_MODE")
+    if raw_value is None or raw_value == "":
+        return ProcedureHistoryMode.REPLACE
+
+    try:
+        return ProcedureHistoryMode(raw_value)
+    except ValueError as exc:
+        allowed = ", ".join(mode.value for mode in ProcedureHistoryMode)
+        name = (
+            "--procedure-mode"
+            if procedure_mode_arg is not None
+            else "REPORTER_V2_PROCEDURE_MODE"
+        )
+        raise ValueError(f"{name} must be one of: {allowed}.") from exc
 
 
 def _resolve_time_range(

--- a/reporter_v2/runner/__init__.py
+++ b/reporter_v2/runner/__init__.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 from reporter_v2.runner.runner import Runner
 from reporter_v2.runner.schemas import ArticleOutput
+from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
 from reporter_v2.runner.tools.registry import ToolRegistry
 
-__all__ = ["ArticleOutput", "Runner", "ToolRegistry"]
+__all__ = [
+    "ArticleOutput",
+    "ProcedureHistoryMode",
+    "Runner",
+    "RunnerConfig",
+    "ToolRegistry",
+]

--- a/reporter_v2/runner/entrypoint.py
+++ b/reporter_v2/runner/entrypoint.py
@@ -13,7 +13,7 @@ from datalayer.sleeper_data.queries._resolvers import resolve_roster_id
 from reporter_v2.config import ReportConfig
 from reporter_v2.runner.runner import CompletionFn, Runner
 from reporter_v2.runner.schemas import ArticleOutput
-from reporter_v2.runner.state import RunnerConfig
+from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
 from reporter_v2.runner.tools.article_tools import register_article_tools
 from reporter_v2.runner.tools.brief_tools import register_brief_tools
 from reporter_v2.runner.tools.datalayer_tools import register_datalayer_tools
@@ -32,6 +32,7 @@ async def generate_article(
     context_store: ContextStore | None = None,
     model: str | None = None,
     max_turns: int = 60,
+    procedure_history_mode: ProcedureHistoryMode | str = ProcedureHistoryMode.REPLACE,
     log_path: Path | None = None,
     complete: CompletionFn | None = None,
 ) -> ArticleOutput:
@@ -59,7 +60,11 @@ async def generate_article(
     runner = Runner(
         registry,
         complete=complete,
-        config=RunnerConfig(model=model, max_turns=max_turns),
+        config=RunnerConfig(
+            model=model,
+            max_turns=max_turns,
+            procedure_history_mode=procedure_history_mode,
+        ),
         log_path=log_path,
     )
     runner.artifacts.brief.meta.league_id = str(data.league_id)

--- a/reporter_v2/runner/runner.py
+++ b/reporter_v2/runner/runner.py
@@ -19,7 +19,12 @@ from reporter_v2.runner.models import (
 )
 from reporter_v2.runner.run_log import RunLog
 from reporter_v2.runner.schemas import ArticleOutput
-from reporter_v2.runner.state import ArtifactStore, ProcedureState, RunnerConfig
+from reporter_v2.runner.state import (
+    ArtifactStore,
+    ProcedureHistoryMode,
+    ProcedureState,
+    RunnerConfig,
+)
 from reporter_v2.runner.tools.context import ToolContext
 from reporter_v2.runner.tools.registry import ToolRegistry
 
@@ -79,7 +84,7 @@ class Runner:
                     results = await self._execute_tool_batch(calls, turn)
                     for call, result_content in zip(calls, results):
                         if call.name == "load_procedure":
-                            self._replace_procedure_message(messages, call, result_content)
+                            self._append_procedure_message(messages, call, result_content)
                         else:
                             messages.append(tool_result_message(call, result_content))
 
@@ -162,18 +167,22 @@ class Runner:
 
         return result_content
 
-    def _replace_procedure_message(
+    def _append_procedure_message(
         self,
         messages: list[ChatMessage],
         call: ToolCall,
         content: str,
     ) -> None:
-        """Compact the previous procedure result and append the new one."""
-        if self._procedure_message_idx is not None:
+        """Append procedure output, compacting prior output when configured."""
+        if (
+            self.config.procedure_history_mode == ProcedureHistoryMode.REPLACE
+            and self._procedure_message_idx is not None
+        ):
             messages[self._procedure_message_idx]["content"] = "[procedure replaced]"
 
         messages.append(tool_result_message(call, content))
-        self._procedure_message_idx = len(messages) - 1
+        if self.config.procedure_history_mode == ProcedureHistoryMode.REPLACE:
+            self._procedure_message_idx = len(messages) - 1
 
     @staticmethod
     def _as_tool_result_content(result: Any) -> str:

--- a/reporter_v2/runner/state.py
+++ b/reporter_v2/runner/state.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+from enum import Enum
+
 from pydantic import BaseModel, Field
 
 from reporter_v2.runner.schemas import Article, ReportBrief
+
+
+class ProcedureHistoryMode(str, Enum):
+    REPLACE = "replace"
+    APPEND = "append"
 
 
 class ArtifactStore(BaseModel):
@@ -19,3 +26,4 @@ class ProcedureState(BaseModel):
 class RunnerConfig(BaseModel):
     max_turns: int = 60
     model: str | None = None
+    procedure_history_mode: ProcedureHistoryMode = ProcedureHistoryMode.REPLACE

--- a/reporter_v2/tests/test_app_runner.py
+++ b/reporter_v2/tests/test_app_runner.py
@@ -1,0 +1,71 @@
+"""Tests for reporter v2 CLI configuration helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from reporter_v2.app.runner import _make_sleeper_data, _resolve_procedure_history_mode
+from reporter_v2.runner.state import ProcedureHistoryMode
+
+
+def test_resolve_procedure_history_mode_defaults_to_replace(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_V2_PROCEDURE_MODE", raising=False)
+
+    assert _resolve_procedure_history_mode(None) == ProcedureHistoryMode.REPLACE
+
+
+def test_resolve_procedure_history_mode_uses_env(monkeypatch) -> None:
+    monkeypatch.setenv("REPORTER_V2_PROCEDURE_MODE", "append")
+
+    assert _resolve_procedure_history_mode(None) == ProcedureHistoryMode.APPEND
+
+
+def test_resolve_procedure_history_mode_cli_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("REPORTER_V2_PROCEDURE_MODE", "append")
+
+    assert _resolve_procedure_history_mode("replace") == ProcedureHistoryMode.REPLACE
+
+
+def test_resolve_procedure_history_mode_rejects_invalid_env(monkeypatch) -> None:
+    monkeypatch.setenv("REPORTER_V2_PROCEDURE_MODE", "bogus")
+
+    with pytest.raises(ValueError, match="REPORTER_V2_PROCEDURE_MODE must be one of"):
+        _resolve_procedure_history_mode(None)
+
+
+def test_make_sleeper_data_uses_cli_week_override_without_env_league(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("SLEEPER_LEAGUE_ID", raising=False)
+
+    data = _make_sleeper_data("league_cli", 8)
+
+    assert data.league_id == "league_cli"
+    assert data.week_override == 8
+
+
+def test_make_sleeper_data_week_override_uses_env_league(monkeypatch) -> None:
+    monkeypatch.setenv("SLEEPER_LEAGUE_ID", "league_env")
+
+    data = _make_sleeper_data(None, 9)
+
+    assert data.league_id == "league_env"
+    assert data.week_override == 9
+
+
+def test_make_sleeper_data_cli_league_overrides_env_for_week_override(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("SLEEPER_LEAGUE_ID", "league_env")
+
+    data = _make_sleeper_data("league_cli", 10)
+
+    assert data.league_id == "league_cli"
+    assert data.week_override == 10
+
+
+def test_make_sleeper_data_week_override_requires_league(monkeypatch) -> None:
+    monkeypatch.delenv("SLEEPER_LEAGUE_ID", raising=False)
+
+    with pytest.raises(ValueError, match="SLEEPER_LEAGUE_ID must be set"):
+        _make_sleeper_data(None, 8)

--- a/reporter_v2/tests/test_runner.py
+++ b/reporter_v2/tests/test_runner.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from reporter_v2.runner.models import ToolCall
 from reporter_v2.runner.runner import Runner
-from reporter_v2.runner.state import RunnerConfig
+from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
 from reporter_v2.runner.tools.context import ToolContext
 from reporter_v2.runner.tools.registry import ToolRegistry
 
@@ -309,6 +309,7 @@ def test_runner_procedure_replacement() -> None:
     runner = Runner(
         registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
         complete=complete,
+        config=RunnerConfig(procedure_history_mode="replace"),
     )
 
     run(runner.run("system", "user"))
@@ -330,6 +331,49 @@ def test_runner_procedure_replacement() -> None:
     assert any(
         message["tool_call_id"] == "call_1"
         and message["content"] == "[procedure replaced]"
+        for message in procedure_messages
+    )
+
+
+def test_runner_procedure_append_mode() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "research"}, "call_1")
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "drafting"}, "call_2")
+                ]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(
+        registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
+        complete=complete,
+        config=RunnerConfig(procedure_history_mode=ProcedureHistoryMode.APPEND),
+    )
+
+    run(runner.run("system", "user"))
+
+    third_request_messages = complete.requests[2]["messages"]
+    procedure_messages = [
+        message
+        for message in third_request_messages
+        if message.get("role") == "tool" and message.get("name") == "load_procedure"
+    ]
+    assert [
+        (message["tool_call_id"], message["content"])
+        for message in procedure_messages
+    ] == [
+        ("call_1", "# Research"),
+        ("call_2", "# Drafting"),
+    ]
+    assert all(
+        message["content"] != "[procedure replaced]"
         for message in procedure_messages
     )
 

--- a/reporter_v2/tests/test_schemas.py
+++ b/reporter_v2/tests/test_schemas.py
@@ -10,7 +10,12 @@ from reporter_v2.runner.schemas import (
     ReportBrief,
     Storyline,
 )
-from reporter_v2.runner.state import ArtifactStore, ProcedureState, RunnerConfig
+from reporter_v2.runner.state import (
+    ArtifactStore,
+    ProcedureHistoryMode,
+    ProcedureState,
+    RunnerConfig,
+)
 
 
 class TestFact:
@@ -192,3 +197,4 @@ class TestRunnerState:
 
         assert config.max_turns == 60
         assert config.model is None
+        assert config.procedure_history_mode == ProcedureHistoryMode.REPLACE

--- a/reporter_v2/workflows.py
+++ b/reporter_v2/workflows.py
@@ -12,6 +12,7 @@ from datalayer.sleeper_data import SleeperLeagueData
 from reporter_v2.config import BiasProfile, ReportConfig, TimeRange, ToneControls
 from reporter_v2.runner.entrypoint import generate_article
 from reporter_v2.runner.schemas import ArticleOutput
+from reporter_v2.runner.state import ProcedureHistoryMode
 
 
 async def generate_report_async(
@@ -32,6 +33,7 @@ async def generate_report_async(
     context_store: ContextStore | None = None,
     data_dir: Path | str = Path(".data"),
     log_path: Path | None = None,
+    procedure_history_mode: ProcedureHistoryMode | str = ProcedureHistoryMode.REPLACE,
 ) -> ArticleOutput:
     """Generate a fantasy football report asynchronously."""
     data = _ensure_data(data)
@@ -54,6 +56,7 @@ async def generate_report_async(
         context_store=context_store,
         data_dir=data_dir,
         log_path=log_path,
+        procedure_history_mode=procedure_history_mode,
     )
 
 
@@ -73,6 +76,7 @@ async def generate_with_config_async(
     context_store: ContextStore | None = None,
     data_dir: Path | str = Path(".data"),
     log_path: Path | None = None,
+    procedure_history_mode: ProcedureHistoryMode | str = ProcedureHistoryMode.REPLACE,
 ) -> ArticleOutput:
     """Generate a report using a pre-built ReportConfig."""
     data = _ensure_data(data)
@@ -83,6 +87,7 @@ async def generate_with_config_async(
         context_store=context_store,
         model=model,
         log_path=log_path,
+        procedure_history_mode=procedure_history_mode,
     )
 
 


### PR DESCRIPTION
Adds configurable reporter v2 procedure history handling so callers can choose replacement or append mode for loaded procedure tool outputs. Exposes the mode through RunnerConfig, generate_article/workflow helpers, the reporter-v2 CLI, and REPORTER_V2_PROCEDURE_MODE. Adds reporter-v2 --week-override to pin the Sleeper effective week during data load while preserving --week as article coverage. Documents the new controls and covers replacement, append, CLI/env parsing, and week override helper behavior with tests. Tested with pytest reporter_v2/tests/.