### PR TITLE
refactor(reporter-v2): CompletionClient owns settings

### DIFF
--- a/reporter_v2/app/runner.py
+++ b/reporter_v2/app/runner.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from datalayer.sleeper_data import SleeperConfig, SleeperLeagueData
 from reporter_memory.context_store import ContextStore
 from reporter_v2.config import BiasProfile, ReportConfig, TimeRange, ToneControls
+from reporter_v2.runner.completion import CompletionSettings, RetryPolicy
 from reporter_v2.runner.entrypoint import generate_article
 from reporter_v2.runner.state import ProcedureHistoryMode
 
@@ -180,12 +181,7 @@ async def run(args: argparse.Namespace) -> None:
     """Run reporter v2 from parsed CLI args."""
     load_dotenv()
     prompt = args.prompt or _prompt_for_request()
-    selected_model = _resolve_model(args.model)
-    fallback_models = _resolve_fallback_models(
-        getattr(args, "fallback_models", None),
-        selected_model,
-    )
-    max_retries = _resolve_max_retries(getattr(args, "max_retries", None))
+    completion = _resolve_completion_settings(args)
     max_turns = _resolve_max_turns(args.max_turns)
     procedure_history_mode = _resolve_procedure_history_mode(
         getattr(args, "procedure_mode", None)
@@ -229,10 +225,10 @@ async def run(args: argparse.Namespace) -> None:
     print(f"Weeks: {time_range.week_start}-{time_range.week_end}")
     if data.week_override is not None:
         print(f"Sleeper week override: {data.week_override}")
-    print(f"Model: {selected_model}")
-    if fallback_models:
-        print(f"Fallback models: {', '.join(fallback_models)}")
-    print(f"Max retries per model: {max_retries}")
+    print(f"Model: {completion.model}")
+    if completion.fallback_models:
+        print(f"Fallback models: {', '.join(completion.fallback_models)}")
+    print(f"Max retries per model: {completion.retry.max_retries}")
     print(f"Max turns: {max_turns}")
     print(f"Procedure mode: {procedure_history_mode.value}")
     if eval_mode:
@@ -248,9 +244,7 @@ async def run(args: argparse.Namespace) -> None:
         data,
         report_config,
         context_store=context_store,
-        model=selected_model,
-        fallback_models=fallback_models,
-        max_retries=max_retries,
+        completion=completion,
         max_turns=max_turns,
         procedure_history_mode=procedure_history_mode,
         log_path=log_path,
@@ -310,6 +304,20 @@ def _prompt_for_request() -> str:
     return prompt
 
 
+def _resolve_completion_settings(args: argparse.Namespace) -> CompletionSettings:
+    model = _resolve_model(args.model)
+    fallback_models = _resolve_fallback_models(
+        getattr(args, "fallback_models", None),
+        model,
+    )
+    max_retries = _resolve_max_retries(getattr(args, "max_retries", None))
+    return CompletionSettings(
+        model=model,
+        fallback_models=tuple(fallback_models),
+        retry=RetryPolicy(max_retries=max_retries),
+    )
+
+
 def _resolve_model(model_arg: str | None) -> str:
     return (
         model_arg
@@ -351,7 +359,7 @@ def _resolve_max_retries(max_retries_arg: int | None) -> int:
 
     raw_value = os.getenv("REPORTER_V2_MAX_RETRIES")
     if raw_value is None or raw_value == "":
-        return 3
+        return RetryPolicy().max_retries
 
     try:
         max_retries = int(raw_value)

--- a/reporter_v2/runner/completion.py
+++ b/reporter_v2/runner/completion.py
@@ -122,14 +122,77 @@ class CompletionClient:
         tools: list[Any] | None = None,
         **kwargs: Any,
     ) -> Any:
-        """Retry + model fallback using owned settings; kwargs are request-only."""
-        return await complete_with_retry(
-            self._complete,
-            settings=self._settings,
-            messages=messages,
-            tools=tools,
-            **kwargs,
-        )
+        """Retry + model fallback using owned settings; kwargs are request-only.
+
+        For each model in ``settings.model_chain()``:
+        1. Attempt the call.
+        2. On a retryable error, wait with exponential backoff and retry up to
+           ``settings.retry.max_retries`` additional times on the same model.
+        3. If that model is exhausted, move to the next fallback model.
+        4. Non-retryable errors are raised immediately.
+        """
+        models = self._settings.model_chain()
+        if not models:
+            # Preserve callers that inject fakes without configuring a model.
+            return await self._complete(
+                model=self._settings.model,
+                messages=messages,
+                tools=tools,
+                **kwargs,
+            )
+
+        retry = self._settings.retry
+        last_error: BaseException | None = None
+        for model_index, candidate in enumerate(models):
+            for attempt in range(retry.max_retries + 1):
+                try:
+                    return await self._complete(
+                        model=candidate,
+                        messages=messages,
+                        tools=tools,
+                        **kwargs,
+                    )
+                except Exception as exc:
+                    if not is_retryable_error(exc):
+                        raise
+
+                    last_error = exc
+                    is_last_attempt = attempt >= retry.max_retries
+                    is_last_model = model_index >= len(models) - 1
+
+                    if is_last_attempt and is_last_model:
+                        break
+
+                    if is_last_attempt:
+                        logger.warning(
+                            "Model %s exhausted after %d retries (%s); "
+                            "falling back to %s",
+                            candidate,
+                            retry.max_retries,
+                            exc,
+                            models[model_index + 1],
+                        )
+                        break
+
+                    delay = retry_delay_seconds(
+                        attempt,
+                        base_delay=retry.base_delay,
+                        max_delay=retry.max_delay,
+                        error=exc,
+                    )
+                    logger.warning(
+                        "Retryable error on model %s (attempt %d/%d): %s; "
+                        "retrying in %.2fs",
+                        candidate,
+                        attempt + 1,
+                        retry.max_retries + 1,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+
+        assert last_error is not None
+        raise last_error
 
 
 def make_completion_client(settings: CompletionSettings) -> CompletionClient:
@@ -215,75 +278,6 @@ def _retry_after_header_seconds(exc: BaseException) -> float | None:
         return float(raw)
     except (TypeError, ValueError):
         return None
-
-
-async def complete_with_retry(
-    complete: CompletionFn,
-    *,
-    settings: CompletionSettings,
-    **kwargs: Any,
-) -> Any:
-    """Call ``complete`` with exponential retries, then model fallbacks.
-
-    For each model in ``settings.model_chain()``:
-    1. Attempt the call.
-    2. On a retryable error, wait with exponential backoff and retry up to
-       ``settings.retry.max_retries`` additional times on the same model.
-    3. If that model is exhausted, move to the next fallback model.
-    4. Non-retryable errors are raised immediately.
-    """
-    models = settings.model_chain()
-    if not models:
-        # Preserve callers that inject fakes without configuring a model.
-        return await complete(model=settings.model, **kwargs)
-
-    retry = settings.retry
-    last_error: BaseException | None = None
-    for model_index, candidate in enumerate(models):
-        for attempt in range(retry.max_retries + 1):
-            try:
-                return await complete(model=candidate, **kwargs)
-            except Exception as exc:
-                if not is_retryable_error(exc):
-                    raise
-
-                last_error = exc
-                is_last_attempt = attempt >= retry.max_retries
-                is_last_model = model_index >= len(models) - 1
-
-                if is_last_attempt and is_last_model:
-                    break
-
-                if is_last_attempt:
-                    logger.warning(
-                        "Model %s exhausted after %d retries (%s); "
-                        "falling back to %s",
-                        candidate,
-                        retry.max_retries,
-                        exc,
-                        models[model_index + 1],
-                    )
-                    break
-
-                delay = retry_delay_seconds(
-                    attempt,
-                    base_delay=retry.base_delay,
-                    max_delay=retry.max_delay,
-                    error=exc,
-                )
-                logger.warning(
-                    "Retryable error on model %s (attempt %d/%d): %s; "
-                    "retrying in %.2fs",
-                    candidate,
-                    attempt + 1,
-                    retry.max_retries + 1,
-                    exc,
-                    delay,
-                )
-                await asyncio.sleep(delay)
-
-    assert last_error is not None
-    raise last_error
 
 
 def make_litellm_completion() -> CompletionFn:

--- a/reporter_v2/runner/completion.py
+++ b/reporter_v2/runner/completion.py
@@ -6,10 +6,8 @@ import asyncio
 import logging
 import random
 import re
-from collections.abc import Awaitable, Callable
-from typing import Any
-
-CompletionFn = Callable[..., Awaitable[Any]]
+from dataclasses import dataclass, field
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +52,89 @@ _RETRY_AFTER_RE = re.compile(
     r"try again in\s+(\d+(?:\.\d+)?)\s*(ms|s|sec|secs|second|seconds)?",
     re.IGNORECASE,
 )
+
+
+class CompletionFn(Protocol):
+    async def __call__(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[Any],
+        tools: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be at least 0")
+        if self.base_delay <= 0:
+            raise ValueError("base_delay must be greater than 0")
+        if self.max_delay <= 0:
+            raise ValueError("max_delay must be greater than 0")
+        if self.max_delay < self.base_delay:
+            raise ValueError("max_delay must be greater than or equal to base_delay")
+
+
+@dataclass(frozen=True)
+class CompletionSettings:
+    model: str | None = None
+    fallback_models: tuple[str, ...] = ()
+    retry: RetryPolicy = field(default_factory=RetryPolicy)
+
+    def model_chain(self) -> tuple[str, ...]:
+        """Deduped [model] + fallbacks, skipping empties."""
+        chain: list[str] = []
+        seen: set[str] = set()
+        for candidate in (self.model, *self.fallback_models):
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            chain.append(candidate)
+        return tuple(chain)
+
+
+class CompletionClient:
+    """Owns completion settings for one article run; call with request payload only."""
+
+    def __init__(
+        self,
+        complete: CompletionFn,
+        settings: CompletionSettings,
+    ) -> None:
+        self._complete = complete
+        self._settings = settings
+
+    @property
+    def settings(self) -> CompletionSettings:
+        return self._settings
+
+    async def complete(
+        self,
+        *,
+        messages: list[Any],
+        tools: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Retry + model fallback using owned settings; kwargs are request-only."""
+        return await complete_with_retry(
+            self._complete,
+            settings=self._settings,
+            messages=messages,
+            tools=tools,
+            **kwargs,
+        )
+
+
+def make_completion_client(settings: CompletionSettings) -> CompletionClient:
+    """Build a CompletionClient with the default LiteLLM transport."""
+    return CompletionClient(make_litellm_completion(), settings)
 
 
 def is_retryable_error(exc: BaseException) -> bool:
@@ -139,30 +220,27 @@ def _retry_after_header_seconds(exc: BaseException) -> float | None:
 async def complete_with_retry(
     complete: CompletionFn,
     *,
-    model: str | None,
-    fallback_models: list[str] | None = None,
-    max_retries: int = 3,
-    retry_base_delay: float = 1.0,
-    retry_max_delay: float = 30.0,
+    settings: CompletionSettings,
     **kwargs: Any,
 ) -> Any:
     """Call ``complete`` with exponential retries, then model fallbacks.
 
-    For each model in ``[model] + fallback_models``:
+    For each model in ``settings.model_chain()``:
     1. Attempt the call.
     2. On a retryable error, wait with exponential backoff and retry up to
-       ``max_retries`` additional times on the same model.
+       ``settings.retry.max_retries`` additional times on the same model.
     3. If that model is exhausted, move to the next fallback model.
     4. Non-retryable errors are raised immediately.
     """
-    models = _model_chain(model, fallback_models)
+    models = settings.model_chain()
     if not models:
         # Preserve callers that inject fakes without configuring a model.
-        return await complete(model=model, **kwargs)
+        return await complete(model=settings.model, **kwargs)
 
+    retry = settings.retry
     last_error: BaseException | None = None
     for model_index, candidate in enumerate(models):
-        for attempt in range(max_retries + 1):
+        for attempt in range(retry.max_retries + 1):
             try:
                 return await complete(model=candidate, **kwargs)
             except Exception as exc:
@@ -170,7 +248,7 @@ async def complete_with_retry(
                     raise
 
                 last_error = exc
-                is_last_attempt = attempt >= max_retries
+                is_last_attempt = attempt >= retry.max_retries
                 is_last_model = model_index >= len(models) - 1
 
                 if is_last_attempt and is_last_model:
@@ -181,7 +259,7 @@ async def complete_with_retry(
                         "Model %s exhausted after %d retries (%s); "
                         "falling back to %s",
                         candidate,
-                        max_retries,
+                        retry.max_retries,
                         exc,
                         models[model_index + 1],
                     )
@@ -189,8 +267,8 @@ async def complete_with_retry(
 
                 delay = retry_delay_seconds(
                     attempt,
-                    base_delay=retry_base_delay,
-                    max_delay=retry_max_delay,
+                    base_delay=retry.base_delay,
+                    max_delay=retry.max_delay,
                     error=exc,
                 )
                 logger.warning(
@@ -198,7 +276,7 @@ async def complete_with_retry(
                     "retrying in %.2fs",
                     candidate,
                     attempt + 1,
-                    max_retries + 1,
+                    retry.max_retries + 1,
                     exc,
                     delay,
                 )
@@ -206,20 +284,6 @@ async def complete_with_retry(
 
     assert last_error is not None
     raise last_error
-
-
-def _model_chain(
-    model: str | None,
-    fallback_models: list[str] | None,
-) -> list[str]:
-    chain: list[str] = []
-    seen: set[str] = set()
-    for candidate in [model, *(fallback_models or [])]:
-        if not candidate or candidate in seen:
-            continue
-        seen.add(candidate)
-        chain.append(candidate)
-    return chain
 
 
 def make_litellm_completion() -> CompletionFn:

--- a/reporter_v2/runner/entrypoint.py
+++ b/reporter_v2/runner/entrypoint.py
@@ -11,7 +11,12 @@ from sqlalchemy import text
 from datalayer.sleeper_data import SleeperLeagueData
 from datalayer.sleeper_data.queries._resolvers import resolve_roster_id
 from reporter_v2.config import ReportConfig
-from reporter_v2.runner.completion import CompletionFn
+from reporter_v2.runner.completion import (
+    CompletionClient,
+    CompletionFn,
+    CompletionSettings,
+    make_completion_client,
+)
 from reporter_v2.runner.runner import Runner
 from reporter_v2.runner.schemas import ArticleOutput, ReportBrief
 from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
@@ -31,12 +36,9 @@ async def generate_article(
     config: ReportConfig,
     *,
     context_store: ContextStore | None = None,
-    model: str | None = None,
-    fallback_models: list[str] | None = None,
+    client: CompletionClient | None = None,
+    completion: CompletionSettings | None = None,
     max_turns: int = 60,
-    max_retries: int = 3,
-    retry_base_delay: float = 1.0,
-    retry_max_delay: float = 30.0,
     procedure_history_mode: ProcedureHistoryMode | str = ProcedureHistoryMode.REPLACE,
     log_path: Path | None = None,
     complete: CompletionFn | None = None,
@@ -64,16 +66,18 @@ async def generate_article(
     if log_path is not None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
+    settings = completion or CompletionSettings()
+    if client is None:
+        if complete is not None:
+            client = CompletionClient(complete, settings)
+        else:
+            client = make_completion_client(settings)
+
     runner = Runner(
         registry,
-        complete=complete,
+        client=client,
         config=RunnerConfig(
-            model=model,
-            fallback_models=list(fallback_models or []),
             max_turns=max_turns,
-            max_retries=max_retries,
-            retry_base_delay=retry_base_delay,
-            retry_max_delay=retry_max_delay,
             procedure_history_mode=procedure_history_mode,
         ),
         log_path=log_path,

--- a/reporter_v2/runner/runner.py
+++ b/reporter_v2/runner/runner.py
@@ -9,9 +9,10 @@ from pathlib import Path
 from typing import Any
 
 from reporter_v2.runner.completion import (
+    CompletionClient,
     CompletionFn,
-    complete_with_retry,
-    make_litellm_completion,
+    CompletionSettings,
+    make_completion_client,
 )
 from reporter_v2.runner.models import (
     ChatMessage,
@@ -42,13 +43,19 @@ class Runner:
         self,
         registry: ToolRegistry,
         *,
+        client: CompletionClient | None = None,
         complete: CompletionFn | None = None,
         config: RunnerConfig | None = None,
         log_path: Path | None = None,
     ) -> None:
         self.registry = registry
-        self._complete = complete or make_litellm_completion()
         self.config = config or RunnerConfig()
+        if client is not None:
+            self._client = client
+        elif complete is not None:
+            self._client = CompletionClient(complete, CompletionSettings())
+        else:
+            self._client = make_completion_client(CompletionSettings())
         self.artifacts = ArtifactStore()
         self.procedures = ProcedureState()
         self.log = RunLog()
@@ -74,13 +81,7 @@ class Runner:
         try:
             while turn < self.config.max_turns and not self._submitted:
                 turn += 1
-                response = await complete_with_retry(
-                    self._complete,
-                    model=self.config.model,
-                    fallback_models=self.config.fallback_models,
-                    max_retries=self.config.max_retries,
-                    retry_base_delay=self.config.retry_base_delay,
-                    retry_max_delay=self.config.retry_max_delay,
+                response = await self._client.complete(
                     messages=list(messages),
                     tools=self.registry.tool_specs,
                 )

--- a/reporter_v2/runner/state.py
+++ b/reporter_v2/runner/state.py
@@ -25,9 +25,4 @@ class ProcedureState(BaseModel):
 
 class RunnerConfig(BaseModel):
     max_turns: int = 60
-    model: str | None = None
-    fallback_models: list[str] = Field(default_factory=list)
-    max_retries: int = 3
-    retry_base_delay: float = 1.0
-    retry_max_delay: float = 30.0
     procedure_history_mode: ProcedureHistoryMode = ProcedureHistoryMode.REPLACE

--- a/reporter_v2/tests/test_app_runner.py
+++ b/reporter_v2/tests/test_app_runner.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from reporter_v2.app.runner import (
     _make_sleeper_data,
+    _resolve_completion_settings,
     _resolve_fallback_models,
     _resolve_max_retries,
     _resolve_procedure_history_mode,
 )
+from reporter_v2.runner.completion import RetryPolicy
 from reporter_v2.runner.state import ProcedureHistoryMode
 
 
@@ -79,6 +83,40 @@ def test_resolve_max_retries_rejects_negative(monkeypatch) -> None:
     monkeypatch.setenv("REPORTER_V2_MAX_RETRIES", "-1")
     with pytest.raises(ValueError, match="REPORTER_V2_MAX_RETRIES"):
         _resolve_max_retries(None)
+
+
+def test_resolve_completion_settings_from_cli_and_env(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_V2_MODEL", raising=False)
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    monkeypatch.setenv("REPORTER_V2_FALLBACK_MODELS", "fallback-a, fallback-b")
+    monkeypatch.setenv("REPORTER_V2_MAX_RETRIES", "5")
+
+    settings = _resolve_completion_settings(
+        SimpleNamespace(model="primary", fallback_models=None, max_retries=None)
+    )
+
+    assert settings.model == "primary"
+    assert settings.fallback_models == ("fallback-a", "fallback-b")
+    assert settings.retry.max_retries == 5
+    assert settings.retry.base_delay == RetryPolicy().base_delay
+
+
+def test_resolve_completion_settings_cli_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("REPORTER_V2_MODEL", "from-env")
+    monkeypatch.setenv("REPORTER_FALLBACK_MODELS", "env-fallback")
+    monkeypatch.setenv("REPORTER_V2_MAX_RETRIES", "9")
+
+    settings = _resolve_completion_settings(
+        SimpleNamespace(
+            model="from-cli",
+            fallback_models=["cli-fallback"],
+            max_retries=2,
+        )
+    )
+
+    assert settings.model == "from-cli"
+    assert settings.fallback_models == ("cli-fallback",)
+    assert settings.retry.max_retries == 2
 
 
 def test_make_sleeper_data_uses_cli_week_override_without_env_league(

--- a/reporter_v2/tests/test_completion.py
+++ b/reporter_v2/tests/test_completion.py
@@ -7,12 +7,14 @@ from typing import Any
 import pytest
 
 from reporter_v2.runner.completion import (
+    CompletionClient,
+    CompletionSettings,
+    RetryPolicy,
     complete_with_retry,
     is_retryable_error,
     retry_delay_seconds,
 )
 from reporter_v2.runner.runner import Runner
-from reporter_v2.runner.state import RunnerConfig
 from reporter_v2.runner.tools.registry import ToolRegistry
 from reporter_v2.tests.test_runner import make_response, run
 
@@ -68,6 +70,24 @@ def test_requires_none_reasoning_with_tools_for_luna() -> None:
     assert _requires_none_reasoning_with_tools("openai/gpt-5.6-luna")
     assert not _requires_none_reasoning_with_tools("deepseek/deepseek-v4-pro")
     assert not _requires_none_reasoning_with_tools(None)
+
+
+def test_retry_policy_validation() -> None:
+    with pytest.raises(ValueError, match="max_retries"):
+        RetryPolicy(max_retries=-1)
+    with pytest.raises(ValueError, match="base_delay"):
+        RetryPolicy(base_delay=0)
+    with pytest.raises(ValueError, match="max_delay"):
+        RetryPolicy(base_delay=2.0, max_delay=1.0)
+
+
+def test_completion_settings_model_chain_dedupes() -> None:
+    settings = CompletionSettings(
+        model="primary",
+        fallback_models=("fallback", "primary", "", "other"),
+    )
+    assert settings.model_chain() == ("primary", "fallback", "other")
+    assert CompletionSettings().model_chain() == ()
 
 
 def test_retry_delay_is_bounded(monkeypatch) -> None:
@@ -129,10 +149,10 @@ def test_complete_with_retry_retries_same_model_then_succeeds(monkeypatch) -> No
     result = run(
         complete_with_retry(
             complete,
-            model="primary",
-            max_retries=3,
-            retry_base_delay=1.0,
-            retry_max_delay=30.0,
+            settings=CompletionSettings(
+                model="primary",
+                retry=RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0),
+            ),
             messages=[],
         )
     )
@@ -165,11 +185,11 @@ def test_complete_with_retry_falls_back_after_retries(monkeypatch) -> None:
     result = run(
         complete_with_retry(
             complete,
-            model="primary",
-            fallback_models=["fallback"],
-            max_retries=3,
-            retry_base_delay=0.01,
-            retry_max_delay=0.01,
+            settings=CompletionSettings(
+                model="primary",
+                fallback_models=("fallback",),
+                retry=RetryPolicy(max_retries=3, base_delay=0.01, max_delay=0.01),
+            ),
             messages=[],
         )
     )
@@ -186,9 +206,11 @@ def test_complete_with_retry_raises_non_retryable_immediately() -> None:
         run(
             complete_with_retry(
                 complete,
-                model="primary",
-                fallback_models=["fallback"],
-                max_retries=3,
+                settings=CompletionSettings(
+                    model="primary",
+                    fallback_models=("fallback",),
+                    retry=RetryPolicy(max_retries=3),
+                ),
                 messages=[],
             )
         )
@@ -215,14 +237,44 @@ def test_complete_with_retry_raises_after_all_models_exhausted(monkeypatch) -> N
         run(
             complete_with_retry(
                 complete,
-                model="primary",
-                fallback_models=["fallback"],
-                max_retries=1,
-                retry_base_delay=0.01,
-                retry_max_delay=0.01,
+                settings=CompletionSettings(
+                    model="primary",
+                    fallback_models=("fallback",),
+                    retry=RetryPolicy(max_retries=1, base_delay=0.01, max_delay=0.01),
+                ),
                 messages=[],
             )
         )
+
+
+def test_completion_client_complete_uses_owned_settings(monkeypatch) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("reporter_v2.runner.completion.asyncio.sleep", fake_sleep)
+
+    complete = SequenceCompletion(
+        [
+            RateLimitError("primary down"),
+            make_response(text="from fallback"),
+        ]
+    )
+    client = CompletionClient(
+        complete,
+        CompletionSettings(
+            model="gpt-primary",
+            fallback_models=("gpt-fallback",),
+            retry=RetryPolicy(max_retries=0),
+        ),
+    )
+
+    result = run(client.complete(messages=[]))
+
+    assert result.choices[0].message.content == "from fallback"
+    assert [req["model"] for req in complete.requests] == [
+        "gpt-primary",
+        "gpt-fallback",
+    ]
 
 
 def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
@@ -239,11 +291,13 @@ def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
     )
     runner = Runner(
         ToolRegistry(),
-        complete=complete,
-        config=RunnerConfig(
-            model="gpt-primary",
-            fallback_models=["gpt-fallback"],
-            max_retries=0,
+        client=CompletionClient(
+            complete,
+            CompletionSettings(
+                model="gpt-primary",
+                fallback_models=("gpt-fallback",),
+                retry=RetryPolicy(max_retries=0),
+            ),
         ),
     )
 

--- a/reporter_v2/tests/test_completion.py
+++ b/reporter_v2/tests/test_completion.py
@@ -10,7 +10,6 @@ from reporter_v2.runner.completion import (
     CompletionClient,
     CompletionSettings,
     RetryPolicy,
-    complete_with_retry,
     is_retryable_error,
     retry_delay_seconds,
 )
@@ -42,6 +41,23 @@ class SequenceCompletion:
         if isinstance(outcome, BaseException):
             raise outcome
         return outcome
+
+
+def make_client(
+    complete: SequenceCompletion,
+    *,
+    model: str | None = None,
+    fallback_models: tuple[str, ...] = (),
+    retry: RetryPolicy | None = None,
+) -> CompletionClient:
+    return CompletionClient(
+        complete,
+        CompletionSettings(
+            model=model,
+            fallback_models=fallback_models,
+            retry=retry or RetryPolicy(),
+        ),
+    )
 
 
 def test_is_retryable_detects_rate_limit_by_type_and_status() -> None:
@@ -126,7 +142,7 @@ def test_suggested_retry_delay_parses_message() -> None:
     assert suggested_retry_delay_seconds(ValueError("nope")) is None
 
 
-def test_complete_with_retry_retries_same_model_then_succeeds(monkeypatch) -> None:
+def test_client_retries_same_model_then_succeeds(monkeypatch) -> None:
     sleeps: list[float] = []
 
     async def fake_sleep(delay: float) -> None:
@@ -145,17 +161,13 @@ def test_complete_with_retry_retries_same_model_then_succeeds(monkeypatch) -> No
             make_response(text="ok"),
         ]
     )
-
-    result = run(
-        complete_with_retry(
-            complete,
-            settings=CompletionSettings(
-                model="primary",
-                retry=RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0),
-            ),
-            messages=[],
-        )
+    client = make_client(
+        complete,
+        model="primary",
+        retry=RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0),
     )
+
+    result = run(client.complete(messages=[]))
 
     assert result.choices[0].message.content == "ok"
     assert [req["model"] for req in complete.requests] == [
@@ -166,7 +178,7 @@ def test_complete_with_retry_retries_same_model_then_succeeds(monkeypatch) -> No
     assert sleeps == [1.0, 2.0]
 
 
-def test_complete_with_retry_falls_back_after_retries(monkeypatch) -> None:
+def test_client_falls_back_after_retries(monkeypatch) -> None:
     async def fake_sleep(_delay: float) -> None:
         return None
 
@@ -181,44 +193,36 @@ def test_complete_with_retry_falls_back_after_retries(monkeypatch) -> None:
             make_response(text="fallback-ok"),
         ]
     )
-
-    result = run(
-        complete_with_retry(
-            complete,
-            settings=CompletionSettings(
-                model="primary",
-                fallback_models=("fallback",),
-                retry=RetryPolicy(max_retries=3, base_delay=0.01, max_delay=0.01),
-            ),
-            messages=[],
-        )
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=3, base_delay=0.01, max_delay=0.01),
     )
+
+    result = run(client.complete(messages=[]))
 
     assert result.choices[0].message.content == "fallback-ok"
     models = [req["model"] for req in complete.requests]
     assert models == ["primary", "primary", "primary", "primary", "fallback"]
 
 
-def test_complete_with_retry_raises_non_retryable_immediately() -> None:
+def test_client_raises_non_retryable_immediately() -> None:
     complete = SequenceCompletion([ValueError("invalid request")])
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=3),
+    )
 
     with pytest.raises(ValueError, match="invalid request"):
-        run(
-            complete_with_retry(
-                complete,
-                settings=CompletionSettings(
-                    model="primary",
-                    fallback_models=("fallback",),
-                    retry=RetryPolicy(max_retries=3),
-                ),
-                messages=[],
-            )
-        )
+        run(client.complete(messages=[]))
 
     assert [req["model"] for req in complete.requests] == ["primary"]
 
 
-def test_complete_with_retry_raises_after_all_models_exhausted(monkeypatch) -> None:
+def test_client_raises_after_all_models_exhausted(monkeypatch) -> None:
     async def fake_sleep(_delay: float) -> None:
         return None
 
@@ -232,49 +236,15 @@ def test_complete_with_retry_raises_after_all_models_exhausted(monkeypatch) -> N
             RateLimitError("b2"),
         ]
     )
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=1, base_delay=0.01, max_delay=0.01),
+    )
 
     with pytest.raises(RateLimitError, match="b2"):
-        run(
-            complete_with_retry(
-                complete,
-                settings=CompletionSettings(
-                    model="primary",
-                    fallback_models=("fallback",),
-                    retry=RetryPolicy(max_retries=1, base_delay=0.01, max_delay=0.01),
-                ),
-                messages=[],
-            )
-        )
-
-
-def test_completion_client_complete_uses_owned_settings(monkeypatch) -> None:
-    async def fake_sleep(_delay: float) -> None:
-        return None
-
-    monkeypatch.setattr("reporter_v2.runner.completion.asyncio.sleep", fake_sleep)
-
-    complete = SequenceCompletion(
-        [
-            RateLimitError("primary down"),
-            make_response(text="from fallback"),
-        ]
-    )
-    client = CompletionClient(
-        complete,
-        CompletionSettings(
-            model="gpt-primary",
-            fallback_models=("gpt-fallback",),
-            retry=RetryPolicy(max_retries=0),
-        ),
-    )
-
-    result = run(client.complete(messages=[]))
-
-    assert result.choices[0].message.content == "from fallback"
-    assert [req["model"] for req in complete.requests] == [
-        "gpt-primary",
-        "gpt-fallback",
-    ]
+        run(client.complete(messages=[]))
 
 
 def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
@@ -291,13 +261,11 @@ def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
     )
     runner = Runner(
         ToolRegistry(),
-        client=CompletionClient(
+        client=make_client(
             complete,
-            CompletionSettings(
-                model="gpt-primary",
-                fallback_models=("gpt-fallback",),
-                retry=RetryPolicy(max_retries=0),
-            ),
+            model="gpt-primary",
+            fallback_models=("gpt-fallback",),
+            retry=RetryPolicy(max_retries=0),
         ),
     )
 

--- a/reporter_v2/tests/test_integration.py
+++ b/reporter_v2/tests/test_integration.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from reporter_memory.context_store import ContextStore
 from reporter_v2.config import ReportConfig, TimeRange
+from reporter_v2.runner.completion import CompletionSettings
 from reporter_v2.runner.entrypoint import _persist_brief_facts, generate_article
 from reporter_v2.runner.models import ToolCall
 from reporter_v2.runner.schemas import Fact, ReportBrief, Storyline
@@ -277,7 +278,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                 time_range=TimeRange.single_week(8),
                 custom_instructions="weekly recap",
             ),
-            model="test-model",
+            completion=CompletionSettings(model="test-model"),
             complete=complete,
         )
     )

--- a/reporter_v2/tests/test_runner.py
+++ b/reporter_v2/tests/test_runner.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
+from reporter_v2.runner.completion import CompletionClient, CompletionSettings
 from reporter_v2.runner.models import ToolCall
 from reporter_v2.runner.runner import Runner
 from reporter_v2.runner.state import ProcedureHistoryMode, RunnerConfig
@@ -138,8 +139,10 @@ def test_runner_passes_explicit_model_override() -> None:
     complete = FakeCompletion([make_response(text="Done.")])
     runner = Runner(
         ToolRegistry(),
-        complete=complete,
-        config=RunnerConfig(model="claude-sonnet-4-6"),
+        client=CompletionClient(
+            complete,
+            CompletionSettings(model="claude-sonnet-4-6"),
+        ),
     )
 
     run(runner.run("system", "user"))

--- a/reporter_v2/tests/test_schemas.py
+++ b/reporter_v2/tests/test_schemas.py
@@ -196,5 +196,4 @@ class TestRunnerState:
         config = RunnerConfig()
 
         assert config.max_turns == 60
-        assert config.model is None
         assert config.procedure_history_mode == ProcedureHistoryMode.REPLACE

--- a/reporter_v2/workflows.py
+++ b/reporter_v2/workflows.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 from datalayer.sleeper_data import SleeperLeagueData
 from reporter_memory.context_store import ContextStore
 from reporter_v2.config import BiasProfile, ReportConfig, TimeRange, ToneControls
+from reporter_v2.runner.completion import CompletionSettings
 from reporter_v2.runner.entrypoint import generate_article
 from reporter_v2.runner.schemas import ArticleOutput
 from reporter_v2.runner.state import ProcedureHistoryMode
@@ -20,9 +21,7 @@ async def generate_report_async(
     *,
     week: int | None = None,
     data: SleeperLeagueData | None = None,
-    model: str | None = "gpt-5-mini",
-    fallback_models: list[str] | None = None,
-    max_retries: int = 3,
+    completion: CompletionSettings | None = None,
     voice: str = "sports columnist",
     snark_level: int = 1,
     hype_level: int = 1,
@@ -55,9 +54,7 @@ async def generate_report_async(
     return await generate_with_config_async(
         config,
         data=data,
-        model=model,
-        fallback_models=fallback_models,
-        max_retries=max_retries,
+        completion=completion,
         context_store=context_store,
         data_dir=data_dir,
         log_path=log_path,
@@ -78,9 +75,7 @@ async def generate_with_config_async(
     config: ReportConfig,
     *,
     data: SleeperLeagueData | None = None,
-    model: str | None = "gpt-5-mini",
-    fallback_models: list[str] | None = None,
-    max_retries: int = 3,
+    completion: CompletionSettings | None = None,
     context_store: ContextStore | None = None,
     data_dir: Path | str = Path(".data"),
     log_path: Path | None = None,
@@ -90,13 +85,12 @@ async def generate_with_config_async(
     """Generate a report using a pre-built ReportConfig."""
     data = _ensure_data(data)
     context_store = context_store or _make_context_store(data, Path(data_dir))
+    settings = completion or CompletionSettings(model="gpt-5-mini")
     return await generate_article(
         data,
         config,
         context_store=context_store,
-        model=model,
-        fallback_models=fallback_models,
-        max_retries=max_retries,
+        completion=settings,
         log_path=log_path,
         procedure_history_mode=procedure_history_mode,
         allow_memory_writes=allow_memory_writes,
@@ -115,7 +109,7 @@ async def weekly_recap_async(
     week: int,
     *,
     data: SleeperLeagueData | None = None,
-    model: str | None = "gpt-5-mini",
+    completion: CompletionSettings | None = None,
     snark_level: int = 1,
     hype_level: int = 2,
     **kwargs,
@@ -131,7 +125,7 @@ async def weekly_recap_async(
         "and important transactions.",
         week=week,
         data=data,
-        model=model,
+        completion=completion,
         **kwargs,
     )
 
@@ -148,7 +142,7 @@ async def snarky_recap_async(
     week: int,
     *,
     data: SleeperLeagueData | None = None,
-    model: str | None = "gpt-5-mini",
+    completion: CompletionSettings | None = None,
     disfavored_teams: list[str] | None = None,
     **kwargs,
 ) -> ArticleOutput:
@@ -170,7 +164,7 @@ async def snarky_recap_async(
         request,
         week=week,
         data=data,
-        model=model,
+        completion=completion,
         **kwargs,
     )
 


### PR DESCRIPTION
## Summary
- Introduce `RetryPolicy`, `CompletionSettings`, and `CompletionClient` so completion retry/model policy is bound once per article run
- Slim `RunnerConfig` to runner-only fields (`max_turns`, `procedure_history_mode`) and have the runner loop call `client.complete(messages=..., tools=...)`
- Fold retry/fallback into `CompletionClient.complete`; wire CLI / workflows / entrypoint to build settings once

Closes #79

## Test plan
- [x] `pytest reporter_v2/tests/` (124 passed)
- [ ] Spot-check CLI: `reporter-v2 --help` and env/CLI resolution for model, fallbacks, max-retries still produce expected settings
- [ ] Optional: short dry-run article generation with a fake or cheap model to confirm fallback/retry path still works