### PR TITLE
Add storyline memory schema v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 AIdamShefter-v2 is an AI-powered fantasy football reporter. It has three major subsystems:
 
 1. **Datalayer** (`datalayer/`) — Fetches Sleeper fantasy football league data, normalizes it into dataclasses, loads it into an in-memory SQLite database, and exposes typed query methods + a guarded SQL escape hatch.
-2. **Reporter Memory** (`reporter_memory/`) — Persistent reporter-generated narrative memory: storylines, team context, league notes, history, and persisted facts. Current schema is `2.1`; storyline IDs, history, and facts are scoped by league and season.
+2. **Reporter Memory** (`reporter_memory/`) — Persistent reporter-generated narrative memory: storylines, team context, league notes, history, persisted facts, events, triggers, and access history. Current schema is `3`; memory rows are scoped by league and season.
 3. **Reporter V2** (`reporter_v2/`) — A single-loop agent that uses datalayer tools and reporter memory to research league data, then writes data-grounded articles with configurable voice, bias, and style.
 
 `reporter/` is deprecated v1 source retained for historical reference.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ datalayer/          # Sleeper API data layer
   cli/              # sleeperdl CLI
 
 reporter_memory/    # Persistent narrative memory for reporter-generated context
-  context_store.py  # ContextStore, schema 2.1, league/season-scoped memory
+  context_store.py  # ContextStore, schema 3, league/season-scoped memory
   context_tools.py  # Legacy-style memory tool handlers for integrations
 
 reporter_v2/        # Supported AI reporter agent
@@ -73,7 +73,7 @@ reporter/           # Deprecated v1 reporter source retained for historical refe
 ## Memory Refactor Notes
 
 - Persistent memory lives in `reporter_memory/`, not `datalayer/`.
-- `.data/context.db` uses reporter memory schema `2.1`.
+- `.data/context.db` uses reporter memory schema `3`.
 - Storyline IDs are scoped by `(league_id, season, id)`.
 - `sleeperdl context` and `sleeperdl memory` have been removed.
 - The installed reporter CLI is `reporter-v2`; v1 scripts are no longer

--- a/reporter_memory/README.md
+++ b/reporter_memory/README.md
@@ -7,7 +7,7 @@ in-memory SQLite, while narrative context is persisted in `.data/context.db`.
 
 ## Package Contents
 
-- `context_store.py` — `ContextStore` and schema version `2.1`.
+- `context_store.py` — `ContextStore` and schema version `3`.
 - `context_tools.py` — legacy-style memory tool specs and handlers.
 - `tests/` — store and scoping regression tests.
 
@@ -17,8 +17,9 @@ Storyline identity is scoped by `(league_id, season, id)`. History and persisted
 facts are also scoped by league and season, so the same storyline ID can safely
 exist in different leagues or seasons.
 
-Old context DB schemas are not migrated. Delete or recreate `.data/context.db`
-if the store reports an unsupported schema version.
+Schema `2.1` context databases are migrated in place. Older schemas are not
+supported and should be deleted or recreated if the store reports an unsupported
+schema version.
 
 ## Usage
 

--- a/reporter_memory/context_store.py
+++ b/reporter_memory/context_store.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any
 
 
-SCHEMA_VERSION = "2.1"
+SCHEMA_VERSION = "3"
 
 _DDL = """
 CREATE TABLE IF NOT EXISTS context_meta (
@@ -35,16 +35,24 @@ CREATE TABLE IF NOT EXISTS storylines (
     summary TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'active',
     priority INTEGER NOT NULL DEFAULT 2,
+    arc_type TEXT,
+    importance INTEGER NOT NULL DEFAULT 4,
+    origin_week INTEGER,
+    future_callback_condition TEXT,
     tags TEXT,
     team_ids TEXT,
     week_created INTEGER NOT NULL,
     week_last_updated INTEGER NOT NULL,
+    last_accessed_week INTEGER,
+    last_accessed_at TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     PRIMARY KEY (league_id, season, id)
 );
 CREATE INDEX IF NOT EXISTS idx_storylines_league
     ON storylines(league_id, season, status);
+CREATE INDEX IF NOT EXISTS idx_storylines_importance
+    ON storylines(league_id, season, importance);
 
 CREATE TABLE IF NOT EXISTS team_context (
     league_id TEXT NOT NULL,
@@ -97,6 +105,110 @@ CREATE TABLE IF NOT EXISTS persisted_facts (
 );
 CREATE INDEX IF NOT EXISTS idx_facts_storyline
     ON persisted_facts(league_id, season, storyline_id);
+
+CREATE TABLE IF NOT EXISTS story_events (
+    id TEXT NOT NULL,
+    league_id TEXT NOT NULL,
+    season TEXT NOT NULL,
+    week INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    headline TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    importance INTEGER NOT NULL DEFAULT 1,
+    confidence TEXT NOT NULL DEFAULT 'needs_verification',
+    source_refs_json TEXT,
+    numbers_json TEXT,
+    transaction_id TEXT,
+    matchup_id TEXT,
+    last_accessed_week INTEGER,
+    last_accessed_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (league_id, season, id)
+);
+CREATE INDEX IF NOT EXISTS idx_story_events_week
+    ON story_events(league_id, season, week, event_type);
+CREATE INDEX IF NOT EXISTS idx_story_events_transaction
+    ON story_events(league_id, season, transaction_id);
+CREATE INDEX IF NOT EXISTS idx_story_events_matchup
+    ON story_events(league_id, season, matchup_id);
+
+CREATE TABLE IF NOT EXISTS story_event_entities (
+    league_id TEXT NOT NULL,
+    season TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    display_name TEXT,
+    role TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (league_id, season, event_id, entity_type, entity_id, role)
+);
+CREATE INDEX IF NOT EXISTS idx_story_event_entities_lookup
+    ON story_event_entities(league_id, season, entity_type, entity_id);
+
+CREATE TABLE IF NOT EXISTS storyline_event_links (
+    league_id TEXT NOT NULL,
+    season TEXT NOT NULL,
+    storyline_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    link_type TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (league_id, season, storyline_id, event_id, link_type)
+);
+CREATE INDEX IF NOT EXISTS idx_storyline_event_links_event
+    ON storyline_event_links(league_id, season, event_id);
+
+CREATE TABLE IF NOT EXISTS storyline_triggers (
+    id TEXT NOT NULL,
+    league_id TEXT NOT NULL,
+    season TEXT NOT NULL,
+    storyline_id TEXT,
+    event_id TEXT,
+    trigger_type TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    target_week INTEGER,
+    condition_json TEXT,
+    fire_policy TEXT NOT NULL DEFAULT 'one_shot',
+    fired_week INTEGER,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (league_id, season, id)
+);
+CREATE INDEX IF NOT EXISTS idx_storyline_triggers_status
+    ON storyline_triggers(league_id, season, status, target_week);
+CREATE INDEX IF NOT EXISTS idx_storyline_triggers_storyline
+    ON storyline_triggers(league_id, season, storyline_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS story_memory_fts USING fts5(
+    owner_type UNINDEXED,
+    owner_id UNINDEXED,
+    league_id UNINDEXED,
+    season UNINDEXED,
+    headline,
+    summary,
+    tags,
+    entity_text,
+    trigger_text
+);
+
+CREATE TABLE IF NOT EXISTS memory_accesses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    league_id TEXT NOT NULL,
+    season TEXT NOT NULL,
+    week INTEGER NOT NULL,
+    owner_type TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    usage TEXT NOT NULL,
+    linked_storyline_id TEXT,
+    fact_links_json TEXT,
+    reason TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_memory_accesses_owner
+    ON memory_accesses(league_id, season, owner_type, owner_id);
+CREATE INDEX IF NOT EXISTS idx_memory_accesses_usage
+    ON memory_accesses(league_id, season, usage, week);
 """
 
 
@@ -143,12 +255,55 @@ class ContextStore:
         row = cur.fetchone()
         current = row["value"] if row else "0"
 
+        if current == SCHEMA_VERSION:
+            return
+
+        if current == "2.1":
+            self._migrate_21_to_3()
+            return
+
         if current != SCHEMA_VERSION:
             raise RuntimeError(
                 "Unsupported reporter memory schema version "
                 f"{current!r}; expected {SCHEMA_VERSION!r}. "
-                "Delete or recreate the context database."
+                "Only schema '2.1' can be migrated automatically."
             )
+
+    def _migrate_21_to_3(self) -> None:
+        """Migrate schema 2.1 to schema 3 in place."""
+        self._add_storyline_column_if_missing("arc_type", "TEXT")
+        self._add_storyline_column_if_missing("importance", "INTEGER")
+        self._add_storyline_column_if_missing("origin_week", "INTEGER")
+        self._add_storyline_column_if_missing("future_callback_condition", "TEXT")
+        self._add_storyline_column_if_missing("last_accessed_week", "INTEGER")
+        self._add_storyline_column_if_missing("last_accessed_at", "TEXT")
+
+        self._conn.execute(
+            """UPDATE storylines
+               SET importance = COALESCE(importance, 6 - priority),
+                   origin_week = COALESCE(origin_week, week_created)"""
+        )
+        self._conn.executescript(_DDL)
+        self._rebuild_story_memory_fts()
+        self._conn.execute(
+            """INSERT INTO context_meta (key, value) VALUES ('schema_version', ?)
+               ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+            (SCHEMA_VERSION,),
+        )
+        self._conn.commit()
+
+    def _add_storyline_column_if_missing(
+        self, column_name: str, column_definition: str
+    ) -> None:
+        if column_name in self._column_names("storylines"):
+            return
+        self._conn.execute(
+            f"ALTER TABLE storylines ADD COLUMN {column_name} {column_definition}"
+        )
+
+    def _column_names(self, table_name: str) -> set[str]:
+        cur = self._conn.execute(f"PRAGMA table_info({table_name})")
+        return {row["name"] for row in cur.fetchall()}
 
     # ------------------------------------------------------------------
     # Read
@@ -237,7 +392,9 @@ class ContextStore:
             week: Current week number.
         """
         existing = self._conn.execute(
-            """SELECT id FROM storylines
+            """SELECT id, arc_type, importance, origin_week,
+                      future_callback_condition, last_accessed_week, last_accessed_at
+               FROM storylines
                WHERE league_id = ? AND season = ? AND id = ?""",
             (self.league_id, self.season, storyline["id"]),
         ).fetchone()
@@ -245,6 +402,26 @@ class ContextStore:
             self._append_storyline_history(storyline["id"], week=week)
 
         now = _now_iso()
+        priority = storyline.get("priority", 2)
+        importance = storyline.get(
+            "importance", existing["importance"] if existing else 6 - priority
+        )
+        origin_week = storyline.get(
+            "origin_week", existing["origin_week"] if existing else week
+        )
+        arc_type = storyline.get("arc_type", existing["arc_type"] if existing else None)
+        future_callback_condition = storyline.get(
+            "future_callback_condition",
+            existing["future_callback_condition"] if existing else None,
+        )
+        last_accessed_week = storyline.get(
+            "last_accessed_week",
+            existing["last_accessed_week"] if existing else None,
+        )
+        last_accessed_at = storyline.get(
+            "last_accessed_at",
+            existing["last_accessed_at"] if existing else None,
+        )
         tags = json.dumps(storyline.get("tags", [])) if storyline.get("tags") else None
         team_ids = (
             json.dumps(storyline.get("team_ids", []))
@@ -255,16 +432,33 @@ class ContextStore:
         self._conn.execute(
             """INSERT INTO storylines
                    (id, league_id, season, headline, summary, status, priority,
-                    tags, team_ids, week_created, week_last_updated, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    arc_type, importance, origin_week, future_callback_condition,
+                    tags, team_ids, week_created, week_last_updated,
+                    last_accessed_week, last_accessed_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(league_id, season, id) DO UPDATE SET
                    headline = excluded.headline,
                    summary = excluded.summary,
                    status = excluded.status,
                    priority = excluded.priority,
+                   arc_type = COALESCE(excluded.arc_type, storylines.arc_type),
+                   importance = COALESCE(excluded.importance, storylines.importance),
+                   origin_week = COALESCE(excluded.origin_week, storylines.origin_week),
+                   future_callback_condition = COALESCE(
+                       excluded.future_callback_condition,
+                       storylines.future_callback_condition
+                   ),
                    tags = excluded.tags,
                    team_ids = excluded.team_ids,
                    week_last_updated = excluded.week_last_updated,
+                   last_accessed_week = COALESCE(
+                       excluded.last_accessed_week,
+                       storylines.last_accessed_week
+                   ),
+                   last_accessed_at = COALESCE(
+                       excluded.last_accessed_at,
+                       storylines.last_accessed_at
+                   ),
                    updated_at = excluded.updated_at""",
             (
                 storyline["id"],
@@ -273,15 +467,22 @@ class ContextStore:
                 storyline["headline"],
                 storyline["summary"],
                 storyline.get("status", "active"),
-                storyline.get("priority", 2),
+                priority,
+                arc_type,
+                importance,
+                origin_week,
+                future_callback_condition,
                 tags,
                 team_ids,
                 week,  # week_created (ignored on update due to ON CONFLICT)
                 week,  # week_last_updated
+                last_accessed_week,
+                last_accessed_at,
                 now,  # created_at (ignored on update)
                 now,  # updated_at
             ),
         )
+        self._sync_storyline_fts(storyline["id"])
         self._conn.commit()
 
     def resolve_storyline(self, storyline_id: str) -> None:
@@ -392,7 +593,9 @@ class ContextStore:
         """Lightweight active/stale storyline list for curator input."""
         cur = self._conn.execute(
             """SELECT id, headline, summary, status, tags, team_ids,
-                      priority, week_created, week_last_updated
+                      priority, arc_type, importance, origin_week,
+                      future_callback_condition, week_created, week_last_updated,
+                      last_accessed_week, last_accessed_at
                FROM storylines
                WHERE league_id = ? AND season = ? AND status IN ('active', 'stale')
                ORDER BY priority, week_last_updated DESC""",
@@ -400,10 +603,7 @@ class ContextStore:
         )
         rows = []
         for row in cur.fetchall():
-            d = dict(row)
-            d["tags"] = json.loads(d["tags"]) if d.get("tags") else []
-            d["team_ids"] = json.loads(d["team_ids"]) if d.get("team_ids") else []
-            rows.append(d)
+            rows.append(self._storyline_row_to_dict(row))
         return rows
 
     def get_storyline_history(self, storyline_id: str) -> list[dict[str, Any]]:
@@ -492,6 +692,233 @@ class ContextStore:
         self._conn.commit()
         return inserted
 
+    # ------------------------------------------------------------------
+    # Story Events, Triggers, Accesses, and FTS
+    # ------------------------------------------------------------------
+
+    def upsert_story_event(self, event: dict[str, Any]) -> None:
+        """Create or update source-backed event evidence."""
+        source_refs = event.get("source_refs", event.get("source_refs_json", []))
+        confidence = event.get("confidence", "needs_verification")
+        if confidence == "verified" and not source_refs:
+            raise ValueError("verified story events require at least one source ref")
+
+        now = _now_iso()
+        self._conn.execute(
+            """INSERT INTO story_events
+                   (id, league_id, season, week, event_type, headline, summary,
+                    importance, confidence, source_refs_json, numbers_json,
+                    transaction_id, matchup_id, last_accessed_week, last_accessed_at,
+                    created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(league_id, season, id) DO UPDATE SET
+                   week = excluded.week,
+                   event_type = excluded.event_type,
+                   headline = excluded.headline,
+                   summary = excluded.summary,
+                   importance = excluded.importance,
+                   confidence = excluded.confidence,
+                   source_refs_json = excluded.source_refs_json,
+                   numbers_json = excluded.numbers_json,
+                   transaction_id = excluded.transaction_id,
+                   matchup_id = excluded.matchup_id,
+                   last_accessed_week = COALESCE(
+                       excluded.last_accessed_week,
+                       story_events.last_accessed_week
+                   ),
+                   last_accessed_at = COALESCE(
+                       excluded.last_accessed_at,
+                       story_events.last_accessed_at
+                   ),
+                   updated_at = excluded.updated_at""",
+            (
+                event["id"],
+                self.league_id,
+                self.season,
+                event["week"],
+                event["event_type"],
+                event["headline"],
+                event["summary"],
+                event.get("importance", 1),
+                confidence,
+                self._json_text(source_refs, []),
+                self._json_text(event.get("numbers", event.get("numbers_json", {})), {}),
+                event.get("transaction_id"),
+                event.get("matchup_id"),
+                event.get("last_accessed_week"),
+                event.get("last_accessed_at"),
+                now,
+                now,
+            ),
+        )
+        self._sync_event_fts(event["id"])
+        self._conn.commit()
+
+    def replace_story_event_entities(
+        self, event_id: str, entities: list[dict[str, Any]]
+    ) -> None:
+        """Replace normalized entity links for one story event."""
+        self._conn.execute(
+            """DELETE FROM story_event_entities
+               WHERE league_id = ? AND season = ? AND event_id = ?""",
+            (self.league_id, self.season, event_id),
+        )
+
+        now = _now_iso()
+        for entity in entities:
+            entity_type = entity.get("entity_type", entity.get("type"))
+            if not entity_type:
+                raise ValueError("story event entities require entity_type")
+            display_name = entity.get("display_name", entity.get("name"))
+            entity_id = entity.get("entity_id", entity.get("id", display_name))
+            if not entity_id:
+                raise ValueError("story event entities require entity_id or display_name")
+
+            self._conn.execute(
+                """INSERT INTO story_event_entities
+                       (league_id, season, event_id, entity_type, entity_id,
+                        display_name, role, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    self.league_id,
+                    self.season,
+                    event_id,
+                    entity_type,
+                    str(entity_id),
+                    display_name,
+                    entity.get("role", ""),
+                    now,
+                ),
+            )
+
+        self._sync_event_fts(event_id)
+        self._conn.commit()
+
+    def link_storyline_event(
+        self, storyline_id: str, event_id: str, link_type: str
+    ) -> None:
+        """Link a narrative storyline card to source-backed event evidence."""
+        self._conn.execute(
+            """INSERT OR IGNORE INTO storyline_event_links
+                   (league_id, season, storyline_id, event_id, link_type, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (self.league_id, self.season, storyline_id, event_id, link_type, _now_iso()),
+        )
+        self._conn.commit()
+
+    def upsert_storyline_trigger(self, trigger: dict[str, Any]) -> None:
+        """Create or update a dormant callback trigger."""
+        now = _now_iso()
+        condition = trigger.get("condition", trigger.get("condition_json", {}))
+        self._conn.execute(
+            """INSERT INTO storyline_triggers
+                   (id, league_id, season, storyline_id, event_id, trigger_type,
+                    status, target_week, condition_json, fire_policy, fired_week,
+                    created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(league_id, season, id) DO UPDATE SET
+                   storyline_id = excluded.storyline_id,
+                   event_id = excluded.event_id,
+                   trigger_type = excluded.trigger_type,
+                   status = excluded.status,
+                   target_week = excluded.target_week,
+                   condition_json = excluded.condition_json,
+                   fire_policy = excluded.fire_policy,
+                   fired_week = excluded.fired_week,
+                   updated_at = excluded.updated_at""",
+            (
+                trigger["id"],
+                self.league_id,
+                self.season,
+                trigger.get("storyline_id"),
+                trigger.get("event_id"),
+                trigger["trigger_type"],
+                trigger.get("status", "open"),
+                trigger.get("target_week"),
+                self._json_text(condition, {}),
+                trigger.get("fire_policy", "one_shot"),
+                trigger.get("fired_week"),
+                now,
+                now,
+            ),
+        )
+        self._sync_trigger_fts(trigger["id"])
+        self._conn.commit()
+
+    def record_memory_access(
+        self,
+        *,
+        owner_type: str,
+        owner_id: str,
+        week: int,
+        usage: str,
+        linked_storyline_id: str | None = None,
+        fact_links: list[str] | None = None,
+        reason: str | None = None,
+    ) -> int:
+        """Record retrieval/usage feedback for a memory candidate."""
+        now = _now_iso()
+        cur = self._conn.execute(
+            """INSERT INTO memory_accesses
+                   (league_id, season, week, owner_type, owner_id, usage,
+                    linked_storyline_id, fact_links_json, reason, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                self.league_id,
+                self.season,
+                week,
+                owner_type,
+                owner_id,
+                usage,
+                linked_storyline_id,
+                self._json_text(fact_links or [], []),
+                reason,
+                now,
+            ),
+        )
+
+        if owner_type == "storyline":
+            self._conn.execute(
+                """UPDATE storylines
+                   SET last_accessed_week = ?, last_accessed_at = ?
+                   WHERE league_id = ? AND season = ? AND id = ?""",
+                (week, now, self.league_id, self.season, owner_id),
+            )
+        elif owner_type in {"event", "story_event"}:
+            self._conn.execute(
+                """UPDATE story_events
+                   SET last_accessed_week = ?, last_accessed_at = ?
+                   WHERE league_id = ? AND season = ? AND id = ?""",
+                (week, now, self.league_id, self.season, owner_id),
+            )
+
+        self._conn.commit()
+        return int(cur.lastrowid)
+
+    def rebuild_story_memory_fts(self) -> None:
+        """Rebuild FTS rows for all storylines, events, and triggers in scope."""
+        self._rebuild_story_memory_fts()
+        self._conn.commit()
+
+    def _rebuild_story_memory_fts(self) -> None:
+        self._conn.execute(
+            """DELETE FROM story_memory_fts
+               WHERE league_id = ? AND season = ?""",
+            (self.league_id, self.season),
+        )
+
+        storyline_ids = self._scoped_ids("storylines")
+        for storyline_id in storyline_ids:
+            self._sync_storyline_fts(storyline_id)
+
+        event_ids = self._scoped_ids("story_events")
+        for event_id in event_ids:
+            self._sync_event_fts(event_id)
+
+        trigger_ids = self._scoped_ids("storyline_triggers")
+        for trigger_id in trigger_ids:
+            self._sync_trigger_fts(trigger_id)
+
     def close(self) -> None:
         """Close the database connection."""
         self._conn.close()
@@ -511,4 +938,164 @@ class ContextStore:
             d["team_ids"] = json.loads(d["team_ids"])
         else:
             d["team_ids"] = []
+        d.setdefault("arc_type", None)
+        if d.get("importance") is None:
+            d["importance"] = 6 - d.get("priority", 2)
+        if d.get("origin_week") is None:
+            d["origin_week"] = d.get("week_created")
+        d.setdefault("future_callback_condition", None)
+        d.setdefault("last_accessed_week", None)
+        d.setdefault("last_accessed_at", None)
         return d
+
+    def _sync_storyline_fts(self, storyline_id: str) -> None:
+        self._delete_fts_row("storyline", storyline_id)
+        row = self._conn.execute(
+            """SELECT * FROM storylines
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, storyline_id),
+        ).fetchone()
+        if not row:
+            return
+
+        storyline = self._storyline_row_to_dict(row)
+        self._insert_fts_row(
+            owner_type="storyline",
+            owner_id=storyline_id,
+            headline=storyline["headline"],
+            summary=storyline["summary"],
+            tags=" ".join(storyline["tags"] + [storyline.get("arc_type") or ""]),
+            entity_text=" ".join(str(team_id) for team_id in storyline["team_ids"]),
+            trigger_text=storyline.get("future_callback_condition") or "",
+        )
+
+    def _sync_event_fts(self, event_id: str) -> None:
+        self._delete_fts_row("event", event_id)
+        row = self._conn.execute(
+            """SELECT * FROM story_events
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, event_id),
+        ).fetchone()
+        if not row:
+            return
+
+        entity_rows = self._conn.execute(
+            """SELECT entity_type, entity_id, display_name, role
+               FROM story_event_entities
+               WHERE league_id = ? AND season = ? AND event_id = ?
+               ORDER BY entity_type, role, entity_id""",
+            (self.league_id, self.season, event_id),
+        ).fetchall()
+        entity_text = " ".join(
+            " ".join(
+                str(value)
+                for value in [
+                    entity["entity_type"],
+                    entity["entity_id"],
+                    entity["display_name"],
+                    entity["role"],
+                ]
+                if value
+            )
+            for entity in entity_rows
+        )
+        self._insert_fts_row(
+            owner_type="event",
+            owner_id=event_id,
+            headline=row["headline"],
+            summary=row["summary"],
+            tags=" ".join([row["event_type"], row["confidence"]]),
+            entity_text=entity_text,
+            trigger_text="",
+        )
+
+    def _sync_trigger_fts(self, trigger_id: str) -> None:
+        self._delete_fts_row("trigger", trigger_id)
+        row = self._conn.execute(
+            """SELECT * FROM storyline_triggers
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, trigger_id),
+        ).fetchone()
+        if not row:
+            return
+
+        trigger_text = " ".join(
+            str(value)
+            for value in [
+                row["trigger_type"],
+                row["status"],
+                row["target_week"],
+                row["condition_json"],
+                row["fire_policy"],
+                row["fired_week"],
+            ]
+            if value is not None
+        )
+        entity_text = " ".join(
+            str(value)
+            for value in [row["storyline_id"], row["event_id"]]
+            if value
+        )
+        self._insert_fts_row(
+            owner_type="trigger",
+            owner_id=trigger_id,
+            headline=row["trigger_type"],
+            summary=row["condition_json"] or "",
+            tags=row["status"],
+            entity_text=entity_text,
+            trigger_text=trigger_text,
+        )
+
+    def _delete_fts_row(self, owner_type: str, owner_id: str) -> None:
+        self._conn.execute(
+            """DELETE FROM story_memory_fts
+               WHERE owner_type = ? AND owner_id = ?
+               AND league_id = ? AND season = ?""",
+            (owner_type, owner_id, self.league_id, self.season),
+        )
+
+    def _insert_fts_row(
+        self,
+        *,
+        owner_type: str,
+        owner_id: str,
+        headline: str,
+        summary: str,
+        tags: str,
+        entity_text: str,
+        trigger_text: str,
+    ) -> None:
+        self._conn.execute(
+            """INSERT INTO story_memory_fts
+                   (owner_type, owner_id, league_id, season, headline, summary,
+                    tags, entity_text, trigger_text)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                owner_type,
+                owner_id,
+                self.league_id,
+                self.season,
+                headline,
+                summary,
+                tags,
+                entity_text,
+                trigger_text,
+            ),
+        )
+
+    def _scoped_ids(self, table_name: str) -> list[str]:
+        cur = self._conn.execute(
+            f"""SELECT id FROM {table_name}
+                WHERE league_id = ? AND season = ?
+                ORDER BY id""",
+            (self.league_id, self.season),
+        )
+        return [row["id"] for row in cur.fetchall()]
+
+    @staticmethod
+    def _json_text(value: Any, default: Any) -> str:
+        if value is None:
+            value = default
+        if isinstance(value, str):
+            return value
+        return json.dumps(value)

--- a/reporter_memory/tests/test_context_store.py
+++ b/reporter_memory/tests/test_context_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,103 @@ from reporter_memory.context_store import ContextStore, SCHEMA_VERSION
 def store(tmp_path: Path) -> ContextStore:
     """Create a ContextStore backed by a temp file."""
     return ContextStore(tmp_path / "context.db", league_id="123", season="2024")
+
+
+def create_schema_21_db(db_path: Path) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE context_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE storylines (
+            id TEXT NOT NULL,
+            league_id TEXT NOT NULL,
+            season TEXT NOT NULL,
+            headline TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            priority INTEGER NOT NULL DEFAULT 2,
+            tags TEXT,
+            team_ids TEXT,
+            week_created INTEGER NOT NULL,
+            week_last_updated INTEGER NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (league_id, season, id)
+        );
+        CREATE TABLE team_context (
+            league_id TEXT NOT NULL,
+            season TEXT NOT NULL,
+            roster_id INTEGER NOT NULL,
+            narrative TEXT NOT NULL,
+            outlook TEXT,
+            week_last_updated INTEGER NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (league_id, season, roster_id)
+        );
+        CREATE TABLE league_context (
+            league_id TEXT NOT NULL,
+            season TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            week_last_updated INTEGER NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (league_id, season, key)
+        );
+        CREATE TABLE storyline_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            storyline_id TEXT NOT NULL,
+            league_id TEXT NOT NULL,
+            season TEXT NOT NULL,
+            headline TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL,
+            week INTEGER NOT NULL,
+            snapshot_at TEXT NOT NULL
+        );
+        CREATE TABLE persisted_facts (
+            storyline_id TEXT NOT NULL,
+            week_recorded INTEGER NOT NULL,
+            fact_id TEXT NOT NULL,
+            league_id TEXT NOT NULL,
+            season TEXT NOT NULL,
+            claim_text TEXT NOT NULL,
+            data_refs TEXT,
+            numbers TEXT,
+            category TEXT NOT NULL DEFAULT 'general',
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (league_id, season, storyline_id, week_recorded, fact_id)
+        );
+        INSERT INTO context_meta (key, value) VALUES ('schema_version', '2.1');
+        INSERT INTO storylines
+            (id, league_id, season, headline, summary, status, priority,
+             tags, team_ids, week_created, week_last_updated, created_at, updated_at)
+        VALUES
+            ('s1', '123', '2024', 'Old Story', 'Old summary', 'active', 2,
+             '["trade"]', '[3]', 4, 6, 'created', 'updated');
+        INSERT INTO team_context
+            (league_id, season, roster_id, narrative, outlook,
+             week_last_updated, updated_at)
+        VALUES ('123', '2024', 3, 'Old team note', 'contending', 6, 'updated');
+        INSERT INTO league_context
+            (league_id, season, key, value, week_last_updated, updated_at)
+        VALUES ('123', '2024', 'theme', 'Old league note', 6, 'updated');
+        INSERT INTO storyline_history
+            (storyline_id, league_id, season, headline, summary,
+             status, priority, week, snapshot_at)
+        VALUES ('s1', '123', '2024', 'Older Story', 'Older summary',
+                'active', 2, 5, 'snapshot');
+        INSERT INTO persisted_facts
+            (storyline_id, week_recorded, fact_id, league_id, season,
+             claim_text, data_refs, numbers, category, created_at)
+        VALUES ('s1', 6, 'f1', '123', '2024', 'Old fact',
+                '["source"]', '{"points": 10}', 'score', 'created');
+        """
+    )
+    conn.close()
 
 
 class TestSchemaCreation:
@@ -27,6 +126,12 @@ class TestSchemaCreation:
         assert "context_meta" in tables
         assert "storyline_history" in tables
         assert "persisted_facts" in tables
+        assert "story_events" in tables
+        assert "story_event_entities" in tables
+        assert "storyline_event_links" in tables
+        assert "storyline_triggers" in tables
+        assert "story_memory_fts" in tables
+        assert "memory_accesses" in tables
 
     def test_sets_schema_version(self, store: ContextStore):
         cur = store._conn.execute(
@@ -153,6 +258,33 @@ class TestStorylines:
         stories = store.get_active_storylines()
         assert stories[0]["priority"] == 1
         assert stories[1]["priority"] == 3
+
+    def test_v3_storyline_fields_round_trip(self, store: ContextStore):
+        store.upsert_storyline(
+            {
+                "id": "trade_arc",
+                "headline": "The Trade Receipt Comes Due",
+                "summary": "A Week 3 trade now has a playoff callback.",
+                "status": "active",
+                "priority": 1,
+                "importance": 9,
+                "arc_type": "trade_regret",
+                "origin_week": 3,
+                "future_callback_condition": "Player faces former manager.",
+                "tags": ["trade", "receipt"],
+                "team_ids": [1, 4],
+            },
+            week=8,
+        )
+
+        story = store.get_active_storylines()[0]
+
+        assert story["importance"] == 9
+        assert story["arc_type"] == "trade_regret"
+        assert story["origin_week"] == 3
+        assert story["future_callback_condition"] == "Player faces former manager."
+        assert story["last_accessed_week"] is None
+        assert story["last_accessed_at"] is None
 
 
 class TestTeamContext:
@@ -471,6 +603,203 @@ class TestPersistedFacts:
         store_b.close()
 
 
+class TestV3MemoryStructures:
+    def test_story_event_entities_links_triggers_and_accesses(
+        self, store: ContextStore
+    ):
+        store.upsert_storyline(
+            {
+                "id": "story_trade",
+                "headline": "Trade Arc",
+                "summary": "A trade arc worth remembering.",
+                "status": "active",
+            },
+            week=3,
+        )
+        store.upsert_story_event(
+            {
+                "id": "event_trade_1",
+                "week": 3,
+                "event_type": "trade",
+                "headline": "Team A sends Player X away",
+                "summary": "Team A traded Player X to Team B.",
+                "importance": 7,
+                "confidence": "verified",
+                "source_refs": ["transactions:week=3"],
+                "numbers": {"assets": 2},
+                "transaction_id": "txn_123",
+            }
+        )
+        store.replace_story_event_entities(
+            "event_trade_1",
+            [
+                {
+                    "entity_type": "team",
+                    "entity_id": "1",
+                    "display_name": "Team A",
+                    "role": "seller",
+                },
+                {
+                    "entity_type": "player",
+                    "entity_id": "player_x",
+                    "display_name": "Player X",
+                    "role": "asset_sent",
+                },
+            ],
+        )
+        store.link_storyline_event("story_trade", "event_trade_1", "origin")
+        store.upsert_storyline_trigger(
+            {
+                "id": "trigger_trade_callback",
+                "storyline_id": "story_trade",
+                "event_id": "event_trade_1",
+                "trigger_type": "trade_evaluation",
+                "target_week": 9,
+                "condition": {"player_id": "player_x", "former_roster_id": 1},
+                "fire_policy": "one_shot",
+            }
+        )
+        access_id = store.record_memory_access(
+            owner_type="storyline",
+            owner_id="story_trade",
+            week=9,
+            usage="research_context",
+            linked_storyline_id="brief_story",
+            fact_links=["fact_trade"],
+            reason="Relevant trade callback.",
+        )
+
+        event = store._conn.execute(
+            """SELECT * FROM story_events
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (store.league_id, store.season, "event_trade_1"),
+        ).fetchone()
+        assert event["importance"] == 7
+        assert json.loads(event["source_refs_json"]) == ["transactions:week=3"]
+        assert json.loads(event["numbers_json"]) == {"assets": 2}
+
+        entities = store._conn.execute(
+            """SELECT entity_type, entity_id, display_name, role
+               FROM story_event_entities
+               WHERE league_id = ? AND season = ? AND event_id = ?
+               ORDER BY entity_type, entity_id""",
+            (store.league_id, store.season, "event_trade_1"),
+        ).fetchall()
+        assert [dict(row) for row in entities] == [
+            {
+                "entity_type": "player",
+                "entity_id": "player_x",
+                "display_name": "Player X",
+                "role": "asset_sent",
+            },
+            {
+                "entity_type": "team",
+                "entity_id": "1",
+                "display_name": "Team A",
+                "role": "seller",
+            },
+        ]
+
+        link = store._conn.execute(
+            """SELECT link_type FROM storyline_event_links
+               WHERE league_id = ? AND season = ? AND storyline_id = ?
+               AND event_id = ?""",
+            (store.league_id, store.season, "story_trade", "event_trade_1"),
+        ).fetchone()
+        assert link["link_type"] == "origin"
+
+        trigger = store._conn.execute(
+            """SELECT * FROM storyline_triggers
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (store.league_id, store.season, "trigger_trade_callback"),
+        ).fetchone()
+        assert trigger["status"] == "open"
+        assert trigger["target_week"] == 9
+        assert json.loads(trigger["condition_json"]) == {
+            "player_id": "player_x",
+            "former_roster_id": 1,
+        }
+
+        access = store._conn.execute(
+            "SELECT * FROM memory_accesses WHERE id = ?",
+            (access_id,),
+        ).fetchone()
+        assert access["usage"] == "research_context"
+        assert json.loads(access["fact_links_json"]) == ["fact_trade"]
+        assert store.get_active_storylines()[0]["last_accessed_week"] == 9
+
+    def test_verified_story_event_requires_source_refs(self, store: ContextStore):
+        with pytest.raises(ValueError, match="source ref"):
+            store.upsert_story_event(
+                {
+                    "id": "event_no_source",
+                    "week": 1,
+                    "event_type": "trade",
+                    "headline": "Unsupported event",
+                    "summary": "This claims verification without a source.",
+                    "confidence": "verified",
+                }
+            )
+
+    def test_fts_rows_are_replaced_not_duplicated(self, store: ContextStore):
+        store.upsert_storyline(
+            {
+                "id": "story_fts",
+                "headline": "Original Headline",
+                "summary": "Original summary.",
+                "status": "active",
+            },
+            week=1,
+        )
+        store.upsert_storyline(
+            {
+                "id": "story_fts",
+                "headline": "Updated Headline",
+                "summary": "Updated summary.",
+                "status": "active",
+            },
+            week=2,
+        )
+
+        rows = store._conn.execute(
+            """SELECT owner_type, owner_id, headline
+               FROM story_memory_fts
+               WHERE league_id = ? AND season = ?
+               AND owner_type = 'storyline' AND owner_id = 'story_fts'""",
+            (store.league_id, store.season),
+        ).fetchall()
+
+        assert len(rows) == 1
+        assert rows[0]["headline"] == "Updated Headline"
+
+    def test_rebuild_story_memory_fts(self, store: ContextStore):
+        store.upsert_storyline(
+            {
+                "id": "story_rebuild",
+                "headline": "Rebuild Me",
+                "summary": "This should be reindexed.",
+                "status": "active",
+            },
+            week=1,
+        )
+        store._conn.execute(
+            """DELETE FROM story_memory_fts
+               WHERE league_id = ? AND season = ?""",
+            (store.league_id, store.season),
+        )
+        store._conn.commit()
+
+        store.rebuild_story_memory_fts()
+
+        count = store._conn.execute(
+            """SELECT COUNT(*) AS count FROM story_memory_fts
+               WHERE league_id = ? AND season = ?
+               AND owner_type = 'storyline' AND owner_id = 'story_rebuild'""",
+            (store.league_id, store.season),
+        ).fetchone()["count"]
+        assert count == 1
+
+
 class TestEnrichedStorylines:
     def test_includes_history_and_facts(self, store: ContextStore):
         store.upsert_storyline(
@@ -599,10 +928,51 @@ class TestStorylineSummaries:
 
 
 class TestSchemaMigration:
+    def test_migrates_schema_21_to_3(self, tmp_path: Path):
+        db_path = tmp_path / "schema21.db"
+        create_schema_21_db(db_path)
+
+        store = ContextStore(db_path, league_id="123", season="2024")
+
+        version = store._conn.execute(
+            "SELECT value FROM context_meta WHERE key = 'schema_version'"
+        ).fetchone()["value"]
+        tables = {
+            row["name"]
+            for row in store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        story = store.get_active_storylines()[0]
+
+        assert version == SCHEMA_VERSION
+        assert "story_events" in tables
+        assert "story_event_entities" in tables
+        assert "storyline_event_links" in tables
+        assert "storyline_triggers" in tables
+        assert "story_memory_fts" in tables
+        assert "memory_accesses" in tables
+        assert story["headline"] == "Old Story"
+        assert story["importance"] == 4
+        assert story["origin_week"] == 4
+        assert story["arc_type"] is None
+        assert story["future_callback_condition"] is None
+        assert store.get_team_context(3)["narrative"] == "Old team note"
+        assert store.get_league_context()["theme"] == "Old league note"
+        assert store.get_storyline_history("s1")[0]["headline"] == "Older Story"
+        assert store.get_storyline_facts("s1")[0]["claim_text"] == "Old fact"
+
+        fts_row = store._conn.execute(
+            """SELECT headline FROM story_memory_fts
+               WHERE league_id = ? AND season = ?
+               AND owner_type = 'storyline' AND owner_id = 's1'""",
+            (store.league_id, store.season),
+        ).fetchone()
+        assert fts_row["headline"] == "Old Story"
+        store.close()
+
     def test_legacy_schema_is_rejected(self, tmp_path: Path):
         """Old schema versions are rejected instead of migrated."""
-        import sqlite3
-
         db_path = tmp_path / "legacy.db"
         conn = sqlite3.connect(str(db_path))
         # Create v1 schema manually (without new tables)

--- a/reporter_v2/README.md
+++ b/reporter_v2/README.md
@@ -135,10 +135,10 @@ By default, outputs are written to `.output/`:
 Persistent narrative context is stored in `.data/context.db` unless overridden
 with `REPORTER_DATA_DIR` or `--data-dir`.
 
-The memory database uses `reporter_memory` schema `2.1`. Storyline IDs, history,
-and persisted facts are scoped by league and season. Old context DB schemas are
-not migrated; delete or recreate `.data/context.db` if you see an unsupported
-schema-version error.
+The memory database uses `reporter_memory` schema `3`. Storyline IDs, history,
+persisted facts, events, triggers, and access records are scoped by league and
+season. Schema `2.1` databases are migrated in place; older schemas are not
+supported.
 
 There is no `sleeperdl context` or `sleeperdl memory` surface. Reporter v2 reads
 and writes memory through its persistent tools backed by

--- a/reporter_v2/docs/impl/phase-8-persistent-context.md
+++ b/reporter_v2/docs/impl/phase-8-persistent-context.md
@@ -16,9 +16,10 @@ context, league notes) via `reporter_memory.ContextStore`.
 V2 adds **read tools** that v1 didn't have as explicit tools (v1 injected context
 into the prompt). V2 makes them tool-callable so the model can load them on demand.
 
-The backing store lives in `reporter_memory/` and uses schema `2.1`. Storyline
-identity, storyline history, and persisted facts are scoped by
-`(league_id, season, id)`. Legacy `.data/context.db` files are not migrated.
+The backing store lives in `reporter_memory/` and uses schema `3`. Storyline
+identity, storyline history, persisted facts, events, triggers, and access
+records are scoped by league and season. Schema `2.1` databases are migrated in
+place; older schemas remain unsupported.
 
 ## `reporter_v2/runner/tools/persistent_tools.py`
 

--- a/reporter_v2/docs/long-running-storyline-memory-architecture.md
+++ b/reporter_v2/docs/long-running-storyline-memory-architecture.md
@@ -1,9 +1,9 @@
 # Long-Running Storyline Memory: Architecture
 
-> Part 1 implemented: memory now lives in `reporter_memory/`, datalayer memory
-> shims and `sleeperdl` memory commands were removed, and schema `2.1` scopes
-> existing storylines/history/facts by league and season. The v3 event/search
-> architecture below remains future work.
+> Parts 1-4 implemented: memory now lives in `reporter_memory/`, datalayer
+> memory shims and `sleeperdl` memory commands were removed, schema `3` adds
+> event/entity/link/trigger/FTS tables, and reporter v2 persists brief facts
+> after submitted runs. The search/tool surface below remains future work.
 
 ## Purpose
 

--- a/reporter_v2/docs/long-running-storyline-memory-prompting.md
+++ b/reporter_v2/docs/long-running-storyline-memory-prompting.md
@@ -5,9 +5,8 @@
 Improve `reporter-v2` memory behavior on top of the current `reporter_memory`
 storage layer.
 
-This pass uses the current persistent context tools and schema `2.1`, but
-changes the agent's workflow so it treats persistent memory as research leads,
-not truth.
+This pass uses the current persistent context tools and storage layer, but changes
+the agent's workflow so it treats persistent memory as research leads, not truth.
 
 ## Core Decisions
 

--- a/reporter_v2/docs/runner-design.md
+++ b/reporter_v2/docs/runner-design.md
@@ -104,8 +104,9 @@ tools get `reporter_memory.ContextStore`.
 | **Persistent context** | `save_persistent_storyline`, `save_team_context`, `save_league_note`, `load_persistent_storylines`, `load_team_context`, `load_league_notes` |
 
 Persistent context is implemented in `reporter_memory/`, not `datalayer/`.
-Schema `2.1` scopes storylines, history, and persisted facts by league and
-season. Old `.data/context.db` files should be recreated instead of migrated.
+Schema `3` scopes storylines, history, persisted facts, events, triggers, and
+access records by league and season. Schema `2.1` databases are migrated in
+place; older schemas remain unsupported.
 
 ## Example Flow
 

--- a/reporter_v2/docs/runner-implementation.md
+++ b/reporter_v2/docs/runner-implementation.md
@@ -55,7 +55,7 @@ reporter_v2/
 
 reporter_memory/
   __init__.py
-  context_store.py      # ContextStore, schema 2.1, scoped memory tables
+  context_store.py      # ContextStore, schema 3, scoped memory tables
   context_tools.py      # legacy-style memory tool specs/handlers
   tests/
     test_context_store.py

--- a/reporter_v2/procedures/storyline.md
+++ b/reporter_v2/procedures/storyline.md
@@ -93,7 +93,7 @@ Persist an arc only if it has either a plausible future callback condition or cl
 - `rivalry_escalation`
 - `lineup_mistake_repeat`
 
-When schema fields do not exist for arc metadata, use structured text in the persistent storyline summary:
+When persistent tool fields do not exist for arc metadata, use structured text in the persistent storyline summary:
 
 ```text
 Arc type: trade_regret

--- a/reporter_v2/runner/entrypoint.py
+++ b/reporter_v2/runner/entrypoint.py
@@ -12,7 +12,7 @@ from datalayer.sleeper_data import SleeperLeagueData
 from datalayer.sleeper_data.queries._resolvers import resolve_roster_id
 from reporter_v2.config import ReportConfig
 from reporter_v2.runner.runner import CompletionFn, Runner
-from reporter_v2.runner.schemas import ArticleOutput
+from reporter_v2.runner.schemas import ArticleOutput, ReportBrief
 from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
 from reporter_v2.runner.tools.article_tools import register_article_tools
 from reporter_v2.runner.tools.brief_tools import register_brief_tools
@@ -72,7 +72,34 @@ async def generate_article(
     runner.artifacts.brief.meta.week_start = config.time_range.week_start
     runner.artifacts.brief.meta.week_end = config.time_range.week_end
 
-    return await runner.run(_build_system_prompt(), _build_user_message(config))
+    output = await runner.run(_build_system_prompt(), _build_user_message(config))
+    if context_store is not None and output.run_log_summary.get("submitted") is True:
+        _persist_brief_facts(context_store, output.brief, week=week)
+    return output
+
+
+def _persist_brief_facts(
+    context_store: ContextStore,
+    brief: ReportBrief,
+    *,
+    week: int,
+) -> None:
+    """Persist verified brief facts under their final brief storylines."""
+    for storyline in brief.storylines:
+        facts = [brief.get_fact(fact_id) for fact_id in storyline.supporting_fact_ids]
+        payload = [
+            {
+                "id": fact.id,
+                "claim_text": fact.claim_text,
+                "data_refs": fact.data_refs,
+                "numbers": fact.numbers,
+                "category": fact.category,
+            }
+            for fact in facts
+            if fact is not None
+        ]
+        if payload:
+            context_store.persist_facts(payload, storyline.id, week=week)
 
 
 def _build_system_prompt() -> str:

--- a/reporter_v2/tests/test_integration.py
+++ b/reporter_v2/tests/test_integration.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from reporter_memory.context_store import ContextStore
 from reporter_v2.config import ReportConfig, TimeRange
-from reporter_v2.runner.entrypoint import generate_article
+from reporter_v2.runner.entrypoint import _persist_brief_facts, generate_article
 from reporter_v2.runner.models import ToolCall
+from reporter_v2.runner.schemas import Fact, ReportBrief, Storyline
 
 
 class FakeCompletion:
@@ -80,6 +83,68 @@ def tool_call(
 
 def run(coro: Any) -> Any:
     return asyncio.run(coro)
+
+
+def make_persistence_completion(*, submit: bool = True) -> FakeCompletion:
+    responses = [
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "save_fact",
+                    {
+                        "id": "fact_score",
+                        "claim_text": "Team Taco beat Waiver Wire 142.3-98.7.",
+                        "data_refs": ["league_snapshot:week=8"],
+                        "numbers": {"winner_points": 142.3, "loser_points": 98.7},
+                        "category": "score",
+                    },
+                    "call_fact_score",
+                ),
+                tool_call(
+                    "save_fact",
+                    {
+                        "id": "fact_record",
+                        "claim_text": "Team Taco improved to 7-1.",
+                        "data_refs": ["league_snapshot:week=8"],
+                        "numbers": {"wins": 7, "losses": 1},
+                        "category": "standing",
+                    },
+                    "call_fact_record",
+                ),
+            ]
+        ),
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "save_storyline",
+                    {
+                        "id": "story_taco",
+                        "headline": "Taco Takes Control",
+                        "summary": "Team Taco paired a blowout win with a 7-1 record.",
+                        "supporting_fact_ids": ["fact_score", "fact_record"],
+                        "priority": 1,
+                        "tags": ["blowout", "standings"],
+                    },
+                    "call_story",
+                )
+            ]
+        ),
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "write_section",
+                    {
+                        "name": "lead",
+                        "content": "# Taco Takes Control\n\nTeam Taco won big.",
+                    },
+                    "call_write",
+                )
+            ]
+        ),
+    ]
+    if submit:
+        responses.append(make_response(tool_calls=[tool_call("submit_article")]))
+    return FakeCompletion(responses)
 
 
 def test_generate_article_end_to_end_tool_loop() -> None:
@@ -299,3 +364,122 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
     ]
     assert output.brief.facts[0].id == "fact_late"
     assert "Team Taco was 7-1" in output.article
+
+
+def test_generate_article_persists_storyline_facts_after_submit(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        output = run(
+            generate_article(
+                FakeSleeperLeagueData(),
+                ReportConfig(time_range=TimeRange.single_week(8)),
+                context_store=context_store,
+                complete=make_persistence_completion(),
+            )
+        )
+
+        facts = context_store.get_storyline_facts("story_taco")
+        facts_by_id = {fact["fact_id"]: fact for fact in facts}
+
+        assert output.run_log_summary["submitted"] is True
+        assert set(facts_by_id) == {"fact_score", "fact_record"}
+        assert facts_by_id["fact_score"]["claim_text"] == (
+            "Team Taco beat Waiver Wire 142.3-98.7."
+        )
+        assert facts_by_id["fact_score"]["numbers"] == {
+            "winner_points": 142.3,
+            "loser_points": 98.7,
+        }
+    finally:
+        context_store.close()
+
+
+def test_generate_article_post_run_fact_persistence_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        for _ in range(2):
+            run(
+                generate_article(
+                    FakeSleeperLeagueData(),
+                    ReportConfig(time_range=TimeRange.single_week(8)),
+                    context_store=context_store,
+                    complete=make_persistence_completion(),
+                )
+            )
+
+        facts = context_store.get_storyline_facts("story_taco")
+
+        assert {fact["fact_id"] for fact in facts} == {"fact_score", "fact_record"}
+    finally:
+        context_store.close()
+
+
+def test_persist_brief_facts_skips_missing_supporting_fact_ids(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    brief = ReportBrief(
+        facts=[
+            Fact(
+                id="fact_saved",
+                claim_text="A supported fact.",
+                data_refs=["source"],
+            )
+        ],
+        storylines=[
+            Storyline(
+                id="story_partial",
+                headline="Partial Story",
+                summary="One support ID is stale.",
+                supporting_fact_ids=["fact_saved", "fact_missing"],
+            )
+        ],
+    )
+    try:
+        _persist_brief_facts(context_store, brief, week=8)
+
+        facts = context_store.get_storyline_facts("story_partial")
+
+        assert [fact["fact_id"] for fact in facts] == ["fact_saved"]
+    finally:
+        context_store.close()
+
+
+def test_generate_article_does_not_persist_facts_without_submit(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        output = run(
+            generate_article(
+                FakeSleeperLeagueData(),
+                ReportConfig(time_range=TimeRange.single_week(8)),
+                context_store=context_store,
+                complete=make_persistence_completion(submit=False),
+            )
+        )
+
+        assert output.run_log_summary["submitted"] is False
+        assert context_store.get_storyline_facts("story_taco") == []
+    finally:
+        context_store.close()


### PR DESCRIPTION
## Summary
- upgrade reporter memory to schema 3 with event/entity/link/trigger/FTS/access storage
- migrate schema 2.1 databases in place while preserving existing memory
- persist submitted reporter v2 brief facts back into storyline memory after successful runs
- update docs and procedures for schema 3 behavior

## Tests
- `mise exec python@3.11.14 -- python -m pytest -q`
