### PR TITLE
feat: add agent-facing story memory search and write tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ reporter/
 └── ...                            # Deprecated v1 reporter source
 
 reporter_memory/
-├── context_store.py              # Persistent memory store
+├── context_store.py              # Persistent memory SQL/CRUD store
+├── search.py                     # Agent-facing search, ranking, candidate expansion
 ├── context_tools.py              # Legacy-style memory tool definitions/handlers
 └── tests/                        # Reporter memory tests
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ datalayer/          # Sleeper API data layer
   cli/              # sleeperdl CLI
 
 reporter_memory/    # Persistent narrative memory for reporter-generated context
-  context_store.py  # ContextStore, schema 3, league/season-scoped memory
+  context_store.py  # ContextStore schema/SQL CRUD (schema 3)
+  search.py         # Search, ranking, and candidate expansion
   context_tools.py  # Legacy-style memory tool handlers for integrations
 
 reporter_v2/        # Supported AI reporter agent

--- a/reporter_memory/README.md
+++ b/reporter_memory/README.md
@@ -7,9 +7,10 @@ in-memory SQLite, while narrative context is persisted in `.data/context.db`.
 
 ## Package Contents
 
-- `context_store.py` — `ContextStore` and schema version `3`.
+- `context_store.py` — `ContextStore` schema/SQL CRUD (schema version `3`).
+- `search.py` — agent-facing search, ranking, and candidate expansion.
 - `context_tools.py` — legacy-style memory tool specs and handlers.
-- `tests/` — store and scoping regression tests.
+- `tests/` — store and search regression tests.
 
 ## Schema Behavior
 
@@ -24,7 +25,7 @@ schema version.
 ## Usage
 
 ```python
-from reporter_memory import ContextStore
+from reporter_memory import ContextStore, search_story_memory
 
 store = ContextStore(".data/context.db", league_id="123", season="2026")
 store.upsert_storyline(
@@ -39,8 +40,17 @@ store.upsert_storyline(
     },
     week=8,
 )
+
+leads = search_story_memory(
+    store,
+    week=8,
+    query="playoff surge",
+    current_entities=[{"entity_type": "team", "entity_id": "1"}],
+)
 ```
 
-Reporter v2 registers model-facing persistent tools from
-`reporter_v2/runner/tools/persistent_tools.py`; direct use of `ContextStore` is
-mainly for scripts, tests, and skills that operate outside the v2 runner.
+Reporter v2 registers model-facing tools from
+`reporter_v2/runner/tools/memory_tools.py` (search/write) and
+`reporter_v2/runner/tools/persistent_tools.py` (legacy load/save). Direct use of
+`ContextStore` / `search_story_memory` is mainly for scripts, tests, and skills
+that operate outside the v2 runner.

--- a/reporter_memory/__init__.py
+++ b/reporter_memory/__init__.py
@@ -1,5 +1,11 @@
 """Persistent memory for reporter-generated narrative context."""
 
-from reporter_memory.context_store import ContextStore, SCHEMA_VERSION
+from reporter_memory.context_store import SCHEMA_VERSION, ContextStore
+from reporter_memory.search import get_memory_candidate, search_story_memory
 
-__all__ = ["ContextStore", "SCHEMA_VERSION"]
+__all__ = [
+    "ContextStore",
+    "SCHEMA_VERSION",
+    "get_memory_candidate",
+    "search_story_memory",
+]

--- a/reporter_memory/context_store.py
+++ b/reporter_memory/context_store.py
@@ -895,6 +895,219 @@ class ContextStore:
         self._conn.commit()
         return int(cur.lastrowid)
 
+    def get_story_event(self, event_id: str) -> dict[str, Any] | None:
+        """Return one story event with parsed JSON fields, or None."""
+        row = self._conn.execute(
+            """SELECT * FROM story_events
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, event_id),
+        ).fetchone()
+        if not row:
+            return None
+        return self._event_row_to_dict(row)
+
+    def get_story_event_entities(self, event_id: str) -> list[dict[str, Any]]:
+        """Return normalized entity links for one story event."""
+        cur = self._conn.execute(
+            """SELECT entity_type, entity_id, display_name, role
+               FROM story_event_entities
+               WHERE league_id = ? AND season = ? AND event_id = ?
+               ORDER BY entity_type, role, entity_id""",
+            (self.league_id, self.season, event_id),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def get_storyline_events(self, storyline_id: str) -> list[dict[str, Any]]:
+        """Return events linked to a storyline, including link_type."""
+        cur = self._conn.execute(
+            """SELECT e.*, l.link_type
+               FROM storyline_event_links l
+               JOIN story_events e
+                 ON e.league_id = l.league_id
+                AND e.season = l.season
+                AND e.id = l.event_id
+               WHERE l.league_id = ? AND l.season = ? AND l.storyline_id = ?
+               ORDER BY e.week ASC, e.id ASC""",
+            (self.league_id, self.season, storyline_id),
+        )
+        results = []
+        for row in cur.fetchall():
+            event = self._event_row_to_dict(row)
+            event["link_type"] = row["link_type"]
+            event["entities"] = self.get_story_event_entities(event["id"])
+            results.append(event)
+        return results
+
+    def get_storyline_triggers(
+        self,
+        storyline_id: str | None = None,
+        *,
+        status: str | None = "open",
+    ) -> list[dict[str, Any]]:
+        """Return triggers, optionally filtered by storyline and status."""
+        clauses = ["league_id = ?", "season = ?"]
+        params: list[Any] = [self.league_id, self.season]
+        if storyline_id is not None:
+            clauses.append("storyline_id = ?")
+            params.append(storyline_id)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        cur = self._conn.execute(
+            f"""SELECT * FROM storyline_triggers
+                WHERE {' AND '.join(clauses)}
+                ORDER BY target_week ASC NULLS LAST, id ASC""",
+            params,
+        )
+        return [self._trigger_row_to_dict(row) for row in cur.fetchall()]
+
+    def get_trigger(self, trigger_id: str) -> dict[str, Any] | None:
+        """Return one trigger by id, or None."""
+        row = self._conn.execute(
+            """SELECT * FROM storyline_triggers
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, trigger_id),
+        ).fetchone()
+        if not row:
+            return None
+        return self._trigger_row_to_dict(row)
+
+    def update_trigger_status(
+        self,
+        trigger_id: str,
+        *,
+        status: str,
+        fired_week: int | None = None,
+    ) -> bool:
+        """Update trigger status; returns True if a row was updated."""
+        cur = self._conn.execute(
+            """UPDATE storyline_triggers
+               SET status = ?,
+                   fired_week = COALESCE(?, fired_week),
+                   updated_at = ?
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (
+                status,
+                fired_week,
+                _now_iso(),
+                self.league_id,
+                self.season,
+                trigger_id,
+            ),
+        )
+        self._conn.commit()
+        if cur.rowcount:
+            self._sync_trigger_fts(trigger_id)
+            self._conn.commit()
+        return cur.rowcount > 0
+
+    def storyline_ids_for_event(self, event_id: str) -> list[str]:
+        """Return storyline IDs linked to an event."""
+        cur = self._conn.execute(
+            """SELECT storyline_id FROM storyline_event_links
+               WHERE league_id = ? AND season = ? AND event_id = ?
+               ORDER BY storyline_id""",
+            (self.league_id, self.season, event_id),
+        )
+        return [row["storyline_id"] for row in cur.fetchall()]
+
+    def find_event_entities(
+        self, entity_type: str, entity_id: str
+    ) -> list[dict[str, Any]]:
+        """Return entity rows for events matching one entity key."""
+        cur = self._conn.execute(
+            """SELECT event_id, entity_type, entity_id, display_name, role
+               FROM story_event_entities
+               WHERE league_id = ? AND season = ?
+                 AND entity_type = ? AND entity_id = ?""",
+            (self.league_id, self.season, entity_type, str(entity_id)),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def find_event_ids_by_transaction_ids(
+        self, transaction_ids: set[str] | list[str]
+    ) -> list[str]:
+        """Return event IDs with matching transaction_id values."""
+        ids = [str(value) for value in transaction_ids]
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        cur = self._conn.execute(
+            f"""SELECT id FROM story_events
+                WHERE league_id = ? AND season = ?
+                  AND transaction_id IN ({placeholders})
+                ORDER BY id""",
+            [self.league_id, self.season, *ids],
+        )
+        return [row["id"] for row in cur.fetchall()]
+
+    def find_event_ids_by_matchup_ids(
+        self, matchup_ids: set[str] | list[str]
+    ) -> list[str]:
+        """Return event IDs with matching matchup_id values."""
+        ids = [str(value) for value in matchup_ids]
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        cur = self._conn.execute(
+            f"""SELECT id FROM story_events
+                WHERE league_id = ? AND season = ?
+                  AND matchup_id IN ({placeholders})
+                ORDER BY id""",
+            [self.league_id, self.season, *ids],
+        )
+        return [row["id"] for row in cur.fetchall()]
+
+    def find_storyline_ids_by_team_id(self, team_id: int) -> list[str]:
+        """Return storyline IDs whose team_ids JSON includes team_id."""
+        cur = self._conn.execute(
+            """SELECT id, team_ids FROM storylines
+               WHERE league_id = ? AND season = ?
+               ORDER BY id""",
+            (self.league_id, self.season),
+        )
+        matches: list[str] = []
+        for row in cur.fetchall():
+            team_ids = json.loads(row["team_ids"]) if row["team_ids"] else []
+            if team_id in team_ids:
+                matches.append(row["id"])
+        return matches
+
+    def get_storyline(self, storyline_id: str) -> dict[str, Any] | None:
+        """Return one storyline dict, or None."""
+        row = self._conn.execute(
+            """SELECT * FROM storylines
+               WHERE league_id = ? AND season = ? AND id = ?""",
+            (self.league_id, self.season, storyline_id),
+        ).fetchone()
+        if not row:
+            return None
+        return self._storyline_row_to_dict(row)
+
+    def search_memory_fts(
+        self, match_query: str, *, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """Run an FTS5 MATCH against story_memory_fts.
+
+        Returns rows with owner_type, owner_id, and bm25 rank (lower is better).
+        """
+        if not match_query.strip():
+            return []
+        try:
+            cur = self._conn.execute(
+                """SELECT owner_type, owner_id,
+                          bm25(story_memory_fts) AS rank
+                   FROM story_memory_fts
+                   WHERE story_memory_fts MATCH ?
+                     AND league_id = ? AND season = ?
+                   ORDER BY rank
+                   LIMIT ?""",
+                (match_query, self.league_id, self.season, limit),
+            )
+        except sqlite3.OperationalError:
+            return []
+        return [dict(row) for row in cur.fetchall()]
+
     def rebuild_story_memory_fts(self) -> None:
         """Rebuild FTS rows for all storylines, events, and triggers in scope."""
         self._rebuild_story_memory_fts()
@@ -926,6 +1139,26 @@ class ContextStore:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _event_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+        d = dict(row)
+        d["source_refs"] = (
+            json.loads(d["source_refs_json"]) if d.get("source_refs_json") else []
+        )
+        d["numbers"] = json.loads(d["numbers_json"]) if d.get("numbers_json") else {}
+        d.pop("source_refs_json", None)
+        d.pop("numbers_json", None)
+        return d
+
+    @staticmethod
+    def _trigger_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+        d = dict(row)
+        d["condition"] = (
+            json.loads(d["condition_json"]) if d.get("condition_json") else {}
+        )
+        d.pop("condition_json", None)
+        return d
 
     @staticmethod
     def _storyline_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:

--- a/reporter_memory/search.py
+++ b/reporter_memory/search.py
@@ -1,0 +1,697 @@
+"""Agent-facing memory search and candidate expansion.
+
+Uses ContextStore for SQL/CRUD; this module owns ranking, lead shaping, and
+verification hints for reporter tools.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reporter_memory.context_store import ContextStore
+
+
+def normalize_owner_type(owner_type: str) -> str:
+    if owner_type in {"event", "story_event"}:
+        return "event"
+    return owner_type
+
+
+def get_memory_candidate(
+    store: ContextStore, owner_type: str, owner_id: str
+) -> dict[str, Any] | None:
+    """Expand one memory candidate with linked evidence and history."""
+    normalized_type = normalize_owner_type(owner_type)
+    if normalized_type == "storyline":
+        enriched = store.get_enriched_storylines([owner_id])
+        if not enriched:
+            return None
+        storyline = enriched[0]
+        events = store.get_storyline_events(owner_id)
+        return {
+            "owner_type": "storyline",
+            "owner_id": owner_id,
+            "storyline": storyline,
+            "events": events,
+            "triggers": store.get_storyline_triggers(owner_id, status=None),
+            "persisted_facts": storyline.get("facts", []),
+            "history": storyline.get("history", []),
+            "source_refs": _collect_source_refs(events),
+        }
+
+    if normalized_type == "event":
+        event = store.get_story_event(owner_id)
+        if event is None:
+            return None
+        event["entities"] = store.get_story_event_entities(owner_id)
+        linked_storyline_ids = store.storyline_ids_for_event(owner_id)
+        return {
+            "owner_type": "event",
+            "owner_id": owner_id,
+            "event": event,
+            "linked_storylines": store.get_enriched_storylines(linked_storyline_ids),
+            "triggers": [
+                trigger
+                for trigger in store.get_storyline_triggers(status=None)
+                if trigger.get("event_id") == owner_id
+            ],
+            "source_refs": event.get("source_refs", []),
+        }
+
+    if normalized_type == "trigger":
+        trigger = store.get_trigger(owner_id)
+        if trigger is None:
+            return None
+        payload: dict[str, Any] = {
+            "owner_type": "trigger",
+            "owner_id": owner_id,
+            "trigger": trigger,
+            "events": [],
+            "storyline": None,
+            "source_refs": [],
+        }
+        if trigger.get("event_id"):
+            event = store.get_story_event(trigger["event_id"])
+            if event is not None:
+                event["entities"] = store.get_story_event_entities(trigger["event_id"])
+                payload["events"] = [event]
+                payload["source_refs"] = event.get("source_refs", [])
+        if trigger.get("storyline_id"):
+            enriched = store.get_enriched_storylines([trigger["storyline_id"]])
+            payload["storyline"] = enriched[0] if enriched else None
+        return payload
+
+    return None
+
+
+def search_story_memory(
+    store: ContextStore,
+    *,
+    week: int,
+    query: str | None = None,
+    article_request: str | None = None,
+    current_entities: list[dict[str, Any]] | None = None,
+    current_events: list[dict[str, Any]] | None = None,
+    trigger_types: list[str] | None = None,
+    filters: dict[str, Any] | None = None,
+    include_resolved: bool = False,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return ranked memory leads for the current article week.
+
+    Ranking prioritizes attention; it does not select what to write.
+    """
+    filters = filters or {}
+    entity_keys = _entity_keys(current_entities or [])
+    entity_keys.update(_entity_keys_from_events(current_events or []))
+    event_type_hints = {
+        str(event.get("event_type"))
+        for event in (current_events or [])
+        if event.get("event_type")
+    }
+    transaction_ids = {
+        str(event["transaction_id"])
+        for event in (current_events or [])
+        if event.get("transaction_id")
+    }
+    matchup_ids = {
+        str(event["matchup_id"])
+        for event in (current_events or [])
+        if event.get("matchup_id")
+    }
+
+    candidates: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for trigger, match_reason in _matching_triggers(
+        store,
+        week=week,
+        entity_keys=entity_keys,
+        trigger_types=trigger_types,
+    ):
+        owner_type, owner_id = _owner_for_trigger(trigger)
+        candidate = _ensure_candidate(candidates, owner_type, owner_id)
+        candidate["matched_triggers"].append(trigger)
+        candidate["score_components"]["trigger_match"] = max(
+            candidate["score_components"]["trigger_match"],
+            30 if match_reason == "target_week" else 20,
+        )
+        if match_reason == "target_week":
+            candidate["why_now_parts"].append(
+                f"Open {trigger['trigger_type']} trigger targets week {week}."
+            )
+        else:
+            candidate["why_now_parts"].append(
+                f"Open {trigger['trigger_type']} trigger overlaps current entities."
+            )
+        candidate["why_relevant_parts"].append(
+            f"Trigger {trigger['id']} matched via {match_reason}."
+        )
+
+    for event_id, matched in _events_matching_entities(
+        store,
+        entity_keys=entity_keys,
+        transaction_ids=transaction_ids,
+        matchup_ids=matchup_ids,
+    ):
+        event = store.get_story_event(event_id)
+        if event is None:
+            continue
+        event_entities = store.get_story_event_entities(event_id)
+        for owner_type, owner_id in _owners_for_event(store, event_id):
+            candidate = _ensure_candidate(candidates, owner_type, owner_id)
+            if all(existing.get("id") != event["id"] for existing in candidate["linked_events"]):
+                candidate["linked_events"].append(event)
+            candidate["matched_entities"].extend(matched)
+            overlap = len({(e["entity_type"], e["entity_id"]) for e in matched})
+            candidate["score_components"]["entity_overlap"] = max(
+                candidate["score_components"]["entity_overlap"],
+                min(25, overlap * 5),
+            )
+            if event.get("event_type") in event_type_hints:
+                candidate["score_components"]["event_fit"] = max(
+                    candidate["score_components"]["event_fit"], 10
+                )
+            candidate["why_relevant_parts"].append(
+                f"Event {event_id} shares entities with the current week."
+            )
+            candidate["matched_entity_details"] = _unique_entities(
+                candidate.get("matched_entity_details", []) + event_entities
+            )
+
+    for storyline_id, matched in _storylines_matching_teams(store, entity_keys):
+        candidate = _ensure_candidate(candidates, "storyline", storyline_id)
+        candidate["matched_entities"].extend(matched)
+        overlap = len({(e["entity_type"], e["entity_id"]) for e in matched})
+        candidate["score_components"]["entity_overlap"] = max(
+            candidate["score_components"]["entity_overlap"],
+            min(25, overlap * 5),
+        )
+        candidate["why_relevant_parts"].append(
+            f"Storyline {storyline_id} shares team entities with the current week."
+        )
+
+    search_text = " ".join(
+        part for part in [query, article_request] if part and part.strip()
+    ).strip()
+    if search_text:
+        for owner_type, owner_id, lexical_score in _fts_matches(store, search_text):
+            candidate = _ensure_candidate(candidates, owner_type, owner_id)
+            candidate["score_components"]["lexical_score"] = max(
+                candidate["score_components"]["lexical_score"],
+                lexical_score,
+            )
+            candidate["why_relevant_parts"].append(
+                f"Lexical match for {search_text!r}."
+            )
+
+    if filters.get("arc_type"):
+        allowed = (
+            set(filters["arc_type"])
+            if isinstance(filters["arc_type"], list)
+            else {filters["arc_type"]}
+        )
+        filtered: dict[tuple[str, str], dict[str, Any]] = {}
+        for key, value in candidates.items():
+            if key[0] != "storyline":
+                filtered[key] = value
+                continue
+            storyline = store.get_storyline(key[1])
+            if storyline and storyline.get("arc_type") in allowed:
+                filtered[key] = value
+        candidates = filtered
+
+    results: list[dict[str, Any]] = []
+    for candidate in candidates.values():
+        hydrated = _hydrate_search_candidate(
+            store,
+            candidate,
+            week=week,
+            include_resolved=include_resolved,
+        )
+        if hydrated is not None:
+            results.append(hydrated)
+
+    results.sort(key=lambda item: item["score"], reverse=True)
+    return results[: max(1, limit)]
+
+
+def _collect_source_refs(events: list[dict[str, Any]]) -> list[Any]:
+    refs: list[Any] = []
+    seen: set[str] = set()
+    for event in events:
+        for ref in event.get("source_refs", []):
+            key = json.dumps(ref, sort_keys=True, default=str)
+            if key not in seen:
+                seen.add(key)
+                refs.append(ref)
+    return refs
+
+
+def _owners_for_event(
+    store: ContextStore, event_id: str
+) -> list[tuple[str, str]]:
+    storyline_ids = store.storyline_ids_for_event(event_id)
+    if storyline_ids:
+        return [("storyline", storyline_id) for storyline_id in storyline_ids]
+    return [("event", event_id)]
+
+
+def _owner_for_trigger(trigger: dict[str, Any]) -> tuple[str, str]:
+    if trigger.get("storyline_id"):
+        return "storyline", trigger["storyline_id"]
+    if trigger.get("event_id"):
+        return "event", trigger["event_id"]
+    return "trigger", trigger["id"]
+
+
+def _entity_keys(entities: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for entity in entities:
+        entity_type = entity.get("entity_type", entity.get("type"))
+        entity_id = entity.get("entity_id", entity.get("id"))
+        if entity_type is None or entity_id is None:
+            continue
+        keys.add((str(entity_type), str(entity_id).strip()))
+    return keys
+
+
+def _entity_keys_from_events(events: list[dict[str, Any]]) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for event in events:
+        keys.update(_entity_keys(event.get("entities", [])))
+        if event.get("transaction_id"):
+            keys.add(("transaction", str(event["transaction_id"])))
+        if event.get("matchup_id"):
+            keys.add(("matchup", str(event["matchup_id"])))
+    return keys
+
+
+def _condition_entity_values(condition: dict[str, Any]) -> set[str]:
+    values: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                key_l = str(key).lower()
+                if any(
+                    token in key_l
+                    for token in (
+                        "id",
+                        "roster",
+                        "team",
+                        "player",
+                        "manager",
+                        "transaction",
+                        "matchup",
+                    )
+                ):
+                    if value is not None and not isinstance(value, (dict, list)):
+                        values.add(str(value))
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(condition)
+    return values
+
+
+def _matching_triggers(
+    store: ContextStore,
+    *,
+    week: int,
+    entity_keys: set[tuple[str, str]],
+    trigger_types: list[str] | None,
+) -> list[tuple[dict[str, Any], str]]:
+    allowed_types = set(trigger_types) if trigger_types else None
+    entity_values = {entity_id for _, entity_id in entity_keys}
+    matches: list[tuple[dict[str, Any], str]] = []
+    for trigger in store.get_storyline_triggers(status="open"):
+        if allowed_types is not None and trigger["trigger_type"] not in allowed_types:
+            continue
+        if trigger.get("target_week") == week:
+            matches.append((trigger, "target_week"))
+            continue
+        condition_values = _condition_entity_values(trigger.get("condition", {}))
+        if condition_values & entity_values:
+            matches.append((trigger, "entity_overlap"))
+    return matches
+
+
+def _events_matching_entities(
+    store: ContextStore,
+    *,
+    entity_keys: set[tuple[str, str]],
+    transaction_ids: set[str],
+    matchup_ids: set[str],
+) -> list[tuple[str, list[dict[str, Any]]]]:
+    matched: dict[str, list[dict[str, Any]]] = {}
+
+    for entity_type, entity_id in entity_keys:
+        for row in store.find_event_entities(entity_type, entity_id):
+            matched.setdefault(row["event_id"], []).append(row)
+
+    for event_id in store.find_event_ids_by_transaction_ids(transaction_ids):
+        matched.setdefault(event_id, []).append(
+            {
+                "entity_type": "transaction",
+                "entity_id": event_id,
+                "display_name": None,
+                "role": "transaction",
+            }
+        )
+
+    for event_id in store.find_event_ids_by_matchup_ids(matchup_ids):
+        matched.setdefault(event_id, []).append(
+            {
+                "entity_type": "matchup",
+                "entity_id": event_id,
+                "display_name": None,
+                "role": "matchup",
+            }
+        )
+
+    return [
+        (event_id, _unique_entities(entities))
+        for event_id, entities in matched.items()
+    ]
+
+
+def _storylines_matching_teams(
+    store: ContextStore, entity_keys: set[tuple[str, str]]
+) -> list[tuple[str, list[dict[str, Any]]]]:
+    results: list[tuple[str, list[dict[str, Any]]]] = []
+    for entity_type, entity_id in entity_keys:
+        if entity_type != "team":
+            continue
+        try:
+            team_id = int(entity_id)
+        except (TypeError, ValueError):
+            continue
+        for storyline_id in store.find_storyline_ids_by_team_id(team_id):
+            results.append(
+                (
+                    storyline_id,
+                    [
+                        {
+                            "entity_type": "team",
+                            "entity_id": str(team_id),
+                            "display_name": None,
+                            "role": "team",
+                        }
+                    ],
+                )
+            )
+    return results
+
+
+def _fts_matches(
+    store: ContextStore, search_text: str
+) -> list[tuple[str, str, float]]:
+    match_query = _fts_match_query(search_text)
+    if not match_query:
+        return []
+
+    results: list[tuple[str, str, float]] = []
+    for row in store.search_memory_fts(match_query, limit=50):
+        raw = float(row["rank"])
+        lexical_score = max(1.0, min(20.0, 10.0 - raw))
+        owner_type = normalize_owner_type(row["owner_type"])
+        if owner_type == "trigger":
+            trigger = store.get_trigger(row["owner_id"])
+            if trigger is None:
+                continue
+            owner_type, owner_id = _owner_for_trigger(trigger)
+        else:
+            owner_id = row["owner_id"]
+        results.append((owner_type, owner_id, lexical_score))
+    return results
+
+
+def _fts_match_query(search_text: str) -> str:
+    tokens = [
+        token.strip().strip('"').replace('"', "")
+        for token in search_text.replace(",", " ").split()
+        if token.strip()
+    ]
+    if not tokens:
+        return ""
+    return " OR ".join(f'"{token}"' for token in tokens if token)
+
+
+def _ensure_candidate(
+    candidates: dict[tuple[str, str], dict[str, Any]],
+    owner_type: str,
+    owner_id: str,
+) -> dict[str, Any]:
+    key = (owner_type, owner_id)
+    if key not in candidates:
+        candidates[key] = {
+            "owner_type": owner_type,
+            "owner_id": owner_id,
+            "matched_triggers": [],
+            "matched_entities": [],
+            "matched_entity_details": [],
+            "linked_events": [],
+            "why_relevant_parts": [],
+            "why_now_parts": [],
+            "score_components": {
+                "trigger_match": 0.0,
+                "entity_overlap": 0.0,
+                "event_fit": 0.0,
+                "lexical_score": 0.0,
+                "importance": 0.0,
+                "confidence": 0.0,
+                "dormant_callback_boost": 0.0,
+                "light_recency_bonus": 0.0,
+                "resolved_penalty": 0.0,
+            },
+        }
+    return candidates[key]
+
+
+def _hydrate_search_candidate(
+    store: ContextStore,
+    candidate: dict[str, Any],
+    *,
+    week: int,
+    include_resolved: bool,
+) -> dict[str, Any] | None:
+    owner_type = candidate["owner_type"]
+    owner_id = candidate["owner_id"]
+    components = candidate["score_components"]
+
+    headline = None
+    summary = None
+    status = None
+    importance = 0
+    confidence = "needs_verification"
+    last_accessed_week = None
+    week_last_updated = None
+    event_type = None
+    trigger_type = None
+
+    if owner_type == "storyline":
+        storyline = store.get_storyline(owner_id)
+        if storyline is None:
+            return None
+        if storyline["status"] == "resolved" and not include_resolved:
+            return None
+        headline = storyline["headline"]
+        summary = storyline["summary"]
+        status = storyline["status"]
+        importance = int(storyline.get("importance") or 0)
+        last_accessed_week = storyline.get("last_accessed_week")
+        week_last_updated = storyline.get("week_last_updated")
+        if not candidate["linked_events"]:
+            candidate["linked_events"] = [
+                {
+                    "id": event["id"],
+                    "week": event["week"],
+                    "event_type": event["event_type"],
+                    "headline": event["headline"],
+                    "confidence": event["confidence"],
+                    "source_refs": event.get("source_refs", []),
+                    "link_type": event.get("link_type"),
+                }
+                for event in store.get_storyline_events(owner_id)
+            ]
+        if not candidate["matched_triggers"]:
+            candidate["matched_triggers"] = store.get_storyline_triggers(owner_id)
+
+    elif owner_type == "event":
+        event = store.get_story_event(owner_id)
+        if event is None:
+            return None
+        headline = event["headline"]
+        summary = event["summary"]
+        status = event["confidence"]
+        importance = int(event.get("importance") or 0)
+        confidence = event.get("confidence", "needs_verification")
+        last_accessed_week = event.get("last_accessed_week")
+        week_last_updated = event.get("week")
+        event_type = event.get("event_type")
+        if all(existing.get("id") != event["id"] for existing in candidate["linked_events"]):
+            candidate["linked_events"] = [event]
+
+    elif owner_type == "trigger":
+        trigger = store.get_trigger(owner_id)
+        if trigger is None:
+            return None
+        headline = trigger["trigger_type"]
+        summary = json.dumps(trigger.get("condition", {}), default=str)
+        status = trigger["status"]
+        trigger_type = trigger["trigger_type"]
+        importance = 4
+        if all(
+            existing.get("id") != trigger["id"]
+            for existing in candidate["matched_triggers"]
+        ):
+            candidate["matched_triggers"] = [trigger]
+    else:
+        return None
+
+    components["importance"] = float(importance)
+    confidence_scores = {
+        "verified": 5.0,
+        "inferred": 2.0,
+        "needs_verification": 0.0,
+    }
+    if owner_type == "event":
+        components["confidence"] = confidence_scores.get(confidence, 0.0)
+    elif owner_type == "storyline" and candidate["linked_events"]:
+        components["confidence"] = max(
+            (
+                confidence_scores.get(event.get("confidence", ""), 0.0)
+                for event in candidate["linked_events"]
+            ),
+            default=0.0,
+        )
+
+    if last_accessed_week is None or (week - int(last_accessed_week)) >= 3:
+        components["dormant_callback_boost"] = 8.0
+    if week_last_updated is not None:
+        age = max(0, week - int(week_last_updated))
+        components["light_recency_bonus"] = max(0.0, 3.0 - (age * 0.25))
+    if status == "resolved":
+        components["resolved_penalty"] = 50.0
+
+    score = (
+        components["trigger_match"]
+        + components["entity_overlap"]
+        + components["event_fit"]
+        + components["lexical_score"]
+        + components["importance"]
+        + components["confidence"]
+        + components["dormant_callback_boost"]
+        + components["light_recency_bonus"]
+        - components["resolved_penalty"]
+    )
+
+    required_fact_roles, suggested_calls = _verification_hints(
+        event_type=event_type
+        or next(
+            (
+                event.get("event_type")
+                for event in candidate["linked_events"]
+                if event.get("event_type")
+            ),
+            None,
+        ),
+        trigger_type=trigger_type
+        or next(
+            (
+                trigger.get("trigger_type")
+                for trigger in candidate["matched_triggers"]
+                if trigger.get("trigger_type")
+            ),
+            None,
+        ),
+        week=week,
+    )
+
+    why_relevant = " ".join(dict.fromkeys(candidate["why_relevant_parts"])) or (
+        "Memory candidate matched current search inputs."
+    )
+    why_now = " ".join(dict.fromkeys(candidate["why_now_parts"])) or (
+        "Candidate may change meaning of current-week events."
+    )
+
+    return {
+        "owner_type": owner_type,
+        "owner_id": owner_id,
+        "headline": headline,
+        "summary": summary,
+        "status": status,
+        "score": round(score, 3),
+        "score_components": {
+            key: round(value, 3) for key, value in components.items()
+        },
+        "matched_entities": _unique_entities(
+            candidate["matched_entities"] + candidate.get("matched_entity_details", [])
+        ),
+        "matched_triggers": candidate["matched_triggers"],
+        "linked_events": candidate["linked_events"],
+        "source_refs": _collect_source_refs(candidate["linked_events"]),
+        "why_relevant": why_relevant,
+        "why_now": why_now,
+        "verification_status": (
+            "verified" if components["confidence"] >= 5 else "needs_verification"
+        ),
+        "required_fact_roles": required_fact_roles,
+        "suggested_datalayer_calls": suggested_calls,
+    }
+
+
+def _verification_hints(
+    *,
+    event_type: str | None,
+    trigger_type: str | None,
+    week: int,
+) -> tuple[list[str], list[str]]:
+    roles = ["origin_receipt", "current_payoff"]
+    calls: list[str] = []
+    kind = trigger_type or event_type
+    if kind in {"trade", "trade_evaluation"}:
+        calls.append("transactions(week_from=?, week_to=?)")
+        calls.append(f"team_game(roster_key=?, week={week})")
+    elif kind in {"rematch", "matchup"}:
+        calls.append(f"team_game(roster_key=?, week={week})")
+        calls.append("team_dossier(roster_key=?, week=?)")
+    elif kind in {"playoff_path", "playoff"}:
+        calls.append("playoff_bracket(...)")
+        calls.append("team_playoff_path(...)")
+    elif kind in {"player_against_former_team", "waiver_player_started", "waiver"}:
+        calls.append("player_weekly_log(player_key=?, week_from=?, week_to=?)")
+        calls.append(f"team_game(roster_key=?, week={week})")
+    elif kind == "standings_swing":
+        calls.append("league_snapshot(week=?)")
+        calls.append("team_dossier(roster_key=?, week=?)")
+    else:
+        calls.append(f"league_snapshot(week={week})")
+        calls.append(f"team_game(roster_key=?, week={week})")
+    return roles, calls
+
+
+def _unique_entities(entities: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for entity in entities:
+        entity_type = str(entity.get("entity_type", entity.get("type", "")))
+        entity_id = str(entity.get("entity_id", entity.get("id", "")))
+        role = str(entity.get("role", ""))
+        key = (entity_type, entity_id, role)
+        if not entity_type or not entity_id or key in seen:
+            continue
+        seen.add(key)
+        unique.append(
+            {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "display_name": entity.get("display_name", entity.get("name")),
+                "role": role,
+            }
+        )
+    return unique

--- a/reporter_memory/tests/test_search.py
+++ b/reporter_memory/tests/test_search.py
@@ -1,0 +1,181 @@
+"""Tests for reporter_memory search and candidate expansion."""
+
+from __future__ import annotations
+
+import pytest
+
+from reporter_memory.context_store import ContextStore
+from reporter_memory.search import get_memory_candidate, search_story_memory
+
+
+@pytest.fixture
+def store() -> ContextStore:
+    context_store = ContextStore(
+        ":memory:",
+        league_id="league_123",
+        season="2024",
+    )
+    yield context_store
+    context_store.close()
+
+
+def _seed_trade_arc(store: ContextStore) -> None:
+    store.upsert_storyline(
+        {
+            "id": "story_trade",
+            "headline": "Trade Arc",
+            "summary": "Team A sent Player X away and may regret it.",
+            "status": "active",
+            "importance": 8,
+            "arc_type": "trade_regret",
+            "tags": ["trade", "regret"],
+            "team_ids": [1],
+        },
+        week=3,
+    )
+    store.upsert_story_event(
+        {
+            "id": "event_trade_1",
+            "week": 3,
+            "event_type": "trade",
+            "headline": "Team A sends Player X away",
+            "summary": "Team A traded Player X to Team B.",
+            "importance": 7,
+            "confidence": "verified",
+            "source_refs": ["transactions:week=3"],
+            "transaction_id": "txn_123",
+        }
+    )
+    store.replace_story_event_entities(
+        "event_trade_1",
+        [
+            {
+                "entity_type": "team",
+                "entity_id": "1",
+                "display_name": "Team A",
+                "role": "seller",
+            },
+            {
+                "entity_type": "player",
+                "entity_id": "player_x",
+                "display_name": "Player X",
+                "role": "asset_sent",
+            },
+        ],
+    )
+    store.link_storyline_event("story_trade", "event_trade_1", "origin")
+    store.upsert_storyline_trigger(
+        {
+            "id": "trigger_trade_callback",
+            "storyline_id": "story_trade",
+            "event_id": "event_trade_1",
+            "trigger_type": "trade_evaluation",
+            "target_week": 9,
+            "condition": {"player_id": "player_x", "former_roster_id": 1},
+            "fire_policy": "one_shot",
+        }
+    )
+
+
+def test_search_by_trigger_target_week(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+
+    results = search_story_memory(store, week=9, limit=5)
+
+    assert results
+    top = results[0]
+    assert top["owner_type"] == "storyline"
+    assert top["owner_id"] == "story_trade"
+    assert top["score_components"]["trigger_match"] >= 30
+    assert any(
+        trigger["id"] == "trigger_trade_callback"
+        for trigger in top["matched_triggers"]
+    )
+
+
+def test_search_by_entity_overlap(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+
+    results = search_story_memory(
+        store,
+        week=8,
+        current_entities=[
+            {"entity_type": "player", "entity_id": "player_x"},
+        ],
+        limit=5,
+    )
+
+    assert any(item["owner_id"] == "story_trade" for item in results)
+    match = next(item for item in results if item["owner_id"] == "story_trade")
+    assert match["score_components"]["entity_overlap"] > 0
+    assert match["score_components"]["trigger_match"] >= 20
+
+
+def test_search_by_fts_query(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+
+    results = search_story_memory(
+        store,
+        week=8,
+        query="regret Player X",
+        limit=5,
+    )
+
+    assert any(item["owner_id"] == "story_trade" for item in results)
+    match = next(item for item in results if item["owner_id"] == "story_trade")
+    assert match["score_components"]["lexical_score"] > 0
+
+
+def test_search_excludes_resolved_by_default(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+    store.resolve_storyline("story_trade")
+
+    default_results = search_story_memory(store, week=9, limit=5)
+    included = search_story_memory(
+        store, week=9, include_resolved=True, limit=5
+    )
+
+    assert all(item["owner_id"] != "story_trade" for item in default_results)
+    assert any(item["owner_id"] == "story_trade" for item in included)
+
+
+def test_get_memory_candidate_expands_storyline(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+    store.persist_facts(
+        [{"id": "fact_trade", "claim_text": "Team A traded Player X."}],
+        "story_trade",
+        week=3,
+    )
+
+    candidate = get_memory_candidate(store, "storyline", "story_trade")
+
+    assert candidate is not None
+    assert candidate["owner_type"] == "storyline"
+    assert candidate["storyline"]["id"] == "story_trade"
+    assert candidate["events"][0]["id"] == "event_trade_1"
+    assert candidate["triggers"][0]["id"] == "trigger_trade_callback"
+    assert candidate["persisted_facts"][0]["fact_id"] == "fact_trade"
+    assert "transactions:week=3" in candidate["source_refs"]
+
+
+def test_search_scoped_by_league(tmp_path) -> None:
+    store_a = ContextStore(tmp_path / "ctx.db", league_id="AAA", season="2024")
+    store_b = ContextStore(tmp_path / "ctx.db", league_id="BBB", season="2024")
+    _seed_trade_arc(store_a)
+    store_b.upsert_storyline(
+        {
+            "id": "story_trade",
+            "headline": "Other League Arc",
+            "summary": "Should not leak.",
+            "status": "active",
+        },
+        week=3,
+    )
+
+    results = search_story_memory(store_a, week=9, query="regret", limit=5)
+    assert results
+    assert all(
+        item["headline"] != "Other League Arc" for item in results
+    )
+    store_a.close()
+    store_b.close()

--- a/reporter_v2/docs/long-running-storyline-memory-architecture.md
+++ b/reporter_v2/docs/long-running-storyline-memory-architecture.md
@@ -1,9 +1,12 @@
 # Long-Running Storyline Memory: Architecture
 
-> Parts 1-4 implemented: memory now lives in `reporter_memory/`, datalayer
-> memory shims and `sleeperdl` memory commands were removed, schema `3` adds
-> event/entity/link/trigger/FTS tables, and reporter v2 persists brief facts
-> after submitted runs. The search/tool surface below remains future work.
+> Parts 1-5 implemented: memory lives in `reporter_memory/` (`context_store.py`
+> for SQL/CRUD, `search.py` for ranking/candidate expansion), schema `3` adds
+> event/entity/link/trigger/FTS tables, reporter v2 persists brief facts after
+> submitted runs, and agent tools cover search plus write/usage
+> (`search_story_memory`, `get_memory_candidate`, `save_memory_event`,
+> `upsert_storyline_memory_card`, `save_storyline_trigger`, `mark_memory_used`).
+> Verification planner tools and embeddings remain future work.
 
 ## Purpose
 

--- a/reporter_v2/procedures/research.md
+++ b/reporter_v2/procedures/research.md
@@ -22,10 +22,11 @@ You are gathering verified fantasy football facts for the article brief. Use dat
 4. Run the memory scout loop when the request or data suggests long-running context:
    - Extract the current-week fact map: scores, margins, standings movement, playoff stakes, current matchups, top players, transactions, focus teams, and requested framing.
    - Generate narrative hypotheses from the current week. Ask what changed meaning, reversed, paid off, collapsed, became funny, or now has stakes.
-   - Search or load persistent memory for possible callbacks, then inspect only candidates that look promising.
+   - Prefer `search_story_memory` with current entities/events, then `get_memory_candidate` for promising leads. Use `load_persistent_storylines` only for a broad dump.
    - Verify the old event with datalayer tools or a verified memory receipt, and verify the current event with current-run datalayer facts.
    - Save old-event and current-event facts with `save_fact`, then use `save_memory_callback` if available.
    - Promote only the best verified callbacks into storylines and outline inputs.
+   - Persist durable evidence with `save_memory_event`, `upsert_storyline_memory_card`, and `save_storyline_trigger` when an arc should matter later. Mark usage with `mark_memory_used`.
 5. Call targeted tools for the strongest leads:
    - `team_game(roster_key, week=N)` for player-level detail in a specific matchup.
    - `team_dossier(roster_key, week=N)` for recent form, record, and broader context.

--- a/reporter_v2/procedures/storyline.md
+++ b/reporter_v2/procedures/storyline.md
@@ -75,10 +75,12 @@ For power rankings, build one section per rank or rank tier. For team deep dives
 
 If persistent context tools are available, save narrative state before drafting:
 
-- Use `save_persistent_storyline` for arcs likely to matter in future weeks.
+- Prefer `upsert_storyline_memory_card` for durable arcs (with evidence events and trigger specs when available). `save_persistent_storyline` remains a thinner compatibility wrapper.
+- Use `save_memory_event` for source-backed evidence and `save_storyline_trigger` for dormant callbacks.
 - Use `save_team_context` for researched teams whose trajectory changed.
 - Use `save_league_note` for league-wide context such as season themes, trade activity, or rivalries.
 - Use `save_memory_callback` for verified callbacks that belong in the brief, if the callback was not already saved during research.
+- Use `mark_memory_used` when a retrieved candidate is drafted, used as research context, or discarded.
 
 Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:
 

--- a/reporter_v2/runner/tools/__init__.py
+++ b/reporter_v2/runner/tools/__init__.py
@@ -26,6 +26,10 @@ from reporter_v2.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_SPECS,
     register_datalayer_tools,
 )
+from reporter_v2.runner.tools.memory_tools import (
+    MEMORY_TOOL_SPECS,
+    register_memory_tools,
+)
 from reporter_v2.runner.tools.persistent_tools import (
     PERSISTENT_TOOL_SPECS,
     register_persistent_tools,
@@ -41,6 +45,7 @@ __all__ = [
     "ARTICLE_TOOL_SPECS",
     "BRIEF_TOOL_SPECS",
     "DATALAYER_TOOL_SPECS",
+    "MEMORY_TOOL_SPECS",
     "PERSISTENT_TOOL_SPECS",
     "PROCEDURE_TOOL_SPECS",
     "ToolContext",
@@ -53,6 +58,7 @@ __all__ = [
     "register_brief_tools",
     "rewrite_section",
     "register_datalayer_tools",
+    "register_memory_tools",
     "register_persistent_tools",
     "register_procedure_tools",
     "save_fact",

--- a/reporter_v2/runner/tools/memory_tools.py
+++ b/reporter_v2/runner/tools/memory_tools.py
@@ -1,0 +1,553 @@
+"""Agent-facing storyline memory search and write tools."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from reporter_memory.search import get_memory_candidate, search_story_memory
+from reporter_v2.runner.models import ToolDef
+from reporter_v2.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from reporter_memory.context_store import ContextStore
+
+
+MEMORY_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_story_memory",
+            "description": (
+                "Search persistent story memory for ranked leads relevant to the "
+                "current article. Returns candidates with score components, matched "
+                "triggers/entities, and verification hints. Leads are not article-"
+                "ready facts."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "week": {
+                        "type": "integer",
+                        "description": "Article week. Defaults to the current run week.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Free-text memory search query.",
+                    },
+                    "article_request": {
+                        "type": "string",
+                        "description": "Optional article request text for lexical hints.",
+                    },
+                    "current_entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": (
+                            "Entities involved this week. Prefer "
+                            "{entity_type, entity_id, display_name?}."
+                        ),
+                    },
+                    "current_events": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": (
+                            "Current-week events with optional event_type, "
+                            "transaction_id, matchup_id, and entities."
+                        ),
+                    },
+                    "trigger_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "filters": {"type": "object"},
+                    "include_resolved": {"type": "boolean", "default": False},
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 25,
+                        "default": 10,
+                    },
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_memory_candidate",
+            "description": (
+                "Expand one memory candidate with linked events, persisted facts, "
+                "history, triggers, and source refs. Use after search_story_memory."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                    },
+                    "owner_id": {"type": "string"},
+                },
+                "required": ["owner_type", "owner_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memory_event",
+            "description": (
+                "Save source-backed event evidence for later callbacks. "
+                "confidence=verified requires at least one source_ref."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "event_type": {"type": "string"},
+                    "week": {"type": "integer"},
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "importance": {"type": "integer"},
+                    "confidence": {
+                        "type": "string",
+                        "enum": ["verified", "inferred", "needs_verification"],
+                    },
+                    "source_refs": {
+                        "type": "array",
+                        "items": {},
+                    },
+                    "numbers": {"type": "object"},
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                    "transaction_id": {"type": "string"},
+                    "matchup_id": {"type": "string"},
+                },
+                "required": ["id", "event_type", "week", "headline", "summary"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "upsert_storyline_memory_card",
+            "description": (
+                "Create or update a storyline memory card with optional evidence "
+                "event links and trigger specs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "stale", "resolved"],
+                    },
+                    "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "importance": {"type": "integer"},
+                    "arc_type": {"type": "string"},
+                    "origin_week": {"type": "integer"},
+                    "future_callback_condition": {"type": "string"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "team_keys": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": "Optional entities; team entities become team_ids.",
+                    },
+                    "evidence_event_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "trigger_specs": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                },
+                "required": ["id", "headline", "summary", "status"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_storyline_trigger",
+            "description": "Save or update a dormant callback trigger.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "storyline_id": {"type": "string"},
+                    "event_id": {"type": "string"},
+                    "trigger_type": {"type": "string"},
+                    "target_week": {"type": "integer"},
+                    "condition": {"type": "object"},
+                    "fire_policy": {
+                        "type": "string",
+                        "enum": ["one_shot", "recurring", "until_resolved"],
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["open", "fired", "expired", "resolved"],
+                    },
+                },
+                "required": ["trigger_type"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "mark_memory_used",
+            "description": (
+                "Record how a memory candidate was used this week. For one-shot "
+                "triggers, article_callback marks fired and discarded marks resolved."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {"type": "string"},
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "week": {"type": "integer"},
+                    "usage": {
+                        "type": "string",
+                        "enum": [
+                            "article_callback",
+                            "research_context",
+                            "discarded",
+                        ],
+                    },
+                    "linked_storyline_id": {"type": "string"},
+                    "fact_links": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "reason": {"type": "string"},
+                },
+                "required": ["candidate_id", "usage"],
+            },
+        },
+    },
+]
+
+
+MEMORY_TOOL_SPECS: list[ToolDef] = MEMORY_TOOLS
+
+
+def register_memory_tools(
+    registry: ToolRegistry,
+    context_store: ContextStore,
+    week: int,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+) -> None:
+    """Register search and write/usage memory tools."""
+    week_default = week
+
+    def search_story_memory_tool(
+        *,
+        week: int | None = None,
+        query: str | None = None,
+        article_request: str | None = None,
+        current_entities: list[dict[str, Any]] | None = None,
+        current_events: list[dict[str, Any]] | None = None,
+        trigger_types: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        include_resolved: bool = False,
+        limit: int = 10,
+    ) -> str:
+        results = search_story_memory(
+            context_store,
+            week=week if week is not None else week_default,
+            query=query,
+            article_request=article_request,
+            current_entities=current_entities,
+            current_events=current_events,
+            trigger_types=trigger_types,
+            filters=filters,
+            include_resolved=include_resolved,
+            limit=limit,
+        )
+        return _json({"ok": True, "candidates": results, "count": len(results)})
+
+    def get_memory_candidate_tool(*, owner_type: str, owner_id: str) -> str:
+        candidate = get_memory_candidate(context_store, owner_type, owner_id)
+        if candidate is None:
+            return _json(
+                {
+                    "ok": False,
+                    "found": False,
+                    "error": f"No candidate for {owner_type}:{owner_id}",
+                }
+            )
+        return _json({"ok": True, "found": True, "candidate": candidate})
+
+    def save_memory_event(
+        *,
+        id: str,
+        event_type: str,
+        week: int,
+        headline: str,
+        summary: str,
+        importance: int = 1,
+        confidence: str = "needs_verification",
+        source_refs: list[Any] | None = None,
+        numbers: dict[str, Any] | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        transaction_id: str | None = None,
+        matchup_id: str | None = None,
+    ) -> str:
+        try:
+            context_store.upsert_story_event(
+                {
+                    "id": id,
+                    "event_type": event_type,
+                    "week": week,
+                    "headline": headline,
+                    "summary": summary,
+                    "importance": importance,
+                    "confidence": confidence,
+                    "source_refs": source_refs or [],
+                    "numbers": numbers or {},
+                    "transaction_id": transaction_id,
+                    "matchup_id": matchup_id,
+                }
+            )
+        except ValueError as exc:
+            return _json({"ok": False, "saved": False, "error": str(exc)})
+
+        if entities is not None:
+            context_store.replace_story_event_entities(id, entities)
+        return _json({"ok": True, "saved": True, "id": id, "confidence": confidence})
+
+    def upsert_storyline_memory_card(
+        *,
+        id: str,
+        headline: str,
+        summary: str,
+        status: str,
+        priority: int = 2,
+        importance: int | None = None,
+        arc_type: str | None = None,
+        origin_week: int | None = None,
+        future_callback_condition: str | None = None,
+        tags: list[str] | None = None,
+        team_keys: list[str] | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        evidence_event_ids: list[str] | None = None,
+        trigger_specs: list[dict[str, Any]] | None = None,
+    ) -> str:
+        team_ids, unresolved_team_keys = _resolve_team_keys(
+            team_keys or [], resolve_roster_fn
+        )
+        for entity in entities or []:
+            entity_type = entity.get("entity_type", entity.get("type"))
+            if entity_type != "team":
+                continue
+            entity_id = entity.get("entity_id", entity.get("id"))
+            try:
+                team_ids.append(int(entity_id))
+            except (TypeError, ValueError):
+                unresolved_team_keys.append(str(entity_id))
+
+        # Deduplicate while preserving order.
+        deduped_team_ids = list(dict.fromkeys(team_ids))
+
+        storyline: dict[str, Any] = {
+            "id": id,
+            "headline": headline,
+            "summary": summary,
+            "status": status,
+            "priority": priority,
+            "tags": tags or [],
+            "team_ids": deduped_team_ids,
+        }
+        if importance is not None:
+            storyline["importance"] = importance
+        if arc_type is not None:
+            storyline["arc_type"] = arc_type
+        if origin_week is not None:
+            storyline["origin_week"] = origin_week
+        if future_callback_condition is not None:
+            storyline["future_callback_condition"] = future_callback_condition
+
+        context_store.upsert_storyline(storyline, week=week_default)
+
+        linked_events: list[str] = []
+        for event_id in evidence_event_ids or []:
+            context_store.link_storyline_event(id, event_id, "evidence")
+            linked_events.append(event_id)
+
+        saved_triggers: list[str] = []
+        for spec in trigger_specs or []:
+            trigger_id = spec.get("id") or f"trigger_{id}_{uuid.uuid4().hex[:8]}"
+            context_store.upsert_storyline_trigger(
+                {
+                    "id": trigger_id,
+                    "storyline_id": id,
+                    "event_id": spec.get("event_id"),
+                    "trigger_type": spec["trigger_type"],
+                    "target_week": spec.get("target_week"),
+                    "condition": spec.get("condition", {}),
+                    "fire_policy": spec.get("fire_policy", "one_shot"),
+                    "status": spec.get("status", "open"),
+                }
+            )
+            saved_triggers.append(trigger_id)
+
+        payload: dict[str, Any] = {
+            "ok": True,
+            "saved": True,
+            "id": id,
+            "status": status,
+            "team_ids": deduped_team_ids,
+            "linked_events": linked_events,
+            "triggers": saved_triggers,
+        }
+        if unresolved_team_keys:
+            payload["unresolved_team_keys"] = unresolved_team_keys
+        return _json(payload)
+
+    def save_storyline_trigger(
+        *,
+        trigger_type: str,
+        id: str | None = None,
+        storyline_id: str | None = None,
+        event_id: str | None = None,
+        target_week: int | None = None,
+        condition: dict[str, Any] | None = None,
+        fire_policy: str = "one_shot",
+        status: str = "open",
+    ) -> str:
+        trigger_id = id or f"trigger_{uuid.uuid4().hex[:12]}"
+        context_store.upsert_storyline_trigger(
+            {
+                "id": trigger_id,
+                "storyline_id": storyline_id,
+                "event_id": event_id,
+                "trigger_type": trigger_type,
+                "target_week": target_week,
+                "condition": condition or {},
+                "fire_policy": fire_policy,
+                "status": status,
+            }
+        )
+        return _json(
+            {
+                "ok": True,
+                "saved": True,
+                "id": trigger_id,
+                "trigger_type": trigger_type,
+                "status": status,
+            }
+        )
+
+    def mark_memory_used(
+        *,
+        candidate_id: str,
+        usage: str,
+        owner_type: str = "storyline",
+        week: int | None = None,
+        linked_storyline_id: str | None = None,
+        fact_links: list[str] | None = None,
+        reason: str | None = None,
+    ) -> str:
+        used_week = week if week is not None else week_default
+        normalized_type = (
+            "event" if owner_type == "story_event" else owner_type
+        )
+        access_id = context_store.record_memory_access(
+            owner_type=normalized_type,
+            owner_id=candidate_id,
+            week=used_week,
+            usage=usage,
+            linked_storyline_id=linked_storyline_id,
+            fact_links=fact_links,
+            reason=reason,
+        )
+
+        trigger_update = None
+        if normalized_type == "trigger":
+            trigger = context_store.get_trigger(candidate_id)
+            if trigger and trigger.get("fire_policy", "one_shot") == "one_shot":
+                if usage == "article_callback":
+                    context_store.update_trigger_status(
+                        candidate_id, status="fired", fired_week=used_week
+                    )
+                    trigger_update = "fired"
+                elif usage == "discarded":
+                    context_store.update_trigger_status(
+                        candidate_id, status="resolved", fired_week=used_week
+                    )
+                    trigger_update = "resolved"
+
+        return _json(
+            {
+                "ok": True,
+                "recorded": True,
+                "access_id": access_id,
+                "candidate_id": candidate_id,
+                "owner_type": normalized_type,
+                "usage": usage,
+                "trigger_update": trigger_update,
+            }
+        )
+
+    handlers = {
+        "search_story_memory": search_story_memory_tool,
+        "get_memory_candidate": get_memory_candidate_tool,
+        "save_memory_event": save_memory_event,
+        "upsert_storyline_memory_card": upsert_storyline_memory_card,
+        "save_storyline_trigger": save_storyline_trigger,
+        "mark_memory_used": mark_memory_used,
+    }
+    for spec in MEMORY_TOOL_SPECS:
+        name = spec["function"]["name"]
+        registry.register(name, handlers[name], spec)
+
+
+def _resolve_team_keys(
+    team_keys: list[str],
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> tuple[list[int], list[str]]:
+    team_ids: list[int] = []
+    unresolved_team_keys: list[str] = []
+    for key in team_keys:
+        roster_id = _resolve_roster_id(key, resolve_roster_fn)
+        if roster_id is None:
+            unresolved_team_keys.append(key)
+        else:
+            team_ids.append(roster_id)
+    return team_ids, unresolved_team_keys
+
+
+def _resolve_roster_id(
+    roster_key: str,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> int | None:
+    if resolve_roster_fn is not None:
+        result = resolve_roster_fn(roster_key)
+        if result.get("found"):
+            return int(result["roster_id"])
+        return None
+
+    try:
+        return int(roster_key)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, default=str)

--- a/reporter_v2/runner/tools/persistent_tools.py
+++ b/reporter_v2/runner/tools/persistent_tools.py
@@ -1,4 +1,8 @@
-"""Persistent context tools for reporter v2."""
+"""Legacy persistent context load/save tools for reporter v2.
+
+Search and richer write/usage tools live in memory_tools.py. This module keeps
+the original load/save surface and registers both sets together.
+"""
 
 from __future__ import annotations
 
@@ -7,13 +11,17 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from reporter_v2.runner.models import ToolDef
+from reporter_v2.runner.tools.memory_tools import (
+    MEMORY_TOOL_SPECS,
+    register_memory_tools,
+)
 from reporter_v2.runner.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
     from reporter_memory.context_store import ContextStore
 
 
-PERSISTENT_TOOLS = [
+LEGACY_PERSISTENT_TOOLS = [
     {
         "type": "function",
         "function": {
@@ -139,6 +147,7 @@ PERSISTENT_TOOLS = [
 ]
 
 
+PERSISTENT_TOOLS = LEGACY_PERSISTENT_TOOLS + MEMORY_TOOL_SPECS
 PERSISTENT_TOOL_SPECS: list[ToolDef] = PERSISTENT_TOOLS
 
 
@@ -148,7 +157,7 @@ def register_persistent_tools(
     week: int,
     resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
 ) -> None:
-    """Register persistent context tools against a ContextStore."""
+    """Register legacy load/save tools and the agent memory tool surface."""
 
     def save_persistent_storyline(
         *,
@@ -160,31 +169,18 @@ def register_persistent_tools(
         tags: list[str] | None = None,
         team_keys: list[str] | None = None,
     ) -> str:
-        team_ids, unresolved_team_keys = _resolve_team_keys(
-            team_keys or [], resolve_roster_fn
+        # Legacy wrapper over the richer storyline memory card tool.
+        handler = registry.get_handler("upsert_storyline_memory_card")
+        assert handler is not None
+        return handler(
+            id=id,
+            headline=headline,
+            summary=summary,
+            status=status,
+            priority=priority,
+            tags=tags,
+            team_keys=team_keys,
         )
-        context_store.upsert_storyline(
-            {
-                "id": id,
-                "headline": headline,
-                "summary": summary,
-                "status": status,
-                "priority": priority,
-                "tags": tags or [],
-                "team_ids": team_ids,
-            },
-            week=week,
-        )
-        payload: dict[str, Any] = {
-            "ok": True,
-            "saved": True,
-            "id": id,
-            "status": status,
-            "team_ids": team_ids,
-        }
-        if unresolved_team_keys:
-            payload["unresolved_team_keys"] = unresolved_team_keys
-        return _json(payload)
 
     def save_team_context(
         *,
@@ -242,24 +238,16 @@ def register_persistent_tools(
         "load_team_context": load_team_context,
         "load_league_notes": load_league_notes,
     }
-    for spec in PERSISTENT_TOOL_SPECS:
+    for spec in LEGACY_PERSISTENT_TOOLS:
         name = spec["function"]["name"]
         registry.register(name, handlers[name], spec)
 
-
-def _resolve_team_keys(
-    team_keys: list[str],
-    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
-) -> tuple[list[int], list[str]]:
-    team_ids: list[int] = []
-    unresolved_team_keys: list[str] = []
-    for key in team_keys:
-        roster_id = _resolve_roster_id(key, resolve_roster_fn)
-        if roster_id is None:
-            unresolved_team_keys.append(key)
-        else:
-            team_ids.append(roster_id)
-    return team_ids, unresolved_team_keys
+    register_memory_tools(
+        registry,
+        context_store,
+        week=week,
+        resolve_roster_fn=resolve_roster_fn,
+    )
 
 
 def _resolve_roster_id(

--- a/reporter_v2/tests/test_persistent_tools.py
+++ b/reporter_v2/tests/test_persistent_tools.py
@@ -50,7 +50,7 @@ def decode(result: str) -> Any:
 def test_registers_persistent_tools(store: ContextStore) -> None:
     registry = registered_registry(store)
 
-    assert registry.tool_names == [
+    assert registry.tool_names[:6] == [
         "save_persistent_storyline",
         "save_team_context",
         "save_league_note",
@@ -58,6 +58,12 @@ def test_registers_persistent_tools(store: ContextStore) -> None:
         "load_team_context",
         "load_league_notes",
     ]
+    assert "search_story_memory" in registry.tool_names
+    assert "get_memory_candidate" in registry.tool_names
+    assert "save_memory_event" in registry.tool_names
+    assert "upsert_storyline_memory_card" in registry.tool_names
+    assert "save_storyline_trigger" in registry.tool_names
+    assert "mark_memory_used" in registry.tool_names
     assert registry.tool_specs == PERSISTENT_TOOL_SPECS
 
 
@@ -84,14 +90,12 @@ def test_save_and_load_storyline(store: ContextStore) -> None:
     )
     storylines = decode(load_handler())
 
-    assert save_result == {
-        "ok": True,
-        "saved": True,
-        "id": "story_2024_w8_001",
-        "status": "active",
-        "team_ids": [3],
-        "unresolved_team_keys": ["Unknown Team"],
-    }
+    assert save_result["ok"] is True
+    assert save_result["saved"] is True
+    assert save_result["id"] == "story_2024_w8_001"
+    assert save_result["status"] == "active"
+    assert save_result["team_ids"] == [3]
+    assert save_result["unresolved_team_keys"] == ["Unknown Team"]
     assert len(storylines) == 1
     assert storylines[0]["id"] == "story_2024_w8_001"
     assert storylines[0]["headline"] == "Taco Surges"
@@ -179,3 +183,129 @@ def test_load_empty_context(store: ContextStore) -> None:
     assert decode(load_storylines()) == []
     assert decode(load_team_context()) == []
     assert decode(load_league_notes()) == {}
+
+
+def test_save_memory_event_and_search(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_event = registry.get_handler("save_memory_event")
+    upsert_card = registry.get_handler("upsert_storyline_memory_card")
+    save_trigger = registry.get_handler("save_storyline_trigger")
+    search = registry.get_handler("search_story_memory")
+    get_candidate = registry.get_handler("get_memory_candidate")
+
+    assert save_event is not None
+    assert upsert_card is not None
+    assert save_trigger is not None
+    assert search is not None
+    assert get_candidate is not None
+
+    event_result = decode(
+        save_event(
+            id="event_trade_1",
+            event_type="trade",
+            week=3,
+            headline="Team A sends Player X away",
+            summary="Team A traded Player X to Team B.",
+            importance=7,
+            confidence="verified",
+            source_refs=["transactions:week=3"],
+            entities=[
+                {
+                    "entity_type": "player",
+                    "entity_id": "player_x",
+                    "display_name": "Player X",
+                    "role": "asset_sent",
+                }
+            ],
+        )
+    )
+    card_result = decode(
+        upsert_card(
+            id="story_trade",
+            headline="Trade Arc",
+            summary="A trade that may matter later.",
+            status="active",
+            importance=8,
+            arc_type="trade_regret",
+            evidence_event_ids=["event_trade_1"],
+            trigger_specs=[
+                {
+                    "id": "trigger_trade_callback",
+                    "trigger_type": "trade_evaluation",
+                    "target_week": 9,
+                    "condition": {"player_id": "player_x"},
+                }
+            ],
+        )
+    )
+    search_result = decode(
+        search(
+            week=9,
+            current_entities=[
+                {"entity_type": "player", "entity_id": "player_x"},
+            ],
+        )
+    )
+    candidate = decode(
+        get_candidate(owner_type="storyline", owner_id="story_trade")
+    )
+
+    assert event_result["ok"] is True
+    assert card_result["ok"] is True
+    assert card_result["linked_events"] == ["event_trade_1"]
+    assert search_result["count"] >= 1
+    assert search_result["candidates"][0]["owner_id"] == "story_trade"
+    assert "score_components" in search_result["candidates"][0]
+    assert candidate["found"] is True
+    assert candidate["candidate"]["events"][0]["id"] == "event_trade_1"
+
+
+def test_save_memory_event_verified_requires_source(store: ContextStore) -> None:
+    registry = registered_registry(store)
+    handler = registry.get_handler("save_memory_event")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            id="event_bad",
+            event_type="trade",
+            week=1,
+            headline="No source",
+            summary="Claims verification without evidence.",
+            confidence="verified",
+        )
+    )
+    assert result["ok"] is False
+    assert "source ref" in result["error"]
+
+
+def test_mark_memory_used_updates_one_shot_trigger(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_trigger = registry.get_handler("save_storyline_trigger")
+    mark_used = registry.get_handler("mark_memory_used")
+    assert save_trigger is not None
+    assert mark_used is not None
+
+    decode(
+        save_trigger(
+            id="trigger_1",
+            trigger_type="rematch",
+            target_week=9,
+            fire_policy="one_shot",
+        )
+    )
+    result = decode(
+        mark_used(
+            candidate_id="trigger_1",
+            owner_type="trigger",
+            usage="article_callback",
+            reason="Used in callback paragraph.",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["trigger_update"] == "fired"
+    trigger = store.get_trigger("trigger_1")
+    assert trigger is not None
+    assert trigger["status"] == "fired"
+    assert trigger["fired_week"] == 9


### PR DESCRIPTION
## Summary
- Add `reporter_memory/search.py` for ranked memory search and candidate expansion, keeping SQL/CRUD in `ContextStore`
- Register agent tools for `search_story_memory`, `get_memory_candidate`, `save_memory_event`, `upsert_storyline_memory_card`, `save_storyline_trigger`, and `mark_memory_used`
- Keep legacy load/save tools; wrap `save_persistent_storyline` through the richer card tool and update research/storyline procedures

## Test plan
- [ ] `pytest reporter_memory/tests/test_search.py reporter_memory/tests/test_context_store.py reporter_v2/tests/test_persistent_tools.py reporter_v2/tests/test_integration.py`
- [ ] Save an event + storyline card with a trigger, then confirm `search_story_memory` ranks it for the target week / entity overlap
- [ ] Confirm `get_memory_candidate` expands linked events, facts, and triggers
- [ ] Confirm `mark_memory_used` on a one-shot trigger marks it fired for `article_callback`


Made with [Cursor](https://cursor.com)