### PR TITLE
feat(database): persist Sleeper data

### DIFF
--- a/backend/database/models/sleeper/__init__.py
+++ b/backend/database/models/sleeper/__init__.py
@@ -1,0 +1,41 @@
+"""Sleeper request history, normalized current state, and factual snapshots."""
+
+from .normalized import (
+    DraftPick,
+    League,
+    LeagueUser,
+    Matchup,
+    Player,
+    PlayerPerformance,
+    PlayoffMatchup,
+    Roster,
+    RosterManager,
+    RosterPlayer,
+    Transaction,
+    TransactionMove,
+    User,
+)
+from .requests import ApiPayload, ApiRequest, NormalizedScope, RefreshRun
+from .snapshots import DataSnapshot, DataSnapshotRequest
+
+__all__ = [
+    "ApiPayload",
+    "ApiRequest",
+    "DataSnapshot",
+    "DataSnapshotRequest",
+    "DraftPick",
+    "League",
+    "LeagueUser",
+    "Matchup",
+    "NormalizedScope",
+    "Player",
+    "PlayerPerformance",
+    "PlayoffMatchup",
+    "RefreshRun",
+    "Roster",
+    "RosterManager",
+    "RosterPlayer",
+    "Transaction",
+    "TransactionMove",
+    "User",
+]

--- a/backend/database/models/sleeper/normalized.py
+++ b/backend/database/models/sleeper/normalized.py
@@ -1,0 +1,499 @@
+"""Current normalized Sleeper data models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    Numeric,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class League(Base):
+    __tablename__ = "leagues"
+    __table_args__ = (
+        Index("ix_leagues_source_request", "source_api_request_id"),
+        {"schema": "sleeper"},
+    )
+
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("core.competition_seasons.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+    name: Mapped[str] = mapped_column(Text)
+    status: Mapped[str | None] = mapped_column(Text)
+    season: Mapped[str] = mapped_column(Text)
+    previous_sleeper_league_id: Mapped[str | None] = mapped_column(Text)
+    sleeper_draft_id: Mapped[str | None] = mapped_column(Text)
+    sport: Mapped[str] = mapped_column(Text, server_default=text("'nfl'"))
+    scoring_settings: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    roster_positions: Mapped[list[Any]] = mapped_column(JSONB)
+    provider_settings: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    playoff_start_week: Mapped[int | None] = mapped_column(SmallInteger)
+    playoff_team_count: Mapped[int | None] = mapped_column(SmallInteger)
+    league_average_match: Mapped[int | None] = mapped_column(Integer)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class User(Base):
+    __tablename__ = "users"
+    __table_args__ = (
+        Index("ix_users_display_name_lower", func.lower(text("display_name"))),
+        {"schema": "sleeper"},
+    )
+
+    sleeper_user_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    display_name: Mapped[str] = mapped_column(Text)
+    username: Mapped[str | None] = mapped_column(Text)
+    avatar: Mapped[str | None] = mapped_column(Text)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class LeagueUser(Base):
+    __tablename__ = "league_users"
+    __table_args__ = (
+        Index("ix_league_users_user", "sleeper_user_id"),
+        {"schema": "sleeper"},
+    )
+
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("core.competition_seasons.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    sleeper_user_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("sleeper.users.sleeper_user_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    team_name: Mapped[str | None] = mapped_column(Text)
+    nickname: Mapped[str | None] = mapped_column(Text)
+    is_commissioner: Mapped[bool] = mapped_column(server_default=text("false"))
+    metadata_json: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class Player(Base):
+    __tablename__ = "players"
+    __table_args__ = (
+        Index("ix_players_full_name_lower", func.lower(text("full_name"))),
+        Index("ix_players_team_position", "nfl_team", "position"),
+        {"schema": "sleeper"},
+    )
+
+    sleeper_player_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    full_name: Mapped[str | None] = mapped_column(Text)
+    position: Mapped[str | None] = mapped_column(Text)
+    nfl_team: Mapped[str | None] = mapped_column(Text)
+    active: Mapped[bool | None]
+    status: Mapped[str | None] = mapped_column(Text)
+    injury_status: Mapped[str | None] = mapped_column(Text)
+    age: Mapped[int | None] = mapped_column(SmallInteger)
+    years_experience: Mapped[int | None] = mapped_column(SmallInteger)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class Roster(Base):
+    __tablename__ = "rosters"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_rosters_season_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        Index("ix_rosters_competition_season", "competition_season_id"),
+        {"schema": "sleeper"},
+    )
+
+    season_roster_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+    settings_json: Mapped[dict[str, Any]] = mapped_column("settings", JSONB)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
+    record_string: Mapped[str | None] = mapped_column(Text)
+    wins: Mapped[int] = mapped_column(SmallInteger, server_default=text("0"))
+    losses: Mapped[int] = mapped_column(SmallInteger, server_default=text("0"))
+    ties: Mapped[int] = mapped_column(SmallInteger, server_default=text("0"))
+    points_for: Mapped[Decimal | None] = mapped_column(Numeric(12, 4))
+    points_against: Mapped[Decimal | None] = mapped_column(Numeric(12, 4))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class RosterManager(Base):
+    __tablename__ = "roster_managers"
+    __table_args__ = (
+        Index(
+            "uq_roster_managers_one_owner",
+            "season_roster_id",
+            unique=True,
+            postgresql_where=text("role = 'owner'"),
+        ),
+        Index("ix_roster_managers_user", "sleeper_user_id"),
+        {"schema": "sleeper"},
+    )
+
+    season_roster_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sleeper.rosters.season_roster_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    sleeper_user_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("sleeper.users.sleeper_user_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    role: Mapped[str] = mapped_column(Text)
+    source_order: Mapped[int] = mapped_column(SmallInteger)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class RosterPlayer(Base):
+    __tablename__ = "roster_players"
+    __table_args__ = (
+        Index("ix_roster_players_player", "sleeper_player_id"),
+        {"schema": "sleeper"},
+    )
+
+    season_roster_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sleeper.rosters.season_roster_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    sleeper_player_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("sleeper.players.sleeper_player_id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    role: Mapped[str] = mapped_column(Text)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class Matchup(Base):
+    __tablename__ = "matchups"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_matchups_season_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "competition_season_id",
+            "week",
+            "season_roster_id",
+            name="uq_matchups_season_week_roster",
+        ),
+        Index("ix_matchups_season_week_matchup", "competition_season_id", "week", "sleeper_matchup_id"),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    week: Mapped[int] = mapped_column(SmallInteger)
+    season_roster_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    sleeper_matchup_id: Mapped[int | None] = mapped_column(Integer)
+    points: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class PlayerPerformance(Base):
+    __tablename__ = "player_performances"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_player_performances_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "competition_season_id",
+            "week",
+            "season_roster_id",
+            "sleeper_player_id",
+            name="uq_player_performances_natural",
+        ),
+        Index(
+            "ix_player_performances_player_season_week",
+            "sleeper_player_id",
+            "competition_season_id",
+            "week",
+        ),
+        Index(
+            "ix_player_performances_roster_week",
+            "season_roster_id",
+            "week",
+        ),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    week: Mapped[int] = mapped_column(SmallInteger)
+    season_roster_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    sleeper_matchup_id: Mapped[int | None] = mapped_column(Integer)
+    sleeper_player_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("sleeper.players.sleeper_player_id", ondelete="RESTRICT")
+    )
+    points: Mapped[Decimal] = mapped_column(Numeric(12, 4))
+    role: Mapped[str] = mapped_column(Text)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+    __table_args__ = (
+        UniqueConstraint(
+            "competition_season_id",
+            "sleeper_transaction_id",
+            name="uq_transactions_season_sleeper_id",
+        ),
+        UniqueConstraint(
+            "id", "competition_season_id", name="uq_transactions_id_season"
+        ),
+        Index(
+            "ix_transactions_season_week_type_status",
+            "competition_season_id",
+            "week",
+            "transaction_type",
+            "status",
+        ),
+        Index("ix_transactions_sleeper_id", "sleeper_transaction_id"),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("core.competition_seasons.id", ondelete="RESTRICT"),
+    )
+    sleeper_transaction_id: Mapped[str] = mapped_column(Text)
+    week: Mapped[int] = mapped_column(SmallInteger)
+    transaction_type: Mapped[str] = mapped_column(Text)
+    status: Mapped[str | None] = mapped_column(Text)
+    provider_created_at_ms: Mapped[int | None] = mapped_column(BigInteger)
+    settings_json: Mapped[dict[str, Any]] = mapped_column("settings", JSONB)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class DraftPick(Base):
+    __tablename__ = "draft_picks"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["original_franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_draft_picks_original_franchise_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["current_franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_draft_picks_current_franchise_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "competition_id",
+            "draft_season_year",
+            "round",
+            "original_franchise_id",
+            name="uq_draft_picks_natural",
+        ),
+        UniqueConstraint("id", "competition_id", name="uq_draft_picks_id_competition"),
+        Index(
+            "ix_draft_picks_current_owner",
+            "competition_id",
+            "draft_season_year",
+            "current_franchise_id",
+        ),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.competitions.id", ondelete="RESTRICT")
+    )
+    draft_season_year: Mapped[int] = mapped_column(Integer)
+    round: Mapped[int] = mapped_column(SmallInteger)
+    original_franchise_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    current_franchise_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    sleeper_pick_id: Mapped[str | None] = mapped_column(Text)
+    source: Mapped[str] = mapped_column(Text)
+    source_api_request_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )
+
+
+class TransactionMove(Base):
+    __tablename__ = "transaction_moves"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["transaction_id", "competition_season_id"],
+            ["sleeper.transactions.id", "sleeper.transactions.competition_season_id"],
+            name="fk_transaction_moves_transaction_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["from_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_transaction_moves_from_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["to_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_transaction_moves_to_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "transaction_id", "move_index", name="uq_transaction_moves_index"
+        ),
+        Index("ix_transaction_moves_player", "sleeper_player_id"),
+        Index("ix_transaction_moves_pick", "draft_pick_id"),
+        Index("ix_transaction_moves_from_roster", "from_season_roster_id"),
+        Index("ix_transaction_moves_to_roster", "to_season_roster_id"),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    transaction_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    move_index: Mapped[int] = mapped_column(Integer)
+    move_kind: Mapped[str] = mapped_column(Text)
+    from_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    to_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    sleeper_player_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("sleeper.players.sleeper_player_id", ondelete="RESTRICT")
+    )
+    draft_pick_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.draft_picks.id", ondelete="RESTRICT")
+    )
+    budget_amount: Mapped[int | None] = mapped_column(BigInteger)
+
+
+class PlayoffMatchup(Base):
+    __tablename__ = "playoff_matchups"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["t1_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_playoff_matchups_t1_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["t2_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_playoff_matchups_t2_roster_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["winner_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_playoff_matchups_winner_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["loser_season_roster_id", "competition_season_id"],
+            ["core.season_rosters.id", "core.season_rosters.competition_season_id"],
+            name="fk_playoff_matchups_loser_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "competition_season_id",
+            "bracket_kind",
+            "node_key",
+            name="uq_playoff_matchups_natural",
+        ),
+        Index(
+            "ix_playoff_matchups_bracket_round",
+            "competition_season_id",
+            "bracket_kind",
+            "round",
+        ),
+        Index("ix_playoff_matchups_winner", "winner_season_roster_id"),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_season_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.competition_seasons.id", ondelete="RESTRICT")
+    )
+    bracket_kind: Mapped[str] = mapped_column(Text)
+    node_key: Mapped[str] = mapped_column(Text)
+    round: Mapped[int] = mapped_column(SmallInteger)
+    t1_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    t2_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    t1_from_node_key: Mapped[str | None] = mapped_column(Text)
+    t1_from_outcome: Mapped[str | None] = mapped_column(Text)
+    t2_from_node_key: Mapped[str | None] = mapped_column(Text)
+    t2_from_outcome: Mapped[str | None] = mapped_column(Text)
+    winner_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    loser_season_roster_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    placement: Mapped[int | None] = mapped_column(SmallInteger)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT")
+    )

--- a/backend/database/models/sleeper/requests.py
+++ b/backend/database/models/sleeper/requests.py
@@ -1,0 +1,198 @@
+"""Sleeper request audit and content-addressed payload models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class RefreshRun(Base):
+    __tablename__ = "refresh_runs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            ["core.competition_seasons.id", "core.competition_seasons.competition_id"],
+            name="fk_refresh_runs_season_competition",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "id",
+            "competition_season_id",
+            name="uq_refresh_runs_id_competition_season",
+        ),
+        Index("ix_refresh_runs_competition_started", "competition_id", text("started_at DESC")),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.competitions.id", ondelete="RESTRICT")
+    )
+    competition_season_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    requested_through_week: Mapped[int | None] = mapped_column(SmallInteger)
+    endpoint_scope: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    trigger_source: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text)
+    code_version: Mapped[str] = mapped_column(Text)
+    normalizer_version: Mapped[str] = mapped_column(Text)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    request_count: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+    succeeded_request_count: Mapped[int] = mapped_column(
+        Integer, server_default=text("0")
+    )
+    failed_request_count: Mapped[int] = mapped_column(Integer, server_default=text("0"))
+
+
+class ApiPayload(Base):
+    __tablename__ = "api_payloads"
+    __table_args__ = (
+        UniqueConstraint("sha256_hash", name="uq_api_payloads_sha256_hash"),
+        UniqueConstraint("id", "sha256_hash", name="uq_api_payloads_id_hash"),
+        CheckConstraint(
+            "(storage_kind = 'inline_json' AND inline_payload IS NOT NULL "
+            "AND object_storage_key IS NULL) OR "
+            "(storage_kind = 'object' AND inline_payload IS NULL "
+            "AND object_storage_key IS NOT NULL)",
+            name="exactly_one_location",
+        ),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    sha256_hash: Mapped[str] = mapped_column(Text)
+    byte_length: Mapped[int] = mapped_column(BigInteger)
+    media_type: Mapped[str] = mapped_column(Text)
+    storage_kind: Mapped[str] = mapped_column(Text)
+    inline_payload: Mapped[Any | None] = mapped_column(JSONB)
+    object_storage_key: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class ApiRequest(Base):
+    __tablename__ = "api_requests"
+    __table_args__ = (
+        UniqueConstraint("id", "scope_key", name="uq_api_requests_id_scope"),
+        UniqueConstraint(
+            "id",
+            "competition_season_id",
+            name="uq_api_requests_id_competition_season",
+        ),
+        UniqueConstraint(
+            "id", "scope_key", "response_sha256", name="uq_api_requests_id_scope_hash"
+        ),
+        ForeignKeyConstraint(
+            ["refresh_run_id", "competition_season_id"],
+            ["sleeper.refresh_runs.id", "sleeper.refresh_runs.competition_season_id"],
+            name="fk_api_requests_refresh_run_scope",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["payload_id", "response_sha256"],
+            ["sleeper.api_payloads.id", "sleeper.api_payloads.sha256_hash"],
+            name="fk_api_requests_verified_payload",
+            ondelete="RESTRICT",
+        ),
+        Index("ix_api_requests_refresh_run", "refresh_run_id"),
+        Index(
+            "ix_api_requests_eligible_scope_completed",
+            "scope_key",
+            text("completed_at DESC"),
+            postgresql_where=text("status = 'succeeded' AND is_complete"),
+        ),
+        Index(
+            "ix_api_requests_season_endpoint_week",
+            "competition_season_id",
+            "endpoint_kind",
+            "week",
+        ),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    refresh_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    competition_season_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("core.competition_seasons.id", ondelete="RESTRICT"),
+    )
+    endpoint_kind: Mapped[str] = mapped_column(Text)
+    scope_key: Mapped[str] = mapped_column(Text)
+    request_path: Mapped[str] = mapped_column(Text)
+    request_parameters: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    week: Mapped[int | None] = mapped_column(SmallInteger)
+    bracket_kind: Mapped[str | None] = mapped_column(Text)
+    requested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    latency_ms: Mapped[int | None] = mapped_column(BigInteger)
+    status: Mapped[str] = mapped_column(Text)
+    http_status: Mapped[int | None] = mapped_column(Integer)
+    error: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    is_complete: Mapped[bool] = mapped_column(Boolean, server_default=text("false"))
+    completeness_reason: Mapped[str | None] = mapped_column(Text)
+    payload_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True))
+    response_sha256: Mapped[str | None] = mapped_column(Text)
+    normalization_status: Mapped[str] = mapped_column(
+        Text, server_default=text("'pending'")
+    )
+    normalizer_version: Mapped[str | None] = mapped_column(Text)
+    normalized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class NormalizedScope(Base):
+    __tablename__ = "normalized_scopes"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_api_request_id", name="uq_normalized_scopes_source_request"
+        ),
+        ForeignKeyConstraint(
+            ["source_api_request_id", "scope_key", "response_sha256"],
+            [
+                "sleeper.api_requests.id",
+                "sleeper.api_requests.scope_key",
+                "sleeper.api_requests.response_sha256",
+            ],
+            name="fk_normalized_scopes_request_scope_hash",
+            ondelete="RESTRICT",
+        ),
+        {"schema": "sleeper"},
+    )
+
+    scope_key: Mapped[str] = mapped_column(Text, primary_key=True)
+    source_api_request_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    response_sha256: Mapped[str] = mapped_column(Text)
+    normalized_row_count: Mapped[int] = mapped_column(Integer)
+    applied_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/database/models/sleeper/snapshots.py
+++ b/backend/database/models/sleeper/snapshots.py
@@ -1,0 +1,101 @@
+"""Immutable frozen factual snapshot metadata models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class DataSnapshot(Base):
+    __tablename__ = "data_snapshots"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["primary_competition_season_id", "competition_id"],
+            ["core.competition_seasons.id", "core.competition_seasons.competition_id"],
+            name="fk_data_snapshots_primary_season_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint("id", "competition_id", name="uq_data_snapshots_id_competition"),
+        UniqueConstraint(
+            "id",
+            "primary_competition_season_id",
+            name="uq_data_snapshots_id_primary_season",
+        ),
+        Index(
+            "ix_data_snapshots_season_mode_cutoff_created",
+            "primary_competition_season_id",
+            "mode",
+            "knowledge_cutoff_at",
+            "created_at",
+        ),
+        Index("ix_data_snapshots_competition_status", "competition_id", "status"),
+        {"schema": "sleeper"},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    competition_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.competitions.id", ondelete="RESTRICT")
+    )
+    primary_competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    mode: Mapped[str] = mapped_column(Text)
+    domain_cutoff_week: Mapped[int | None] = mapped_column(SmallInteger)
+    domain_cutoff_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    knowledge_cutoff_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(Text)
+    materializer_version: Mapped[str] = mapped_column(Text)
+    sqlite_schema_version: Mapped[str] = mapped_column(Text)
+    code_version: Mapped[str] = mapped_column(Text)
+    completeness_warnings: Mapped[list[Any]] = mapped_column(JSONB)
+    selected_request_set_sha256: Mapped[str | None] = mapped_column(Text)
+    sqlite_artifact_sha256: Mapped[str | None] = mapped_column(Text)
+    sqlite_artifact_byte_length: Mapped[int | None] = mapped_column(BigInteger)
+    sqlite_artifact_storage_key: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class DataSnapshotRequest(Base):
+    __tablename__ = "data_snapshot_requests"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["api_request_id", "scope_key"],
+            ["sleeper.api_requests.id", "sleeper.api_requests.scope_key"],
+            name="fk_data_snapshot_requests_request_scope",
+            ondelete="RESTRICT",
+        ),
+        UniqueConstraint(
+            "data_snapshot_id", "scope_key", name="uq_data_snapshot_requests_snapshot_scope"
+        ),
+        Index("ix_data_snapshot_requests_api_request", "api_request_id"),
+        {"schema": "sleeper"},
+    )
+
+    data_snapshot_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sleeper.data_snapshots.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    api_request_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    scope_key: Mapped[str] = mapped_column(Text)
+    selection_role: Mapped[str] = mapped_column(Text)

--- a/backend/database/registry.py
+++ b/backend/database/registry.py
@@ -7,7 +7,8 @@ resource managers or services.
 
 from backend.database.base import Base
 from backend.database.models import core as core_models
+from backend.database.models import sleeper as sleeper_models
 
 metadata = Base.metadata
 
-__all__ = ["core_models", "metadata"]
+__all__ = ["core_models", "metadata", "sleeper_models"]

--- a/backend/migrations/versions/0003_sleeper_persistence.py
+++ b/backend/migrations/versions/0003_sleeper_persistence.py
@@ -1,0 +1,541 @@
+"""Create request-oriented Sleeper persistence and frozen snapshot metadata.
+
+Revision ID: 0003
+Revises: 0002
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Text
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _create_sleeper_triggers() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_sealed_data_snapshot()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshots cannot be deleted';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.status IN ('ready', 'expired') THEN
+                IF NEW.status NOT IN ('ready', 'expired')
+                   OR ROW(
+                       NEW.competition_id, NEW.primary_competition_season_id, NEW.mode,
+                       NEW.domain_cutoff_week, NEW.domain_cutoff_at,
+                       NEW.knowledge_cutoff_at, NEW.materializer_version,
+                       NEW.sqlite_schema_version, NEW.code_version,
+                       NEW.completeness_warnings, NEW.selected_request_set_sha256,
+                       NEW.sqlite_artifact_sha256, NEW.sqlite_artifact_byte_length,
+                       NEW.sqlite_artifact_storage_key, NEW.created_at, NEW.completed_at
+                   ) IS DISTINCT FROM ROW(
+                       OLD.competition_id, OLD.primary_competition_season_id, OLD.mode,
+                       OLD.domain_cutoff_week, OLD.domain_cutoff_at,
+                       OLD.knowledge_cutoff_at, OLD.materializer_version,
+                       OLD.sqlite_schema_version, OLD.code_version,
+                       OLD.completeness_warnings, OLD.selected_request_set_sha256,
+                       OLD.sqlite_artifact_sha256, OLD.sqlite_artifact_byte_length,
+                       OLD.sqlite_artifact_storage_key, OLD.created_at, OLD.completed_at
+                   ) THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshot meaning is immutable';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshots_protect_sealed
+        BEFORE UPDATE OR DELETE ON sleeper.data_snapshots
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_sealed_data_snapshot()
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_snapshot_request_membership()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        DECLARE
+            snapshot_status text;
+            snapshot_season_id uuid;
+            request_season_id uuid;
+        BEGIN
+            IF TG_OP IN ('UPDATE', 'DELETE') THEN
+                SELECT status INTO snapshot_status
+                FROM sleeper.data_snapshots
+                WHERE id = OLD.data_snapshot_id;
+                IF snapshot_status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+                END IF;
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+
+            SELECT status, primary_competition_season_id
+            INTO snapshot_status, snapshot_season_id
+            FROM sleeper.data_snapshots
+            WHERE id = NEW.data_snapshot_id
+            FOR UPDATE;
+            IF snapshot_status IN ('ready', 'expired') THEN
+                RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+            END IF;
+
+            SELECT competition_season_id INTO request_season_id
+            FROM sleeper.api_requests
+            WHERE id = NEW.api_request_id;
+            IF request_season_id IS NOT NULL
+               AND request_season_id <> snapshot_season_id THEN
+                RAISE EXCEPTION 'snapshot request belongs to another competition season';
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshot_requests_protect_membership
+        BEFORE INSERT OR UPDATE OR DELETE ON sleeper.data_snapshot_requests
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_snapshot_request_membership()
+        """
+    )
+
+
+def _drop_sleeper_triggers() -> None:
+    op.execute(
+        "DROP FUNCTION sleeper.protect_snapshot_request_membership() CASCADE"
+    )
+    op.execute("DROP FUNCTION sleeper.protect_sealed_data_snapshot() CASCADE")
+
+def upgrade() -> None:
+    op.create_table('refresh_runs',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_id', sa.UUID(), nullable=True),
+    sa.Column('competition_season_id', sa.UUID(), nullable=True),
+    sa.Column('requested_through_week', sa.SmallInteger(), nullable=True),
+    sa.Column('endpoint_scope', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('trigger_source', sa.Text(), nullable=False),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('code_version', sa.Text(), nullable=False),
+    sa.Column('normalizer_version', sa.Text(), nullable=False),
+    sa.Column('started_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('error_summary', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('request_count', sa.Integer(), server_default=sa.text('0'), nullable=False),
+    sa.Column('succeeded_request_count', sa.Integer(), server_default=sa.text('0'), nullable=False),
+    sa.Column('failed_request_count', sa.Integer(), server_default=sa.text('0'), nullable=False),
+    sa.ForeignKeyConstraint(['competition_id'], ['core.competitions.id'], name=op.f('fk_refresh_runs_competition_id_competitions'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['competition_season_id', 'competition_id'], ['core.competition_seasons.id', 'core.competition_seasons.competition_id'], name='fk_refresh_runs_season_competition', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_refresh_runs')),
+    sa.UniqueConstraint('id', 'competition_season_id', name='uq_refresh_runs_id_competition_season'),
+    schema='sleeper'
+    )
+    op.create_index('ix_refresh_runs_competition_started', 'refresh_runs', ['competition_id', sa.literal_column('started_at DESC')], unique=False, schema='sleeper')
+    op.create_table('api_payloads',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('sha256_hash', sa.Text(), nullable=False),
+    sa.Column('byte_length', sa.BigInteger(), nullable=False),
+    sa.Column('media_type', sa.Text(), nullable=False),
+    sa.Column('storage_kind', sa.Text(), nullable=False),
+    sa.Column('inline_payload', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('object_storage_key', sa.Text(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.CheckConstraint("(storage_kind = 'inline_json' AND inline_payload IS NOT NULL AND object_storage_key IS NULL) OR (storage_kind = 'object' AND inline_payload IS NULL AND object_storage_key IS NOT NULL)", name=op.f('ck_api_payloads_exactly_one_location')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_api_payloads')),
+    sa.UniqueConstraint('id', 'sha256_hash', name='uq_api_payloads_id_hash'),
+    sa.UniqueConstraint('sha256_hash', name='uq_api_payloads_sha256_hash'),
+    schema='sleeper'
+    )
+    op.create_table('api_requests',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('refresh_run_id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=True),
+    sa.Column('endpoint_kind', sa.Text(), nullable=False),
+    sa.Column('scope_key', sa.Text(), nullable=False),
+    sa.Column('request_path', sa.Text(), nullable=False),
+    sa.Column('request_parameters', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('week', sa.SmallInteger(), nullable=True),
+    sa.Column('bracket_kind', sa.Text(), nullable=True),
+    sa.Column('requested_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('latency_ms', sa.BigInteger(), nullable=True),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('http_status', sa.Integer(), nullable=True),
+    sa.Column('error', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('is_complete', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    sa.Column('completeness_reason', sa.Text(), nullable=True),
+    sa.Column('payload_id', sa.UUID(), nullable=True),
+    sa.Column('response_sha256', sa.Text(), nullable=True),
+    sa.Column('normalization_status', sa.Text(), server_default=sa.text("'pending'"), nullable=False),
+    sa.Column('normalizer_version', sa.Text(), nullable=True),
+    sa.Column('normalized_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['competition_season_id'], ['core.competition_seasons.id'], name=op.f('fk_api_requests_competition_season_id_competition_seasons'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['payload_id', 'response_sha256'], ['sleeper.api_payloads.id', 'sleeper.api_payloads.sha256_hash'], name='fk_api_requests_verified_payload', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['refresh_run_id', 'competition_season_id'], ['sleeper.refresh_runs.id', 'sleeper.refresh_runs.competition_season_id'], name='fk_api_requests_refresh_run_scope', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_api_requests')),
+    sa.UniqueConstraint('id', 'competition_season_id', name='uq_api_requests_id_competition_season'),
+    sa.UniqueConstraint('id', 'scope_key', 'response_sha256', name='uq_api_requests_id_scope_hash'),
+    sa.UniqueConstraint('id', 'scope_key', name='uq_api_requests_id_scope'),
+    schema='sleeper'
+    )
+    op.create_index('ix_api_requests_eligible_scope_completed', 'api_requests', ['scope_key', sa.literal_column('completed_at DESC')], unique=False, schema='sleeper', postgresql_where=sa.text("status = 'succeeded' AND is_complete"))
+    op.create_index('ix_api_requests_refresh_run', 'api_requests', ['refresh_run_id'], unique=False, schema='sleeper')
+    op.create_index('ix_api_requests_season_endpoint_week', 'api_requests', ['competition_season_id', 'endpoint_kind', 'week'], unique=False, schema='sleeper')
+    op.create_table('normalized_scopes',
+    sa.Column('scope_key', sa.Text(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.Column('response_sha256', sa.Text(), nullable=False),
+    sa.Column('normalized_row_count', sa.Integer(), nullable=False),
+    sa.Column('applied_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['source_api_request_id', 'scope_key', 'response_sha256'], ['sleeper.api_requests.id', 'sleeper.api_requests.scope_key', 'sleeper.api_requests.response_sha256'], name='fk_normalized_scopes_request_scope_hash', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('scope_key', name=op.f('pk_normalized_scopes')),
+    sa.UniqueConstraint('source_api_request_id', name='uq_normalized_scopes_source_request'),
+    schema='sleeper'
+    )
+    op.create_table('leagues',
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.Column('name', sa.Text(), nullable=False),
+    sa.Column('status', sa.Text(), nullable=True),
+    sa.Column('season', sa.Text(), nullable=False),
+    sa.Column('previous_sleeper_league_id', sa.Text(), nullable=True),
+    sa.Column('sleeper_draft_id', sa.Text(), nullable=True),
+    sa.Column('sport', sa.Text(), server_default=sa.text("'nfl'"), nullable=False),
+    sa.Column('scoring_settings', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('roster_positions', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('provider_settings', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('playoff_start_week', sa.SmallInteger(), nullable=True),
+    sa.Column('playoff_team_count', sa.SmallInteger(), nullable=True),
+    sa.Column('league_average_match', sa.Integer(), nullable=True),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['competition_season_id'], ['core.competition_seasons.id'], name=op.f('fk_leagues_competition_season_id_competition_seasons'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_leagues_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('competition_season_id', name=op.f('pk_leagues')),
+    schema='sleeper'
+    )
+    op.create_index('ix_leagues_source_request', 'leagues', ['source_api_request_id'], unique=False, schema='sleeper')
+    op.create_table('users',
+    sa.Column('sleeper_user_id', sa.Text(), nullable=False),
+    sa.Column('display_name', sa.Text(), nullable=False),
+    sa.Column('username', sa.Text(), nullable=True),
+    sa.Column('avatar', sa.Text(), nullable=True),
+    sa.Column('metadata', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_users_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('sleeper_user_id', name=op.f('pk_users')),
+    schema='sleeper'
+    )
+    op.create_index('ix_users_display_name_lower', 'users', [sa.literal_column('lower(display_name)')], unique=False, schema='sleeper')
+    op.create_table('league_users',
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_user_id', sa.Text(), nullable=False),
+    sa.Column('team_name', sa.Text(), nullable=True),
+    sa.Column('nickname', sa.Text(), nullable=True),
+    sa.Column('is_commissioner', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    sa.Column('metadata', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['competition_season_id'], ['core.competition_seasons.id'], name=op.f('fk_league_users_competition_season_id_competition_seasons'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['sleeper_user_id'], ['sleeper.users.sleeper_user_id'], name=op.f('fk_league_users_sleeper_user_id_users'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_league_users_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('competition_season_id', 'sleeper_user_id', name=op.f('pk_league_users')),
+    schema='sleeper'
+    )
+    op.create_index('ix_league_users_user', 'league_users', ['sleeper_user_id'], unique=False, schema='sleeper')
+    op.create_table('players',
+    sa.Column('sleeper_player_id', sa.Text(), nullable=False),
+    sa.Column('full_name', sa.Text(), nullable=True),
+    sa.Column('position', sa.Text(), nullable=True),
+    sa.Column('nfl_team', sa.Text(), nullable=True),
+    sa.Column('active', sa.Boolean(), nullable=True),
+    sa.Column('status', sa.Text(), nullable=True),
+    sa.Column('injury_status', sa.Text(), nullable=True),
+    sa.Column('age', sa.SmallInteger(), nullable=True),
+    sa.Column('years_experience', sa.SmallInteger(), nullable=True),
+    sa.Column('metadata', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_players_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('sleeper_player_id', name=op.f('pk_players')),
+    schema='sleeper'
+    )
+    op.create_index('ix_players_full_name_lower', 'players', [sa.literal_column('lower(full_name)')], unique=False, schema='sleeper')
+    op.create_index('ix_players_team_position', 'players', ['nfl_team', 'position'], unique=False, schema='sleeper')
+    op.create_table('rosters',
+    sa.Column('season_roster_id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.Column('settings', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('metadata', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('record_string', sa.Text(), nullable=True),
+    sa.Column('wins', sa.SmallInteger(), server_default=sa.text('0'), nullable=False),
+    sa.Column('losses', sa.SmallInteger(), server_default=sa.text('0'), nullable=False),
+    sa.Column('ties', sa.SmallInteger(), server_default=sa.text('0'), nullable=False),
+    sa.Column('points_for', sa.Numeric(precision=12, scale=4), nullable=True),
+    sa.Column('points_against', sa.Numeric(precision=12, scale=4), nullable=True),
+    sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_rosters_season_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_rosters_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('season_roster_id', name=op.f('pk_rosters')),
+    schema='sleeper'
+    )
+    op.create_index('ix_rosters_competition_season', 'rosters', ['competition_season_id'], unique=False, schema='sleeper')
+    op.create_table('roster_managers',
+    sa.Column('season_roster_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_user_id', sa.Text(), nullable=False),
+    sa.Column('role', sa.Text(), nullable=False),
+    sa.Column('source_order', sa.SmallInteger(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['season_roster_id'], ['sleeper.rosters.season_roster_id'], name=op.f('fk_roster_managers_season_roster_id_rosters'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['sleeper_user_id'], ['sleeper.users.sleeper_user_id'], name=op.f('fk_roster_managers_sleeper_user_id_users'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_roster_managers_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('season_roster_id', 'sleeper_user_id', name=op.f('pk_roster_managers')),
+    schema='sleeper'
+    )
+    op.create_index('ix_roster_managers_user', 'roster_managers', ['sleeper_user_id'], unique=False, schema='sleeper')
+    op.create_index('uq_roster_managers_one_owner', 'roster_managers', ['season_roster_id'], unique=True, schema='sleeper', postgresql_where=sa.text("role = 'owner'"))
+    op.create_table('roster_players',
+    sa.Column('season_roster_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_player_id', sa.Text(), nullable=False),
+    sa.Column('role', sa.Text(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['season_roster_id'], ['sleeper.rosters.season_roster_id'], name=op.f('fk_roster_players_season_roster_id_rosters'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['sleeper_player_id'], ['sleeper.players.sleeper_player_id'], name=op.f('fk_roster_players_sleeper_player_id_players'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_roster_players_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('season_roster_id', 'sleeper_player_id', name=op.f('pk_roster_players')),
+    schema='sleeper'
+    )
+    op.create_index('ix_roster_players_player', 'roster_players', ['sleeper_player_id'], unique=False, schema='sleeper')
+    op.create_table('matchups',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('week', sa.SmallInteger(), nullable=False),
+    sa.Column('season_roster_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_matchup_id', sa.Integer(), nullable=True),
+    sa.Column('points', sa.Numeric(precision=12, scale=4), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_matchups_season_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_matchups_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_matchups')),
+    sa.UniqueConstraint('competition_season_id', 'week', 'season_roster_id', name='uq_matchups_season_week_roster'),
+    schema='sleeper'
+    )
+    op.create_index('ix_matchups_season_week_matchup', 'matchups', ['competition_season_id', 'week', 'sleeper_matchup_id'], unique=False, schema='sleeper')
+    op.create_table('player_performances',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('week', sa.SmallInteger(), nullable=False),
+    sa.Column('season_roster_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_matchup_id', sa.Integer(), nullable=True),
+    sa.Column('sleeper_player_id', sa.Text(), nullable=False),
+    sa.Column('points', sa.Numeric(precision=12, scale=4), nullable=False),
+    sa.Column('role', sa.Text(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_player_performances_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['sleeper_player_id'], ['sleeper.players.sleeper_player_id'], name=op.f('fk_player_performances_sleeper_player_id_players'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_player_performances_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_player_performances')),
+    sa.UniqueConstraint('competition_season_id', 'week', 'season_roster_id', 'sleeper_player_id', name='uq_player_performances_natural'),
+    schema='sleeper'
+    )
+    op.create_index('ix_player_performances_player_season_week', 'player_performances', ['sleeper_player_id', 'competition_season_id', 'week'], unique=False, schema='sleeper')
+    op.create_index('ix_player_performances_roster_week', 'player_performances', ['season_roster_id', 'week'], unique=False, schema='sleeper')
+    op.create_table('transactions',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_transaction_id', sa.Text(), nullable=False),
+    sa.Column('week', sa.SmallInteger(), nullable=False),
+    sa.Column('transaction_type', sa.Text(), nullable=False),
+    sa.Column('status', sa.Text(), nullable=True),
+    sa.Column('provider_created_at_ms', sa.BigInteger(), nullable=True),
+    sa.Column('settings', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('metadata', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['competition_season_id'], ['core.competition_seasons.id'], name=op.f('fk_transactions_competition_season_id_competition_seasons'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_transactions_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_transactions')),
+    sa.UniqueConstraint('competition_season_id', 'sleeper_transaction_id', name='uq_transactions_season_sleeper_id'),
+    sa.UniqueConstraint('id', 'competition_season_id', name='uq_transactions_id_season'),
+    schema='sleeper'
+    )
+    op.create_index('ix_transactions_season_week_type_status', 'transactions', ['competition_season_id', 'week', 'transaction_type', 'status'], unique=False, schema='sleeper')
+    op.create_index('ix_transactions_sleeper_id', 'transactions', ['sleeper_transaction_id'], unique=False, schema='sleeper')
+    op.create_table('draft_picks',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_id', sa.UUID(), nullable=False),
+    sa.Column('draft_season_year', sa.Integer(), nullable=False),
+    sa.Column('round', sa.SmallInteger(), nullable=False),
+    sa.Column('original_franchise_id', sa.UUID(), nullable=False),
+    sa.Column('current_franchise_id', sa.UUID(), nullable=False),
+    sa.Column('sleeper_pick_id', sa.Text(), nullable=True),
+    sa.Column('source', sa.Text(), nullable=False),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=True),
+    sa.ForeignKeyConstraint(['competition_id'], ['core.competitions.id'], name=op.f('fk_draft_picks_competition_id_competitions'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['current_franchise_id', 'competition_id'], ['core.franchises.id', 'core.franchises.competition_id'], name='fk_draft_picks_current_franchise_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['original_franchise_id', 'competition_id'], ['core.franchises.id', 'core.franchises.competition_id'], name='fk_draft_picks_original_franchise_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_draft_picks_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_draft_picks')),
+    sa.UniqueConstraint('competition_id', 'draft_season_year', 'round', 'original_franchise_id', name='uq_draft_picks_natural'),
+    sa.UniqueConstraint('id', 'competition_id', name='uq_draft_picks_id_competition'),
+    schema='sleeper'
+    )
+    op.create_index('ix_draft_picks_current_owner', 'draft_picks', ['competition_id', 'draft_season_year', 'current_franchise_id'], unique=False, schema='sleeper')
+    op.create_table('transaction_moves',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('transaction_id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('move_index', sa.Integer(), nullable=False),
+    sa.Column('move_kind', sa.Text(), nullable=False),
+    sa.Column('from_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('to_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('sleeper_player_id', sa.Text(), nullable=True),
+    sa.Column('draft_pick_id', sa.UUID(), nullable=True),
+    sa.Column('budget_amount', sa.BigInteger(), nullable=True),
+    sa.ForeignKeyConstraint(['draft_pick_id'], ['sleeper.draft_picks.id'], name=op.f('fk_transaction_moves_draft_pick_id_draft_picks'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['from_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_transaction_moves_from_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['sleeper_player_id'], ['sleeper.players.sleeper_player_id'], name=op.f('fk_transaction_moves_sleeper_player_id_players'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['to_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_transaction_moves_to_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['transaction_id', 'competition_season_id'], ['sleeper.transactions.id', 'sleeper.transactions.competition_season_id'], name='fk_transaction_moves_transaction_scope', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_transaction_moves')),
+    sa.UniqueConstraint('transaction_id', 'move_index', name='uq_transaction_moves_index'),
+    schema='sleeper'
+    )
+    op.create_index('ix_transaction_moves_from_roster', 'transaction_moves', ['from_season_roster_id'], unique=False, schema='sleeper')
+    op.create_index('ix_transaction_moves_pick', 'transaction_moves', ['draft_pick_id'], unique=False, schema='sleeper')
+    op.create_index('ix_transaction_moves_player', 'transaction_moves', ['sleeper_player_id'], unique=False, schema='sleeper')
+    op.create_index('ix_transaction_moves_to_roster', 'transaction_moves', ['to_season_roster_id'], unique=False, schema='sleeper')
+    op.create_table('playoff_matchups',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('bracket_kind', sa.Text(), nullable=False),
+    sa.Column('node_key', sa.Text(), nullable=False),
+    sa.Column('round', sa.SmallInteger(), nullable=False),
+    sa.Column('t1_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('t2_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('t1_from_node_key', sa.Text(), nullable=True),
+    sa.Column('t1_from_outcome', sa.Text(), nullable=True),
+    sa.Column('t2_from_node_key', sa.Text(), nullable=True),
+    sa.Column('t2_from_outcome', sa.Text(), nullable=True),
+    sa.Column('winner_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('loser_season_roster_id', sa.UUID(), nullable=True),
+    sa.Column('placement', sa.SmallInteger(), nullable=True),
+    sa.Column('source_api_request_id', sa.UUID(), nullable=False),
+    sa.ForeignKeyConstraint(['competition_season_id'], ['core.competition_seasons.id'], name=op.f('fk_playoff_matchups_competition_season_id_competition_seasons'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['loser_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_playoff_matchups_loser_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_api_request_id'], ['sleeper.api_requests.id'], name=op.f('fk_playoff_matchups_source_api_request_id_api_requests'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['t1_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_playoff_matchups_t1_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['t2_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_playoff_matchups_t2_roster_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['winner_season_roster_id', 'competition_season_id'], ['core.season_rosters.id', 'core.season_rosters.competition_season_id'], name='fk_playoff_matchups_winner_scope', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_playoff_matchups')),
+    sa.UniqueConstraint('competition_season_id', 'bracket_kind', 'node_key', name='uq_playoff_matchups_natural'),
+    schema='sleeper'
+    )
+    op.create_index('ix_playoff_matchups_bracket_round', 'playoff_matchups', ['competition_season_id', 'bracket_kind', 'round'], unique=False, schema='sleeper')
+    op.create_index('ix_playoff_matchups_winner', 'playoff_matchups', ['winner_season_roster_id'], unique=False, schema='sleeper')
+    op.create_table('data_snapshots',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_id', sa.UUID(), nullable=False),
+    sa.Column('primary_competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('mode', sa.Text(), nullable=False),
+    sa.Column('domain_cutoff_week', sa.SmallInteger(), nullable=True),
+    sa.Column('domain_cutoff_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('knowledge_cutoff_at', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('materializer_version', sa.Text(), nullable=False),
+    sa.Column('sqlite_schema_version', sa.Text(), nullable=False),
+    sa.Column('code_version', sa.Text(), nullable=False),
+    sa.Column('completeness_warnings', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('selected_request_set_sha256', sa.Text(), nullable=True),
+    sa.Column('sqlite_artifact_sha256', sa.Text(), nullable=True),
+    sa.Column('sqlite_artifact_byte_length', sa.BigInteger(), nullable=True),
+    sa.Column('sqlite_artifact_storage_key', sa.Text(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['competition_id'], ['core.competitions.id'], name=op.f('fk_data_snapshots_competition_id_competitions'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['primary_competition_season_id', 'competition_id'], ['core.competition_seasons.id', 'core.competition_seasons.competition_id'], name='fk_data_snapshots_primary_season_scope', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_data_snapshots')),
+    sa.UniqueConstraint('id', 'competition_id', name='uq_data_snapshots_id_competition'),
+    sa.UniqueConstraint('id', 'primary_competition_season_id', name='uq_data_snapshots_id_primary_season'),
+    schema='sleeper'
+    )
+    op.create_index('ix_data_snapshots_competition_status', 'data_snapshots', ['competition_id', 'status'], unique=False, schema='sleeper')
+    op.create_index('ix_data_snapshots_season_mode_cutoff_created', 'data_snapshots', ['primary_competition_season_id', 'mode', 'knowledge_cutoff_at', 'created_at'], unique=False, schema='sleeper')
+    op.create_table('data_snapshot_requests',
+    sa.Column('data_snapshot_id', sa.UUID(), nullable=False),
+    sa.Column('api_request_id', sa.UUID(), nullable=False),
+    sa.Column('scope_key', sa.Text(), nullable=False),
+    sa.Column('selection_role', sa.Text(), nullable=False),
+    sa.ForeignKeyConstraint(['api_request_id', 'scope_key'], ['sleeper.api_requests.id', 'sleeper.api_requests.scope_key'], name='fk_data_snapshot_requests_request_scope', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['data_snapshot_id'], ['sleeper.data_snapshots.id'], name=op.f('fk_data_snapshot_requests_data_snapshot_id_data_snapshots'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('data_snapshot_id', 'api_request_id', name=op.f('pk_data_snapshot_requests')),
+    sa.UniqueConstraint('data_snapshot_id', 'scope_key', name='uq_data_snapshot_requests_snapshot_scope'),
+    schema='sleeper'
+    )
+    op.create_index('ix_data_snapshot_requests_api_request', 'data_snapshot_requests', ['api_request_id'], unique=False, schema='sleeper')
+    _create_sleeper_triggers()
+
+
+
+def downgrade() -> None:
+    _drop_sleeper_triggers()
+    op.drop_index('ix_data_snapshot_requests_api_request', table_name='data_snapshot_requests', schema='sleeper')
+    op.drop_table('data_snapshot_requests', schema='sleeper')
+    op.drop_index('ix_data_snapshots_season_mode_cutoff_created', table_name='data_snapshots', schema='sleeper')
+    op.drop_index('ix_data_snapshots_competition_status', table_name='data_snapshots', schema='sleeper')
+    op.drop_table('data_snapshots', schema='sleeper')
+    op.drop_index('ix_playoff_matchups_winner', table_name='playoff_matchups', schema='sleeper')
+    op.drop_index('ix_playoff_matchups_bracket_round', table_name='playoff_matchups', schema='sleeper')
+    op.drop_table('playoff_matchups', schema='sleeper')
+    op.drop_index('ix_transaction_moves_to_roster', table_name='transaction_moves', schema='sleeper')
+    op.drop_index('ix_transaction_moves_player', table_name='transaction_moves', schema='sleeper')
+    op.drop_index('ix_transaction_moves_pick', table_name='transaction_moves', schema='sleeper')
+    op.drop_index('ix_transaction_moves_from_roster', table_name='transaction_moves', schema='sleeper')
+    op.drop_table('transaction_moves', schema='sleeper')
+    op.drop_index('ix_draft_picks_current_owner', table_name='draft_picks', schema='sleeper')
+    op.drop_table('draft_picks', schema='sleeper')
+    op.drop_index('ix_transactions_sleeper_id', table_name='transactions', schema='sleeper')
+    op.drop_index('ix_transactions_season_week_type_status', table_name='transactions', schema='sleeper')
+    op.drop_table('transactions', schema='sleeper')
+    op.drop_index('ix_player_performances_roster_week', table_name='player_performances', schema='sleeper')
+    op.drop_index('ix_player_performances_player_season_week', table_name='player_performances', schema='sleeper')
+    op.drop_table('player_performances', schema='sleeper')
+    op.drop_index('ix_matchups_season_week_matchup', table_name='matchups', schema='sleeper')
+    op.drop_table('matchups', schema='sleeper')
+    op.drop_index('ix_roster_players_player', table_name='roster_players', schema='sleeper')
+    op.drop_table('roster_players', schema='sleeper')
+    op.drop_index('uq_roster_managers_one_owner', table_name='roster_managers', schema='sleeper', postgresql_where=sa.text("role = 'owner'"))
+    op.drop_index('ix_roster_managers_user', table_name='roster_managers', schema='sleeper')
+    op.drop_table('roster_managers', schema='sleeper')
+    op.drop_index('ix_rosters_competition_season', table_name='rosters', schema='sleeper')
+    op.drop_table('rosters', schema='sleeper')
+    op.drop_index('ix_players_team_position', table_name='players', schema='sleeper')
+    op.drop_index('ix_players_full_name_lower', table_name='players', schema='sleeper')
+    op.drop_table('players', schema='sleeper')
+    op.drop_index('ix_league_users_user', table_name='league_users', schema='sleeper')
+    op.drop_table('league_users', schema='sleeper')
+    op.drop_index('ix_users_display_name_lower', table_name='users', schema='sleeper')
+    op.drop_table('users', schema='sleeper')
+    op.drop_index('ix_leagues_source_request', table_name='leagues', schema='sleeper')
+    op.drop_table('leagues', schema='sleeper')
+    op.drop_table('normalized_scopes', schema='sleeper')
+    op.drop_index('ix_api_requests_season_endpoint_week', table_name='api_requests', schema='sleeper')
+    op.drop_index('ix_api_requests_refresh_run', table_name='api_requests', schema='sleeper')
+    op.drop_index('ix_api_requests_eligible_scope_completed', table_name='api_requests', schema='sleeper', postgresql_where=sa.text("status = 'succeeded' AND is_complete"))
+    op.drop_table('api_requests', schema='sleeper')
+    op.drop_table('api_payloads', schema='sleeper')
+    op.drop_index('ix_refresh_runs_competition_started', table_name='refresh_runs', schema='sleeper')
+    op.drop_table('refresh_runs', schema='sleeper')

--- a/backend/tests/database/constraints/test_sleeper_constraints.py
+++ b/backend/tests/database/constraints/test_sleeper_constraints.py
@@ -1,0 +1,407 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, Engine, Numeric
+from sqlalchemy.exc import DBAPIError
+
+from backend.database.base import Base
+from backend.database.models.core import (
+    Competition,
+    CompetitionSeason,
+    Franchise,
+    SeasonRoster,
+)
+from backend.database.models.sleeper import (
+    ApiPayload,
+    ApiRequest,
+    DataSnapshot,
+    DataSnapshotRequest,
+    Matchup,
+    NormalizedScope,
+    RefreshRun,
+    Roster,
+    RosterManager,
+    User,
+)
+
+
+def _hash() -> str:
+    return uuid4().hex + uuid4().hex
+
+
+def _assert_database_error(engine: Engine, statement: sa.Executable) -> None:
+    with pytest.raises(DBAPIError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def _insert_competition_scope(engine: Engine) -> dict[str, UUID]:
+    ids = {
+        "competition": uuid4(),
+        "season": uuid4(),
+        "franchise": uuid4(),
+        "roster": uuid4(),
+    }
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": ids["competition"], "display_name": "Sleeper Test League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": ids["season"],
+                "competition_id": ids["competition"],
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            {
+                "id": ids["franchise"],
+                "competition_id": ids["competition"],
+                "display_name": "Sleeper Test Franchise",
+            },
+        )
+        connection.execute(
+            sa.insert(SeasonRoster),
+            {
+                "id": ids["roster"],
+                "competition_id": ids["competition"],
+                "competition_season_id": ids["season"],
+                "franchise_id": ids["franchise"],
+                "sleeper_roster_id": str(uuid4()),
+            },
+        )
+    return ids
+
+
+def _insert_request(
+    engine: Engine,
+    scope: dict[str, UUID],
+    *,
+    scope_key: str,
+) -> dict[str, UUID | str]:
+    now = datetime.now(timezone.utc)
+    refresh_run_id = uuid4()
+    payload_id = uuid4()
+    api_request_id = uuid4()
+    response_hash = _hash()
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(RefreshRun),
+            {
+                "id": refresh_run_id,
+                "competition_id": scope["competition"],
+                "competition_season_id": scope["season"],
+                "endpoint_scope": {},
+                "trigger_source": "test",
+                "status": "test",
+                "code_version": "test",
+                "normalizer_version": "test",
+            },
+        )
+        connection.execute(
+            sa.insert(ApiPayload),
+            {
+                "id": payload_id,
+                "sha256_hash": response_hash,
+                "byte_length": 2,
+                "media_type": "application/json",
+                "storage_kind": "inline_json",
+                "inline_payload": {},
+            },
+        )
+        connection.execute(
+            sa.insert(ApiRequest),
+            {
+                "id": api_request_id,
+                "refresh_run_id": refresh_run_id,
+                "competition_season_id": scope["season"],
+                "endpoint_kind": "test",
+                "scope_key": scope_key,
+                "request_path": "/test",
+                "request_parameters": {},
+                "requested_at": now,
+                "completed_at": now,
+                "status": "test",
+                "payload_id": payload_id,
+                "response_sha256": response_hash,
+                "normalization_status": "test",
+            },
+        )
+    return {
+        "refresh_run": refresh_run_id,
+        "payload": payload_id,
+        "request": api_request_id,
+        "hash": response_hash,
+        "scope_key": scope_key,
+    }
+
+
+def test_sleeper_model_contract_is_structural_and_uses_exact_scores() -> None:
+    sleeper_tables = {
+        name for name in Base.metadata.tables if name.startswith("sleeper.")
+    }
+    assert len(sleeper_tables) == 19
+
+    checks = [
+        (table_name, constraint.name)
+        for table_name in sleeper_tables
+        for constraint in Base.metadata.tables[table_name].constraints
+        if isinstance(constraint, CheckConstraint)
+    ]
+    assert checks == [
+        ("sleeper.api_payloads", "ck_api_payloads_exactly_one_location")
+    ]
+
+    for table_name, column_name in (
+        ("sleeper.matchups", "points"),
+        ("sleeper.player_performances", "points"),
+        ("sleeper.rosters", "points_for"),
+        ("sleeper.rosters", "points_against"),
+    ):
+        column_type = Base.metadata.tables[table_name].c[column_name].type
+        assert isinstance(column_type, Numeric)
+        assert (column_type.precision, column_type.scale) == (12, 4)
+
+
+def test_api_payload_requires_exactly_one_content_location(
+    database_engine: Engine,
+) -> None:
+    base = {
+        "id": uuid4(),
+        "sha256_hash": _hash(),
+        "byte_length": 2,
+        "media_type": "application/json",
+        "storage_kind": "inline_json",
+    }
+    _assert_database_error(
+        database_engine,
+        sa.insert(ApiPayload).values(
+            **base,
+            inline_payload={},
+            object_storage_key="payloads/also-present.json",
+        ),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.insert(ApiPayload).values(**(base | {"id": uuid4(), "sha256_hash": _hash()})),
+    )
+
+
+def test_request_and_normalized_head_provenance_is_relational(
+    database_engine: Engine,
+) -> None:
+    first_scope = _insert_competition_scope(database_engine)
+    second_scope = _insert_competition_scope(database_engine)
+    first_request = _insert_request(
+        database_engine, first_scope, scope_key=f"league:{uuid4()}"
+    )
+    second_request = _insert_request(
+        database_engine,
+        first_scope,
+        scope_key=str(first_request["scope_key"]),
+    )
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(ApiRequest).values(
+            id=uuid4(),
+            refresh_run_id=first_request["refresh_run"],
+            competition_season_id=second_scope["season"],
+            endpoint_kind="test",
+            scope_key=f"league:{uuid4()}",
+            request_path="/test",
+            request_parameters={},
+            requested_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+            status="test",
+            normalization_status="test",
+        ),
+    )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(NormalizedScope),
+            {
+                "scope_key": first_request["scope_key"],
+                "source_api_request_id": first_request["request"],
+                "response_sha256": first_request["hash"],
+                "normalized_row_count": 0,
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(NormalizedScope)
+        .where(NormalizedScope.scope_key == first_request["scope_key"])
+        .values(response_sha256=_hash()),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.insert(NormalizedScope).values(
+            scope_key=second_request["scope_key"],
+            source_api_request_id=second_request["request"],
+            response_sha256=second_request["hash"],
+            normalized_row_count=0,
+        ),
+    )
+
+
+def test_normalized_scope_keys_and_roster_ownership_are_unique(
+    database_engine: Engine,
+) -> None:
+    scope = _insert_competition_scope(database_engine)
+    request = _insert_request(database_engine, scope, scope_key=f"rosters:{uuid4()}")
+    first_user = str(uuid4())
+    second_user = str(uuid4())
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(User),
+            [
+                {
+                    "sleeper_user_id": first_user,
+                    "display_name": "First",
+                    "metadata": {},
+                    "source_api_request_id": request["request"],
+                },
+                {
+                    "sleeper_user_id": second_user,
+                    "display_name": "Second",
+                    "metadata": {},
+                    "source_api_request_id": request["request"],
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Roster),
+            {
+                "season_roster_id": scope["roster"],
+                "competition_season_id": scope["season"],
+                "source_api_request_id": request["request"],
+                "settings": {},
+                "metadata": {},
+            },
+        )
+        connection.execute(
+            sa.insert(RosterManager),
+            {
+                "season_roster_id": scope["roster"],
+                "sleeper_user_id": first_user,
+                "role": "owner",
+                "source_order": 0,
+                "source_api_request_id": request["request"],
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(RosterManager).values(
+            season_roster_id=scope["roster"],
+            sleeper_user_id=second_user,
+            role="owner",
+            source_order=1,
+            source_api_request_id=request["request"],
+        ),
+    )
+
+
+def test_matchup_rejects_a_roster_from_another_season(
+    database_engine: Engine,
+) -> None:
+    first_scope = _insert_competition_scope(database_engine)
+    second_scope = _insert_competition_scope(database_engine)
+    request = _insert_request(
+        database_engine, first_scope, scope_key=f"matchups:{uuid4()}"
+    )
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(Matchup).values(
+            id=uuid4(),
+            competition_season_id=first_scope["season"],
+            week=1,
+            season_roster_id=second_scope["roster"],
+            sleeper_matchup_id=1,
+            points=Decimal("123.4567"),
+            source_api_request_id=request["request"],
+        ),
+    )
+
+
+def test_sealed_snapshot_and_membership_are_immutable_and_scope_safe(
+    database_engine: Engine,
+) -> None:
+    first_scope = _insert_competition_scope(database_engine)
+    second_scope = _insert_competition_scope(database_engine)
+    first_request = _insert_request(
+        database_engine, first_scope, scope_key=f"league:{uuid4()}"
+    )
+    second_request = _insert_request(
+        database_engine, second_scope, scope_key=f"league:{uuid4()}"
+    )
+    snapshot_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(DataSnapshot),
+            {
+                "id": snapshot_id,
+                "competition_id": first_scope["competition"],
+                "primary_competition_season_id": first_scope["season"],
+                "mode": "test",
+                "knowledge_cutoff_at": datetime.now(timezone.utc),
+                "status": "building",
+                "materializer_version": "test",
+                "sqlite_schema_version": "test",
+                "code_version": "test",
+                "completeness_warnings": [],
+            },
+        )
+        connection.execute(
+            sa.insert(DataSnapshotRequest),
+            {
+                "data_snapshot_id": snapshot_id,
+                "api_request_id": first_request["request"],
+                "scope_key": first_request["scope_key"],
+                "selection_role": "test",
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(DataSnapshotRequest).values(
+            data_snapshot_id=snapshot_id,
+            api_request_id=second_request["request"],
+            scope_key=second_request["scope_key"],
+            selection_role="test",
+        ),
+    )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(DataSnapshot)
+            .where(DataSnapshot.id == snapshot_id)
+            .values(status="ready")
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.delete(DataSnapshotRequest).where(
+            DataSnapshotRequest.data_snapshot_id == snapshot_id
+        ),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(DataSnapshot)
+        .where(DataSnapshot.id == snapshot_id)
+        .values(materializer_version="rewritten"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(DataSnapshot).where(DataSnapshot.id == snapshot_id),
+    )


### PR DESCRIPTION
## Summary

- adds 19 Sleeper request, payload, normalized-current, and immutable snapshot tables
- adds Alembic revision `0003` with normalized-head concurrency guarantees, request provenance, scope keys, exact numeric scoring, and sealed snapshot membership
- adds PostgreSQL tests for relational scope, concurrency, storage shape, and immutable history

## Design decisions

Sleeper remains the factual source of truth. Raw receipts are durable, normalized rows represent current query state, and ready snapshot inputs are frozen without duplicating application-level lifecycle semantics in DDL.

## Verification

- Sleeper PostgreSQL tests: passed
- migration/metadata comparison: zero drift
- final stacked database suite: 66 passed

## Stack

3 of 7. Previous: #87. Next: #89
