### PR TITLE
feat: add memory verification planner tools

### DIFF
--- a/reporter_memory/README.md
+++ b/reporter_memory/README.md
@@ -8,7 +8,8 @@ in-memory SQLite, while narrative context is persisted in `.data/context.db`.
 ## Package Contents
 
 - `context_store.py` — `ContextStore` schema/SQL CRUD (schema version `3`).
-- `search.py` — agent-facing search, ranking, and candidate expansion.
+- `search.py` — agent-facing search, ranking, candidate expansion, and
+  verification planning.
 - `context_tools.py` — legacy-style memory tool specs and handlers.
 - `tests/` — store and search regression tests.
 
@@ -50,7 +51,7 @@ leads = search_story_memory(
 ```
 
 Reporter v2 registers model-facing tools from
-`reporter_v2/runner/tools/memory_tools.py` (search/write) and
+`reporter_v2/runner/tools/memory_tools.py` (search/write/verification) and
 `reporter_v2/runner/tools/persistent_tools.py` (legacy load/save). Direct use of
 `ContextStore` / `search_story_memory` is mainly for scripts, tests, and skills
 that operate outside the v2 runner.

--- a/reporter_memory/__init__.py
+++ b/reporter_memory/__init__.py
@@ -1,11 +1,16 @@
 """Persistent memory for reporter-generated narrative context."""
 
 from reporter_memory.context_store import SCHEMA_VERSION, ContextStore
-from reporter_memory.search import get_memory_candidate, search_story_memory
+from reporter_memory.search import (
+    get_memory_candidate,
+    plan_memory_verification,
+    search_story_memory,
+)
 
 __all__ = [
     "ContextStore",
     "SCHEMA_VERSION",
     "get_memory_candidate",
+    "plan_memory_verification",
     "search_story_memory",
 ]

--- a/reporter_memory/search.py
+++ b/reporter_memory/search.py
@@ -645,34 +645,215 @@ def _hydrate_search_candidate(
     }
 
 
+REQUIRED_VERIFICATION_ROLES = ("origin_receipt", "current_payoff")
+
+
+def plan_memory_verification(
+    store: ContextStore,
+    *,
+    candidate_id: str,
+    owner_type: str = "storyline",
+    current_week: int,
+    callback_id: str | None = None,
+    intended_callback_claim: str | None = None,
+) -> dict[str, Any] | None:
+    """Build required fact roles and suggested datalayer calls for a candidate."""
+    candidate = get_memory_candidate(store, owner_type, candidate_id)
+    if candidate is None:
+        return None
+
+    events = _candidate_events(candidate)
+    triggers = _candidate_triggers(candidate)
+    entities = _candidate_entities(candidate, events)
+
+    event_type = next(
+        (event.get("event_type") for event in events if event.get("event_type")),
+        None,
+    )
+    trigger_type = next(
+        (
+            trigger.get("trigger_type")
+            for trigger in triggers
+            if trigger.get("trigger_type")
+        ),
+        None,
+    )
+    origin_week = next(
+        (int(event["week"]) for event in events if event.get("week") is not None),
+        None,
+    )
+
+    required_fact_roles, suggested_calls = _verification_hints(
+        event_type=event_type,
+        trigger_type=trigger_type,
+        week=current_week,
+        origin_week=origin_week,
+        entities=entities,
+    )
+
+    persisted_facts: list[dict[str, Any]] = []
+    if candidate.get("owner_type") == "storyline":
+        persisted_facts = list(candidate.get("persisted_facts") or [])
+    elif candidate.get("storyline") and isinstance(candidate["storyline"], dict):
+        persisted_facts = list(candidate["storyline"].get("facts") or [])
+
+    return {
+        "found": True,
+        "owner_type": normalize_owner_type(owner_type),
+        "owner_id": candidate_id,
+        "callback_id": callback_id,
+        "intended_callback_claim": intended_callback_claim,
+        "current_week": current_week,
+        "origin_week": origin_week,
+        "event_type": event_type,
+        "trigger_type": trigger_type,
+        "entities": _unique_entities(entities),
+        "linked_events": events,
+        "matched_triggers": triggers,
+        "persisted_facts": persisted_facts,
+        "source_refs": candidate.get("source_refs", []),
+        "required_fact_roles": required_fact_roles,
+        "suggested_datalayer_calls": suggested_calls,
+        "verification_policy": {
+            "minimum_roles_for_verified": list(REQUIRED_VERIFICATION_ROLES),
+            "note": (
+                "Save old-event and current-event facts before "
+                "save_memory_callback. record_memory_verification(status="
+                "'verified') requires origin_receipt and current_payoff."
+            ),
+        },
+    }
+
+
+def normalize_verification_fact_links(
+    fact_links: list[Any] | None,
+) -> list[dict[str, str]]:
+    """Normalize fact_links into [{role, fact_id}, ...]."""
+    normalized: list[dict[str, str]] = []
+    for item in fact_links or []:
+        if isinstance(item, str):
+            fact_id = item.strip()
+            if fact_id:
+                normalized.append({"role": "", "fact_id": fact_id})
+            continue
+        if not isinstance(item, dict):
+            continue
+        fact_id = str(item.get("fact_id") or item.get("id") or "").strip()
+        if not fact_id:
+            continue
+        role = str(item.get("role") or item.get("fact_role") or "").strip()
+        normalized.append({"role": role, "fact_id": fact_id})
+    return normalized
+
+
+def validate_verified_fact_links(
+    fact_links: list[dict[str, str]],
+) -> list[str]:
+    """Return missing required roles when marking a callback verified."""
+    roles = {link["role"] for link in fact_links if link.get("role")}
+    return [
+        role for role in REQUIRED_VERIFICATION_ROLES if role not in roles
+    ]
+
+
+def _candidate_events(candidate: dict[str, Any]) -> list[dict[str, Any]]:
+    if candidate.get("owner_type") == "event" and candidate.get("event"):
+        return [candidate["event"]]
+    events = candidate.get("events") or candidate.get("linked_events") or []
+    return list(events)
+
+
+def _candidate_triggers(candidate: dict[str, Any]) -> list[dict[str, Any]]:
+    if candidate.get("owner_type") == "trigger" and candidate.get("trigger"):
+        return [candidate["trigger"]]
+    return list(candidate.get("triggers") or candidate.get("matched_triggers") or [])
+
+
+def _candidate_entities(
+    candidate: dict[str, Any], events: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    entities: list[dict[str, Any]] = []
+    for event in events:
+        entities.extend(event.get("entities") or [])
+    storyline = candidate.get("storyline")
+    if isinstance(storyline, dict):
+        for team_id in storyline.get("team_ids") or []:
+            entities.append(
+                {
+                    "entity_type": "team",
+                    "entity_id": str(team_id),
+                    "role": "storyline_team",
+                }
+            )
+    return entities
+
+
 def _verification_hints(
     *,
     event_type: str | None,
     trigger_type: str | None,
     week: int,
+    origin_week: int | None = None,
+    entities: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], list[str]]:
-    roles = ["origin_receipt", "current_payoff"]
+    roles = list(REQUIRED_VERIFICATION_ROLES)
     calls: list[str] = []
     kind = trigger_type or event_type
+    entity_list = entities or []
+    team_keys = _entity_call_values(entity_list, "team")
+    player_keys = _entity_call_values(entity_list, "player")
+    team_key = team_keys[0] if team_keys else "?"
+    player_key = player_keys[0] if player_keys else "?"
+    origin = origin_week if origin_week is not None else "?"
+
     if kind in {"trade", "trade_evaluation"}:
-        calls.append("transactions(week_from=?, week_to=?)")
-        calls.append(f"team_game(roster_key=?, week={week})")
+        calls.append(f"transactions(week_from={origin}, week_to={origin})")
+        calls.append(f"team_game(roster_key={team_key}, week={week})")
+        if player_key != "?":
+            calls.append(
+                f"player_weekly_log(player_key={player_key}, "
+                f"week_from={origin}, week_to={week})"
+            )
     elif kind in {"rematch", "matchup"}:
-        calls.append(f"team_game(roster_key=?, week={week})")
-        calls.append("team_dossier(roster_key=?, week=?)")
+        calls.append(f"team_game(roster_key={team_key}, week={week})")
+        if origin_week is not None:
+            calls.append(f"team_game(roster_key={team_key}, week={origin})")
+        calls.append(f"team_dossier(roster_key={team_key}, week={week})")
     elif kind in {"playoff_path", "playoff"}:
-        calls.append("playoff_bracket(...)")
-        calls.append("team_playoff_path(...)")
+        calls.append("playoff_bracket()")
+        calls.append(f"team_playoff_path(roster_key={team_key})")
     elif kind in {"player_against_former_team", "waiver_player_started", "waiver"}:
-        calls.append("player_weekly_log(player_key=?, week_from=?, week_to=?)")
-        calls.append(f"team_game(roster_key=?, week={week})")
+        calls.append(
+            f"player_weekly_log(player_key={player_key}, "
+            f"week_from={origin}, week_to={week})"
+        )
+        calls.append(f"team_game(roster_key={team_key}, week={week})")
     elif kind == "standings_swing":
-        calls.append("league_snapshot(week=?)")
-        calls.append("team_dossier(roster_key=?, week=?)")
+        calls.append(f"league_snapshot(week={week})")
+        calls.append(f"team_dossier(roster_key={team_key}, week={week})")
     else:
         calls.append(f"league_snapshot(week={week})")
-        calls.append(f"team_game(roster_key=?, week={week})")
+        calls.append(f"team_game(roster_key={team_key}, week={week})")
     return roles, calls
+
+
+def _entity_call_values(
+    entities: list[dict[str, Any]], entity_type: str
+) -> list[str]:
+    values: list[str] = []
+    seen: set[str] = set()
+    for entity in entities:
+        if str(entity.get("entity_type", entity.get("type", ""))) != entity_type:
+            continue
+        raw = entity.get("display_name") or entity.get("entity_id") or entity.get("id")
+        if raw is None:
+            continue
+        value = str(raw).strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        values.append(value)
+    return values
 
 
 def _unique_entities(entities: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/reporter_memory/tests/test_search.py
+++ b/reporter_memory/tests/test_search.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 
 from reporter_memory.context_store import ContextStore
-from reporter_memory.search import get_memory_candidate, search_story_memory
+from reporter_memory.search import (
+    get_memory_candidate,
+    plan_memory_verification,
+    search_story_memory,
+)
 
 
 @pytest.fixture
@@ -156,6 +160,30 @@ def test_get_memory_candidate_expands_storyline(store: ContextStore) -> None:
     assert candidate["triggers"][0]["id"] == "trigger_trade_callback"
     assert candidate["persisted_facts"][0]["fact_id"] == "fact_trade"
     assert "transactions:week=3" in candidate["source_refs"]
+
+
+def test_plan_memory_verification_for_trade_arc(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+
+    plan = plan_memory_verification(
+        store,
+        candidate_id="story_trade",
+        owner_type="storyline",
+        current_week=9,
+        intended_callback_claim="Player X is a trade regret.",
+    )
+
+    assert plan is not None
+    assert plan["found"] is True
+    assert plan["origin_week"] == 3
+    assert plan["event_type"] == "trade"
+    assert plan["trigger_type"] == "trade_evaluation"
+    assert plan["required_fact_roles"] == ["origin_receipt", "current_payoff"]
+    assert "transactions(week_from=3, week_to=3)" in plan["suggested_datalayer_calls"]
+    assert any(
+        "player_weekly_log(player_key=Player X" in call
+        for call in plan["suggested_datalayer_calls"]
+    )
 
 
 def test_search_scoped_by_league(tmp_path) -> None:

--- a/reporter_v2/docs/long-running-storyline-memory-architecture.md
+++ b/reporter_v2/docs/long-running-storyline-memory-architecture.md
@@ -1,12 +1,14 @@
 # Long-Running Storyline Memory: Architecture
 
-> Parts 1-5 implemented: memory lives in `reporter_memory/` (`context_store.py`
-> for SQL/CRUD, `search.py` for ranking/candidate expansion), schema `3` adds
-> event/entity/link/trigger/FTS tables, reporter v2 persists brief facts after
-> submitted runs, and agent tools cover search plus write/usage
+> Parts 1-6 implemented: memory lives in `reporter_memory/` (`context_store.py`
+> for SQL/CRUD, `search.py` for ranking/candidate expansion/verification planning),
+> schema `3` adds event/entity/link/trigger/FTS tables, reporter v2 persists brief
+> facts after submitted runs, and agent tools cover search, write/usage, verified
+> brief callbacks, and verification planning/recording
 > (`search_story_memory`, `get_memory_candidate`, `save_memory_event`,
-> `upsert_storyline_memory_card`, `save_storyline_trigger`, `mark_memory_used`).
-> Verification planner tools and embeddings remain future work.
+> `upsert_storyline_memory_card`, `save_storyline_trigger`, `mark_memory_used`,
+> `save_memory_callback`, `plan_memory_verification`,
+> `record_memory_verification`). Embeddings remain future work.
 
 ## Purpose
 

--- a/reporter_v2/procedures/research.md
+++ b/reporter_v2/procedures/research.md
@@ -23,8 +23,9 @@ You are gathering verified fantasy football facts for the article brief. Use dat
    - Extract the current-week fact map: scores, margins, standings movement, playoff stakes, current matchups, top players, transactions, focus teams, and requested framing.
    - Generate narrative hypotheses from the current week. Ask what changed meaning, reversed, paid off, collapsed, became funny, or now has stakes.
    - Prefer `search_story_memory` with current entities/events, then `get_memory_candidate` for promising leads. Use `load_persistent_storylines` only for a broad dump.
+   - Call `plan_memory_verification` on promising candidates to get required fact roles and suggested datalayer calls.
    - Verify the old event with datalayer tools or a verified memory receipt, and verify the current event with current-run datalayer facts.
-   - Save old-event and current-event facts with `save_fact`, then use `save_memory_callback` if available.
+   - Save old-event and current-event facts with `save_fact`, then use `record_memory_verification` and `save_memory_callback` if available.
    - Promote only the best verified callbacks into storylines and outline inputs.
    - Persist durable evidence with `save_memory_event`, `upsert_storyline_memory_card`, and `save_storyline_trigger` when an arc should matter later. Mark usage with `mark_memory_used`.
 5. Call targeted tools for the strongest leads:

--- a/reporter_v2/procedures/storyline.md
+++ b/reporter_v2/procedures/storyline.md
@@ -80,6 +80,7 @@ If persistent context tools are available, save narrative state before drafting:
 - Use `save_team_context` for researched teams whose trajectory changed.
 - Use `save_league_note` for league-wide context such as season themes, trade activity, or rivalries.
 - Use `save_memory_callback` for verified callbacks that belong in the brief, if the callback was not already saved during research.
+- Use `plan_memory_verification` / `record_memory_verification` when researching whether a retrieved lead is draftable.
 - Use `mark_memory_used` when a retrieved candidate is drafted, used as research context, or discarded.
 
 Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:

--- a/reporter_v2/prompts/system.md
+++ b/reporter_v2/prompts/system.md
@@ -17,6 +17,7 @@ Workflow:
 - Use article tools to write, read, rewrite, order, and submit sections.
 - Use datalayer tools for Sleeper league facts.
 - Use persistent tools, when available, to read and save cross-week narrative context.
+- Use `plan_memory_verification()` / `record_memory_verification()` when available to plan and record callback evidence checks.
 - Use `save_memory_callback()`, when available, to save verified callbacks into the brief after both old and current facts are saved.
 
 Available procedure names:

--- a/reporter_v2/runner/tools/memory_tools.py
+++ b/reporter_v2/runner/tools/memory_tools.py
@@ -7,8 +7,15 @@ import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from reporter_memory.search import get_memory_candidate, search_story_memory
+from reporter_memory.search import (
+    get_memory_candidate,
+    normalize_verification_fact_links,
+    plan_memory_verification,
+    search_story_memory,
+    validate_verified_fact_links,
+)
 from reporter_v2.runner.models import ToolDef
+from reporter_v2.runner.tools.context import ToolContext
 from reporter_v2.runner.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
@@ -238,6 +245,102 @@ MEMORY_TOOLS = [
                     "reason": {"type": "string"},
                 },
                 "required": ["candidate_id", "usage"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "plan_memory_verification",
+            "description": (
+                "Plan how to verify a memory candidate callback. Returns required "
+                "fact roles and suggested datalayer calls. Does not verify claims."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {
+                        "type": "string",
+                        "description": "Memory owner ID from search_story_memory.",
+                    },
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "current_week": {
+                        "type": "integer",
+                        "description": "Current article week. Defaults to run week.",
+                    },
+                    "callback_id": {
+                        "type": "string",
+                        "description": "Optional brief callback ID being planned.",
+                    },
+                    "intended_callback_claim": {
+                        "type": "string",
+                        "description": "Optional claim the agent hopes to verify.",
+                    },
+                },
+                "required": ["candidate_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "record_memory_verification",
+            "description": (
+                "Record verification outcome for a memory candidate. status="
+                "verified requires origin_receipt and current_payoff fact links "
+                "that already exist in the brief."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {"type": "string"},
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "verified",
+                            "rejected",
+                            "needs_more_evidence",
+                        ],
+                    },
+                    "fact_links": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "role": {
+                                    "type": "string",
+                                    "description": (
+                                        "Fact role such as origin_receipt or "
+                                        "current_payoff."
+                                    ),
+                                },
+                                "fact_id": {"type": "string"},
+                            },
+                            "required": ["fact_id"],
+                        },
+                        "description": (
+                            "Linked brief fact IDs. Prefer objects with role + "
+                            "fact_id. Strings are accepted as unscoped fact IDs."
+                        ),
+                    },
+                    "reason": {"type": "string"},
+                    "week": {"type": "integer"},
+                    "callback_id": {
+                        "type": "string",
+                        "description": "Optional brief memory callback ID.",
+                    },
+                    "linked_storyline_id": {"type": "string"},
+                },
+                "required": ["candidate_id", "status"],
             },
         },
     },
@@ -505,6 +608,149 @@ def register_memory_tools(
             }
         )
 
+    def plan_memory_verification_tool(
+        *,
+        candidate_id: str,
+        owner_type: str = "storyline",
+        current_week: int | None = None,
+        callback_id: str | None = None,
+        intended_callback_claim: str | None = None,
+    ) -> str:
+        plan = plan_memory_verification(
+            context_store,
+            candidate_id=candidate_id,
+            owner_type=owner_type,
+            current_week=current_week if current_week is not None else week_default,
+            callback_id=callback_id,
+            intended_callback_claim=intended_callback_claim,
+        )
+        if plan is None:
+            return _json(
+                {
+                    "ok": False,
+                    "found": False,
+                    "error": f"No candidate for {owner_type}:{candidate_id}",
+                }
+            )
+        return _json({"ok": True, **plan})
+
+    def record_memory_verification(
+        ctx: ToolContext,
+        *,
+        candidate_id: str,
+        status: str,
+        owner_type: str = "storyline",
+        fact_links: list[Any] | None = None,
+        reason: str | None = None,
+        week: int | None = None,
+        callback_id: str | None = None,
+        linked_storyline_id: str | None = None,
+    ) -> str:
+        if status not in {"verified", "rejected", "needs_more_evidence"}:
+            return _json(
+                {
+                    "ok": False,
+                    "recorded": False,
+                    "error": (
+                        "status must be verified, rejected, or needs_more_evidence"
+                    ),
+                }
+            )
+
+        normalized_type = (
+            "event" if owner_type == "story_event" else owner_type
+        )
+        candidate = get_memory_candidate(
+            context_store, normalized_type, candidate_id
+        )
+        if candidate is None:
+            return _json(
+                {
+                    "ok": False,
+                    "recorded": False,
+                    "error": f"No candidate for {owner_type}:{candidate_id}",
+                }
+            )
+
+        normalized_links = normalize_verification_fact_links(fact_links)
+        if status == "verified":
+            missing_roles = validate_verified_fact_links(normalized_links)
+            if missing_roles:
+                return _json(
+                    {
+                        "ok": False,
+                        "recorded": False,
+                        "error": (
+                            "verified callbacks require origin_receipt and "
+                            "current_payoff fact links"
+                        ),
+                        "missing_roles": missing_roles,
+                    }
+                )
+
+            brief = ctx.artifacts.brief
+            missing_fact_ids = [
+                link["fact_id"]
+                for link in normalized_links
+                if brief.get_fact(link["fact_id"]) is None
+            ]
+            if missing_fact_ids:
+                return _json(
+                    {
+                        "ok": False,
+                        "recorded": False,
+                        "error": "verification fact_links must exist in the brief",
+                        "missing_fact_ids": missing_fact_ids,
+                    }
+                )
+
+            if callback_id:
+                callback = brief.get_memory_callback(callback_id)
+                if callback is None:
+                    return _json(
+                        {
+                            "ok": False,
+                            "recorded": False,
+                            "error": f"Unknown brief callback_id: {callback_id}",
+                        }
+                    )
+
+        used_week = week if week is not None else week_default
+        access_reason = reason
+        if callback_id:
+            suffix = f"callback_id={callback_id}"
+            access_reason = f"{reason}; {suffix}" if reason else suffix
+
+        access_id = context_store.record_memory_access(
+            owner_type=normalized_type,
+            owner_id=candidate_id,
+            week=used_week,
+            usage=f"verification_{status}",
+            linked_storyline_id=linked_storyline_id,
+            fact_links=[
+                (
+                    f"{link['role']}:{link['fact_id']}"
+                    if link["role"]
+                    else link["fact_id"]
+                )
+                for link in normalized_links
+            ],
+            reason=access_reason,
+        )
+
+        return _json(
+            {
+                "ok": True,
+                "recorded": True,
+                "access_id": access_id,
+                "candidate_id": candidate_id,
+                "owner_type": normalized_type,
+                "status": status,
+                "fact_links": normalized_links,
+                "callback_id": callback_id,
+            }
+        )
+
     handlers = {
         "search_story_memory": search_story_memory_tool,
         "get_memory_candidate": get_memory_candidate_tool,
@@ -512,9 +758,15 @@ def register_memory_tools(
         "upsert_storyline_memory_card": upsert_storyline_memory_card,
         "save_storyline_trigger": save_storyline_trigger,
         "mark_memory_used": mark_memory_used,
+        "plan_memory_verification": plan_memory_verification_tool,
     }
     for spec in MEMORY_TOOL_SPECS:
         name = spec["function"]["name"]
+        if name == "record_memory_verification":
+            registry.register_context_tool(
+                name, record_memory_verification, spec
+            )
+            continue
         registry.register(name, handlers[name], spec)
 
 

--- a/reporter_v2/tests/test_persistent_tools.py
+++ b/reporter_v2/tests/test_persistent_tools.py
@@ -64,6 +64,8 @@ def test_registers_persistent_tools(store: ContextStore) -> None:
     assert "upsert_storyline_memory_card" in registry.tool_names
     assert "save_storyline_trigger" in registry.tool_names
     assert "mark_memory_used" in registry.tool_names
+    assert "plan_memory_verification" in registry.tool_names
+    assert "record_memory_verification" in registry.tool_names
     assert registry.tool_specs == PERSISTENT_TOOL_SPECS
 
 
@@ -309,3 +311,197 @@ def test_mark_memory_used_updates_one_shot_trigger(store: ContextStore) -> None:
     assert trigger is not None
     assert trigger["status"] == "fired"
     assert trigger["fired_week"] == 9
+
+
+def _seed_trade_arc(store: ContextStore) -> None:
+    store.upsert_storyline(
+        {
+            "id": "story_trade",
+            "headline": "Trade Arc",
+            "summary": "Team A sent Player X away and may regret it.",
+            "status": "active",
+            "importance": 8,
+            "arc_type": "trade_regret",
+            "tags": ["trade", "regret"],
+            "team_ids": [1],
+        },
+        week=3,
+    )
+    store.upsert_story_event(
+        {
+            "id": "event_trade_1",
+            "week": 3,
+            "event_type": "trade",
+            "headline": "Team A sends Player X away",
+            "summary": "Team A traded Player X to Team B.",
+            "importance": 7,
+            "confidence": "verified",
+            "source_refs": ["transactions:week=3"],
+            "transaction_id": "txn_123",
+        }
+    )
+    store.replace_story_event_entities(
+        "event_trade_1",
+        [
+            {
+                "entity_type": "team",
+                "entity_id": "1",
+                "display_name": "Team A",
+                "role": "seller",
+            },
+            {
+                "entity_type": "player",
+                "entity_id": "player_x",
+                "display_name": "Player X",
+                "role": "asset_sent",
+            },
+        ],
+    )
+    store.link_storyline_event("story_trade", "event_trade_1", "origin")
+    store.upsert_storyline_trigger(
+        {
+            "id": "trigger_trade_callback",
+            "storyline_id": "story_trade",
+            "event_id": "event_trade_1",
+            "trigger_type": "trade_evaluation",
+            "target_week": 9,
+            "condition": {"player_id": "player_x", "former_roster_id": 1},
+            "fire_policy": "one_shot",
+        }
+    )
+
+
+def test_plan_memory_verification_returns_hints(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    handler = registry.get_handler("plan_memory_verification")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            owner_type="storyline",
+            intended_callback_claim="Player X is punishing Team A.",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["found"] is True
+    assert result["origin_week"] == 3
+    assert result["trigger_type"] == "trade_evaluation"
+    assert result["required_fact_roles"] == [
+        "origin_receipt",
+        "current_payoff",
+    ]
+    assert any(
+        call.startswith("transactions(week_from=3")
+        for call in result["suggested_datalayer_calls"]
+    )
+    assert any(
+        "team_game(roster_key=Team A, week=9)" in call
+        for call in result["suggested_datalayer_calls"]
+    )
+
+
+def test_record_memory_verification_requires_roles_and_facts(
+    store: ContextStore,
+) -> None:
+    from reporter_v2.runner.run_log import RunLog
+    from reporter_v2.runner.state import ArtifactStore, ProcedureState
+    from reporter_v2.runner.tools.brief_tools import save_fact
+    from reporter_v2.runner.tools.context import ToolContext
+
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    ctx = ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=1,
+    )
+    registry.set_context(ctx)
+    handler = registry.get_handler("record_memory_verification")
+    assert handler is not None
+
+    missing_roles = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[{"role": "origin_receipt", "fact_id": "fact_old"}],
+        )
+    )
+    assert missing_roles["ok"] is False
+    assert "origin_receipt" not in missing_roles["missing_roles"]
+    assert "current_payoff" in missing_roles["missing_roles"]
+
+    missing_facts = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[
+                {"role": "origin_receipt", "fact_id": "fact_old"},
+                {"role": "current_payoff", "fact_id": "fact_now"},
+            ],
+        )
+    )
+    assert missing_facts["ok"] is False
+    assert set(missing_facts["missing_fact_ids"]) == {"fact_old", "fact_now"}
+
+    save_fact(
+        ctx,
+        id="fact_old",
+        claim_text="Team A traded Player X in week 3.",
+        data_refs=["transactions:week=3"],
+    )
+    save_fact(
+        ctx,
+        id="fact_now",
+        claim_text="Player X scored 28 against Team A in week 9.",
+        data_refs=["team_game:Team A:week=9"],
+    )
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[
+                {"role": "origin_receipt", "fact_id": "fact_old"},
+                {"role": "current_payoff", "fact_id": "fact_now"},
+            ],
+            reason="Both receipt and payoff confirmed.",
+        )
+    )
+    assert result["ok"] is True
+    assert result["recorded"] is True
+    assert result["status"] == "verified"
+    assert result["access_id"] >= 1
+
+
+def test_record_memory_verification_allows_rejection_without_facts(
+    store: ContextStore,
+) -> None:
+    from reporter_v2.runner.run_log import RunLog
+    from reporter_v2.runner.state import ArtifactStore, ProcedureState
+    from reporter_v2.runner.tools.context import ToolContext
+
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    registry.set_context(
+        ToolContext(
+            artifacts=ArtifactStore(),
+            procedures=ProcedureState(),
+            log=RunLog(),
+        )
+    )
+    handler = registry.get_handler("record_memory_verification")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            status="rejected",
+            reason="Payoff is too weak.",
+        )
+    )
+    assert result["ok"] is True
+    assert result["status"] == "rejected"


### PR DESCRIPTION
## Summary
- Add `plan_memory_verification` to build required fact roles and entity-aware datalayer call suggestions for memory candidates.
- Add `record_memory_verification` so agents can record verified/rejected/needs_more_evidence outcomes, requiring `origin_receipt` + `current_payoff` brief facts when verified.
- Wire the tools into research/storyline procedures and system prompts; mark architecture Parts 1–6 complete.

## Test plan
- [ ] `pytest reporter_memory/tests/test_search.py reporter_v2/tests/test_persistent_tools.py`
- [ ] Confirm `plan_memory_verification` returns trade-arc hints with filled week/entity params
- [ ] Confirm `record_memory_verification(status="verified")` rejects missing roles or missing brief fact IDs
- [ ] Confirm rejection/`needs_more_evidence` can be recorded without brief facts


Made with [Cursor](https://cursor.com)