### PR TITLE
refactor(datalayer): modularize schema and clarify layer contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,11 @@ reporter-v2 "power rankings with analysis" --week 8          # Any article type
 datalayer/
 ├── sleeper_data/
 │   ├── sleeper_league_data.py    # Facade: SleeperLeagueData (main entry point)
+│   ├── load.py                   # Fetch → normalize → store orchestration
 │   ├── config.py                 # SleeperConfig, load_config()
 │   ├── sleeper_api/              # HTTP fetch layer (client.py, endpoints.py)
 │   ├── normalize/                # Raw JSON → dataclasses (one module per entity)
-│   ├── schema/
-│   │   ├── models.py             # 15 dataclass models (single source of truth)
-│   │   └── ddl.py                # DDL generation, DDL_REGISTRY
+│   ├── schema/                   # One module per table (row DTO + Core Table)
 │   ├── store/sqlite_store.py     # create_tables(), bulk_insert()
 │   └── queries/                  # Query functions + resolvers + sql_tool
 ├── tools.py                      # SLEEPER_TOOLS (OpenAI function-calling format)
@@ -93,16 +92,17 @@ reporter_v2/
 ### Python Style
 
 - **Python 3.11+** — use modern syntax (`X | Y` unions, `match` statements where appropriate)
-- **Dataclasses over dicts** — all domain models are `@dataclass` in `schema/models.py`
+- **Dataclasses over dicts** — domain row models are `@dataclass` in `schema/<table>.py`
 - **Type hints everywhere** — function signatures, return types, variables where non-obvious
 - **Naming**: `snake_case` for functions/variables, `PascalCase` for classes, `UPPER_SNAKE` for constants
-- **Imports**: stdlib → third-party → local, separated by blank lines. Use absolute imports from package root (`from datalayer.sleeper_data.schema.models import Player`)
+- **Imports**: stdlib → third-party → local, separated by blank lines. Prefer `from datalayer.sleeper_data.schema import Player`
 
 ### Patterns
 
 - **Facade pattern**: `SleeperLeagueData` is the single public entry point for all datalayer queries
+- **Load pipeline**: `load.load_league` owns fetch → normalize → store; facade owns connection lifecycle
 - **Normalize layer**: Each entity type has its own normalizer module — raw JSON in, dataclass out
-- **Query functions**: Pure functions that take a `sqlite3.Connection` and return dicts. Name resolution handled by `_resolvers.py`
+- **Query functions**: Pure functions that take a SQLAlchemy `Connection` and return dicts. Name resolution handled by `_resolvers.py`
 - **Tool definitions**: OpenAI function-calling format in `datalayer/tools.py`; reporter v2 registers model-facing tools under `reporter_v2/runner/tools/`
 
 ### Error Handling
@@ -122,7 +122,7 @@ reporter_v2/
 ## Design Principles
 
 - **Fresh load every run**: No persistence; Sleeper API is source of truth
-- **Dataclasses as schema**: `schema/models.py` is the single source of truth for entity shape
+- **One module per table**: `schema/<table>.py` owns the row DTO and SQLAlchemy Core `Table`
 - **Query-time joins**: Names resolved at query time, not denormalized into storage
 - **Brief-first writing**: Research produces a verified artifact before any drafting happens
 - **Bias = framing only**: Bias changes word choice and emphasis, never facts or numbers

--- a/datalayer/AGENTS.md
+++ b/datalayer/AGENTS.md
@@ -128,17 +128,33 @@ Most queries return dicts with a `found` key. List-returning queries return `lis
 
 Not-found responses return `{"found": false, ...}` with context about what was searched.
 
+## Layer Contracts
+
+| Layer | Responsibility | Depends on | Must not |
+|---|---|---|---|
+| `sleeper_api/` | HTTP fetch + JSON cache | — | schema, store, queries |
+| `normalize/` | Raw JSON → row dataclasses | `schema` | SQL, tools |
+| `schema/` | One module per table (DTO + Core `Table`) | SQLAlchemy Core | fetch, queries |
+| `store/` | `create_tables`, `bulk_insert` | `schema.metadata` | API, normalize, tools |
+| `load.py` | Orchestrate fetch → normalize → store | api, normalize, store | curated queries, tools |
+| `queries/` | Curated SQL → dict outputs | Connection + schema | API, normalize, tools |
+| `SleeperLeagueData` | Public API + connection lifecycle | load, queries | raw business SQL |
+| `tools.py` / CLI | Agent/operator surface | facade only | SQL, normalize, store |
+
 ## Load Flow (what `data.load()` does)
 
-1. Creates in-memory SQLite (`check_same_thread=False` for async)
+Implemented in `sleeper_data/load.py` (`load_league`):
+
+1. Creates in-memory SQLite engine (`check_same_thread=False` for async)
 2. Fetches league metadata, users, rosters, NFL state → normalizes → inserts
 3. Seeds draft picks (roster × 3 seasons × rounds), applies traded picks
 4. Fetches all players → inserts
 5. For each week 1..effective_week: matchups → MatchupRows + PlayerPerformances + Games; transactions → TransactionMoves
 6. Derives standings from roster metadata
 7. Stores SeasonContext (computed_week, override_week, effective_week)
+8. Facade opens a long-lived query connection
 
-## SQLite Schema (13 tables)
+## SQLite Schema (15 tables)
 
 | Table | Model | Key Columns |
 |---|---|---|
@@ -156,8 +172,9 @@ Not-found responses return `{"found": false, ...}` with context about what was s
 | `standings` | StandingsWeek | league_id, season, week, roster_id, wins, losses, rank, streak_type/len |
 | `transactions` | Transaction | league_id, season, week, transaction_id, type, status |
 | `transaction_moves` | TransactionMove | transaction_id, roster_id, player_id, asset_type, direction, pick metadata |
+| `playoff_matchups` | PlayoffMatchup | league_id, season, bracket_type, matchup_id, roster/outcome fields |
 
-All models defined in `sleeper_data/schema/models.py`. DDL with indexes in `schema/ddl.py`.
+Schema layout: one module per table under `sleeper_data/schema/` (co-located row dataclass + SQLAlchemy Core `Table`). Import from `datalayer.sleeper_data.schema`. Shared `metadata` lives in `schema/_base.py`.
 
 ## Name Resolution
 

--- a/datalayer/docs/01_datalayer.md
+++ b/datalayer/docs/01_datalayer.md
@@ -1,3 +1,5 @@
+> **Note:** Historical design doc. Paths like `ddl.py`, `defaults.py`, or monolith `schema/models.py` may be stale. See `datalayer/AGENTS.md` and `docs/architecture.md` for the current layout (one module per table under `schema/`, queries split by domain, load orchestration in `load.py`).
+
 # Design Doc: Python-First Sleeper Fantasy League Data Layer (MVP)
 
 ## Summary

--- a/datalayer/docs/02_surfacing_names.md
+++ b/datalayer/docs/02_surfacing_names.md
@@ -1,3 +1,5 @@
+> **Note:** Historical design doc. Paths like `ddl.py`, `defaults.py`, or monolith `schema/models.py` may be stale. See `datalayer/AGENTS.md` and `docs/architecture.md` for the current layout (one module per table under `schema/`, queries split by domain, load orchestration in `load.py`).
+
 ---
 
 # Design Doc: Name-Enriched Outputs + Name-Based Query Inputs

--- a/datalayer/docs/03_picks.md
+++ b/datalayer/docs/03_picks.md
@@ -1,3 +1,5 @@
+> **Note:** Historical design doc. Paths like `ddl.py`, `defaults.py`, or monolith `schema/models.py` may be stale. See `datalayer/AGENTS.md` and `docs/architecture.md` for the current layout (one module per table under `schema/`, queries split by domain, load orchestration in `load.py`).
+
 Below is a self‑contained design doc tailored to your current codebase and conventions. It assumes **Ask mode** (no edits), so this is documentation only.
 
 ---

--- a/datalayer/docs/04_transactions.md
+++ b/datalayer/docs/04_transactions.md
@@ -1,3 +1,5 @@
+> **Note:** Historical design doc. Paths like `ddl.py`, `defaults.py`, or monolith `schema/models.py` may be stale. See `datalayer/AGENTS.md` and `docs/architecture.md` for the current layout (one module per table under `schema/`, queries split by domain, load orchestration in `load.py`).
+
 Below is a full, self‑contained design doc for **Option A** (single `transaction_moves` table with explicit pick metadata).
 
 ---

--- a/datalayer/docs/05_player_performances.md
+++ b/datalayer/docs/05_player_performances.md
@@ -1,3 +1,5 @@
+> **Note:** Historical design doc. Paths like `ddl.py`, `defaults.py`, or monolith `schema/models.py` may be stale. See `datalayer/AGENTS.md` and `docs/architecture.md` for the current layout (one module per table under `schema/`, queries split by domain, load orchestration in `load.py`).
+
 # Player Performances Table
 
 ## Context

--- a/datalayer/docs/06_sqlalchemy_migration.md
+++ b/datalayer/docs/06_sqlalchemy_migration.md
@@ -1,5 +1,11 @@
 # 06 — SQLAlchemy Core Migration
 
+> **Status: COMPLETE (historical).** The datalayer uses SQLAlchemy Core today:
+> `create_engine`, shared `schema.metadata`, per-table `Table` modules under
+> `sleeper_data/schema/`, and `text()` queries via a SQLAlchemy `Connection`.
+> `ddl.py` has been removed. Persistence / Alembic remain future work — see
+> `datalayer/AGENTS.md` for the current architecture.
+
 ## Motivation
 
 The datalayer currently uses raw `sqlite3` for all database operations: connection management, DDL, bulk inserts, and queries. This works well for the current in-memory, load-once architecture, but two upcoming changes make it worth revisiting:

--- a/datalayer/docs/07_persistent_context.md
+++ b/datalayer/docs/07_persistent_context.md
@@ -21,7 +21,8 @@ and `sleeperdl memory` have been removed.
 
 ## Schema
 
-The current memory schema version is `2.1`.
+Canonical memory schema docs live in `reporter_memory/`. Current schema version
+is `3` (`reporter_memory.schema.SCHEMA_VERSION`).
 
 The store supports multiple leagues and seasons in the same SQLite file. Storyline
 identity is scoped by `(league_id, season, id)`, and all storyline history and

--- a/datalayer/docs/08_aidam_skills.md
+++ b/datalayer/docs/08_aidam_skills.md
@@ -36,7 +36,7 @@ Default DB path:
 
 Schema:
 
-- Current schema version: `2.1`.
+- Current schema version: `3` (see `reporter_memory.schema.SCHEMA_VERSION`).
 - Storyline identity is scoped by `(league_id, season, id)`.
 - Storyline history and persisted facts are scoped by league and season.
 - Legacy DB schemas are not migrated; delete or recreate old context DBs.

--- a/datalayer/docs/architecture.md
+++ b/datalayer/docs/architecture.md
@@ -1,74 +1,92 @@
- # Datalayer Architecture
- 
- ## Purpose
- 
- This datalayer provides a clean, queryable view of a Sleeper fantasy football league.
- It is built to serve downstream consumers such as an AI fantasy football reporter, while
- remaining a developer-friendly system for extension and analysis.
- 
- ## High-Level Architecture
- 
- The system follows a layered pipeline that converts raw API responses into a stable,
- relational model and exposes curated query methods.
- 
- 1. Fetch raw JSON from the Sleeper API.
- 2. Normalize raw data into canonical dataclasses.
- 3. Load normalized rows into an in-memory SQLite schema.
- 4. Expose queries that return enriched, reporter-ready data shapes.
- 
- ```mermaid
- flowchart LR
-   SleeperAPI[ SleeperAPI ] --> Normalize[ Normalize ]
-   Normalize --> SQLiteStore[ SQLiteStore ]
-   SQLiteStore --> QueryAPI[ QueryAPI ]
-   QueryAPI --> ReporterConsumers[ ReporterConsumers ]
- ```
- 
- ## Core Entry Point
- 
- `SleeperLeagueData` is the facade that orchestrates loading and querying. It:
- - Resolves the effective week (computed or override).
- - Orchestrates fetch → normalize → store.
- - Exposes high-level query methods and guarded SQL access.
- 
- ## Design Rationale
- 
- - **In-memory SQLite** keeps loads fast and enables rich joins without persistence
-   complexity during early iteration.
- - **Dataclasses-as-schema** provide a single source of truth for data shape and
-   simplify table generation and bulk inserts.
- - **Query-time joins** avoid denormalized name fields and keep identities current
-   without write-time maintenance.
- - **Name resolution** allows inputs by name or ID, producing human-readable outputs
-   that are suitable for narrative generation.
- - **Guarded SQL access** supports exploration while preventing writes and unbounded
-   queries in agent workflows.
- - **Unified transaction assets + draft pick ownership** provide a coherent view of
-   roster movement and pick state.
- 
- ## AI Reporter Context (Developer-Facing)
- 
- The datalayer emphasizes stable, enriched outputs that downstream narrative systems
- can depend on. Queries return readable names (manager, team, player) and include temporal
- context such as `as_of_week`, enabling consistent, explainable story generation without
- embedding reporter logic in this layer.
- 
- ## Key Modules
- 
- - Facade and orchestration: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\sleeper_league_data.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\sleeper_league_data.py)
- - API client and endpoints: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\sleeper_api](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\sleeper_api)
- - Normalization pipeline: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\normalize](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\normalize)
- - Canonical schema models: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\schema\models.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\schema\models.py)
- - DDL generation: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\schema\ddl.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\schema\ddl.py)
- - SQLite store: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\store\sqlite_store.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\store\sqlite_store.py)
- - Default queries: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\queries\defaults.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\queries\defaults.py)
- - Guarded SQL tool: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\queries\sql_tool.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\queries\sql_tool.py)
- - Configuration: [c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\config.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\sleeper_data\config.py)
- - CLI entrypoint: [c:\Users\maxwn\AIdamShefter-v2\datalayer\cli\main.py](c:\Users\maxwn\AIdamShefter-v2\datalayer\cli\main.py)
- 
- ## Related Design Docs
- 
- - [c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\01_datalayer.md](c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\01_datalayer.md)
- - [c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\02_surfacing_names.md](c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\02_surfacing_names.md)
- - [c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\03_picks.md](c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\03_picks.md)
- - [c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\04_transactions.md](c:\Users\maxwn\AIdamShefter-v2\datalayer\designs\04_transactions.md)
+# Datalayer Architecture
+
+## Purpose
+
+This datalayer provides a clean, queryable view of a Sleeper fantasy football league.
+It is built to serve downstream consumers such as an AI fantasy football reporter, while
+remaining a developer-friendly system for extension and analysis.
+
+Persistent reporter narrative memory lives in `reporter_memory/`, not here.
+
+## High-Level Architecture
+
+The system follows a layered pipeline that converts raw API responses into a stable,
+relational model and exposes curated query methods.
+
+1. Fetch raw JSON from the Sleeper API.
+2. Normalize raw data into canonical row dataclasses.
+3. Load normalized rows into an in-memory SQLite schema (SQLAlchemy Core).
+4. Expose queries that return enriched, reporter-ready data shapes.
+
+```mermaid
+flowchart LR
+  SleeperAPI[SleeperAPI] --> Normalize[Normalize]
+  Normalize --> SQLiteStore[SQLiteStore]
+  Load[load.py] --> SleeperAPI
+  Load --> Normalize
+  Load --> SQLiteStore
+  Facade[SleeperLeagueData] --> Load
+  Facade --> QueryAPI[queries]
+  QueryAPI --> ReporterConsumers[ReporterConsumers]
+  Tools[tools.py / CLI] --> Facade
+```
+
+## Layer Contracts
+
+| Layer | May depend on | Must not |
+|-------|---------------|----------|
+| `sleeper_api/` | HTTP/cache only | schema, store, queries |
+| `normalize/` | `schema` row types | SQL, engine, tools |
+| `schema/` | SQLAlchemy Core + dataclasses | fetch, queries, tools |
+| `store/` | `schema.metadata`, row types | API, normalize, tools |
+| `load.py` | api, normalize, store | curated queries, tools |
+| `queries/` | Connection + SQL + resolvers | API, normalize, tools |
+| `SleeperLeagueData` | load + queries | raw business SQL |
+| `tools.py` / CLI | facade only | SQL, normalize, store |
+
+## Core Entry Point
+
+`SleeperLeagueData` is the facade that:
+
+- Resolves config (`league_id`, week override).
+- Delegates fetch → normalize → store to `load.load_league`.
+- Owns engine / long-lived query connection lifecycle.
+- Exposes high-level query methods and guarded SQL access.
+
+## Design Rationale
+
+- **In-memory SQLite** keeps loads fast and enables rich joins without persistence
+  complexity during early iteration.
+- **One module per table** co-locates the insert DTO and SQLAlchemy Core `Table`,
+  avoiding dual-file schema drift.
+- **SQLAlchemy Core (not ORM)** matches dict-shaped query outputs without Session/mapped-class overhead.
+- **Query-time joins** avoid denormalized name fields and keep identities current
+  without write-time maintenance.
+- **Name resolution** allows inputs by name or ID, producing human-readable outputs
+  that are suitable for narrative generation.
+- **Guarded SQL access** supports exploration while preventing writes and unbounded
+  queries in agent workflows.
+
+## Key Modules
+
+- Facade: `datalayer/sleeper_data/sleeper_league_data.py`
+- Load pipeline: `datalayer/sleeper_data/load.py`
+- API client and endpoints: `datalayer/sleeper_data/sleeper_api/`
+- Normalization: `datalayer/sleeper_data/normalize/`
+- Schema (one file per table): `datalayer/sleeper_data/schema/`
+- SQLite store: `datalayer/sleeper_data/store/sqlite_store.py`
+- Queries: `datalayer/sleeper_data/queries/` (`league`, `team`, `player`, `transactions`, `playoffs`, `sql_tool`)
+- Configuration: `datalayer/sleeper_data/config.py`
+- Tools: `datalayer/tools.py`
+- CLI: `datalayer/cli/main.py`
+
+## Related Design Docs
+
+- `docs/01_datalayer.md` — Core data layer design (historical; paths may be stale)
+- `docs/02_surfacing_names.md` — Name resolution strategy (historical)
+- `docs/03_picks.md` — Draft pick ownership tracking (historical)
+- `docs/04_transactions.md` — Transaction + pick metadata design
+- `docs/05_player_performances.md` — Player-level scoring extraction (historical)
+- `docs/06_sqlalchemy_migration.md` — SQLAlchemy Core migration (**complete**)
+- `docs/07_persistent_context.md` — Memory ownership boundary → `reporter_memory/`
+- `docs/08_aidam_skills.md` — AIda skill workflow with snapshot + memory split

--- a/datalayer/sleeper_data/__init__.py
+++ b/datalayer/sleeper_data/__init__.py
@@ -1,15 +1,14 @@
-"""Public package exports for sleeper data layer."""
+"""Public package exports for sleeper data layer.
+
+Prefer ``SleeperLeagueData`` as the integration surface. Store helpers and
+schema internals are available via deeper imports when needed by tests.
+"""
 
 from .config import SleeperConfig, load_config
-from .schema import models as schema_models
 from .sleeper_league_data import SleeperLeagueData
-from .store.sqlite_store import bulk_insert, create_tables
 
 __all__ = [
     "SleeperConfig",
     "SleeperLeagueData",
     "load_config",
-    "schema_models",
-    "bulk_insert",
-    "create_tables",
 ]

--- a/datalayer/sleeper_data/load.py
+++ b/datalayer/sleeper_data/load.py
@@ -1,0 +1,283 @@
+"""Load pipeline: fetch → normalize → store into a SQLite engine.
+
+Contract: owns orchestration only. Does not expose curated query APIs.
+Callers (SleeperLeagueData) open the query connection after load returns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy.engine import Connection, Engine
+
+from .normalize import (
+    apply_traded_picks,
+    derive_games,
+    derive_team_profiles,
+    normalize_bracket,
+    normalize_league,
+    normalize_matchups,
+    normalize_players,
+    normalize_roster_players,
+    normalize_rosters,
+    normalize_standings,
+    normalize_transaction_moves,
+    normalize_transactions,
+    normalize_users,
+    seed_draft_picks,
+)
+from .schema import SeasonContext, StandingsWeek
+from .sleeper_api import (
+    SleeperClient,
+    get_league,
+    get_league_rosters,
+    get_league_users,
+    get_losers_bracket,
+    get_matchups,
+    get_players,
+    get_state,
+    get_traded_picks,
+    get_transactions as api_get_transactions,
+    get_winners_bracket,
+)
+from .store.sqlite_store import bulk_insert, create_tables
+
+
+@dataclass(frozen=True)
+class LoadResult:
+    """Metadata produced by a successful league load."""
+
+    league_id: str
+    season: str
+    computed_week: int
+    effective_week: int
+    week_override: int | None
+
+
+def _record_string_to_weeks(
+    record_string: str | None,
+    *,
+    chars_per_week: int,
+) -> list[tuple[int, int, int, int]]:
+    if not record_string:
+        return []
+    trimmed = "".join(ch for ch in record_string.strip().upper() if ch.strip())
+    if not trimmed:
+        return []
+    week_count = len(trimmed) // chars_per_week
+    results: list[tuple[int, int, int, int]] = []
+    wins = 0
+    losses = 0
+    ties = 0
+    for week in range(1, week_count + 1):
+        end_idx = week * chars_per_week
+        slice_value = trimmed[end_idx - chars_per_week : end_idx]
+        for outcome in slice_value:
+            if outcome == "W":
+                wins += 1
+            elif outcome == "L":
+                losses += 1
+            elif outcome == "T":
+                ties += 1
+        results.append((week, wins, losses, ties))
+    return results
+
+
+def _insert_rows(conn: Connection, rows: list) -> None:
+    if rows:
+        bulk_insert(conn, rows[0].table_name, rows)
+
+
+def load_league(
+    engine: Engine,
+    *,
+    client: SleeperClient,
+    league_id: str,
+    week_override: int | None = None,
+) -> LoadResult:
+    """Fetch Sleeper data, normalize, and populate ``engine`` from scratch."""
+    raw_league = get_league(league_id, client=client)
+    raw_users = get_league_users(league_id, client=client)
+    raw_rosters = get_league_rosters(league_id, client=client)
+    raw_state = get_state("nfl", client=client)
+
+    league = normalize_league(raw_league)
+    users = normalize_users(raw_users)
+    rosters = normalize_rosters(raw_rosters, league_id=league_id)
+    roster_players = normalize_roster_players(raw_rosters, league_id=league_id)
+    team_profiles = derive_team_profiles(
+        raw_rosters, raw_users, league_id=league_id
+    )
+
+    with engine.begin() as conn:
+        create_tables(conn)
+
+        bulk_insert(conn, league.table_name, [league])
+        _insert_rows(conn, users)
+        _insert_rows(conn, rosters)
+        _insert_rows(conn, team_profiles)
+
+        draft_rounds = int(
+            (raw_league.get("settings") or {}).get("draft_rounds") or 0
+        )
+        draft_picks = seed_draft_picks(
+            rosters, league_id, league.season, draft_rounds
+        )
+        _insert_rows(conn, draft_picks)
+
+        raw_traded_picks = get_traded_picks(league_id, client=client)
+        apply_traded_picks(conn, raw_traded_picks, league_id)
+
+        raw_players = get_players("nfl", client=client)
+        players = normalize_players(raw_players)
+        _insert_rows(conn, players)
+        _insert_rows(conn, roster_players)
+
+        computed_week = int(raw_state.get("week") or 0)
+        effective_week = int(week_override or computed_week or 0)
+        season = str(raw_league.get("season") or raw_state.get("season") or "")
+        league_average_match = (
+            int((raw_league.get("settings") or {}).get("league_average_match") or 0)
+            if raw_league.get("settings") is not None
+            else 0
+        )
+        chars_per_week = 2 if league_average_match == 1 else 1
+
+        playoff_week_start = (
+            int(league.playoff_week_start)
+            if league.playoff_week_start is not None
+            else None
+        )
+
+        if effective_week > 0:
+            for week in range(1, effective_week + 1):
+                raw_matchups = get_matchups(league_id, week, client=client)
+                matchup_rows, player_performances = normalize_matchups(
+                    raw_matchups,
+                    league_id=league_id,
+                    season=season,
+                    week=week,
+                )
+                is_playoffs = (
+                    playoff_week_start is not None
+                    and week >= int(playoff_week_start)
+                )
+                games = derive_games(matchup_rows, is_playoffs=is_playoffs)
+                _insert_rows(conn, matchup_rows)
+                _insert_rows(conn, player_performances)
+                _insert_rows(conn, games)
+
+                raw_transactions = api_get_transactions(
+                    league_id, week, client=client
+                )
+                transactions = normalize_transactions(
+                    raw_transactions,
+                    league_id=league_id,
+                    season=season,
+                    week=week,
+                )
+                moves = normalize_transaction_moves(raw_transactions)
+                _insert_rows(conn, transactions)
+                _insert_rows(conn, moves)
+
+            record_standings: list[StandingsWeek] = []
+            record_weeks: set[int] = set()
+
+            for raw_roster in raw_rosters:
+                roster_id = int(raw_roster["roster_id"])
+                record_string = (raw_roster.get("metadata") or {}).get("record")
+                if isinstance(record_string, list):
+                    record_string = "".join(
+                        str(item) for item in record_string if item
+                    )
+                if isinstance(record_string, str):
+                    for week, wins, losses, ties in _record_string_to_weeks(
+                        record_string, chars_per_week=chars_per_week
+                    ):
+                        if week > effective_week:
+                            break
+                        if (
+                            playoff_week_start is not None
+                            and week >= playoff_week_start
+                        ):
+                            continue
+                        record_standings.append(
+                            StandingsWeek(
+                                league_id=league_id,
+                                season=season,
+                                week=int(week),
+                                roster_id=roster_id,
+                                wins=wins,
+                                losses=losses,
+                                ties=ties,
+                                points_for=0.0,
+                                points_against=0.0,
+                                rank=None,
+                                streak_type=None,
+                                streak_len=None,
+                            )
+                        )
+                        record_weeks.add(int(week))
+
+            _insert_rows(conn, record_standings)
+
+            should_insert_current = False
+            if not record_weeks:
+                should_insert_current = True
+            elif effective_week > max(record_weeks):
+                if (
+                    playoff_week_start is None
+                    or effective_week < playoff_week_start
+                ):
+                    should_insert_current = True
+
+            if should_insert_current:
+                standings = normalize_standings(
+                    raw_rosters,
+                    league_id=league_id,
+                    season=season,
+                    week=effective_week,
+                )
+                _insert_rows(conn, standings)
+
+        # Only load playoff brackets if we've reached the playoff weeks.
+        # Loading them earlier would leak future results when using
+        # week_override to view a mid-season snapshot.
+        should_load_brackets = (
+            playoff_week_start is None or effective_week >= playoff_week_start
+        )
+        if should_load_brackets:
+            raw_winners = get_winners_bracket(league_id, client=client)
+            raw_losers = get_losers_bracket(league_id, client=client)
+            winners = normalize_bracket(
+                raw_winners,
+                league_id=league_id,
+                season=season,
+                bracket_type="winners",
+            )
+            losers = normalize_bracket(
+                raw_losers,
+                league_id=league_id,
+                season=season,
+                bracket_type="losers",
+            )
+            _insert_rows(conn, winners)
+            _insert_rows(conn, losers)
+
+        season_context = SeasonContext(
+            league_id=league_id,
+            computed_week=computed_week,
+            override_week=week_override,
+            effective_week=effective_week,
+            generated_at=datetime.now(timezone.utc).isoformat(),
+        )
+        bulk_insert(conn, season_context.table_name, [season_context])
+
+    return LoadResult(
+        league_id=league_id,
+        season=season,
+        computed_week=computed_week,
+        effective_week=effective_week,
+        week_override=week_override,
+    )

--- a/datalayer/sleeper_data/normalize/bracket.py
+++ b/datalayer/sleeper_data/normalize/bracket.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping, Optional
 
-from ..schema.models import PlayoffMatchup
+from ..schema import PlayoffMatchup
 
 
 def _extract_from_ref(

--- a/datalayer/sleeper_data/normalize/league.py
+++ b/datalayer/sleeper_data/normalize/league.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping
 
-from ..schema.models import League
+from ..schema import League
 
 
 def _json_dumps(value: Any) -> str | None:

--- a/datalayer/sleeper_data/normalize/matchups.py
+++ b/datalayer/sleeper_data/normalize/matchups.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Iterable, Mapping
 
-from ..schema.models import Game, MatchupRow, PlayerPerformance
+from ..schema import Game, MatchupRow, PlayerPerformance
 
 
 def _normalize_player_ids(value: Any) -> list[str]:

--- a/datalayer/sleeper_data/normalize/picks.py
+++ b/datalayer/sleeper_data/normalize/picks.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from sqlalchemy import text
 
-from ..schema.models import DraftPick, Roster
+from ..schema import DraftPick, Roster
 
 
 def seed_draft_picks(

--- a/datalayer/sleeper_data/normalize/players.py
+++ b/datalayer/sleeper_data/normalize/players.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping
 
-from ..schema.models import Player
+from ..schema import Player
 
 
 def _json_dumps(value: Any) -> str | None:

--- a/datalayer/sleeper_data/normalize/rosters.py
+++ b/datalayer/sleeper_data/normalize/rosters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Mapping
 
-from ..schema.models import Roster, RosterPlayer, TeamProfile
+from ..schema import Roster, RosterPlayer, TeamProfile
 
 
 def _json_dumps(value: Any) -> str | None:

--- a/datalayer/sleeper_data/normalize/standings.py
+++ b/datalayer/sleeper_data/normalize/standings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping
 
-from ..schema.models import StandingsWeek
+from ..schema import StandingsWeek
 
 
 def _points_from_settings(settings: Mapping[str, int | float | None], *, prefix: str) -> float:

--- a/datalayer/sleeper_data/normalize/transactions.py
+++ b/datalayer/sleeper_data/normalize/transactions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Mapping
 
-from ..schema.models import Transaction, TransactionMove
+from ..schema import Transaction, TransactionMove
 
 
 def _json_dumps(value: Any) -> str | None:

--- a/datalayer/sleeper_data/normalize/users.py
+++ b/datalayer/sleeper_data/normalize/users.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Mapping
 
-from ..schema.models import User
+from ..schema import User
 
 
 def _json_dumps(value: Any) -> str | None:

--- a/datalayer/sleeper_data/queries/_helpers.py
+++ b/datalayer/sleeper_data/queries/_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Iterable, Mapping
 
 from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
 # Position order for sorting (standard fantasy football order)
 POSITION_ORDER = {"QB": 0, "RB": 1, "WR": 2, "TE": 3, "K": 4, "DEF": 5}
@@ -14,13 +15,17 @@ POSITIONS = ["qb", "rb", "wr", "te", "k", "def"]
 _TEAM_PROFILE_EXCLUDE = {"avatar_url"}
 
 
-def fetch_all(conn, sql: str, params: Mapping[str, Any] | None = None) -> list[dict[str, Any]]:
+def fetch_all(
+    conn: Connection, sql: str, params: Mapping[str, Any] | None = None
+) -> list[dict[str, Any]]:
     """Execute SQL and return all rows as list of dicts."""
     result = conn.execute(text(sql), params or {})
     return [dict(row) for row in result.mappings().all()]
 
 
-def fetch_one(conn, sql: str, params: Mapping[str, Any] | None = None) -> dict[str, Any] | None:
+def fetch_one(
+    conn: Connection, sql: str, params: Mapping[str, Any] | None = None
+) -> dict[str, Any] | None:
     """Execute SQL and return first row as dict, or None."""
     result = conn.execute(text(sql), params or {})
     row = result.mappings().first()

--- a/datalayer/sleeper_data/schema/__init__.py
+++ b/datalayer/sleeper_data/schema/__init__.py
@@ -1,33 +1,57 @@
-"""Schema models and SQLAlchemy table definitions."""
+"""Schema models and SQLAlchemy table definitions.
 
-from .models import (
-    Game,
-    League,
-    MatchupRow,
-    Player,
-    PlayoffMatchup,
-    Roster,
-    SeasonContext,
-    StandingsWeek,
-    TeamProfile,
-    Transaction,
-    TransactionMove,
-    User,
-)
-from .tables import metadata
+One module per table: each file owns the insert DTO and the Core Table.
+Import row types and `metadata` from this package.
+"""
+
+from ._base import RowMixin, metadata
+from .draft_picks import DraftPick, draft_picks
+from .games import Game, games
+from .leagues import League, leagues
+from .matchups import MatchupRow, matchups
+from .player_performances import PlayerPerformance, player_performances
+from .players import Player, players
+from .playoff_matchups import PlayoffMatchup, playoff_matchups
+from .roster_players import RosterPlayer, roster_players
+from .rosters import Roster, rosters
+from .season_context import SeasonContext, season_context
+from .standings import StandingsWeek, standings
+from .team_profiles import TeamProfile, team_profiles
+from .transaction_moves import TransactionMove, transaction_moves
+from .transactions import Transaction, transactions
+from .users import User, users
 
 __all__ = [
+    "RowMixin",
+    "metadata",
+    "DraftPick",
     "Game",
     "League",
     "MatchupRow",
     "Player",
+    "PlayerPerformance",
     "PlayoffMatchup",
     "Roster",
+    "RosterPlayer",
     "SeasonContext",
     "StandingsWeek",
     "TeamProfile",
     "Transaction",
     "TransactionMove",
     "User",
-    "metadata",
+    "draft_picks",
+    "games",
+    "leagues",
+    "matchups",
+    "player_performances",
+    "players",
+    "playoff_matchups",
+    "roster_players",
+    "rosters",
+    "season_context",
+    "standings",
+    "team_profiles",
+    "transaction_moves",
+    "transactions",
+    "users",
 ]

--- a/datalayer/sleeper_data/schema/_base.py
+++ b/datalayer/sleeper_data/schema/_base.py
@@ -1,0 +1,19 @@
+"""Shared schema primitives for the Sleeper data layer."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, ClassVar
+
+from sqlalchemy import MetaData
+
+metadata = MetaData()
+
+
+class RowMixin:
+    """Insert DTO helper: dataclasses expose table_name + to_row()."""
+
+    table_name: ClassVar[str]
+
+    def to_row(self) -> dict[str, Any]:
+        return asdict(self)

--- a/datalayer/sleeper_data/schema/draft_picks.py
+++ b/datalayer/sleeper_data/schema/draft_picks.py
@@ -1,0 +1,39 @@
+"""draft_picks table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+draft_picks = Table(
+    "draft_picks",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("round", Integer, nullable=False),
+    Column("original_roster_id", Integer, nullable=False),
+    Column("current_roster_id", Integer, nullable=False),
+    Column("pick_id", Text),
+    Column("source", Text),
+    PrimaryKeyConstraint("league_id", "season", "round", "original_roster_id"),
+    Index("idx_draft_picks_current", "league_id", "current_roster_id"),
+    Index("idx_draft_picks_original", "league_id", "original_roster_id"),
+    Index("idx_draft_picks_season_round", "league_id", "season", "round"),
+)
+
+
+@dataclass
+class DraftPick(RowMixin):
+    table_name: ClassVar[str] = "draft_picks"
+
+    league_id: str
+    season: str
+    round: int
+    original_roster_id: int
+    current_roster_id: int
+    pick_id: Optional[str] = None
+    source: Optional[str] = None

--- a/datalayer/sleeper_data/schema/games.py
+++ b/datalayer/sleeper_data/schema/games.py
@@ -1,0 +1,43 @@
+"""games table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Float, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+games = Table(
+    "games",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("week", Integer, nullable=False),
+    Column("matchup_id", Integer, nullable=False),
+    Column("roster_id_a", Integer, nullable=False),
+    Column("roster_id_b", Integer, nullable=False),
+    Column("points_a", Float, nullable=False),
+    Column("points_b", Float, nullable=False),
+    Column("winner_roster_id", Integer),
+    Column("is_playoffs", Integer, nullable=False),
+    PrimaryKeyConstraint("league_id", "week", "matchup_id"),
+    Index("idx_games_league_season_week", "league_id", "season", "week"),
+)
+
+
+@dataclass
+class Game(RowMixin):
+    table_name: ClassVar[str] = "games"
+
+    league_id: str
+    season: str
+    week: int
+    matchup_id: int
+    roster_id_a: int
+    roster_id_b: int
+    points_a: float
+    points_b: float
+    winner_roster_id: Optional[int]
+    is_playoffs: bool

--- a/datalayer/sleeper_data/schema/leagues.py
+++ b/datalayer/sleeper_data/schema/leagues.py
@@ -1,0 +1,39 @@
+"""leagues table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Integer, Table, Text
+
+from ._base import RowMixin, metadata
+
+leagues = Table(
+    "leagues",
+    metadata,
+    Column("league_id", Text, primary_key=True),
+    Column("season", Text, nullable=False),
+    Column("name", Text, nullable=False),
+    Column("sport", Text, nullable=False),
+    Column("scoring_settings_json", Text),
+    Column("roster_positions_json", Text),
+    Column("playoff_week_start", Integer),
+    Column("playoff_teams", Integer),
+    Column("league_average_match", Integer),
+)
+
+
+@dataclass
+class League(RowMixin):
+    table_name: ClassVar[str] = "leagues"
+
+    league_id: str
+    season: str
+    name: str
+    sport: str
+    scoring_settings_json: Optional[str] = None
+    roster_positions_json: Optional[str] = None
+    playoff_week_start: Optional[int] = None
+    playoff_teams: Optional[int] = None
+    league_average_match: Optional[int] = None

--- a/datalayer/sleeper_data/schema/matchups.py
+++ b/datalayer/sleeper_data/schema/matchups.py
@@ -1,0 +1,36 @@
+"""matchups table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from sqlalchemy import Column, Float, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+matchups = Table(
+    "matchups",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("week", Integer, nullable=False),
+    Column("matchup_id", Integer, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("points", Float, nullable=False),
+    PrimaryKeyConstraint("league_id", "week", "matchup_id", "roster_id"),
+    Index("idx_matchups_league_season_week", "league_id", "season", "week"),
+    Index("idx_matchups_week_matchup", "week", "matchup_id"),
+)
+
+
+@dataclass
+class MatchupRow(RowMixin):
+    table_name: ClassVar[str] = "matchups"
+
+    league_id: str
+    season: str
+    week: int
+    matchup_id: int
+    roster_id: int
+    points: float

--- a/datalayer/sleeper_data/schema/models.py
+++ b/datalayer/sleeper_data/schema/models.py
@@ -1,226 +1,42 @@
-"""Canonical schema models for Sleeper data layer."""
+"""Backward-compatible re-exports of row models.
 
-from __future__ import annotations
+Prefer: `from datalayer.sleeper_data.schema import League, ...`
+"""
 
-from dataclasses import asdict, dataclass
-from typing import Any, ClassVar, Optional
+from . import (
+    DraftPick,
+    Game,
+    League,
+    MatchupRow,
+    Player,
+    PlayerPerformance,
+    PlayoffMatchup,
+    Roster,
+    RosterPlayer,
+    RowMixin,
+    SeasonContext,
+    StandingsWeek,
+    TeamProfile,
+    Transaction,
+    TransactionMove,
+    User,
+)
 
-
-class RowMixin:
-    """Small helper to prepare values for sqlite inserts."""
-
-    table_name: ClassVar[str]
-
-    def to_row(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class League(RowMixin):
-    table_name: ClassVar[str] = "leagues"
-
-    league_id: str
-    season: str
-    name: str
-    sport: str
-    scoring_settings_json: Optional[str] = None
-    roster_positions_json: Optional[str] = None
-    playoff_week_start: Optional[int] = None
-    playoff_teams: Optional[int] = None
-    league_average_match: Optional[int] = None
-
-
-@dataclass
-class SeasonContext(RowMixin):
-    table_name: ClassVar[str] = "season_context"
-
-    league_id: str
-    computed_week: int
-    override_week: Optional[int]
-    effective_week: int
-    generated_at: str
-
-
-@dataclass
-class User(RowMixin):
-    table_name: ClassVar[str] = "users"
-
-    user_id: str
-    display_name: str
-    avatar: Optional[str] = None
-    metadata_json: Optional[str] = None
-
-
-@dataclass
-class Roster(RowMixin):
-    table_name: ClassVar[str] = "rosters"
-
-    league_id: str
-    roster_id: int
-    owner_user_id: Optional[str] = None
-    settings_json: Optional[str] = None
-    metadata_json: Optional[str] = None
-    record_string: Optional[str] = None
-
-
-@dataclass
-class RosterPlayer(RowMixin):
-    table_name: ClassVar[str] = "roster_players"
-
-    league_id: str
-    roster_id: int
-    player_id: str
-    role: str
-
-
-@dataclass
-class TeamProfile(RowMixin):
-    table_name: ClassVar[str] = "team_profiles"
-
-    league_id: str
-    roster_id: int
-    team_name: Optional[str] = None
-    manager_name: Optional[str] = None
-    avatar_url: Optional[str] = None
-
-
-@dataclass
-class DraftPick(RowMixin):
-    table_name: ClassVar[str] = "draft_picks"
-
-    league_id: str
-    season: str
-    round: int
-    original_roster_id: int
-    current_roster_id: int
-    pick_id: Optional[str] = None
-    source: Optional[str] = None
-
-
-@dataclass
-class MatchupRow(RowMixin):
-    table_name: ClassVar[str] = "matchups"
-
-    league_id: str
-    season: str
-    week: int
-    matchup_id: int
-    roster_id: int
-    points: float
-
-
-@dataclass
-class PlayerPerformance(RowMixin):
-    table_name: ClassVar[str] = "player_performances"
-
-    league_id: str
-    season: str
-    week: int
-    player_id: str
-    roster_id: int
-    matchup_id: int
-    points: float
-    role: Optional[str] = None
-
-
-@dataclass
-class Game(RowMixin):
-    table_name: ClassVar[str] = "games"
-
-    league_id: str
-    season: str
-    week: int
-    matchup_id: int
-    roster_id_a: int
-    roster_id_b: int
-    points_a: float
-    points_b: float
-    winner_roster_id: Optional[int]
-    is_playoffs: bool
-
-
-@dataclass
-class Player(RowMixin):
-    table_name: ClassVar[str] = "players"
-
-    player_id: str
-    full_name: Optional[str] = None
-    position: Optional[str] = None
-    nfl_team: Optional[str] = None
-    status: Optional[str] = None
-    injury_status: Optional[str] = None
-    age: Optional[int] = None
-    years_exp: Optional[int] = None
-    metadata_json: Optional[str] = None
-    updated_at: Optional[str] = None
-
-
-@dataclass
-class Transaction(RowMixin):
-    table_name: ClassVar[str] = "transactions"
-
-    league_id: str
-    season: str
-    week: int
-    transaction_id: str
-    type: str
-    status: Optional[str] = None
-    created_ts: Optional[int] = None
-    settings_json: Optional[str] = None
-    metadata_json: Optional[str] = None
-
-
-@dataclass
-class TransactionMove(RowMixin):
-    table_name: ClassVar[str] = "transaction_moves"
-
-    transaction_id: str
-    roster_id: Optional[int]
-    player_id: Optional[str]
-    asset_type: str
-    direction: str
-    bid_amount: Optional[int] = None
-    from_roster_id: Optional[int] = None
-    to_roster_id: Optional[int] = None
-    pick_season: Optional[str] = None
-    pick_round: Optional[int] = None
-    pick_original_roster_id: Optional[int] = None
-    pick_id: Optional[str] = None
-
-
-@dataclass
-class PlayoffMatchup(RowMixin):
-    table_name: ClassVar[str] = "playoff_matchups"
-
-    league_id: str
-    season: str
-    bracket_type: str
-    round: int
-    matchup_id: int
-    t1_roster_id: Optional[int] = None
-    t2_roster_id: Optional[int] = None
-    t1_from_matchup_id: Optional[int] = None
-    t1_from_outcome: Optional[str] = None
-    t2_from_matchup_id: Optional[int] = None
-    t2_from_outcome: Optional[str] = None
-    winner_roster_id: Optional[int] = None
-    loser_roster_id: Optional[int] = None
-    placement: Optional[int] = None
-
-
-@dataclass
-class StandingsWeek(RowMixin):
-    table_name: ClassVar[str] = "standings"
-
-    league_id: str
-    season: str
-    week: int
-    roster_id: int
-    wins: int
-    losses: int
-    ties: int
-    points_for: float
-    points_against: float
-    rank: Optional[int] = None
-    streak_type: Optional[str] = None
-    streak_len: Optional[int] = None
+__all__ = [
+    "RowMixin",
+    "League",
+    "SeasonContext",
+    "User",
+    "Roster",
+    "RosterPlayer",
+    "TeamProfile",
+    "DraftPick",
+    "MatchupRow",
+    "PlayerPerformance",
+    "Game",
+    "Player",
+    "Transaction",
+    "TransactionMove",
+    "PlayoffMatchup",
+    "StandingsWeek",
+]

--- a/datalayer/sleeper_data/schema/player_performances.py
+++ b/datalayer/sleeper_data/schema/player_performances.py
@@ -1,0 +1,41 @@
+"""player_performances table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Float, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+player_performances = Table(
+    "player_performances",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("week", Integer, nullable=False),
+    Column("player_id", Text, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("matchup_id", Integer, nullable=False),
+    Column("points", Float, nullable=False),
+    Column("role", Text),
+    PrimaryKeyConstraint("league_id", "season", "week", "player_id", "roster_id"),
+    Index("idx_player_perf_league_week", "league_id", "week"),
+    Index("idx_player_perf_player_week", "player_id", "season", "week"),
+    Index("idx_player_perf_roster_week", "league_id", "roster_id", "week"),
+)
+
+
+@dataclass
+class PlayerPerformance(RowMixin):
+    table_name: ClassVar[str] = "player_performances"
+
+    league_id: str
+    season: str
+    week: int
+    player_id: str
+    roster_id: int
+    matchup_id: int
+    points: float
+    role: Optional[str] = None

--- a/datalayer/sleeper_data/schema/players.py
+++ b/datalayer/sleeper_data/schema/players.py
@@ -1,0 +1,42 @@
+"""players table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, Table, Text
+
+from ._base import RowMixin, metadata
+
+players = Table(
+    "players",
+    metadata,
+    Column("player_id", Text, primary_key=True),
+    Column("full_name", Text),
+    Column("position", Text),
+    Column("nfl_team", Text),
+    Column("status", Text),
+    Column("injury_status", Text),
+    Column("age", Integer),
+    Column("years_exp", Integer),
+    Column("metadata_json", Text),
+    Column("updated_at", Text),
+    Index("idx_players_full_name", "full_name"),
+)
+
+
+@dataclass
+class Player(RowMixin):
+    table_name: ClassVar[str] = "players"
+
+    player_id: str
+    full_name: Optional[str] = None
+    position: Optional[str] = None
+    nfl_team: Optional[str] = None
+    status: Optional[str] = None
+    injury_status: Optional[str] = None
+    age: Optional[int] = None
+    years_exp: Optional[int] = None
+    metadata_json: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/datalayer/sleeper_data/schema/playoff_matchups.py
+++ b/datalayer/sleeper_data/schema/playoff_matchups.py
@@ -1,0 +1,58 @@
+"""playoff_matchups table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+playoff_matchups = Table(
+    "playoff_matchups",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("bracket_type", Text, nullable=False),
+    Column("round", Integer, nullable=False),
+    Column("matchup_id", Integer, nullable=False),
+    Column("t1_roster_id", Integer),
+    Column("t2_roster_id", Integer),
+    Column("t1_from_matchup_id", Integer),
+    Column("t1_from_outcome", Text),
+    Column("t2_from_matchup_id", Integer),
+    Column("t2_from_outcome", Text),
+    Column("winner_roster_id", Integer),
+    Column("loser_roster_id", Integer),
+    Column("placement", Integer),
+    PrimaryKeyConstraint("league_id", "season", "bracket_type", "matchup_id"),
+    Index(
+        "idx_playoff_matchups_bracket_round",
+        "league_id",
+        "season",
+        "bracket_type",
+        "round",
+    ),
+    Index("idx_playoff_matchups_winner", "league_id", "winner_roster_id"),
+)
+
+
+@dataclass
+class PlayoffMatchup(RowMixin):
+    table_name: ClassVar[str] = "playoff_matchups"
+
+    league_id: str
+    season: str
+    bracket_type: str
+    round: int
+    matchup_id: int
+    t1_roster_id: Optional[int] = None
+    t2_roster_id: Optional[int] = None
+    t1_from_matchup_id: Optional[int] = None
+    t1_from_outcome: Optional[str] = None
+    t2_from_matchup_id: Optional[int] = None
+    t2_from_outcome: Optional[str] = None
+    winner_roster_id: Optional[int] = None
+    loser_roster_id: Optional[int] = None
+    placement: Optional[int] = None

--- a/datalayer/sleeper_data/schema/roster_players.py
+++ b/datalayer/sleeper_data/schema/roster_players.py
@@ -1,0 +1,32 @@
+"""roster_players table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from sqlalchemy import Column, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+roster_players = Table(
+    "roster_players",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("player_id", Text, nullable=False),
+    Column("role", Text, nullable=False),
+    PrimaryKeyConstraint("league_id", "roster_id", "player_id"),
+    Index("idx_roster_players_league_roster", "league_id", "roster_id"),
+    Index("idx_roster_players_player", "player_id"),
+)
+
+
+@dataclass
+class RosterPlayer(RowMixin):
+    table_name: ClassVar[str] = "roster_players"
+
+    league_id: str
+    roster_id: int
+    player_id: str
+    role: str

--- a/datalayer/sleeper_data/schema/rosters.py
+++ b/datalayer/sleeper_data/schema/rosters.py
@@ -1,0 +1,35 @@
+"""rosters table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+rosters = Table(
+    "rosters",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("owner_user_id", Text),
+    Column("settings_json", Text),
+    Column("metadata_json", Text),
+    Column("record_string", Text),
+    PrimaryKeyConstraint("league_id", "roster_id"),
+    Index("idx_rosters_league_roster", "league_id", "roster_id"),
+)
+
+
+@dataclass
+class Roster(RowMixin):
+    table_name: ClassVar[str] = "rosters"
+
+    league_id: str
+    roster_id: int
+    owner_user_id: Optional[str] = None
+    settings_json: Optional[str] = None
+    metadata_json: Optional[str] = None
+    record_string: Optional[str] = None

--- a/datalayer/sleeper_data/schema/season_context.py
+++ b/datalayer/sleeper_data/schema/season_context.py
@@ -1,0 +1,31 @@
+"""season_context table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Integer, Table, Text
+
+from ._base import RowMixin, metadata
+
+season_context = Table(
+    "season_context",
+    metadata,
+    Column("league_id", Text, primary_key=True),
+    Column("computed_week", Integer, nullable=False),
+    Column("override_week", Integer),
+    Column("effective_week", Integer, nullable=False),
+    Column("generated_at", Text, nullable=False),
+)
+
+
+@dataclass
+class SeasonContext(RowMixin):
+    table_name: ClassVar[str] = "season_context"
+
+    league_id: str
+    computed_week: int
+    override_week: Optional[int]
+    effective_week: int
+    generated_at: str

--- a/datalayer/sleeper_data/schema/standings.py
+++ b/datalayer/sleeper_data/schema/standings.py
@@ -1,0 +1,46 @@
+"""standings table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Float, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+standings = Table(
+    "standings",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("week", Integer, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("wins", Integer, nullable=False),
+    Column("losses", Integer, nullable=False),
+    Column("ties", Integer, nullable=False),
+    Column("points_for", Float, nullable=False),
+    Column("points_against", Float, nullable=False),
+    Column("rank", Integer),
+    Column("streak_type", Text),
+    Column("streak_len", Integer),
+    PrimaryKeyConstraint("league_id", "week", "roster_id"),
+)
+
+
+@dataclass
+class StandingsWeek(RowMixin):
+    table_name: ClassVar[str] = "standings"
+
+    league_id: str
+    season: str
+    week: int
+    roster_id: int
+    wins: int
+    losses: int
+    ties: int
+    points_for: float
+    points_against: float
+    rank: Optional[int] = None
+    streak_type: Optional[str] = None
+    streak_len: Optional[int] = None

--- a/datalayer/sleeper_data/schema/tables.py
+++ b/datalayer/sleeper_data/schema/tables.py
@@ -1,245 +1,42 @@
-"""SQLAlchemy Core table definitions for the Sleeper data layer."""
+"""Backward-compatible re-exports of SQLAlchemy tables.
 
-from sqlalchemy import (
-    Column,
-    Float,
-    Index,
-    Integer,
-    MetaData,
-    PrimaryKeyConstraint,
-    Table,
-    Text,
+Prefer: `from datalayer.sleeper_data.schema import metadata, leagues, ...`
+"""
+
+from . import (
+    draft_picks,
+    games,
+    leagues,
+    matchups,
+    metadata,
+    player_performances,
+    players,
+    playoff_matchups,
+    roster_players,
+    rosters,
+    season_context,
+    standings,
+    team_profiles,
+    transaction_moves,
+    transactions,
+    users,
 )
 
-metadata = MetaData()
-
-leagues = Table(
+__all__ = [
+    "metadata",
     "leagues",
-    metadata,
-    Column("league_id", Text, primary_key=True),
-    Column("season", Text, nullable=False),
-    Column("name", Text, nullable=False),
-    Column("sport", Text, nullable=False),
-    Column("scoring_settings_json", Text),
-    Column("roster_positions_json", Text),
-    Column("playoff_week_start", Integer),
-    Column("playoff_teams", Integer),
-    Column("league_average_match", Integer),
-)
-
-season_context = Table(
     "season_context",
-    metadata,
-    Column("league_id", Text, primary_key=True),
-    Column("computed_week", Integer, nullable=False),
-    Column("override_week", Integer),
-    Column("effective_week", Integer, nullable=False),
-    Column("generated_at", Text, nullable=False),
-)
-
-users = Table(
     "users",
-    metadata,
-    Column("user_id", Text, primary_key=True),
-    Column("display_name", Text, nullable=False),
-    Column("avatar", Text),
-    Column("metadata_json", Text),
-)
-
-rosters = Table(
     "rosters",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("owner_user_id", Text),
-    Column("settings_json", Text),
-    Column("metadata_json", Text),
-    Column("record_string", Text),
-    PrimaryKeyConstraint("league_id", "roster_id"),
-    Index("idx_rosters_league_roster", "league_id", "roster_id"),
-)
-
-team_profiles = Table(
     "team_profiles",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("team_name", Text),
-    Column("manager_name", Text),
-    Column("avatar_url", Text),
-    PrimaryKeyConstraint("league_id", "roster_id"),
-    Index("idx_team_profiles_team_name", "team_name"),
-    Index("idx_team_profiles_manager_name", "manager_name"),
-)
-
-draft_picks = Table(
     "draft_picks",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("round", Integer, nullable=False),
-    Column("original_roster_id", Integer, nullable=False),
-    Column("current_roster_id", Integer, nullable=False),
-    Column("pick_id", Text),
-    Column("source", Text),
-    PrimaryKeyConstraint("league_id", "season", "round", "original_roster_id"),
-    Index("idx_draft_picks_current", "league_id", "current_roster_id"),
-    Index("idx_draft_picks_original", "league_id", "original_roster_id"),
-    Index("idx_draft_picks_season_round", "league_id", "season", "round"),
-)
-
-players = Table(
     "players",
-    metadata,
-    Column("player_id", Text, primary_key=True),
-    Column("full_name", Text),
-    Column("position", Text),
-    Column("nfl_team", Text),
-    Column("status", Text),
-    Column("injury_status", Text),
-    Column("age", Integer),
-    Column("years_exp", Integer),
-    Column("metadata_json", Text),
-    Column("updated_at", Text),
-    Index("idx_players_full_name", "full_name"),
-)
-
-matchups = Table(
     "matchups",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("week", Integer, nullable=False),
-    Column("matchup_id", Integer, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("points", Float, nullable=False),
-    PrimaryKeyConstraint("league_id", "week", "matchup_id", "roster_id"),
-    Index("idx_matchups_league_season_week", "league_id", "season", "week"),
-    Index("idx_matchups_week_matchup", "week", "matchup_id"),
-)
-
-player_performances = Table(
     "player_performances",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("week", Integer, nullable=False),
-    Column("player_id", Text, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("matchup_id", Integer, nullable=False),
-    Column("points", Float, nullable=False),
-    Column("role", Text),
-    PrimaryKeyConstraint("league_id", "season", "week", "player_id", "roster_id"),
-    Index("idx_player_perf_league_week", "league_id", "week"),
-    Index("idx_player_perf_player_week", "player_id", "season", "week"),
-    Index("idx_player_perf_roster_week", "league_id", "roster_id", "week"),
-)
-
-games = Table(
     "games",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("week", Integer, nullable=False),
-    Column("matchup_id", Integer, nullable=False),
-    Column("roster_id_a", Integer, nullable=False),
-    Column("roster_id_b", Integer, nullable=False),
-    Column("points_a", Float, nullable=False),
-    Column("points_b", Float, nullable=False),
-    Column("winner_roster_id", Integer),
-    Column("is_playoffs", Integer, nullable=False),
-    PrimaryKeyConstraint("league_id", "week", "matchup_id"),
-    Index("idx_games_league_season_week", "league_id", "season", "week"),
-)
-
-roster_players = Table(
     "roster_players",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("player_id", Text, nullable=False),
-    Column("role", Text, nullable=False),
-    PrimaryKeyConstraint("league_id", "roster_id", "player_id"),
-    Index("idx_roster_players_league_roster", "league_id", "roster_id"),
-    Index("idx_roster_players_player", "player_id"),
-)
-
-transactions = Table(
     "transactions",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("week", Integer, nullable=False),
-    Column("transaction_id", Text, primary_key=True),
-    Column("type", Text, nullable=False),
-    Column("status", Text),
-    Column("created_ts", Integer),
-    Column("settings_json", Text),
-    Column("metadata_json", Text),
-    Index("idx_transactions_league_season_week", "league_id", "season", "week"),
-)
-
-transaction_moves = Table(
     "transaction_moves",
-    metadata,
-    Column("transaction_id", Text, nullable=False),
-    Column("roster_id", Integer),
-    Column("player_id", Text),
-    Column("asset_type", Text, nullable=False),
-    Column("direction", Text, nullable=False),
-    Column("bid_amount", Integer),
-    Column("from_roster_id", Integer),
-    Column("to_roster_id", Integer),
-    Column("pick_season", Text),
-    Column("pick_round", Integer),
-    Column("pick_original_roster_id", Integer),
-    Column("pick_id", Text),
-    Index("idx_transaction_moves_tx", "transaction_id"),
-    Index("idx_transaction_moves_roster", "roster_id"),
-)
-
-playoff_matchups = Table(
     "playoff_matchups",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("bracket_type", Text, nullable=False),
-    Column("round", Integer, nullable=False),
-    Column("matchup_id", Integer, nullable=False),
-    Column("t1_roster_id", Integer),
-    Column("t2_roster_id", Integer),
-    Column("t1_from_matchup_id", Integer),
-    Column("t1_from_outcome", Text),
-    Column("t2_from_matchup_id", Integer),
-    Column("t2_from_outcome", Text),
-    Column("winner_roster_id", Integer),
-    Column("loser_roster_id", Integer),
-    Column("placement", Integer),
-    PrimaryKeyConstraint("league_id", "season", "bracket_type", "matchup_id"),
-    Index(
-        "idx_playoff_matchups_bracket_round",
-        "league_id",
-        "season",
-        "bracket_type",
-        "round",
-    ),
-    Index("idx_playoff_matchups_winner", "league_id", "winner_roster_id"),
-)
-
-standings = Table(
     "standings",
-    metadata,
-    Column("league_id", Text, nullable=False),
-    Column("season", Text, nullable=False),
-    Column("week", Integer, nullable=False),
-    Column("roster_id", Integer, nullable=False),
-    Column("wins", Integer, nullable=False),
-    Column("losses", Integer, nullable=False),
-    Column("ties", Integer, nullable=False),
-    Column("points_for", Float, nullable=False),
-    Column("points_against", Float, nullable=False),
-    Column("rank", Integer),
-    Column("streak_type", Text),
-    Column("streak_len", Integer),
-    PrimaryKeyConstraint("league_id", "week", "roster_id"),
-)
+]

--- a/datalayer/sleeper_data/schema/team_profiles.py
+++ b/datalayer/sleeper_data/schema/team_profiles.py
@@ -1,0 +1,34 @@
+"""team_profiles table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, PrimaryKeyConstraint, Table, Text
+
+from ._base import RowMixin, metadata
+
+team_profiles = Table(
+    "team_profiles",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("roster_id", Integer, nullable=False),
+    Column("team_name", Text),
+    Column("manager_name", Text),
+    Column("avatar_url", Text),
+    PrimaryKeyConstraint("league_id", "roster_id"),
+    Index("idx_team_profiles_team_name", "team_name"),
+    Index("idx_team_profiles_manager_name", "manager_name"),
+)
+
+
+@dataclass
+class TeamProfile(RowMixin):
+    table_name: ClassVar[str] = "team_profiles"
+
+    league_id: str
+    roster_id: int
+    team_name: Optional[str] = None
+    manager_name: Optional[str] = None
+    avatar_url: Optional[str] = None

--- a/datalayer/sleeper_data/schema/transaction_moves.py
+++ b/datalayer/sleeper_data/schema/transaction_moves.py
@@ -1,0 +1,47 @@
+"""transaction_moves table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, Table, Text
+
+from ._base import RowMixin, metadata
+
+transaction_moves = Table(
+    "transaction_moves",
+    metadata,
+    Column("transaction_id", Text, nullable=False),
+    Column("roster_id", Integer),
+    Column("player_id", Text),
+    Column("asset_type", Text, nullable=False),
+    Column("direction", Text, nullable=False),
+    Column("bid_amount", Integer),
+    Column("from_roster_id", Integer),
+    Column("to_roster_id", Integer),
+    Column("pick_season", Text),
+    Column("pick_round", Integer),
+    Column("pick_original_roster_id", Integer),
+    Column("pick_id", Text),
+    Index("idx_transaction_moves_tx", "transaction_id"),
+    Index("idx_transaction_moves_roster", "roster_id"),
+)
+
+
+@dataclass
+class TransactionMove(RowMixin):
+    table_name: ClassVar[str] = "transaction_moves"
+
+    transaction_id: str
+    roster_id: Optional[int]
+    player_id: Optional[str]
+    asset_type: str
+    direction: str
+    bid_amount: Optional[int] = None
+    from_roster_id: Optional[int] = None
+    to_roster_id: Optional[int] = None
+    pick_season: Optional[str] = None
+    pick_round: Optional[int] = None
+    pick_original_roster_id: Optional[int] = None
+    pick_id: Optional[str] = None

--- a/datalayer/sleeper_data/schema/transactions.py
+++ b/datalayer/sleeper_data/schema/transactions.py
@@ -1,0 +1,40 @@
+"""transactions table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Index, Integer, Table, Text
+
+from ._base import RowMixin, metadata
+
+transactions = Table(
+    "transactions",
+    metadata,
+    Column("league_id", Text, nullable=False),
+    Column("season", Text, nullable=False),
+    Column("week", Integer, nullable=False),
+    Column("transaction_id", Text, primary_key=True),
+    Column("type", Text, nullable=False),
+    Column("status", Text),
+    Column("created_ts", Integer),
+    Column("settings_json", Text),
+    Column("metadata_json", Text),
+    Index("idx_transactions_league_season_week", "league_id", "season", "week"),
+)
+
+
+@dataclass
+class Transaction(RowMixin):
+    table_name: ClassVar[str] = "transactions"
+
+    league_id: str
+    season: str
+    week: int
+    transaction_id: str
+    type: str
+    status: Optional[str] = None
+    created_ts: Optional[int] = None
+    settings_json: Optional[str] = None
+    metadata_json: Optional[str] = None

--- a/datalayer/sleeper_data/schema/users.py
+++ b/datalayer/sleeper_data/schema/users.py
@@ -1,0 +1,29 @@
+"""users table + row model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Optional
+
+from sqlalchemy import Column, Table, Text
+
+from ._base import RowMixin, metadata
+
+users = Table(
+    "users",
+    metadata,
+    Column("user_id", Text, primary_key=True),
+    Column("display_name", Text, nullable=False),
+    Column("avatar", Text),
+    Column("metadata_json", Text),
+)
+
+
+@dataclass
+class User(RowMixin):
+    table_name: ClassVar[str] = "users"
+
+    user_id: str
+    display_name: str
+    avatar: Optional[str] = None
+    metadata_json: Optional[str] = None

--- a/datalayer/sleeper_data/sleeper_league_data.py
+++ b/datalayer/sleeper_data/sleeper_league_data.py
@@ -1,47 +1,25 @@
-"""Facade for loading Sleeper league data into SQLite."""
+"""Public facade for Sleeper league data: load orchestration + curated queries.
+
+Layer contract:
+- Owns engine/connection lifecycle and the public query API.
+- Delegates fetch/normalize/store to ``load.load_league``.
+- Delegates SQL to ``queries.*``; does not contain business SQL itself.
+- Tools/CLI should call this class only.
+"""
 
 from __future__ import annotations
 
 import os
 import sqlite3
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
 
 from .config import SleeperConfig, load_config
-from .normalize import (
-    apply_traded_picks,
-    derive_games,
-    derive_team_profiles,
-    normalize_bracket,
-    normalize_league,
-    normalize_matchups,
-    normalize_players,
-    normalize_roster_players,
-    normalize_rosters,
-    normalize_standings,
-    normalize_transaction_moves,
-    normalize_transactions,
-    normalize_users,
-    seed_draft_picks,
-)
-from .schema.models import SeasonContext, StandingsWeek
-from .sleeper_api import (
-    SleeperClient,
-    get_league,
-    get_league_rosters,
-    get_league_users,
-    get_losers_bracket,
-    get_matchups,
-    get_players,
-    get_state,
-    get_traded_picks,
-    get_transactions as api_get_transactions,
-    get_winners_bracket,
-)
-from .store.sqlite_store import bulk_insert, create_tables
+from .load import load_league
+from .sleeper_api import SleeperClient
 from .queries import (
     get_bench_analysis,
     get_league_snapshot,
@@ -79,8 +57,13 @@ class SleeperLeagueData:
         self.week_override = resolved_config.week_override
         self.client = client or SleeperClient()
         self.engine = None
-        self._query_conn = None
+        self._query_conn: Connection | None = None
         self.effective_week: Optional[int] = None
+
+    def _conn(self) -> Connection:
+        if not self._query_conn:
+            raise RuntimeError("Data not loaded. Call load() before querying.")
+        return self._query_conn
 
     @classmethod
     def from_file(cls, path: str | os.PathLike[str]) -> "SleeperLeagueData":
@@ -136,240 +119,13 @@ class SleeperLeagueData:
         self.engine = create_engine(
             "sqlite://", connect_args={"check_same_thread": False}
         )
-
-        raw_league = get_league(self.league_id, client=self.client)
-        raw_users = get_league_users(self.league_id, client=self.client)
-        raw_rosters = get_league_rosters(self.league_id, client=self.client)
-        raw_state = get_state("nfl", client=self.client)
-
-        league = normalize_league(raw_league)
-        users = normalize_users(raw_users)
-        rosters = normalize_rosters(raw_rosters, league_id=self.league_id)
-        roster_players = normalize_roster_players(raw_rosters, league_id=self.league_id)
-        team_profiles = derive_team_profiles(
-            raw_rosters, raw_users, league_id=self.league_id
+        result = load_league(
+            self.engine,
+            client=self.client,
+            league_id=self.league_id,
+            week_override=self.week_override,
         )
-
-        with self.engine.begin() as conn:
-            create_tables(conn)
-
-            bulk_insert(conn, league.table_name, [league])
-            if users:
-                bulk_insert(conn, users[0].table_name, users)
-            if rosters:
-                bulk_insert(conn, rosters[0].table_name, rosters)
-            if team_profiles:
-                bulk_insert(conn, team_profiles[0].table_name, team_profiles)
-
-            draft_rounds = int(
-                (raw_league.get("settings") or {}).get("draft_rounds") or 0
-            )
-            draft_picks = seed_draft_picks(
-                rosters, self.league_id, league.season, draft_rounds
-            )
-            if draft_picks:
-                bulk_insert(conn, draft_picks[0].table_name, draft_picks)
-
-            raw_traded_picks = get_traded_picks(self.league_id, client=self.client)
-            apply_traded_picks(conn, raw_traded_picks, self.league_id)
-
-            raw_players = get_players("nfl", client=self.client)
-            players = normalize_players(raw_players)
-            if players:
-                bulk_insert(conn, players[0].table_name, players)
-            if roster_players:
-                bulk_insert(conn, roster_players[0].table_name, roster_players)
-
-            computed_week = int(raw_state.get("week") or 0)
-            effective_week = int(self.week_override or computed_week or 0)
-            season = str(raw_league.get("season") or raw_state.get("season") or "")
-            league_average_match = (
-                int(
-                    (raw_league.get("settings") or {}).get("league_average_match") or 0
-                )
-                if raw_league.get("settings") is not None
-                else 0
-            )
-            chars_per_week = 2 if league_average_match == 1 else 1
-
-            playoff_week_start = (
-                int(league.playoff_week_start)
-                if league.playoff_week_start is not None
-                else None
-            )
-
-            def _record_string_to_weeks(
-                record_string: str | None,
-            ) -> list[tuple[int, int, int, int]]:
-                if not record_string:
-                    return []
-                trimmed = "".join(
-                    ch for ch in record_string.strip().upper() if ch.strip()
-                )
-                if not trimmed:
-                    return []
-                week_count = len(trimmed) // chars_per_week
-                results: list[tuple[int, int, int, int]] = []
-                wins = 0
-                losses = 0
-                ties = 0
-                for week in range(1, week_count + 1):
-                    end_idx = week * chars_per_week
-                    slice_value = trimmed[end_idx - chars_per_week : end_idx]
-                    for outcome in slice_value:
-                        if outcome == "W":
-                            wins += 1
-                        elif outcome == "L":
-                            losses += 1
-                        elif outcome == "T":
-                            ties += 1
-                    results.append((week, wins, losses, ties))
-                return results
-
-            self.effective_week = effective_week
-            if effective_week > 0:
-                for week in range(1, effective_week + 1):
-                    raw_matchups = get_matchups(
-                        self.league_id, week, client=self.client
-                    )
-                    matchup_rows, player_performances = normalize_matchups(
-                        raw_matchups,
-                        league_id=self.league_id,
-                        season=season,
-                        week=week,
-                    )
-                    is_playoffs = playoff_week_start is not None and week >= int(
-                        playoff_week_start
-                    )
-                    games = derive_games(matchup_rows, is_playoffs=is_playoffs)
-                    if matchup_rows:
-                        bulk_insert(conn, matchup_rows[0].table_name, matchup_rows)
-                    if player_performances:
-                        bulk_insert(
-                            conn,
-                            player_performances[0].table_name,
-                            player_performances,
-                        )
-                    if games:
-                        bulk_insert(conn, games[0].table_name, games)
-
-                    raw_transactions = api_get_transactions(
-                        self.league_id, week, client=self.client
-                    )
-                    transactions = normalize_transactions(
-                        raw_transactions,
-                        league_id=self.league_id,
-                        season=season,
-                        week=week,
-                    )
-                    moves = normalize_transaction_moves(raw_transactions)
-                    if transactions:
-                        bulk_insert(conn, transactions[0].table_name, transactions)
-                    if moves:
-                        bulk_insert(conn, moves[0].table_name, moves)
-
-                record_standings: list[StandingsWeek] = []
-                record_weeks: set[int] = set()
-
-                for raw_roster in raw_rosters:
-                    roster_id = int(raw_roster["roster_id"])
-                    record_string = (raw_roster.get("metadata") or {}).get("record")
-                    if isinstance(record_string, list):
-                        record_string = "".join(
-                            str(item) for item in record_string if item
-                        )
-                    if isinstance(record_string, str):
-                        for week, wins, losses, ties in _record_string_to_weeks(
-                            record_string
-                        ):
-                            if week > effective_week:
-                                break
-                            if (
-                                playoff_week_start is not None
-                                and week >= playoff_week_start
-                            ):
-                                continue
-                            record_standings.append(
-                                StandingsWeek(
-                                    league_id=self.league_id,
-                                    season=season,
-                                    week=int(week),
-                                    roster_id=roster_id,
-                                    wins=wins,
-                                    losses=losses,
-                                    ties=ties,
-                                    points_for=0.0,
-                                    points_against=0.0,
-                                    rank=None,
-                                    streak_type=None,
-                                    streak_len=None,
-                                )
-                            )
-                            record_weeks.add(int(week))
-
-                if record_standings:
-                    bulk_insert(
-                        conn,
-                        record_standings[0].table_name,
-                        record_standings,
-                    )
-
-                should_insert_current = False
-                if not record_weeks:
-                    should_insert_current = True
-                elif effective_week > max(record_weeks):
-                    if (
-                        playoff_week_start is None
-                        or effective_week < playoff_week_start
-                    ):
-                        should_insert_current = True
-
-                if should_insert_current:
-                    standings = normalize_standings(
-                        raw_rosters,
-                        league_id=self.league_id,
-                        season=season,
-                        week=effective_week,
-                    )
-                    if standings:
-                        bulk_insert(conn, standings[0].table_name, standings)
-
-            # Only load playoff brackets if we've reached the playoff weeks.
-            # Loading them earlier would leak future results when using
-            # week_override to view a mid-season snapshot.
-            should_load_brackets = (
-                playoff_week_start is None
-                or effective_week >= playoff_week_start
-            )
-            if should_load_brackets:
-                raw_winners = get_winners_bracket(self.league_id, client=self.client)
-                raw_losers = get_losers_bracket(self.league_id, client=self.client)
-                winners = normalize_bracket(
-                    raw_winners,
-                    league_id=self.league_id,
-                    season=season,
-                    bracket_type="winners",
-                )
-                losers = normalize_bracket(
-                    raw_losers,
-                    league_id=self.league_id,
-                    season=season,
-                    bracket_type="losers",
-                )
-                if winners:
-                    bulk_insert(conn, winners[0].table_name, winners)
-                if losers:
-                    bulk_insert(conn, losers[0].table_name, losers)
-
-            season_context = SeasonContext(
-                league_id=self.league_id,
-                computed_week=computed_week,
-                override_week=self.week_override,
-                effective_week=effective_week,
-                generated_at=datetime.now(timezone.utc).isoformat(),
-            )
-            bulk_insert(conn, season_context.table_name, [season_context])
-
+        self.effective_week = result.effective_week
         # Open a long-lived connection for queries
         self._query_conn = self.engine.connect()
 
@@ -392,14 +148,24 @@ class SleeperLeagueData:
 
         return output_path
 
+    def _get_effective_week(self, week: int | None = None) -> int | None:
+        """Get effective week, defaulting to current week if not specified."""
+        if week is not None:
+            return week
+        conn = self._query_conn
+        if conn is None:
+            return None
+        result = conn.execute(
+            text("SELECT effective_week FROM season_context LIMIT 1")
+        ).first()
+        return result[0] if result else None
+
     def get_league_snapshot(self, week: int | None = None) -> dict[str, Any]:
         """Get league standings, games, and transactions for a week.
 
-        See queries.defaults.get_league_snapshot for full return structure.
+        See queries.league.get_league_snapshot for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_league_snapshot(self._query_conn, week)
+        return get_league_snapshot(self._conn(), week)
 
     def get_bench_analysis(
         self, roster_key: Any = None, week: int | None = None
@@ -413,15 +179,14 @@ class SleeperLeagueData:
 
         See queries.league.get_bench_analysis for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             if roster_key is not None:
                 return {"found": False, "roster_key": roster_key}
             return []
         return get_bench_analysis(
-            self._query_conn, self.league_id, int(effective_week), roster_key
+            conn, self.league_id, int(effective_week), roster_key
         )
 
     def get_standings(self, week: int | None = None) -> dict[str, Any]:
@@ -432,9 +197,7 @@ class SleeperLeagueData:
 
         See queries.league.get_standings for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_standings(self._query_conn, self.league_id, week)
+        return get_standings(self._conn(), self.league_id, week)
 
     def get_team_dossier(
         self, roster_key: Any, week: int | None = None
@@ -445,11 +208,9 @@ class SleeperLeagueData:
             roster_key: Team name, manager name, or roster_id.
             week: Week for standings (defaults to current week).
 
-        See queries.defaults.get_team_dossier for full return structure.
+        See queries.team.get_team_dossier for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_team_dossier(self._query_conn, self.league_id, roster_key, week)
+        return get_team_dossier(self._conn(), self.league_id, roster_key, week)
 
     def get_team_schedule(self, roster_key: Any) -> dict[str, Any]:
         """Get full season schedule with game-by-game results.
@@ -457,22 +218,9 @@ class SleeperLeagueData:
         Args:
             roster_key: Team name, manager name, or roster_id.
 
-        See queries.defaults.get_team_schedule for full return structure.
+        See queries.team.get_team_schedule for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_team_schedule(self._query_conn, self.league_id, roster_key)
-
-    def _get_effective_week(self, week: int | None = None) -> int | None:
-        """Get effective week, defaulting to current week if not specified."""
-        if week is not None:
-            return week
-        if not self._query_conn:
-            return None
-        result = self._query_conn.execute(
-            text("SELECT effective_week FROM season_context LIMIT 1")
-        ).first()
-        return result[0] if result else None
+        return get_team_schedule(self._conn(), self.league_id, roster_key)
 
     def get_week_games(self, week: int | None = None) -> list[dict[str, Any]]:
         """Get all matchup games for a week with scores and winners.
@@ -482,12 +230,11 @@ class SleeperLeagueData:
 
         See queries.league.get_week_games for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return []
-        return get_week_games(self._query_conn, self.league_id, int(effective_week))
+        return get_week_games(conn, self.league_id, int(effective_week))
 
     def get_week_games_with_players(
         self, week: int | None = None
@@ -499,13 +246,12 @@ class SleeperLeagueData:
 
         See queries.league.get_week_games_with_players for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return []
         return get_week_games_with_players(
-            self._query_conn, self.league_id, int(effective_week)
+            conn, self.league_id, int(effective_week)
         )
 
     def get_team_game(self, roster_key: Any, week: int | None = None) -> dict[str, Any]:
@@ -517,12 +263,11 @@ class SleeperLeagueData:
 
         See queries.league.get_team_game for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return {"found": False, "roster_key": roster_key}
-        return get_team_game(self._query_conn, self.league_id, int(effective_week), roster_key)
+        return get_team_game(conn, self.league_id, int(effective_week), roster_key)
 
     def get_team_game_with_players(
         self, roster_key: Any, week: int | None = None
@@ -535,13 +280,12 @@ class SleeperLeagueData:
 
         See queries.league.get_team_game_with_players for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return {"found": False, "roster_key": roster_key}
         return get_team_game_with_players(
-            self._query_conn, self.league_id, int(effective_week), roster_key
+            conn, self.league_id, int(effective_week), roster_key
         )
 
     def get_week_player_leaderboard(
@@ -555,13 +299,12 @@ class SleeperLeagueData:
 
         See queries.league.get_week_player_leaderboard for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return []
         return get_week_player_leaderboard(
-            self._query_conn, self.league_id, int(effective_week), limit=limit
+            conn, self.league_id, int(effective_week), limit=limit
         )
 
     def get_season_leaders(
@@ -588,10 +331,8 @@ class SleeperLeagueData:
 
         See queries.league.get_season_leaders for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
         return get_season_leaders(
-            self._query_conn,
+            self._conn(),
             self.league_id,
             week_from=week_from,
             week_to=week_to,
@@ -611,9 +352,9 @@ class SleeperLeagueData:
 
         See queries.transactions.get_transactions for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return query_get_transactions(self._query_conn, self.league_id, week_from, week_to)
+        return query_get_transactions(
+            self._conn(), self.league_id, week_from, week_to
+        )
 
     def get_team_transactions(
         self, roster_key: Any, week_from: int, week_to: int
@@ -627,10 +368,8 @@ class SleeperLeagueData:
 
         See queries.transactions.get_team_transactions for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
         return get_team_transactions(
-            self._query_conn, self.league_id, week_from, week_to, roster_key
+            self._conn(), self.league_id, week_from, week_to, roster_key
         )
 
     def get_week_transactions(self, week: int | None = None) -> list[dict[str, Any]]:
@@ -641,13 +380,12 @@ class SleeperLeagueData:
 
         See queries.transactions.get_transactions for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         effective_week = self._get_effective_week(week)
         if effective_week is None:
             return []
         return query_get_transactions(
-            self._query_conn, self.league_id, effective_week, effective_week
+            conn, self.league_id, effective_week, effective_week
         )
 
     def get_team_week_transactions(
@@ -665,8 +403,7 @@ class SleeperLeagueData:
 
         See queries.transactions.get_team_transactions for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         if week_from is not None:
             resolved_from = week_from
             resolved_to = week_to if week_to is not None else week_from
@@ -677,7 +414,7 @@ class SleeperLeagueData:
             resolved_from = effective_week
             resolved_to = week_to if week_to is not None else effective_week
         return get_team_transactions(
-            self._query_conn, self.league_id, resolved_from, resolved_to, roster_key
+            conn, self.league_id, resolved_from, resolved_to, roster_key
         )
 
     def get_player_summary(self, player_key: Any) -> dict[str, Any]:
@@ -686,11 +423,9 @@ class SleeperLeagueData:
         Args:
             player_key: Player name or player_id.
 
-        See queries.defaults.get_player_summary for full return structure.
+        See queries.player.get_player_summary for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_player_summary(self._query_conn, player_key)
+        return get_player_summary(self._conn(), player_key)
 
     def get_player_weekly_log(
         self,
@@ -707,11 +442,12 @@ class SleeperLeagueData:
 
         See queries.player.get_player_weekly_log for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
         return get_player_weekly_log(
-            self._query_conn, self.league_id, player_key,
-            week_from=week_from, week_to=week_to,
+            self._conn(),
+            self.league_id,
+            player_key,
+            week_from=week_from,
+            week_to=week_to,
         )
 
     def get_roster_current(self, roster_key: Any) -> dict[str, Any]:
@@ -724,15 +460,14 @@ class SleeperLeagueData:
         Args:
             roster_key: Team name, manager name, or roster_id.
 
-        See queries.defaults.get_roster_current for full return structure.
+        See queries.team.get_roster_current for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
+        conn = self._conn()
         if self.week_override is not None and self.effective_week is not None:
             return get_roster_snapshot(
-                self._query_conn, self.league_id, roster_key, self.effective_week
+                conn, self.league_id, roster_key, self.effective_week
             )
-        return get_roster_current(self._query_conn, self.league_id, roster_key)
+        return get_roster_current(conn, self.league_id, roster_key)
 
     def get_roster_snapshot(self, roster_key: Any, week: int) -> dict[str, Any]:
         """Get a team's roster as it was during a specific week.
@@ -741,11 +476,11 @@ class SleeperLeagueData:
             roster_key: Team name, manager name, or roster_id.
             week: The week number to query.
 
-        See queries.defaults.get_roster_snapshot for full return structure.
+        See queries.team.get_roster_snapshot for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return get_roster_snapshot(self._query_conn, self.league_id, roster_key, week)
+        return get_roster_snapshot(
+            self._conn(), self.league_id, roster_key, week
+        )
 
     def run_sql(
         self,
@@ -763,9 +498,7 @@ class SleeperLeagueData:
 
         See queries.sql_tool.run_sql for full documentation and table list.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return run_sql(self._query_conn, query, params, limit=limit)
+        return run_sql(self._conn(), query, params, limit=limit)
 
     def get_playoff_bracket(self, bracket_type: str | None = None) -> dict[str, Any]:
         """Get the playoff bracket structure with team names and results.
@@ -775,9 +508,9 @@ class SleeperLeagueData:
 
         See queries.playoffs.get_playoff_bracket for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return query_get_playoff_bracket(self._query_conn, self.league_id, bracket_type)
+        return query_get_playoff_bracket(
+            self._conn(), self.league_id, bracket_type
+        )
 
     def get_team_playoff_path(self, roster_key: Any) -> dict[str, Any]:
         """Get a specific team's playoff bracket journey.
@@ -787,6 +520,6 @@ class SleeperLeagueData:
 
         See queries.playoffs.get_team_playoff_path for full return structure.
         """
-        if not self._query_conn:
-            raise RuntimeError("Data not loaded. Call load() before querying.")
-        return query_get_team_playoff_path(self._query_conn, self.league_id, roster_key)
+        return query_get_team_playoff_path(
+            self._conn(), self.league_id, roster_key
+        )

--- a/datalayer/sleeper_data/store/sqlite_store.py
+++ b/datalayer/sleeper_data/store/sqlite_store.py
@@ -1,40 +1,57 @@
-"""SQLite store helpers for in-memory data layer."""
+"""SQLite store helpers for the in-memory data layer.
+
+Contract: accepts SQLAlchemy Connection + row DTOs (RowMixin) or mappings.
+Does not fetch from the API or run curated queries.
+"""
 
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence, Union
 
-from sqlalchemy import text
+from sqlalchemy import Table, text
+from sqlalchemy.engine import Connection
 
-from ..schema.tables import metadata
+from ..schema import RowMixin, metadata
+
+TableRef = Union[Table, str]
 
 
-def create_tables(conn) -> None:
+def create_tables(conn: Connection) -> None:
     conn.execute(text("PRAGMA journal_mode = MEMORY"))
     conn.execute(text("PRAGMA temp_store = MEMORY"))
     metadata.create_all(conn.engine)
 
 
 def _normalize_row(row: Any) -> Mapping[str, Any]:
-    if is_dataclass(row):
+    if isinstance(row, RowMixin) or is_dataclass(row):
+        if hasattr(row, "to_row"):
+            return row.to_row()
         return asdict(row)
-    if hasattr(row, "to_row"):
-        return row.to_row()
     if isinstance(row, Mapping):
         return row
-    raise TypeError("Row must be dataclass, Mapping, or expose to_row().")
+    raise TypeError("Row must be RowMixin, dataclass, Mapping, or expose to_row().")
 
 
-def bulk_insert(conn, table: str, rows: Iterable[Any]) -> int:
-    normalized = [dict(_normalize_row(row)) for row in rows]
+def _table_name(table: TableRef) -> str:
+    if isinstance(table, Table):
+        return table.name
+    if isinstance(table, str):
+        return table
+    raise TypeError("table must be a SQLAlchemy Table or table name string.")
+
+
+def bulk_insert(conn: Connection, table: TableRef, rows: Iterable[Any]) -> int:
+    """Insert rows into ``table`` (Table object or name). Returns row count."""
+    normalized: Sequence[dict[str, Any]] = [dict(_normalize_row(row)) for row in rows]
 
     if not normalized:
         return 0
 
+    name = _table_name(table)
     columns = list(normalized[0].keys())
     placeholders = ", ".join(f":{col}" for col in columns)
     col_list = ", ".join(columns)
-    sql = text(f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})")
+    sql = text(f"INSERT INTO {name} ({col_list}) VALUES ({placeholders})")
     conn.execute(sql, normalized)
     return len(normalized)

--- a/datalayer/tests/conftest.py
+++ b/datalayer/tests/conftest.py
@@ -51,55 +51,58 @@ def sleeper_config() -> SleeperConfig:
 
 @pytest.fixture
 def monkeypatch_sleeper_api(monkeypatch, sleeper_fixtures):
-    import datalayer.sleeper_data.sleeper_league_data as sld
+    # API symbols are imported into load.py (the load pipeline).
+    import datalayer.sleeper_data.load as load_mod
 
-    monkeypatch.setattr(sld, "get_league", lambda league_id, client=None: sleeper_fixtures["league"])
     monkeypatch.setattr(
-        sld,
+        load_mod, "get_league", lambda league_id, client=None: sleeper_fixtures["league"]
+    )
+    monkeypatch.setattr(
+        load_mod,
         "get_league_users",
         lambda league_id, client=None: sleeper_fixtures["users"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_league_rosters",
         lambda league_id, client=None: sleeper_fixtures["rosters"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_state",
         lambda sport, client=None: sleeper_fixtures["state"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_matchups",
         lambda league_id, week, client=None: sleeper_fixtures["matchups_by_week"].get(
             week, []
         ),
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "api_get_transactions",
-        lambda league_id, week, client=None: sleeper_fixtures["transactions_by_week"].get(
-            week, []
-        ),
+        lambda league_id, week, client=None: sleeper_fixtures[
+            "transactions_by_week"
+        ].get(week, []),
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_players",
         lambda sport, client=None: sleeper_fixtures["players"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_traded_picks",
         lambda league_id, client=None: sleeper_fixtures["traded_picks"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_winners_bracket",
         lambda league_id, client=None: sleeper_fixtures["winners_bracket"],
     )
     monkeypatch.setattr(
-        sld,
+        load_mod,
         "get_losers_bracket",
         lambda league_id, client=None: sleeper_fixtures["losers_bracket"],
     )

--- a/datalayer/tests/unit/normalize/test_matchups.py
+++ b/datalayer/tests/unit/normalize/test_matchups.py
@@ -1,5 +1,5 @@
 from datalayer.sleeper_data.normalize.matchups import derive_games, normalize_matchups
-from datalayer.sleeper_data.schema.models import MatchupRow
+from datalayer.sleeper_data.schema import MatchupRow
 
 
 def test_derive_games_pairs_two_rows():

--- a/datalayer/tests/unit/queries/test_defaults.py
+++ b/datalayer/tests/unit/queries/test_defaults.py
@@ -1,6 +1,6 @@
 from datalayer.sleeper_data.queries import get_team_game_with_players
 from datalayer.sleeper_data.queries._resolvers import resolve_player_id
-from datalayer.sleeper_data.schema.models import (
+from datalayer.sleeper_data.schema import (
     Game,
     League,
     MatchupRow,

--- a/datalayer/tests/unit/queries/test_league_leaders.py
+++ b/datalayer/tests/unit/queries/test_league_leaders.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from datalayer.sleeper_data.queries.league import get_season_leaders
-from datalayer.sleeper_data.schema.models import (
+from datalayer.sleeper_data.schema import (
     League,
     Player,
     PlayerPerformance,

--- a/datalayer/tests/unit/queries/test_player.py
+++ b/datalayer/tests/unit/queries/test_player.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from datalayer.sleeper_data.queries.player import get_player_weekly_log
-from datalayer.sleeper_data.schema.models import (
+from datalayer.sleeper_data.schema import (
     League,
     Player,
     PlayerPerformance,

--- a/datalayer/tools.py
+++ b/datalayer/tools.py
@@ -23,7 +23,10 @@ Usage with OpenAI Agents SDK:
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from datalayer.sleeper_data import SleeperLeagueData
 
 # Tool definitions in OpenAI function calling format
 SLEEPER_TOOLS = [
@@ -444,8 +447,3 @@ def create_tool_handlers(data: "SleeperLeagueData") -> dict[str, Callable[..., A
         "team_playoff_path": lambda roster_key: data.get_team_playoff_path(roster_key),
         "run_sql": lambda query, limit=200: data.run_sql(query, limit=limit),
     }
-
-
-# Type import for type hints only
-if False:  # TYPE_CHECKING equivalent without import
-    from datalayer.sleeper_data import SleeperLeagueData


### PR DESCRIPTION
## Summary
- Split datalayer schema into one module per table (co-located row DTO + SQLAlchemy Core `Table`) and extract load orchestration into `load.py`, leaving `SleeperLeagueData` as a thin public facade.
- Tighten layer contracts (store/query typing, narrowed package exports, tools `TYPE_CHECKING`) without changing the curated query / tool API.
- Sync AGENTS/docs for the current layout; mark the SQLAlchemy migration as complete and correct reporter memory schema refs to v3.

Addresses the structure-cleanup portion of #82 (persistence / multi-season deferred).

## Test plan
- [x] `pytest datalayer/tests` (54 passed)
- [x] Smoke-import `SleeperLeagueData`, schema metadata, and `reporter_v2` datalayer tool registration
- [ ] Spot-check `sleeperdl app` / a reporter run still loads and queries as before


Made with [Cursor](https://cursor.com)