### PR TITLE
feat(database): add core identity schema

### DIFF
--- a/backend/database/models/core/__init__.py
+++ b/backend/database/models/core/__init__.py
@@ -1,0 +1,9 @@
+from backend.database.models.core.competitions import Competition, CompetitionSeason
+from backend.database.models.core.franchises import Franchise, SeasonRoster
+
+__all__ = [
+    "Competition",
+    "CompetitionSeason",
+    "Franchise",
+    "SeasonRoster",
+]

--- a/backend/database/models/core/competitions.py
+++ b/backend/database/models/core/competitions.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID as PostgreSQLUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class Competition(Base):
+    __tablename__ = "competitions"
+    __table_args__ = ({"schema": "core"},)
+
+    id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    display_name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+
+class CompetitionSeason(Base):
+    __tablename__ = "competition_seasons"
+    __table_args__ = (
+        UniqueConstraint(
+            "competition_id",
+            "season_year",
+            name="uq_competition_seasons_competition_id_season_year",
+        ),
+        UniqueConstraint(
+            "competition_id",
+            "sequence_number",
+            name="uq_competition_seasons_competition_id_sequence_number",
+        ),
+        UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_competition_seasons_id_competition_id",
+        ),
+        UniqueConstraint(
+            "sleeper_league_id",
+            name="uq_competition_seasons_sleeper_league_id",
+        ),
+        {"schema": "core"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        ForeignKey(
+            "core.competitions.id",
+            name="fk_competition_seasons_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    season_year: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    sequence_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    sleeper_league_id: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/database/models/core/franchises.py
+++ b/backend/database/models/core/franchises.py
@@ -1,0 +1,145 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID as PostgreSQLUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class Franchise(Base):
+    __tablename__ = "franchises"
+    __table_args__ = (
+        UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_franchises_id_competition_id",
+        ),
+        Index(
+            "ix_franchises_competition_id_archived_at",
+            "competition_id",
+            "archived_at",
+        ),
+        {"schema": "core"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        ForeignKey(
+            "core.competitions.id",
+            name="fk_franchises_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    display_name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+
+class SeasonRoster(Base):
+    __tablename__ = "season_rosters"
+    __table_args__ = (
+        UniqueConstraint(
+            "competition_season_id",
+            "sleeper_roster_id",
+            name="uq_season_rosters_competition_season_id_sleeper_roster_id",
+        ),
+        UniqueConstraint(
+            "competition_season_id",
+            "franchise_id",
+            name="uq_season_rosters_competition_season_id_franchise_id",
+        ),
+        UniqueConstraint(
+            "id",
+            "competition_season_id",
+            name="uq_season_rosters_id_competition_season_id",
+        ),
+        UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_season_rosters_id_competition_id",
+        ),
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_season_rosters_season_competition_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_season_rosters_franchise_competition_scope",
+            ondelete="RESTRICT",
+        ),
+        Index("ix_season_rosters_competition_id", "competition_id"),
+        Index(
+            "ix_season_rosters_season_competition_scope",
+            "competition_season_id",
+            "competition_id",
+        ),
+        Index(
+            "ix_season_rosters_franchise_competition_scope",
+            "franchise_id",
+            "competition_id",
+        ),
+        {"schema": "core"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        ForeignKey(
+            "core.competitions.id",
+            name="fk_season_rosters_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+    )
+    competition_season_id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        nullable=False,
+    )
+    franchise_id: Mapped[UUID] = mapped_column(
+        PostgreSQLUUID(as_uuid=True),
+        nullable=False,
+    )
+    sleeper_roster_id: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/database/registry.py
+++ b/backend/database/registry.py
@@ -6,7 +6,8 @@ resource managers or services.
 """
 
 from backend.database.base import Base
+from backend.database.models import core as core_models
 
 metadata = Base.metadata
 
-__all__ = ["metadata"]
+__all__ = ["core_models", "metadata"]

--- a/backend/migrations/versions/0002_core_identity.py
+++ b/backend/migrations/versions/0002_core_identity.py
@@ -1,0 +1,231 @@
+"""Create the core identity schema.
+
+Revision ID: 0002
+Revises: 0001
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "competitions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name="pk_competitions"),
+        schema="core",
+    )
+
+    op.create_table(
+        "competition_seasons",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("season_year", sa.SmallInteger(), nullable=False),
+        sa.Column("sequence_number", sa.SmallInteger(), nullable=False),
+        sa.Column("sleeper_league_id", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_competition_seasons_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_competition_seasons"),
+        sa.UniqueConstraint(
+            "competition_id",
+            "season_year",
+            name="uq_competition_seasons_competition_id_season_year",
+        ),
+        sa.UniqueConstraint(
+            "competition_id",
+            "sequence_number",
+            name="uq_competition_seasons_competition_id_sequence_number",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_competition_seasons_id_competition_id",
+        ),
+        sa.UniqueConstraint(
+            "sleeper_league_id",
+            name="uq_competition_seasons_sleeper_league_id",
+        ),
+        schema="core",
+    )
+
+    op.create_table(
+        "franchises",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_franchises_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_franchises"),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_franchises_id_competition_id",
+        ),
+        schema="core",
+    )
+    op.create_index(
+        "ix_franchises_competition_id_archived_at",
+        "franchises",
+        ["competition_id", "archived_at"],
+        unique=False,
+        schema="core",
+    )
+
+    op.create_table(
+        "season_rosters",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("franchise_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sleeper_roster_id", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_season_rosters_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_season_rosters_season_competition_scope",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_season_rosters_franchise_competition_scope",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_season_rosters"),
+        sa.UniqueConstraint(
+            "competition_season_id",
+            "sleeper_roster_id",
+            name="uq_season_rosters_competition_season_id_sleeper_roster_id",
+        ),
+        sa.UniqueConstraint(
+            "competition_season_id",
+            "franchise_id",
+            name="uq_season_rosters_competition_season_id_franchise_id",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "competition_season_id",
+            name="uq_season_rosters_id_competition_season_id",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_season_rosters_id_competition_id",
+        ),
+        schema="core",
+    )
+    op.create_index(
+        "ix_season_rosters_competition_id",
+        "season_rosters",
+        ["competition_id"],
+        unique=False,
+        schema="core",
+    )
+    op.create_index(
+        "ix_season_rosters_season_competition_scope",
+        "season_rosters",
+        ["competition_season_id", "competition_id"],
+        unique=False,
+        schema="core",
+    )
+    op.create_index(
+        "ix_season_rosters_franchise_competition_scope",
+        "season_rosters",
+        ["franchise_id", "competition_id"],
+        unique=False,
+        schema="core",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_season_rosters_franchise_competition_scope",
+        table_name="season_rosters",
+        schema="core",
+    )
+    op.drop_index(
+        "ix_season_rosters_season_competition_scope",
+        table_name="season_rosters",
+        schema="core",
+    )
+    op.drop_index(
+        "ix_season_rosters_competition_id",
+        table_name="season_rosters",
+        schema="core",
+    )
+    op.drop_table("season_rosters", schema="core")
+    op.drop_index(
+        "ix_franchises_competition_id_archived_at",
+        table_name="franchises",
+        schema="core",
+    )
+    op.drop_table("franchises", schema="core")
+    op.drop_table("competition_seasons", schema="core")
+    op.drop_table("competitions", schema="core")

--- a/backend/tests/database/constraints/test_core_constraints.py
+++ b/backend/tests/database/constraints/test_core_constraints.py
@@ -1,0 +1,392 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from backend.database.models.core import (
+    Competition,
+    CompetitionSeason,
+    Franchise,
+    SeasonRoster,
+)
+
+
+def _insert_identity_graph(engine: Engine) -> dict[str, UUID]:
+    ids = {
+        "competition": uuid4(),
+        "season": uuid4(),
+        "franchise": uuid4(),
+        "roster": uuid4(),
+    }
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": ids["competition"], "display_name": "The League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": ids["season"],
+                "competition_id": ids["competition"],
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            {
+                "id": ids["franchise"],
+                "competition_id": ids["competition"],
+                "display_name": "Fourth and Long",
+            },
+        )
+        connection.execute(
+            sa.insert(SeasonRoster),
+            {
+                "id": ids["roster"],
+                "competition_id": ids["competition"],
+                "competition_season_id": ids["season"],
+                "franchise_id": ids["franchise"],
+                "sleeper_roster_id": "1",
+            },
+        )
+    return ids
+
+
+def _assert_integrity_error(engine: Engine, statement: sa.Executable) -> None:
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def test_core_constraints_and_indexes_are_named(
+    database_engine: Engine,
+) -> None:
+    expected_constraints = {
+        "pk_competitions",
+        "pk_competition_seasons",
+        "fk_competition_seasons_competition_id_competitions",
+        "uq_competition_seasons_competition_id_season_year",
+        "uq_competition_seasons_competition_id_sequence_number",
+        "uq_competition_seasons_id_competition_id",
+        "uq_competition_seasons_sleeper_league_id",
+        "pk_franchises",
+        "fk_franchises_competition_id_competitions",
+        "uq_franchises_id_competition_id",
+        "pk_season_rosters",
+        "fk_season_rosters_competition_id_competitions",
+        "fk_season_rosters_season_competition_scope",
+        "fk_season_rosters_franchise_competition_scope",
+        "uq_season_rosters_competition_season_id_sleeper_roster_id",
+        "uq_season_rosters_competition_season_id_franchise_id",
+        "uq_season_rosters_id_competition_season_id",
+        "uq_season_rosters_id_competition_id",
+    }
+    expected_indexes = {
+        "ix_franchises_competition_id_archived_at",
+        "ix_season_rosters_competition_id",
+        "ix_season_rosters_season_competition_scope",
+        "ix_season_rosters_franchise_competition_scope",
+    }
+
+    with database_engine.connect() as connection:
+        constraints = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT constraint_name
+                    FROM information_schema.table_constraints
+                    WHERE constraint_schema = 'core'
+                    """
+                )
+            ).scalars()
+        )
+        indexes = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = 'core'
+                    """
+                )
+            ).scalars()
+        )
+        foreign_key_delete_actions = dict(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT constraint_name, delete_rule
+                    FROM information_schema.referential_constraints
+                    WHERE constraint_schema = 'core'
+                    """
+                )
+            ).all()
+        )
+
+    assert expected_constraints <= constraints
+    assert expected_indexes <= indexes
+    assert foreign_key_delete_actions
+    assert set(foreign_key_delete_actions.values()) == {"RESTRICT"}
+
+
+def test_core_uses_application_uuids_and_server_timestamps(
+    database_engine: Engine,
+) -> None:
+    competition_id = uuid4()
+    with database_engine.begin() as connection:
+        row = connection.execute(
+            sa.text(
+                """
+                INSERT INTO core.competitions (id, display_name)
+                VALUES (:id, 'Timestamp League')
+                RETURNING created_at, updated_at
+                """
+            ),
+            {"id": competition_id},
+        ).one()
+
+    assert isinstance(row.created_at, datetime)
+    assert row.created_at.tzinfo is not None
+    assert row.updated_at.tzinfo is not None
+
+    _assert_integrity_error(
+        database_engine,
+        sa.text("INSERT INTO core.competitions (display_name) VALUES ('Missing UUID')"),
+    )
+
+
+def test_competition_season_unique_coordinates_and_sleeper_id(
+    database_engine: Engine,
+) -> None:
+    first_competition = uuid4()
+    second_competition = uuid4()
+    sleeper_league_id = f"league-{uuid4()}"
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": first_competition, "display_name": "First"},
+                {"id": second_competition, "display_name": "Second"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": uuid4(),
+                "competition_id": first_competition,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": sleeper_league_id,
+            },
+        )
+
+    invalid_seasons = [
+        {
+            "id": uuid4(),
+            "competition_id": first_competition,
+            "season_year": 2026,
+            "sequence_number": 2,
+            "sleeper_league_id": f"league-{uuid4()}",
+        },
+        {
+            "id": uuid4(),
+            "competition_id": first_competition,
+            "season_year": 2027,
+            "sequence_number": 1,
+            "sleeper_league_id": f"league-{uuid4()}",
+        },
+        {
+            "id": uuid4(),
+            "competition_id": second_competition,
+            "season_year": 2026,
+            "sequence_number": 1,
+            "sleeper_league_id": sleeper_league_id,
+        },
+    ]
+    for values in invalid_seasons:
+        _assert_integrity_error(
+            database_engine,
+            sa.insert(CompetitionSeason).values(**values),
+        )
+
+
+def test_season_and_franchise_uniqueness_is_competition_scoped(
+    database_engine: Engine,
+) -> None:
+    competition_id = uuid4()
+    season_one_id = uuid4()
+    season_two_id = uuid4()
+    franchise_id = uuid4()
+    second_franchise_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Dynasty"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                {
+                    "id": season_one_id,
+                    "competition_id": competition_id,
+                    "season_year": 2025,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+                {
+                    "id": season_two_id,
+                    "competition_id": competition_id,
+                    "season_year": 2026,
+                    "sequence_number": 2,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": franchise_id,
+                    "competition_id": competition_id,
+                    "display_name": "Same Team",
+                },
+                {
+                    "id": second_franchise_id,
+                    "competition_id": competition_id,
+                    "display_name": "Other Team",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(SeasonRoster),
+            [
+                {
+                    "id": uuid4(),
+                    "competition_id": competition_id,
+                    "competition_season_id": season_one_id,
+                    "franchise_id": franchise_id,
+                    "sleeper_roster_id": "1",
+                },
+                {
+                    "id": uuid4(),
+                    "competition_id": competition_id,
+                    "competition_season_id": season_two_id,
+                    "franchise_id": franchise_id,
+                    "sleeper_roster_id": "1",
+                },
+            ],
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(SeasonRoster).values(
+            id=uuid4(),
+            competition_id=competition_id,
+            competition_season_id=season_one_id,
+            franchise_id=second_franchise_id,
+            sleeper_roster_id="1",
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(SeasonRoster).values(
+            id=uuid4(),
+            competition_id=competition_id,
+            competition_season_id=season_one_id,
+            franchise_id=franchise_id,
+            sleeper_roster_id="2",
+        ),
+    )
+
+
+def test_season_roster_rejects_cross_competition_references(
+    database_engine: Engine,
+) -> None:
+    first_competition = uuid4()
+    second_competition = uuid4()
+    first_season = uuid4()
+    second_season = uuid4()
+    first_franchise = uuid4()
+    second_franchise = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": first_competition, "display_name": "First"},
+                {"id": second_competition, "display_name": "Second"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                {
+                    "id": first_season,
+                    "competition_id": first_competition,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+                {
+                    "id": second_season,
+                    "competition_id": second_competition,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": first_franchise,
+                    "competition_id": first_competition,
+                    "display_name": "First Team",
+                },
+                {
+                    "id": second_franchise,
+                    "competition_id": second_competition,
+                    "display_name": "Second Team",
+                },
+            ],
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(SeasonRoster).values(
+            id=uuid4(),
+            competition_id=first_competition,
+            competition_season_id=second_season,
+            franchise_id=first_franchise,
+            sleeper_roster_id="1",
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(SeasonRoster).values(
+            id=uuid4(),
+            competition_id=first_competition,
+            competition_season_id=first_season,
+            franchise_id=second_franchise,
+            sleeper_roster_id="1",
+        ),
+    )
+
+
+@pytest.mark.parametrize("parent", ["competition", "season", "franchise"])
+def test_core_durable_parents_use_restrict_deletes(
+    database_engine: Engine,
+    parent: str,
+) -> None:
+    ids = _insert_identity_graph(database_engine)
+    statements = {
+        "competition": sa.delete(Competition).where(Competition.id == ids["competition"]),
+        "season": sa.delete(CompetitionSeason).where(CompetitionSeason.id == ids["season"]),
+        "franchise": sa.delete(Franchise).where(Franchise.id == ids["franchise"]),
+    }
+
+    _assert_integrity_error(database_engine, statements[parent])

--- a/docs/database/status.md
+++ b/docs/database/status.md
@@ -93,8 +93,9 @@ Coordination notes:
 - Shared registry and test-harness changes are integrated by `root` after agents
   report their namespace outputs.
 - `core_agent`: added the four core ORM tables, revision `0002`, and PostgreSQL
-  constraint tests. Metadata and offline upgrade/downgrade DDL pass; live tests
-  are CI-ready and skip locally when `AIDAM_TEST_DATABASE_URL` is unavailable.
+  relational-integrity tests. DB-028 cleanup removed semantic range/nonblank
+  checks. Metadata and offline upgrade/downgrade DDL pass; live tests are
+  CI-ready.
 - `foundation_agent`: added shared Base/types, runtime engine/session/health and
   environment configuration, Alembic environment plus revision `0001`, local
   PostgreSQL role bootstrap/Compose and database CI, and isolated migration,


### PR DESCRIPTION
## Summary

- adds the four core identity tables: competitions, competition seasons, franchises, and season rosters
- adds Alembic revision `0002` with natural uniqueness, same-competition composite foreign keys, restrictive deletion, and query indexes
- adds PostgreSQL constraint tests for identity and scope isolation

## Design decisions

The database owns relational identity, uniqueness, and competition/season isolation. Product-semantic validation such as ranges and nonblank display text stays with the later Pydantic resource layer under DB-028.

## Verification

- core metadata and offline upgrade/downgrade checks: passed
- core PostgreSQL constraint coverage: passed
- final stacked database suite: 66 passed

## Stack

2 of 7. Previous: #86. Next: #88
