### PR TITLE
feat(database): add canonical memory state

### DIFF
--- a/backend/database/models/memory/__init__.py
+++ b/backend/database/models/memory/__init__.py
@@ -1,0 +1,26 @@
+from backend.database.models.memory.items import (
+    ContextNote,
+    ContextNoteVersion,
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+from backend.database.models.memory.revisions import CurrentRevision, MemoryRevision
+
+__all__ = [
+    "ContextNote",
+    "ContextNoteVersion",
+    "CurrentRevision",
+    "EventVersion",
+    "FactVersion",
+    "MemoryItem",
+    "MemoryRevision",
+    "MemorySearchDocument",
+    "MemoryVersion",
+    "StorylineVersion",
+    "TriggerVersion",
+]

--- a/backend/database/models/memory/items.py
+++ b/backend/database/models/memory/items.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    Computed,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, TSVECTOR, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class MemoryItem(Base):
+    __tablename__ = "memory_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "competition_id", name="uq_memory_items_id_competition"
+        ),
+        Index("ix_memory_items_competition_kind", "competition_id", "kind"),
+        Index("ix_memory_items_competition_agent_key", "competition_id", "agent_key"),
+        {"schema": "memory"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("core.competitions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    agent_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class MemoryVersion(Base):
+    __tablename__ = "memory_versions"
+    __table_args__ = (
+        UniqueConstraint(
+            "item_id", "revision_number", name="uq_memory_versions_item_revision"
+        ),
+        UniqueConstraint(
+            "id", "competition_id", name="uq_memory_versions_id_competition"
+        ),
+        ForeignKeyConstraint(
+            ["item_id", "competition_id"],
+            ["memory.memory_items.id", "memory.memory_items.competition_id"],
+            name="fk_memory_versions_item_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["introduced_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_versions_introduced_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["retired_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_versions_retired_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_memory_versions_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        Index("ix_memory_versions_item_revision", "item_id", "revision_number"),
+        Index("ix_memory_versions_introduced_revision", "introduced_revision_id"),
+        Index("ix_memory_versions_retired_revision", "retired_revision_id"),
+        Index("ix_memory_versions_creating_generation", "creating_generation_id"),
+        Index(
+            "ix_memory_versions_competition_season_week",
+            "competition_id",
+            "competition_season_id",
+            "week",
+        ),
+        Index(
+            "ix_memory_versions_season_competition",
+            "competition_season_id",
+            "competition_id",
+        ),
+        {"schema": "memory"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    item_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    competition_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    revision_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    content_schema_version: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        default=1,
+        server_default=text("1"),
+    )
+    introduced_revision_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), nullable=False
+    )
+    retired_revision_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    competition_season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    occurred_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Cross-namespace FKs to reporting are added in revision 0006.
+    creating_generation_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    creating_tool_call_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    change_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class StorylineVersion(Base):
+    __tablename__ = "storyline_versions"
+    __table_args__ = (
+        {"schema": "memory"},
+    )
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("memory.memory_versions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    headline: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    arc_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    salience: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    tags: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    subjects: Mapped[list[dict[str, object]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+    )
+    evidence: Mapped[list[dict[str, object]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+    )
+    related_storylines: Mapped[list[dict[str, object]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+    )
+    callback_condition: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resolution_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class FactVersion(Base):
+    __tablename__ = "fact_versions"
+    __table_args__ = (
+        Index("ix_fact_versions_primary_tool_call", "primary_tool_call_id"),
+        Index("ix_fact_versions_primary_api_request", "primary_api_request_id"),
+        {"schema": "memory"},
+    )
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("memory.memory_versions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    claim: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    structured_numbers: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    confidence: Mapped[str] = mapped_column(Text, nullable=False)
+    subjects: Mapped[list[dict[str, object]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+    )
+    originating_event_version_ids: Mapped[list[UUID]] = mapped_column(
+        ARRAY(PGUUID(as_uuid=True)),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'::uuid[]"),
+    )
+    # Reporting provenance and cross-namespace receipt scope land in revision 0006.
+    primary_tool_call_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    primary_api_request_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    additional_source_hints: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class EventVersion(Base):
+    __tablename__ = "event_versions"
+    __table_args__ = (
+        Index("ix_event_versions_primary_tool_call", "primary_tool_call_id"),
+        Index("ix_event_versions_primary_api_request", "primary_api_request_id"),
+        {"schema": "memory"},
+    )
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("memory.memory_versions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    headline: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    salience: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    confidence: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    details: Mapped[dict[str, object]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
+    )
+    additional_source_hints: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    # Reporting provenance and cross-namespace receipt scope land in revision 0006.
+    primary_tool_call_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    primary_api_request_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("sleeper.api_requests.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+
+
+class TriggerVersion(Base):
+    __tablename__ = "trigger_versions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["version_id", "competition_id"],
+            ["memory.memory_versions.id", "memory.memory_versions.competition_id"],
+            name="fk_trigger_versions_version_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["target_competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_trigger_versions_target_same_competition",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "ix_trigger_versions_target_season_competition",
+            "target_competition_season_id",
+            "competition_id",
+        ),
+        {"schema": "memory"},
+    )
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+    )
+    competition_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    trigger_type: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    fire_policy: Mapped[str] = mapped_column(Text, nullable=False)
+    target_competition_season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+    )
+    target_storyline_item_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+    )
+    origin_event_item_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+    )
+    target_week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    target_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    condition: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    resolution_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class ContextNote(Base):
+    __tablename__ = "context_notes"
+    __table_args__ = (
+        UniqueConstraint(
+            "item_id", "competition_id", name="uq_context_notes_item_competition"
+        ),
+        ForeignKeyConstraint(
+            ["item_id", "competition_id"],
+            ["memory.memory_items.id", "memory.memory_items.competition_id"],
+            name="fk_context_notes_item_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_context_notes_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_context_notes_franchise_same_competition",
+            ondelete="RESTRICT",
+        ),
+        CheckConstraint(
+            "(scope = 'competition' AND competition_season_id IS NULL AND "
+            "franchise_id IS NULL) OR "
+            "(scope = 'competition_season' AND competition_season_id IS NOT NULL "
+            "AND franchise_id IS NULL) OR "
+            "(scope = 'franchise' AND competition_season_id IS NULL AND "
+            "franchise_id IS NOT NULL)",
+            name="scope_shape",
+        ),
+        Index(
+            "uq_context_notes_competition_key",
+            "competition_id",
+            "note_key",
+            unique=True,
+            postgresql_where=text("scope = 'competition'"),
+        ),
+        Index(
+            "uq_context_notes_season_key",
+            "competition_season_id",
+            "note_key",
+            unique=True,
+            postgresql_where=text("scope = 'competition_season'"),
+        ),
+        Index(
+            "uq_context_notes_franchise_key",
+            "franchise_id",
+            "note_key",
+            unique=True,
+            postgresql_where=text("scope = 'franchise'"),
+        ),
+        {"schema": "memory"},
+    )
+
+    item_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    competition_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    scope: Mapped[str] = mapped_column(Text, nullable=False)
+    competition_season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    franchise_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    note_key: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class ContextNoteVersion(Base):
+    __tablename__ = "context_note_versions"
+    __table_args__ = ({"schema": "memory"},)
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("memory.memory_versions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    narrative_text: Mapped[str] = mapped_column(Text, nullable=False)
+    outlook: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+
+
+class MemorySearchDocument(Base):
+    __tablename__ = "memory_search_documents"
+    __table_args__ = (
+        Index(
+            "ix_memory_search_documents_competition_kind_status",
+            "competition_id",
+            "kind",
+            "status",
+        ),
+        Index("ix_memory_search_documents_item", "item_id"),
+        Index(
+            "ix_memory_search_documents_entity_keys",
+            "entity_keys",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_memory_search_documents_evidence_versions",
+            "evidence_version_ids",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_memory_search_documents_related_items",
+            "related_item_ids",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_memory_search_documents_tags",
+            "tags",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_memory_search_documents_search_vector",
+            "search_vector",
+            postgresql_using="gin",
+        ),
+        {"schema": "memory"},
+    )
+
+    version_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("memory.memory_versions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    item_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    competition_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    salience: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    competition_season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+    )
+    week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    entity_keys: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'::text[]"),
+    )
+    evidence_version_ids: Mapped[list[UUID]] = mapped_column(
+        ARRAY(PGUUID(as_uuid=True)),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'::uuid[]"),
+    )
+    related_item_ids: Mapped[list[UUID]] = mapped_column(
+        ARRAY(PGUUID(as_uuid=True)),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'::uuid[]"),
+    )
+    tags: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'::text[]"),
+    )
+    document_text: Mapped[str] = mapped_column(Text, nullable=False)
+    search_vector: Mapped[str] = mapped_column(
+        TSVECTOR,
+        Computed("to_tsvector('english', document_text)", persisted=True),
+        nullable=False,
+    )
+    builder_version: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    content_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    indexed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/backend/database/models/memory/revisions.py
+++ b/backend/database/models/memory/revisions.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class MemoryRevision(Base):
+    __tablename__ = "memory_revisions"
+    __table_args__ = (
+        UniqueConstraint(
+            "competition_id",
+            "sequence_number",
+            name="uq_memory_revisions_competition_sequence",
+        ),
+        UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_memory_revisions_id_competition",
+        ),
+        UniqueConstraint(
+            "producing_generation_id",
+            name="uq_memory_revisions_producing_generation",
+        ),
+        ForeignKeyConstraint(
+            ["previous_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_revisions_previous_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_memory_revisions_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "ix_memory_revisions_competition_sequence_desc",
+            "competition_id",
+            text("sequence_number DESC"),
+        ),
+        Index(
+            "ix_memory_revisions_previous_competition",
+            "previous_revision_id",
+            "competition_id",
+        ),
+        Index(
+            "ix_memory_revisions_season_competition",
+            "competition_season_id",
+            "competition_id",
+        ),
+        Index(
+            "ix_memory_revisions_producing_generation",
+            "producing_generation_id",
+        ),
+        {"schema": "memory"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("core.competitions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    sequence_number: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    previous_revision_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    # Cross-namespace FK to reporting.generations is added in revision 0006.
+    producing_generation_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    competition_season_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    knowledge_cutoff_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    state_content_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class CurrentRevision(Base):
+    __tablename__ = "current_revisions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["current_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_current_revisions_revision_same_competition",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "ix_current_revisions_revision_competition",
+            "current_revision_id",
+            "competition_id",
+        ),
+        {"schema": "memory"},
+    )
+
+    competition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("core.competitions.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    current_revision_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    lock_version: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/database/registry.py
+++ b/backend/database/registry.py
@@ -8,7 +8,8 @@ resource managers or services.
 from backend.database.base import Base
 from backend.database.models import core as core_models
 from backend.database.models import sleeper as sleeper_models
+from backend.database.models import memory as memory_models
 
 metadata = Base.metadata
 
-__all__ = ["core_models", "metadata", "sleeper_models"]
+__all__ = ["core_models", "memory_models", "metadata", "sleeper_models"]

--- a/backend/migrations/versions/0004_memory_state.py
+++ b/backend/migrations/versions/0004_memory_state.py
@@ -1,0 +1,809 @@
+"""Create linear canonical reporter memory.
+
+Revision ID: 0004
+Revises: 0003
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _create_history_guards() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION memory.reject_sealed_history_mutation()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            RAISE EXCEPTION 'sealed canonical memory history is immutable';
+        END;
+        $aida$
+        """
+    )
+    immutable_tables = (
+        "memory_revisions",
+        "memory_items",
+        "storyline_versions",
+        "fact_versions",
+        "event_versions",
+        "trigger_versions",
+        "context_notes",
+        "context_note_versions",
+    )
+    for table_name in immutable_tables:
+        op.execute(
+            f"""
+            CREATE TRIGGER {table_name}_reject_mutation
+            BEFORE UPDATE OR DELETE ON memory.{table_name}
+            FOR EACH ROW EXECUTE FUNCTION memory.reject_sealed_history_mutation()
+            """
+        )
+
+    op.execute(
+        """
+        CREATE FUNCTION memory.protect_memory_version()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                RAISE EXCEPTION 'canonical memory versions cannot be deleted';
+            END IF;
+            IF (to_jsonb(NEW) - 'retired_revision_id') IS DISTINCT FROM
+               (to_jsonb(OLD) - 'retired_revision_id') THEN
+                RAISE EXCEPTION 'canonical memory version content is immutable';
+            END IF;
+            IF OLD.retired_revision_id IS NOT NULL
+               AND NEW.retired_revision_id IS DISTINCT FROM OLD.retired_revision_id THEN
+                RAISE EXCEPTION 'a retired memory version cannot be changed';
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER memory_versions_protect_history
+        BEFORE UPDATE OR DELETE ON memory.memory_versions
+        FOR EACH ROW EXECUTE FUNCTION memory.protect_memory_version()
+        """
+    )
+
+    op.execute(
+        """
+        CREATE FUNCTION memory.protect_current_revision()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                RAISE EXCEPTION 'the canonical current revision pointer cannot be deleted';
+            END IF;
+            IF NEW.competition_id IS DISTINCT FROM OLD.competition_id THEN
+                RAISE EXCEPTION 'the canonical current revision scope is immutable';
+            END IF;
+            IF NEW.current_revision_id IS DISTINCT FROM OLD.current_revision_id THEN
+                IF NEW.lock_version <> OLD.lock_version + 1 THEN
+                    RAISE EXCEPTION 'advancing canonical memory must increment lock_version once';
+                END IF;
+            ELSIF NEW.lock_version IS DISTINCT FROM OLD.lock_version THEN
+                RAISE EXCEPTION 'lock_version may change only with the current revision';
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER current_revisions_protect_concurrency
+        BEFORE UPDATE OR DELETE ON memory.current_revisions
+        FOR EACH ROW EXECUTE FUNCTION memory.protect_current_revision()
+        """
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_revisions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sequence_number", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "previous_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        # Reporting provenance and promotion FKs are added in revision 0006.
+        sa.Column(
+            "producing_generation_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("week", sa.SmallInteger(), nullable=True),
+        sa.Column("knowledge_cutoff_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("state_content_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_memory_revisions_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["previous_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_revisions_previous_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_memory_revisions_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_memory_revisions"),
+        sa.UniqueConstraint(
+            "competition_id",
+            "sequence_number",
+            name="uq_memory_revisions_competition_sequence",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_memory_revisions_id_competition",
+        ),
+        sa.UniqueConstraint(
+            "producing_generation_id",
+            name="uq_memory_revisions_producing_generation",
+        ),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_revisions_competition_sequence_desc",
+        "memory_revisions",
+        ["competition_id", sa.text("sequence_number DESC")],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_revisions_previous_competition",
+        "memory_revisions",
+        ["previous_revision_id", "competition_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_revisions_season_competition",
+        "memory_revisions",
+        ["competition_season_id", "competition_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_revisions_producing_generation",
+        "memory_revisions",
+        ["producing_generation_id"],
+        schema="memory",
+    )
+
+    op.create_table(
+        "current_revisions",
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "current_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("lock_version", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_current_revisions_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["current_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_current_revisions_revision_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("competition_id", name="pk_current_revisions"),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_current_revisions_revision_competition",
+        "current_revisions",
+        ["current_revision_id", "competition_id"],
+        schema="memory",
+    )
+
+    op.create_table(
+        "memory_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("agent_key", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_id"],
+            ["core.competitions.id"],
+            name="fk_memory_items_competition_id_competitions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_memory_items"),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_memory_items_id_competition",
+        ),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_items_competition_kind",
+        "memory_items",
+        ["competition_id", "kind"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_items_competition_agent_key",
+        "memory_items",
+        ["competition_id", "agent_key"],
+        schema="memory",
+    )
+
+    op.create_table(
+        "memory_versions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("revision_number", sa.SmallInteger(), nullable=False),
+        sa.Column(
+            "content_schema_version",
+            sa.SmallInteger(),
+            server_default=sa.text("1"),
+            nullable=False,
+        ),
+        sa.Column(
+            "introduced_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "retired_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("week", sa.SmallInteger(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=True),
+        # Reporting generation/tool-call scope FKs are added in revision 0006.
+        sa.Column(
+            "creating_generation_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "creating_tool_call_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("change_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id", "competition_id"],
+            ["memory.memory_items.id", "memory.memory_items.competition_id"],
+            name="fk_memory_versions_item_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["introduced_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_versions_introduced_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["retired_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_memory_versions_retired_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_memory_versions_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_memory_versions"),
+        sa.UniqueConstraint(
+            "item_id",
+            "revision_number",
+            name="uq_memory_versions_item_revision",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "competition_id",
+            name="uq_memory_versions_id_competition",
+        ),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_item_revision",
+        "memory_versions",
+        ["item_id", "revision_number"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_introduced_revision",
+        "memory_versions",
+        ["introduced_revision_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_retired_revision",
+        "memory_versions",
+        ["retired_revision_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_creating_generation",
+        "memory_versions",
+        ["creating_generation_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_competition_season_week",
+        "memory_versions",
+        ["competition_id", "competition_season_id", "week"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_versions_season_competition",
+        "memory_versions",
+        ["competition_season_id", "competition_id"],
+        schema="memory",
+    )
+
+    op.create_table(
+        "storyline_versions",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("headline", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("arc_type", sa.Text(), nullable=True),
+        sa.Column("salience", sa.SmallInteger(), nullable=False),
+        sa.Column("tags", postgresql.ARRAY(sa.Text()), nullable=False),
+        sa.Column(
+            "subjects",
+            postgresql.JSONB(),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "evidence",
+            postgresql.JSONB(),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "related_storylines",
+            postgresql.JSONB(),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("callback_condition", sa.Text(), nullable=True),
+        sa.Column("resolution_summary", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["version_id"],
+            ["memory.memory_versions.id"],
+            name="fk_storyline_versions_version_id_memory_versions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("version_id", name="pk_storyline_versions"),
+        schema="memory",
+    )
+    op.create_table(
+        "fact_versions",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("claim", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=False),
+        sa.Column("structured_numbers", postgresql.JSONB(), nullable=True),
+        sa.Column("confidence", sa.Text(), nullable=False),
+        sa.Column(
+            "subjects",
+            postgresql.JSONB(),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "originating_event_version_ids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            server_default=sa.text("'{}'::uuid[]"),
+            nullable=False,
+        ),
+        # The reporting tool-call FK is added in revision 0006.
+        sa.Column(
+            "primary_tool_call_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "primary_api_request_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("additional_source_hints", postgresql.JSONB(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["version_id"],
+            ["memory.memory_versions.id"],
+            name="fk_fact_versions_version_id_memory_versions",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["primary_api_request_id"],
+            ["sleeper.api_requests.id"],
+            name="fk_fact_versions_primary_api_request_id_api_requests",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("version_id", name="pk_fact_versions"),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_fact_versions_primary_tool_call",
+        "fact_versions",
+        ["primary_tool_call_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_fact_versions_primary_api_request",
+        "fact_versions",
+        ["primary_api_request_id"],
+        schema="memory",
+    )
+    op.create_table(
+        "event_versions",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("headline", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("salience", sa.SmallInteger(), nullable=False),
+        sa.Column("confidence", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column(
+            "details",
+            postgresql.JSONB(),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("additional_source_hints", postgresql.JSONB(), nullable=True),
+        # The reporting tool-call FK is added in revision 0006.
+        sa.Column(
+            "primary_tool_call_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "primary_api_request_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ["version_id"],
+            ["memory.memory_versions.id"],
+            name="fk_event_versions_version_id_memory_versions",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["primary_api_request_id"],
+            ["sleeper.api_requests.id"],
+            name="fk_event_versions_primary_api_request_id_api_requests",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("version_id", name="pk_event_versions"),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_event_versions_primary_tool_call",
+        "event_versions",
+        ["primary_tool_call_id"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_event_versions_primary_api_request",
+        "event_versions",
+        ["primary_api_request_id"],
+        schema="memory",
+    )
+    op.create_table(
+        "trigger_versions",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("trigger_type", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("fire_policy", sa.Text(), nullable=False),
+        sa.Column(
+            "target_competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "target_storyline_item_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "origin_event_item_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("target_week", sa.SmallInteger(), nullable=True),
+        sa.Column("target_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("condition", postgresql.JSONB(), nullable=False),
+        sa.Column("resolution_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["version_id", "competition_id"],
+            ["memory.memory_versions.id", "memory.memory_versions.competition_id"],
+            name="fk_trigger_versions_version_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_trigger_versions_target_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("version_id", name="pk_trigger_versions"),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_trigger_versions_target_season_competition",
+        "trigger_versions",
+        ["target_competition_season_id", "competition_id"],
+        schema="memory",
+    )
+
+    op.create_table(
+        "context_notes",
+        sa.Column("item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope", sa.Text(), nullable=False),
+        sa.Column(
+            "competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("franchise_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("note_key", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "(scope = 'competition' AND competition_season_id IS NULL AND "
+            "franchise_id IS NULL) OR "
+            "(scope = 'competition_season' AND competition_season_id IS NOT NULL "
+            "AND franchise_id IS NULL) OR "
+            "(scope = 'franchise' AND competition_season_id IS NULL AND "
+            "franchise_id IS NOT NULL)",
+            name=op.f("ck_context_notes_scope_shape"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["item_id", "competition_id"],
+            ["memory.memory_items.id", "memory.memory_items.competition_id"],
+            name="fk_context_notes_item_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_context_notes_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["franchise_id", "competition_id"],
+            ["core.franchises.id", "core.franchises.competition_id"],
+            name="fk_context_notes_franchise_same_competition",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("item_id", name="pk_context_notes"),
+        sa.UniqueConstraint(
+            "item_id",
+            "competition_id",
+            name="uq_context_notes_item_competition",
+        ),
+        schema="memory",
+    )
+    op.create_index(
+        "uq_context_notes_competition_key",
+        "context_notes",
+        ["competition_id", "note_key"],
+        unique=True,
+        postgresql_where=sa.text("scope = 'competition'"),
+        schema="memory",
+    )
+    op.create_index(
+        "uq_context_notes_season_key",
+        "context_notes",
+        ["competition_season_id", "note_key"],
+        unique=True,
+        postgresql_where=sa.text("scope = 'competition_season'"),
+        schema="memory",
+    )
+    op.create_index(
+        "uq_context_notes_franchise_key",
+        "context_notes",
+        ["franchise_id", "note_key"],
+        unique=True,
+        postgresql_where=sa.text("scope = 'franchise'"),
+        schema="memory",
+    )
+
+    op.create_table(
+        "context_note_versions",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("narrative_text", sa.Text(), nullable=False),
+        sa.Column("outlook", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("tags", postgresql.ARRAY(sa.Text()), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["version_id"],
+            ["memory.memory_versions.id"],
+            name="fk_context_note_versions_version_id_memory_versions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("version_id", name="pk_context_note_versions"),
+        schema="memory",
+    )
+    op.create_table(
+        "memory_search_documents",
+        sa.Column("version_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("competition_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("salience", sa.SmallInteger(), nullable=True),
+        sa.Column(
+            "competition_season_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("week", sa.SmallInteger(), nullable=True),
+        sa.Column(
+            "entity_keys",
+            postgresql.ARRAY(sa.Text()),
+            server_default=sa.text("'{}'::text[]"),
+            nullable=False,
+        ),
+        sa.Column(
+            "evidence_version_ids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            server_default=sa.text("'{}'::uuid[]"),
+            nullable=False,
+        ),
+        sa.Column(
+            "related_item_ids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            server_default=sa.text("'{}'::uuid[]"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tags",
+            postgresql.ARRAY(sa.Text()),
+            server_default=sa.text("'{}'::text[]"),
+            nullable=False,
+        ),
+        sa.Column("document_text", sa.Text(), nullable=False),
+        sa.Column(
+            "search_vector",
+            postgresql.TSVECTOR(),
+            sa.Computed(
+                "to_tsvector('english', document_text)",
+                persisted=True,
+            ),
+            nullable=False,
+        ),
+        sa.Column("builder_version", sa.SmallInteger(), nullable=False),
+        sa.Column("content_hash", sa.Text(), nullable=False),
+        sa.Column(
+            "indexed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["version_id"],
+            ["memory.memory_versions.id"],
+            name="fk_memory_search_documents_version_id_memory_versions",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint(
+            "version_id",
+            name="pk_memory_search_documents",
+        ),
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_search_documents_competition_kind_status",
+        "memory_search_documents",
+        ["competition_id", "kind", "status"],
+        schema="memory",
+    )
+    op.create_index(
+        "ix_memory_search_documents_item",
+        "memory_search_documents",
+        ["item_id"],
+        schema="memory",
+    )
+    for index_name, column in (
+        ("ix_memory_search_documents_entity_keys", "entity_keys"),
+        ("ix_memory_search_documents_evidence_versions", "evidence_version_ids"),
+        ("ix_memory_search_documents_related_items", "related_item_ids"),
+        ("ix_memory_search_documents_tags", "tags"),
+        ("ix_memory_search_documents_search_vector", "search_vector"),
+    ):
+        op.create_index(
+            index_name,
+            "memory_search_documents",
+            [column],
+            postgresql_using="gin",
+            schema="memory",
+        )
+
+    _create_history_guards()
+
+
+def downgrade() -> None:
+    op.drop_table("memory_search_documents", schema="memory")
+    op.drop_table("context_note_versions", schema="memory")
+    op.drop_table("context_notes", schema="memory")
+    op.drop_table("trigger_versions", schema="memory")
+    op.drop_table("event_versions", schema="memory")
+    op.drop_table("fact_versions", schema="memory")
+    op.drop_table("storyline_versions", schema="memory")
+    op.drop_table("memory_versions", schema="memory")
+    op.drop_table("memory_items", schema="memory")
+    op.drop_table("current_revisions", schema="memory")
+    op.drop_table("memory_revisions", schema="memory")
+    op.execute("DROP FUNCTION memory.protect_current_revision()")
+    op.execute("DROP FUNCTION memory.protect_memory_version()")
+    op.execute("DROP FUNCTION memory.reject_sealed_history_mutation()")

--- a/backend/tests/database/constraints/test_memory_constraints.py
+++ b/backend/tests/database/constraints/test_memory_constraints.py
@@ -1,0 +1,811 @@
+from collections.abc import Mapping
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from backend.database.models.core import (
+    Competition,
+    CompetitionSeason,
+    Franchise,
+    SeasonRoster,
+)
+from backend.database.models.memory import (
+    ContextNote,
+    CurrentRevision,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+
+
+def _seed_domain(connection: Connection, label: str) -> dict[str, UUID]:
+    ids = {
+        "competition": uuid4(),
+        "season": uuid4(),
+        "franchise": uuid4(),
+        "roster": uuid4(),
+    }
+    connection.execute(
+        sa.insert(Competition),
+        {"id": ids["competition"], "display_name": f"{label} Competition"},
+    )
+    connection.execute(
+        sa.insert(CompetitionSeason),
+        {
+            "id": ids["season"],
+            "competition_id": ids["competition"],
+            "season_year": 2026,
+            "sequence_number": 1,
+            "sleeper_league_id": f"league-{uuid4()}",
+        },
+    )
+    connection.execute(
+        sa.insert(Franchise),
+        {
+            "id": ids["franchise"],
+            "competition_id": ids["competition"],
+            "display_name": f"{label} Franchise",
+        },
+    )
+    connection.execute(
+        sa.insert(SeasonRoster),
+        {
+            "id": ids["roster"],
+            "competition_id": ids["competition"],
+            "competition_season_id": ids["season"],
+            "franchise_id": ids["franchise"],
+            "sleeper_roster_id": f"roster-{uuid4()}",
+        },
+    )
+    return ids
+
+
+def _insert_generation_if_present(
+    connection: Connection,
+    domain: Mapping[str, UUID],
+) -> UUID:
+    generation_id = uuid4()
+    has_reporting = connection.scalar(
+        sa.text("SELECT to_regclass('reporting.generations') IS NOT NULL")
+    )
+    if has_reporting:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO reporting.generations (
+                    id, competition_id, competition_season_id, kind, status,
+                    request_text, requested_primary_model, settings_jsonb,
+                    current_turn
+                ) VALUES (
+                    :id, :competition_id, :competition_season_id, 'test', 'pending',
+                    'memory constraint fixture', 'test-model', '{}'::jsonb, 0
+                )
+                """
+            ),
+            {
+                "id": generation_id,
+                "competition_id": domain["competition"],
+                "competition_season_id": domain["season"],
+            },
+        )
+    return generation_id
+
+
+def _insert_revision(
+    connection: Connection,
+    domain: Mapping[str, UUID],
+    *,
+    sequence_number: int,
+    previous_revision_id: UUID | None = None,
+    producing_generation_id: UUID | None = None,
+) -> UUID:
+    revision_id = uuid4()
+    connection.execute(
+        sa.insert(MemoryRevision),
+        {
+            "id": revision_id,
+            "competition_id": domain["competition"],
+            "sequence_number": sequence_number,
+            "previous_revision_id": previous_revision_id,
+            "producing_generation_id": producing_generation_id,
+            "competition_season_id": domain["season"],
+            "week": sequence_number,
+            "state_content_hash": f"state-{uuid4()}",
+        },
+    )
+    return revision_id
+
+
+def _insert_item_and_version(
+    connection: Connection,
+    domain: Mapping[str, UUID],
+    revision_id: UUID,
+    *,
+    kind: str = "storyline",
+    revision_number: int = 1,
+) -> tuple[UUID, UUID, UUID]:
+    item_id = uuid4()
+    version_id = uuid4()
+    generation_id = _insert_generation_if_present(connection, domain)
+    connection.execute(
+        sa.insert(MemoryItem),
+        {
+            "id": item_id,
+            "competition_id": domain["competition"],
+            "kind": kind,
+            "agent_key": f"item-{uuid4()}",
+        },
+    )
+    connection.execute(
+        sa.insert(MemoryVersion),
+        {
+            "id": version_id,
+            "item_id": item_id,
+            "competition_id": domain["competition"],
+            "revision_number": revision_number,
+            "introduced_revision_id": revision_id,
+            "competition_season_id": domain["season"],
+            "week": 1,
+            "creating_generation_id": generation_id,
+        },
+    )
+    return item_id, version_id, generation_id
+
+
+def _assert_integrity_error(
+    engine: Engine,
+    statement: sa.Executable,
+) -> None:
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def _assert_database_error(
+    engine: Engine,
+    statement: sa.Executable,
+) -> None:
+    with pytest.raises(DBAPIError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def test_memory_schema_keeps_only_structural_checks_and_history_guards(
+    database_engine: Engine,
+) -> None:
+    expected_tables = {
+        "memory_revisions",
+        "current_revisions",
+        "memory_items",
+        "memory_versions",
+        "storyline_versions",
+        "fact_versions",
+        "event_versions",
+        "trigger_versions",
+        "context_notes",
+        "context_note_versions",
+        "memory_search_documents",
+    }
+    expected_checks = {"ck_context_notes_scope_shape"}
+    expected_triggers = {
+        "memory_revisions_reject_mutation",
+        "memory_items_reject_mutation",
+        "storyline_versions_reject_mutation",
+        "fact_versions_reject_mutation",
+        "event_versions_reject_mutation",
+        "trigger_versions_reject_mutation",
+        "context_notes_reject_mutation",
+        "context_note_versions_reject_mutation",
+        "memory_versions_protect_history",
+        "current_revisions_protect_concurrency",
+    }
+
+    with database_engine.connect() as connection:
+        tables = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT tablename
+                    FROM pg_catalog.pg_tables
+                    WHERE schemaname = 'memory'
+                    """
+                )
+            ).scalars()
+        )
+        checks = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT postgres_constraints.conname
+                    FROM pg_catalog.pg_constraint AS postgres_constraints
+                    JOIN pg_catalog.pg_namespace AS namespaces
+                      ON namespaces.oid = postgres_constraints.connamespace
+                    WHERE namespaces.nspname = 'memory'
+                      AND postgres_constraints.contype = 'c'
+                    """
+                )
+            ).scalars()
+        )
+        triggers = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT trigger_name
+                    FROM information_schema.triggers
+                    WHERE trigger_schema = 'memory'
+                    """
+                )
+            ).scalars()
+        )
+        delete_rules = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT delete_rule
+                    FROM information_schema.referential_constraints
+                    WHERE constraint_schema = 'memory'
+                    """
+                )
+            ).scalars()
+        )
+        uuid_defaults = connection.execute(
+            sa.text(
+                """
+                SELECT table_name, column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'memory'
+                  AND column_name = 'id'
+                  AND table_name IN (
+                      'memory_revisions', 'memory_items', 'memory_versions'
+                  )
+                """
+            )
+        ).all()
+
+    assert expected_tables == tables
+    assert expected_checks == checks
+    assert expected_triggers <= triggers
+    assert delete_rules == {"RESTRICT"}
+    assert len(uuid_defaults) == 3
+    assert all(default is None for _, default in uuid_defaults)
+
+
+def test_database_accepts_application_validated_memory_semantics(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Semantic Boundary")
+        revision_id = _insert_revision(
+            connection,
+            domain,
+            sequence_number=-9,
+        )
+        item_id, version_id, _ = _insert_item_and_version(
+            connection,
+            domain,
+            revision_id,
+            kind="future_memory_kind",
+            revision_number=-4,
+        )
+        connection.execute(
+            sa.update(MemoryVersion)
+            .where(MemoryVersion.id == version_id)
+            .values(retired_revision_id=revision_id)
+        )
+        connection.execute(
+            sa.insert(StorylineVersion),
+            {
+                "version_id": version_id,
+                "headline": "",
+                "summary": "",
+                "status": "future_status",
+                "salience": -100,
+                "tags": [],
+            },
+        )
+
+    with database_engine.connect() as connection:
+        row = connection.execute(
+            sa.select(MemoryItem.kind, MemoryVersion.revision_number)
+            .join(MemoryVersion, MemoryVersion.item_id == MemoryItem.id)
+            .where(MemoryItem.id == item_id)
+        ).one()
+    assert row == ("future_memory_kind", -4)
+
+
+def test_memory_scope_isolation_rejects_cross_competition_ids(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        first = _seed_domain(connection, "First")
+        second = _seed_domain(connection, "Second")
+        first_revision = _insert_revision(connection, first, sequence_number=0)
+        second_revision = _insert_revision(connection, second, sequence_number=0)
+        first_item, first_version, first_generation = _insert_item_and_version(
+            connection,
+            first,
+            first_revision,
+        )
+        second_item, _, _ = _insert_item_and_version(
+            connection,
+            second,
+            second_revision,
+        )
+
+    invalid_statements = [
+        sa.insert(MemoryRevision).values(
+            id=uuid4(),
+            competition_id=first["competition"],
+            sequence_number=10,
+            previous_revision_id=second_revision,
+            state_content_hash="cross-competition-previous",
+        ),
+        sa.insert(CurrentRevision).values(
+            competition_id=first["competition"],
+            current_revision_id=second_revision,
+            lock_version=0,
+        ),
+        sa.insert(MemoryVersion).values(
+            id=uuid4(),
+            item_id=second_item,
+            competition_id=first["competition"],
+            revision_number=10,
+            introduced_revision_id=first_revision,
+            creating_generation_id=first_generation,
+        ),
+        sa.insert(MemoryVersion).values(
+            id=uuid4(),
+            item_id=first_item,
+            competition_id=first["competition"],
+            revision_number=11,
+            introduced_revision_id=second_revision,
+            creating_generation_id=first_generation,
+        ),
+        sa.insert(MemoryVersion).values(
+            id=uuid4(),
+            item_id=first_item,
+            competition_id=first["competition"],
+            revision_number=12,
+            introduced_revision_id=first_revision,
+            competition_season_id=second["season"],
+            creating_generation_id=first_generation,
+        ),
+        sa.insert(TriggerVersion).values(
+            version_id=first_version,
+            competition_id=first["competition"],
+            trigger_type="test",
+            status="open",
+            fire_policy="one_shot",
+            target_competition_season_id=second["season"],
+            condition={},
+        ),
+        sa.insert(ContextNote).values(
+            item_id=first_item,
+            competition_id=first["competition"],
+            scope="competition_season",
+            competition_season_id=second["season"],
+            note_key="cross-scope",
+        ),
+    ]
+    for statement in invalid_statements:
+        _assert_integrity_error(database_engine, statement)
+
+
+def test_current_pointer_and_revision_uniqueness_support_stale_writer_rejection(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Concurrency")
+        other_domain = _seed_domain(connection, "Other Concurrency")
+        root_revision = _insert_revision(connection, domain, sequence_number=0)
+        other_revision = _insert_revision(
+            connection,
+            other_domain,
+            sequence_number=0,
+        )
+        next_revision = _insert_revision(
+            connection,
+            domain,
+            sequence_number=1,
+            previous_revision_id=root_revision,
+        )
+        generation_id = _insert_generation_if_present(connection, domain)
+        _insert_revision(
+            connection,
+            domain,
+            sequence_number=2,
+            previous_revision_id=next_revision,
+            producing_generation_id=generation_id,
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": domain["competition"],
+                "current_revision_id": root_revision,
+                "lock_version": 0,
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(CurrentRevision)
+        .where(CurrentRevision.competition_id == domain["competition"])
+        .values(current_revision_id=next_revision, lock_version=0),
+    )
+
+    with database_engine.begin() as connection:
+        result = connection.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain["competition"])
+            .where(CurrentRevision.lock_version == 0)
+            .values(current_revision_id=next_revision, lock_version=1)
+        )
+        assert result.rowcount == 1
+
+    with database_engine.begin() as connection:
+        stale_result = connection.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain["competition"])
+            .where(CurrentRevision.lock_version == 0)
+            .values(current_revision_id=root_revision, lock_version=1)
+        )
+        assert stale_result.rowcount == 0
+
+    _assert_database_error(
+        database_engine,
+        sa.update(CurrentRevision)
+        .where(CurrentRevision.competition_id == domain["competition"])
+        .values(
+            competition_id=other_domain["competition"],
+            current_revision_id=other_revision,
+            lock_version=2,
+        ),
+    )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(MemoryRevision).values(
+            id=uuid4(),
+            competition_id=domain["competition"],
+            sequence_number=1,
+            previous_revision_id=root_revision,
+            state_content_hash="duplicate-sequence",
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(CurrentRevision).values(
+            competition_id=domain["competition"],
+            current_revision_id=next_revision,
+            lock_version=1,
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(MemoryRevision).values(
+            id=uuid4(),
+            competition_id=domain["competition"],
+            sequence_number=3,
+            previous_revision_id=next_revision,
+            producing_generation_id=generation_id,
+            state_content_hash="duplicate-producing-generation",
+        ),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(CurrentRevision).where(
+            CurrentRevision.competition_id == domain["competition"]
+        ),
+    )
+
+
+def test_memory_version_and_search_document_identity_is_unique(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Unique Memory")
+        revision_id = _insert_revision(connection, domain, sequence_number=0)
+        source_item, source_version, generation_id = _insert_item_and_version(
+            connection,
+            domain,
+            revision_id,
+        )
+        connection.execute(
+            sa.insert(MemorySearchDocument),
+            {
+                "version_id": source_version,
+                "item_id": source_item,
+                "competition_id": domain["competition"],
+                "kind": "storyline",
+                "document_text": "A searchable storyline",
+                "builder_version": 1,
+                "content_hash": "search-document-hash",
+            },
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(MemoryVersion).values(
+            id=uuid4(),
+            item_id=source_item,
+            competition_id=domain["competition"],
+            revision_number=1,
+            introduced_revision_id=revision_id,
+            creating_generation_id=generation_id,
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(MemorySearchDocument).values(
+            version_id=source_version,
+            item_id=source_item,
+            competition_id=domain["competition"],
+            kind="storyline",
+            document_text="Duplicate projection",
+            builder_version=1,
+            content_hash="duplicate-hash",
+        ),
+    )
+
+
+def test_canonical_history_is_immutable_except_one_retirement(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Immutable")
+        root_revision = _insert_revision(connection, domain, sequence_number=0)
+        retirement_revision = _insert_revision(
+            connection,
+            domain,
+            sequence_number=1,
+            previous_revision_id=root_revision,
+        )
+        later_revision = _insert_revision(
+            connection,
+            domain,
+            sequence_number=2,
+            previous_revision_id=retirement_revision,
+        )
+        item_id, version_id, _ = _insert_item_and_version(
+            connection,
+            domain,
+            root_revision,
+        )
+        connection.execute(
+            sa.insert(StorylineVersion),
+            {
+                "version_id": version_id,
+                "headline": "Immutable headline",
+                "summary": "Immutable summary",
+                "status": "active",
+                "salience": 3,
+                "tags": [],
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(MemoryRevision)
+        .where(MemoryRevision.id == root_revision)
+        .values(state_content_hash="changed"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(MemoryItem).where(MemoryItem.id == item_id),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(MemoryVersion)
+        .where(MemoryVersion.id == version_id)
+        .values(change_reason="changed"),
+    )
+
+    with database_engine.begin() as connection:
+        result = connection.execute(
+            sa.update(MemoryVersion)
+            .where(MemoryVersion.id == version_id)
+            .values(retired_revision_id=retirement_revision)
+        )
+        assert result.rowcount == 1
+
+    _assert_database_error(
+        database_engine,
+        sa.update(MemoryVersion)
+        .where(MemoryVersion.id == version_id)
+        .values(retired_revision_id=later_revision),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(MemoryVersion).where(MemoryVersion.id == version_id),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(StorylineVersion)
+        .where(StorylineVersion.version_id == version_id)
+        .values(headline="changed"),
+    )
+
+
+def test_context_note_scope_shape_and_keys_are_unambiguous(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Context")
+        second_franchise = uuid4()
+        connection.execute(
+            sa.insert(Franchise),
+            {
+                "id": second_franchise,
+                "competition_id": domain["competition"],
+                "display_name": "Second Franchise",
+            },
+        )
+        item_ids = [uuid4() for _ in range(5)]
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                {
+                    "id": item_id,
+                    "competition_id": domain["competition"],
+                    "kind": "context_note",
+                }
+                for item_id in item_ids
+            ],
+        )
+        connection.execute(
+            sa.insert(ContextNote),
+            {
+                "item_id": item_ids[0],
+                "competition_id": domain["competition"],
+                "scope": "competition",
+                "note_key": "overview",
+            },
+        )
+        connection.execute(
+            sa.insert(ContextNote),
+            [
+                {
+                    "item_id": item_ids[2],
+                    "competition_id": domain["competition"],
+                    "scope": "franchise",
+                    "franchise_id": domain["franchise"],
+                    "note_key": "identity",
+                },
+                {
+                    "item_id": item_ids[3],
+                    "competition_id": domain["competition"],
+                    "scope": "franchise",
+                    "franchise_id": second_franchise,
+                    "note_key": "identity",
+                },
+            ],
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(ContextNote).values(
+            item_id=item_ids[1],
+            competition_id=domain["competition"],
+            scope="competition",
+            note_key="overview",
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(ContextNote).values(
+            item_id=item_ids[4],
+            competition_id=domain["competition"],
+            scope="franchise",
+            note_key="missing-target",
+        ),
+    )
+
+
+def test_typed_payloads_are_canonical_and_search_documents_are_rebuildable(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Typed Search")
+        revision_id = _insert_revision(connection, domain, sequence_number=0)
+        item_id, version_id, _ = _insert_item_and_version(
+            connection,
+            domain,
+            revision_id,
+        )
+        evidence_version_id = uuid4()
+        related_item_id = uuid4()
+        subjects = [
+            {
+                "kind": "franchise",
+                "id": str(domain["franchise"]),
+                "role": "focus",
+            }
+        ]
+        evidence = [
+            {
+                "kind": "fact",
+                "version_id": str(evidence_version_id),
+                "role": "support",
+            }
+        ]
+        related_storylines = [
+            {"item_id": str(related_item_id), "role": "counterpoint"}
+        ]
+        connection.execute(
+            sa.insert(StorylineVersion),
+            {
+                "version_id": version_id,
+                "headline": "Playoff collapse",
+                "summary": "A typed storyline with exact evidence.",
+                "status": "active",
+                "salience": 4,
+                "tags": ["playoffs"],
+                "subjects": subjects,
+                "evidence": evidence,
+                "related_storylines": related_storylines,
+            },
+        )
+        connection.execute(
+            sa.insert(MemorySearchDocument),
+            {
+                "version_id": version_id,
+                "item_id": item_id,
+                "competition_id": domain["competition"],
+                "kind": "storyline",
+                "status": "active",
+                "salience": 4,
+                "competition_season_id": domain["season"],
+                "week": 1,
+                "entity_keys": [f"franchise:{domain['franchise']}"],
+                "evidence_version_ids": [evidence_version_id],
+                "related_item_ids": [related_item_id],
+                "tags": ["playoffs"],
+                "document_text": "Playoff collapse for the focus franchise",
+                "builder_version": 1,
+                "content_hash": "typed-search-v1",
+            },
+        )
+
+    with database_engine.connect() as connection:
+        stored = connection.execute(
+            sa.select(
+                MemoryVersion.content_schema_version,
+                StorylineVersion.subjects,
+                StorylineVersion.evidence,
+                StorylineVersion.related_storylines,
+            )
+            .join(StorylineVersion, StorylineVersion.version_id == MemoryVersion.id)
+            .where(MemoryVersion.id == version_id)
+        ).one()
+        lexical_match = connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemorySearchDocument)
+            .where(
+                MemorySearchDocument.search_vector.op("@@")(
+                    sa.func.plainto_tsquery("english", "playoff collapse")
+                )
+            )
+        )
+
+    assert stored == (1, subjects, evidence, related_storylines)
+    assert lexical_match == 1
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(MemorySearchDocument)
+            .where(MemorySearchDocument.version_id == version_id)
+            .values(
+                document_text="Rebuilt projection",
+                builder_version=2,
+                content_hash="typed-search-v2",
+            )
+        )
+        connection.execute(
+            sa.delete(MemorySearchDocument).where(
+                MemorySearchDocument.version_id == version_id
+            )
+        )

--- a/docs/database/log.md
+++ b/docs/database/log.md
@@ -599,3 +599,23 @@ transactions own product semantics and readable validation errors.
   belong with the later application objects and workflows.
 - DB-027's surrogate-ID choice remains settled; its year-range and nonblank-text
   enforcement move to application validation.
+
+### DB-029 — Prefer scoped relational keys over scope-validation triggers
+
+**Date:** 2026-08-08  
+**Status:** Settled  
+**Source:** Memory implementation review
+
+When a child row targets a competition-scoped resource, denormalize
+`competition_id` only where it enables an ordinary composite foreign key. Do not
+replace a simple scope-safe foreign key with a policy trigger merely to avoid the
+scope column.
+
+**Consequences:**
+
+- `memory.trigger_versions` carries `competition_id`, allowing its version and
+  optional target season to be constrained to the same competition.
+- Similar integration keys may use documented denormalized scope columns when
+  their only purpose is preventing cross-competition references.
+- The scope column is relational integrity, not a second domain identity or an
+  authorization mechanism.

--- a/docs/database/memory.md
+++ b/docs/database/memory.md
@@ -198,6 +198,10 @@ A future callback condition:
 - versioned condition JSONB;
 - optional resolution reason.
 
+The physical row also carries the version's `competition_id` so both the parent
+version and optional target season use composite same-competition foreign keys.
+This is a relational scope key under DB-029, not duplicate product identity.
+
 Trigger evaluation attempts remain ordinary reporting tool calls. A durable
 state change creates a new canonical trigger version.
 

--- a/docs/database/status.md
+++ b/docs/database/status.md
@@ -77,11 +77,11 @@ agent takes over the same scope.
 | --- | --- | --- | --- |
 | 1. Foundation/private schemas | `foundation_agent` | Complete | `backend/database/` excluding namespace model files; `backend/migrations/` foundation; database test harness; dependency/config files |
 | 2. Core identity | `core_agent` | Complete | `backend/database/models/core/`; core migration; core constraint tests |
-| 3. Sleeper persistence | `sleeper_agent` | In progress | `backend/database/models/sleeper/`; Sleeper migration; Sleeper constraint tests |
-| 4. Memory state | `core_agent` | In progress | `backend/database/models/memory/`; memory migration; memory constraint tests |
-| 5. Reporting history | `root` | In progress | `backend/database/models/reporting/`; reporting migration; reporting constraint tests |
+| 3. Sleeper persistence | `sleeper_agent` | Complete | `backend/database/models/sleeper/`; Sleeper migration; Sleeper constraint tests |
+| 4. Memory state | `core_agent` | Complete | `backend/database/models/memory/`; memory migration; memory constraint tests |
+| 5. Reporting history | `sleeper_agent` | In progress | `backend/database/models/reporting/`; reporting migration; reporting constraint tests |
 | 6. Cross-namespace integrity | `root` | Pending | integration migration; immutability/scope/leakage tests |
-| 7. Supabase hardening | `root` | Pending | CI and deployment/restore/role/TLS runbooks |
+| 7. Supabase hardening | `foundation_agent` | Complete | CI and deployment/restore/role/TLS runbooks |
 
 Coordination notes:
 
@@ -102,3 +102,17 @@ Coordination notes:
   session, health, engine, and role-permission tests. Python 3.11 compilation,
   static assertions, Compose validation, and basedpyright pass; live PostgreSQL
   execution remains CI-ready because local execution requires explicit approval.
+- `sleeper_agent`: added all 19 request/current/snapshot ORM tables, revision
+  `0003`, and DB-028-focused relational/concurrency/storage-shape/immutability
+  tests. Live PostgreSQL tests pass and migrated schema matches ORM metadata.
+- `foundation_agent` layer 7: added a role-only hosted bootstrap, manual
+  preview/staging verification workflow, mandatory verify-full operator checks,
+  credential-free schema reporting, guarded logical backup/restore-drill
+  scripts, and deployment/recovery/observability runbooks. Shell/Python syntax,
+  Compose validation, static safety assertions, and basedpyright pass; no hosted
+  environment was contacted and live hosted gates remain intentionally manual.
+- `core_agent` layer 4: hardened the 12-table linear memory model to DB-028,
+  added same-competition trigger-target scope, revision/current concurrency and
+  sealed-history guards in revision `0004`, and added relational/storage-shape/
+  immutability tests. Offline stack upgrade/downgrade passes and live PostgreSQL
+  memory tests pass 8/8; reporting provenance remains reserved for `0006`.


### PR DESCRIPTION
## Summary

- adds the 12-table linear canonical-memory model and Alembic revision `0004`
- models atomic revisions, introduced/retired version visibility, one current pointer, facts/events/storylines/context, entities, triggers, and access history
- adds PostgreSQL FTS indexes plus sealed canonical-history and current-pointer guards

## Design decisions

Canonical memory is intentionally linear. Evaluation branches, snapshots, and merge semantics are excluded; reporting-owned evaluation workspaces carry alternative memory as artifacts instead.

## Verification

- memory PostgreSQL tests: passed
- offline upgrade/downgrade: passed
- reflected FTS expressions produce zero Alembic drift
- final stacked database suite: 66 passed

## Stack

4 of 7. Previous: #88. Next: #90
