### PR TITLE
feat(database): add reporting history

### DIFF
--- a/backend/database/models/reporting/__init__.py
+++ b/backend/database/models/reporting/__init__.py
@@ -1,0 +1,12 @@
+from backend.database.models.reporting.artifacts import Artifact, ArtifactVersion
+from backend.database.models.reporting.calls import AICall, ToolCall
+from backend.database.models.reporting.generations import EvaluationWorkspace, Generation
+
+__all__ = [
+    "AICall",
+    "Artifact",
+    "ArtifactVersion",
+    "EvaluationWorkspace",
+    "Generation",
+    "ToolCall",
+]

--- a/backend/database/models/reporting/artifacts.py
+++ b/backend/database/models/reporting/artifacts.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class Artifact(Base):
+    __tablename__ = "artifacts"
+    __table_args__ = (
+        UniqueConstraint(
+            "generation_id", "kind", "name", name="uq_artifacts_generation_kind_name"
+        ),
+        UniqueConstraint(
+            "id", "generation_id", name="uq_artifacts_id_generation"
+        ),
+        Index("ix_artifacts_generation_kind", "generation_id", "kind"),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    generation_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("reporting.generations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    format: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+
+
+class ArtifactVersion(Base):
+    __tablename__ = "artifact_versions"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "generation_id", name="uq_artifact_versions_id_generation"
+        ),
+        UniqueConstraint(
+            "artifact_id",
+            "revision_number",
+            name="uq_artifact_versions_artifact_revision",
+        ),
+        Index(
+            "uq_artifact_versions_one_final",
+            "artifact_id",
+            unique=True,
+            postgresql_where=text("status = 'final'"),
+        ),
+        ForeignKeyConstraint(
+            ["artifact_id", "generation_id"],
+            ["reporting.artifacts.id", "reporting.artifacts.generation_id"],
+            name="fk_artifact_versions_artifact_same_generation",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["source_ai_call_id", "generation_id"],
+            ["reporting.ai_calls.id", "reporting.ai_calls.generation_id"],
+            name="fk_artifact_versions_ai_call_same_generation",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["source_tool_call_id", "generation_id"],
+            ["reporting.tool_calls.id", "reporting.tool_calls.generation_id"],
+            name="fk_artifact_versions_tool_call_same_generation",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "ix_artifact_versions_artifact_revision_desc",
+            "artifact_id",
+            text("revision_number DESC"),
+        ),
+        Index(
+            "ix_artifact_versions_final",
+            "artifact_id",
+            postgresql_where=text("status = 'final'"),
+        ),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    artifact_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    generation_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    revision_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    content_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    source_ai_call_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    source_tool_call_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )

--- a/backend/database/models/reporting/calls.py
+++ b/backend/database/models/reporting/calls.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class AICall(Base):
+    __tablename__ = "ai_calls"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "generation_id", name="uq_ai_calls_id_generation"
+        ),
+        UniqueConstraint(
+            "generation_id",
+            "turn_number",
+            "attempt_number",
+            name="uq_ai_calls_generation_turn_attempt",
+        ),
+        Index(
+            "uq_ai_calls_one_success_per_turn",
+            "generation_id",
+            "turn_number",
+            unique=True,
+            postgresql_where=text("status = 'succeeded'"),
+        ),
+        Index(
+            "ix_ai_calls_generation_turn_attempt",
+            "generation_id",
+            "turn_number",
+            "attempt_number",
+        ),
+        Index("ix_ai_calls_actual_model_completed", "actual_model", "completed_at"),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    generation_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("reporting.generations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    turn_number: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    attempt_number: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    requested_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    requested_model: Mapped[str] = mapped_column(Text, nullable=False)
+    actual_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    actual_model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    input_messages: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    tool_definitions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    request_parameters: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    provider_response: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    error_jsonb: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    finish_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_request_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_response_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    input_tokens: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    cached_input_tokens: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    reasoning_tokens: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    total_tokens: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    raw_provider_usage: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    latency_ms: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+
+class ToolCall(Base):
+    __tablename__ = "tool_calls"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "generation_id", name="uq_tool_calls_id_generation"
+        ),
+        UniqueConstraint(
+            "ai_call_id", "tool_ordinal", name="uq_tool_calls_ai_call_ordinal"
+        ),
+        ForeignKeyConstraint(
+            ["ai_call_id", "generation_id"],
+            ["reporting.ai_calls.id", "reporting.ai_calls.generation_id"],
+            name="fk_tool_calls_ai_call_same_generation",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "ix_tool_calls_generation_ai_ordinal",
+            "generation_id",
+            "ai_call_id",
+            "tool_ordinal",
+        ),
+        Index("ix_tool_calls_name_started", "tool_name", "started_at"),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    generation_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("reporting.generations.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    ai_call_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    tool_ordinal: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    provider_tool_call_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tool_name: Mapped[str] = mapped_column(Text, nullable=False)
+    implementation_version: Mapped[str] = mapped_column(Text, nullable=False)
+    arguments_jsonb: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    full_result_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    structured_result_jsonb: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    error_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_jsonb: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    duration_ms: Mapped[int | None] = mapped_column(BigInteger, nullable=True)

--- a/backend/database/models/reporting/generations.py
+++ b/backend/database/models/reporting/generations.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database.base import Base
+
+
+class Generation(Base):
+    __tablename__ = "generations"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "competition_id", name="uq_generations_id_competition"
+        ),
+        UniqueConstraint(
+            "evaluation_workspace_id",
+            "workspace_sequence_number",
+            name="uq_generations_workspace_sequence",
+        ),
+        ForeignKeyConstraint(
+            ["competition_season_id", "competition_id"],
+            [
+                "core.competition_seasons.id",
+                "core.competition_seasons.competition_id",
+            ],
+            name="fk_generations_season_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["data_snapshot_id", "competition_id"],
+            ["sleeper.data_snapshots.id", "sleeper.data_snapshots.competition_id"],
+            name="fk_generations_snapshot_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["input_memory_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_generations_memory_revision_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["evaluation_workspace_id", "competition_id"],
+            [
+                "reporting.evaluation_workspaces.id",
+                "reporting.evaluation_workspaces.competition_id",
+            ],
+            name="fk_generations_workspace_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["rerun_of_generation_id", "competition_id"],
+            ["reporting.generations.id", "reporting.generations.competition_id"],
+            name="fk_generations_rerun_same_competition",
+            ondelete="RESTRICT",
+        ),
+        CheckConstraint(
+            "(evaluation_workspace_id IS NULL AND workspace_sequence_number IS NULL) OR "
+            "(evaluation_workspace_id IS NOT NULL AND workspace_sequence_number IS NOT NULL)",
+            name="workspace_shape",
+        ),
+        CheckConstraint(
+            "num_nonnulls(input_memory_revision_id, input_memory_artifact_version_id) <= 1",
+            name="unambiguous_memory_input",
+        ),
+        Index("ix_generations_competition_created", "competition_id", text("created_at DESC")),
+        Index("ix_generations_status_progress", "status", "progress_updated_at"),
+        Index("ix_generations_competition_season", "competition_season_id"),
+        Index("ix_generations_data_snapshot", "data_snapshot_id"),
+        Index("ix_generations_memory_revision", "input_memory_revision_id"),
+        Index(
+            "ix_generations_workspace_sequence",
+            "evaluation_workspace_id",
+            "workspace_sequence_number",
+        ),
+        Index("ix_generations_requested_model", "requested_primary_model"),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("core.competitions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    competition_season_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    data_snapshot_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    input_memory_revision_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    # Artifact/workspace scope FKs are added with the cyclic integrations in 0006.
+    input_memory_artifact_version_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    evaluation_workspace_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    workspace_sequence_number: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
+    rerun_of_generation_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    request_text: Mapped[str] = mapped_column(Text, nullable=False)
+    week_start: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    week_end: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    domain_cutoff_week: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    domain_cutoff_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    knowledge_cutoff_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    requested_primary_model: Mapped[str] = mapped_column(Text, nullable=False)
+    settings_jsonb: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    input_manifest_jsonb: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+    manifest_schema_version: Mapped[int | None] = mapped_column(
+        SmallInteger, nullable=True
+    )
+    manifest_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    current_turn: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    current_stage: Mapped[str | None] = mapped_column(Text, nullable=True)
+    progress_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    failure_category: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
+class EvaluationWorkspace(Base):
+    __tablename__ = "evaluation_workspaces"
+    __table_args__ = (
+        UniqueConstraint(
+            "id", "competition_id", name="uq_evaluation_workspaces_id_competition"
+        ),
+        ForeignKeyConstraint(
+            ["base_memory_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_evaluation_workspaces_base_same_competition",
+            ondelete="RESTRICT",
+        ),
+        ForeignKeyConstraint(
+            ["promoted_memory_revision_id", "competition_id"],
+            ["memory.memory_revisions.id", "memory.memory_revisions.competition_id"],
+            name="fk_evaluation_workspaces_promoted_same_competition",
+            ondelete="RESTRICT",
+        ),
+        Index(
+            "uq_evaluation_workspaces_one_active",
+            "competition_id",
+            unique=True,
+            postgresql_where=text("status = 'active'"),
+        ),
+        Index(
+            "ix_evaluation_workspaces_competition_status",
+            "competition_id",
+            "status",
+        ),
+        Index("ix_evaluation_workspaces_base_revision", "base_memory_revision_id"),
+        {"schema": "reporting"},
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    competition_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("core.competitions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    base_memory_revision_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), nullable=False
+    )
+    # Artifact/workspace scope FKs are added with the cyclic integrations in 0006.
+    current_memory_artifact_version_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    promoted_memory_revision_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=text("now()"), nullable=False
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/backend/database/registry.py
+++ b/backend/database/registry.py
@@ -9,7 +9,14 @@ from backend.database.base import Base
 from backend.database.models import core as core_models
 from backend.database.models import sleeper as sleeper_models
 from backend.database.models import memory as memory_models
+from backend.database.models import reporting as reporting_models
 
 metadata = Base.metadata
 
-__all__ = ["core_models", "memory_models", "metadata", "sleeper_models"]
+__all__ = [
+    "core_models",
+    "memory_models",
+    "metadata",
+    "reporting_models",
+    "sleeper_models",
+]

--- a/backend/migrations/versions/0005_reporting_history.py
+++ b/backend/migrations/versions/0005_reporting_history.py
@@ -1,0 +1,404 @@
+"""Create generation-centered reporting history.
+
+Revision ID: 0005
+Revises: 0004
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Text
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_GENERATION_TERMINAL_STATUSES = ("succeeded", "failed", "cancelled")
+_AI_CALL_TERMINAL_STATUSES = (
+    "succeeded",
+    "retryable_error",
+    "fatal_error",
+    "cancelled",
+    "unknown_outcome",
+)
+_TOOL_CALL_TERMINAL_STATUSES = ("succeeded", "failed", "cancelled")
+_WORKSPACE_CLOSED_STATUSES = ("discarded", "promoted")
+
+
+def _sql_statuses(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def _create_reporting_history_triggers() -> None:
+    op.execute(
+        f"""
+        CREATE FUNCTION reporting.protect_terminal_generation()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            IF OLD.status IN ({_sql_statuses(_GENERATION_TERMINAL_STATUSES)}) THEN
+                RAISE EXCEPTION 'terminal generations are immutable';
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER generations_protect_terminal
+        BEFORE UPDATE OR DELETE ON reporting.generations
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_terminal_generation()
+        """
+    )
+    op.execute(
+        f"""
+        CREATE FUNCTION reporting.protect_evaluation_workspace()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ({_sql_statuses(_WORKSPACE_CLOSED_STATUSES)}) THEN
+                    RAISE EXCEPTION 'closed evaluation workspaces are immutable';
+                END IF;
+                RETURN OLD;
+            END IF;
+            IF ROW(NEW.competition_id, NEW.base_memory_revision_id, NEW.created_at)
+               IS DISTINCT FROM
+               ROW(OLD.competition_id, OLD.base_memory_revision_id, OLD.created_at) THEN
+                RAISE EXCEPTION 'evaluation workspace identity and base are immutable';
+            END IF;
+            IF OLD.status IN ({_sql_statuses(_WORKSPACE_CLOSED_STATUSES)}) THEN
+                RAISE EXCEPTION 'closed evaluation workspaces are immutable';
+            END IF;
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER evaluation_workspaces_protect_history
+        BEFORE UPDATE OR DELETE ON reporting.evaluation_workspaces
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_evaluation_workspace()
+        """
+    )
+    op.execute(
+        f"""
+        CREATE FUNCTION reporting.protect_workspace_generation_membership()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        DECLARE
+            workspace_status text;
+        BEGIN
+            IF TG_OP IN ('UPDATE', 'DELETE') AND OLD.evaluation_workspace_id IS NOT NULL THEN
+                SELECT status INTO workspace_status
+                FROM reporting.evaluation_workspaces
+                WHERE id = OLD.evaluation_workspace_id;
+                IF workspace_status IN ({_sql_statuses(_WORKSPACE_CLOSED_STATUSES)}) THEN
+                    RAISE EXCEPTION 'closed workspace generation membership is immutable';
+                END IF;
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            IF NEW.evaluation_workspace_id IS NOT NULL THEN
+                SELECT status INTO workspace_status
+                FROM reporting.evaluation_workspaces
+                WHERE id = NEW.evaluation_workspace_id
+                FOR UPDATE;
+                IF workspace_status IN ({_sql_statuses(_WORKSPACE_CLOSED_STATUSES)}) THEN
+                    RAISE EXCEPTION 'closed workspace generation membership is immutable';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER generations_protect_workspace_membership
+        BEFORE INSERT OR UPDATE OR DELETE ON reporting.generations
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_workspace_generation_membership()
+        """
+    )
+    op.execute(
+        f"""
+        CREATE FUNCTION reporting.protect_terminal_ai_call()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            IF OLD.status IN ({_sql_statuses(_AI_CALL_TERMINAL_STATUSES)}) THEN
+                RAISE EXCEPTION 'terminal AI call records are immutable';
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER ai_calls_protect_terminal
+        BEFORE UPDATE OR DELETE ON reporting.ai_calls
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_terminal_ai_call()
+        """
+    )
+    op.execute(
+        f"""
+        CREATE FUNCTION reporting.protect_terminal_tool_call()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            IF OLD.status IN ({_sql_statuses(_TOOL_CALL_TERMINAL_STATUSES)}) THEN
+                RAISE EXCEPTION 'terminal tool call records are immutable';
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER tool_calls_protect_terminal
+        BEFORE UPDATE OR DELETE ON reporting.tool_calls
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_terminal_tool_call()
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION reporting.protect_artifact_version()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            RAISE EXCEPTION 'artifact versions are append-only';
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER artifact_versions_append_only
+        BEFORE UPDATE OR DELETE ON reporting.artifact_versions
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_artifact_version()
+        """
+    )
+
+
+def _drop_reporting_history_triggers() -> None:
+    op.execute("DROP FUNCTION reporting.protect_artifact_version() CASCADE")
+    op.execute("DROP FUNCTION reporting.protect_terminal_tool_call() CASCADE")
+    op.execute("DROP FUNCTION reporting.protect_terminal_ai_call() CASCADE")
+    op.execute(
+        "DROP FUNCTION reporting.protect_workspace_generation_membership() CASCADE"
+    )
+    op.execute("DROP FUNCTION reporting.protect_evaluation_workspace() CASCADE")
+    op.execute("DROP FUNCTION reporting.protect_terminal_generation() CASCADE")
+
+
+def upgrade() -> None:
+    op.create_table('evaluation_workspaces',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_id', sa.UUID(), nullable=False),
+    sa.Column('base_memory_revision_id', sa.UUID(), nullable=False),
+    sa.Column('current_memory_artifact_version_id', sa.UUID(), nullable=True),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('promoted_memory_revision_id', sa.UUID(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['base_memory_revision_id', 'competition_id'], ['memory.memory_revisions.id', 'memory.memory_revisions.competition_id'], name='fk_evaluation_workspaces_base_same_competition', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['competition_id'], ['core.competitions.id'], name=op.f('fk_evaluation_workspaces_competition_id_competitions'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['promoted_memory_revision_id', 'competition_id'], ['memory.memory_revisions.id', 'memory.memory_revisions.competition_id'], name='fk_evaluation_workspaces_promoted_same_competition', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_evaluation_workspaces')),
+    sa.UniqueConstraint('id', 'competition_id', name='uq_evaluation_workspaces_id_competition'),
+    schema='reporting'
+    )
+    op.create_index('ix_evaluation_workspaces_base_revision', 'evaluation_workspaces', ['base_memory_revision_id'], unique=False, schema='reporting')
+    op.create_index('ix_evaluation_workspaces_competition_status', 'evaluation_workspaces', ['competition_id', 'status'], unique=False, schema='reporting')
+    op.create_index('uq_evaluation_workspaces_one_active', 'evaluation_workspaces', ['competition_id'], unique=True, schema='reporting', postgresql_where=sa.text("status = 'active'"))
+    op.create_table('generations',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('competition_id', sa.UUID(), nullable=False),
+    sa.Column('competition_season_id', sa.UUID(), nullable=False),
+    sa.Column('data_snapshot_id', sa.UUID(), nullable=True),
+    sa.Column('input_memory_revision_id', sa.UUID(), nullable=True),
+    sa.Column('input_memory_artifact_version_id', sa.UUID(), nullable=True),
+    sa.Column('evaluation_workspace_id', sa.UUID(), nullable=True),
+    sa.Column('workspace_sequence_number', sa.BigInteger(), nullable=True),
+    sa.Column('rerun_of_generation_id', sa.UUID(), nullable=True),
+    sa.Column('kind', sa.Text(), nullable=False),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('request_text', sa.Text(), nullable=False),
+    sa.Column('week_start', sa.SmallInteger(), nullable=True),
+    sa.Column('week_end', sa.SmallInteger(), nullable=True),
+    sa.Column('domain_cutoff_week', sa.SmallInteger(), nullable=True),
+    sa.Column('domain_cutoff_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('knowledge_cutoff_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('requested_primary_model', sa.Text(), nullable=False),
+    sa.Column('settings_jsonb', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('input_manifest_jsonb', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('manifest_schema_version', sa.SmallInteger(), nullable=True),
+    sa.Column('manifest_hash', sa.Text(), nullable=True),
+    sa.Column('current_turn', sa.BigInteger(), nullable=False),
+    sa.Column('current_stage', sa.Text(), nullable=True),
+    sa.Column('progress_updated_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('failure_category', sa.Text(), nullable=True),
+    sa.Column('failure_summary', sa.Text(), nullable=True),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.CheckConstraint('(evaluation_workspace_id IS NULL AND workspace_sequence_number IS NULL) OR (evaluation_workspace_id IS NOT NULL AND workspace_sequence_number IS NOT NULL)', name=op.f('ck_generations_workspace_shape')),
+    sa.CheckConstraint('num_nonnulls(input_memory_revision_id, input_memory_artifact_version_id) <= 1', name=op.f('ck_generations_unambiguous_memory_input')),
+    sa.ForeignKeyConstraint(['competition_id'], ['core.competitions.id'], name=op.f('fk_generations_competition_id_competitions'), ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['competition_season_id', 'competition_id'], ['core.competition_seasons.id', 'core.competition_seasons.competition_id'], name='fk_generations_season_same_competition', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['data_snapshot_id', 'competition_id'], ['sleeper.data_snapshots.id', 'sleeper.data_snapshots.competition_id'], name='fk_generations_snapshot_same_competition', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['evaluation_workspace_id', 'competition_id'], ['reporting.evaluation_workspaces.id', 'reporting.evaluation_workspaces.competition_id'], name='fk_generations_workspace_same_competition', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['input_memory_revision_id', 'competition_id'], ['memory.memory_revisions.id', 'memory.memory_revisions.competition_id'], name='fk_generations_memory_revision_same_competition', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['rerun_of_generation_id', 'competition_id'], ['reporting.generations.id', 'reporting.generations.competition_id'], name='fk_generations_rerun_same_competition', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_generations')),
+    sa.UniqueConstraint('evaluation_workspace_id', 'workspace_sequence_number', name='uq_generations_workspace_sequence'),
+    sa.UniqueConstraint('id', 'competition_id', name='uq_generations_id_competition'),
+    schema='reporting'
+    )
+    op.create_index('ix_generations_competition_created', 'generations', ['competition_id', sa.literal_column('created_at DESC')], unique=False, schema='reporting')
+    op.create_index('ix_generations_competition_season', 'generations', ['competition_season_id'], unique=False, schema='reporting')
+    op.create_index('ix_generations_data_snapshot', 'generations', ['data_snapshot_id'], unique=False, schema='reporting')
+    op.create_index('ix_generations_memory_revision', 'generations', ['input_memory_revision_id'], unique=False, schema='reporting')
+    op.create_index('ix_generations_requested_model', 'generations', ['requested_primary_model'], unique=False, schema='reporting')
+    op.create_index('ix_generations_status_progress', 'generations', ['status', 'progress_updated_at'], unique=False, schema='reporting')
+    op.create_index('ix_generations_workspace_sequence', 'generations', ['evaluation_workspace_id', 'workspace_sequence_number'], unique=False, schema='reporting')
+    op.create_table('ai_calls',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('generation_id', sa.UUID(), nullable=False),
+    sa.Column('turn_number', sa.BigInteger(), nullable=False),
+    sa.Column('attempt_number', sa.SmallInteger(), nullable=False),
+    sa.Column('requested_provider', sa.Text(), nullable=True),
+    sa.Column('requested_model', sa.Text(), nullable=False),
+    sa.Column('actual_provider', sa.Text(), nullable=True),
+    sa.Column('actual_model', sa.Text(), nullable=True),
+    sa.Column('input_messages', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('tool_definitions', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('request_parameters', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('provider_response', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('error_jsonb', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('finish_reason', sa.Text(), nullable=True),
+    sa.Column('provider_request_id', sa.Text(), nullable=True),
+    sa.Column('provider_response_id', sa.Text(), nullable=True),
+    sa.Column('input_tokens', sa.BigInteger(), nullable=True),
+    sa.Column('cached_input_tokens', sa.BigInteger(), nullable=True),
+    sa.Column('output_tokens', sa.BigInteger(), nullable=True),
+    sa.Column('reasoning_tokens', sa.BigInteger(), nullable=True),
+    sa.Column('total_tokens', sa.BigInteger(), nullable=True),
+    sa.Column('raw_provider_usage', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('started_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('latency_ms', sa.BigInteger(), nullable=True),
+    sa.ForeignKeyConstraint(['generation_id'], ['reporting.generations.id'], name=op.f('fk_ai_calls_generation_id_generations'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_ai_calls')),
+    sa.UniqueConstraint('generation_id', 'turn_number', 'attempt_number', name='uq_ai_calls_generation_turn_attempt'),
+    sa.UniqueConstraint('id', 'generation_id', name='uq_ai_calls_id_generation'),
+    schema='reporting'
+    )
+    op.create_index('ix_ai_calls_actual_model_completed', 'ai_calls', ['actual_model', 'completed_at'], unique=False, schema='reporting')
+    op.create_index('ix_ai_calls_generation_turn_attempt', 'ai_calls', ['generation_id', 'turn_number', 'attempt_number'], unique=False, schema='reporting')
+    op.create_index('uq_ai_calls_one_success_per_turn', 'ai_calls', ['generation_id', 'turn_number'], unique=True, schema='reporting', postgresql_where=sa.text("status = 'succeeded'"))
+    op.create_table('tool_calls',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('generation_id', sa.UUID(), nullable=False),
+    sa.Column('ai_call_id', sa.UUID(), nullable=False),
+    sa.Column('tool_ordinal', sa.SmallInteger(), nullable=False),
+    sa.Column('provider_tool_call_id', sa.Text(), nullable=True),
+    sa.Column('tool_name', sa.Text(), nullable=False),
+    sa.Column('implementation_version', sa.Text(), nullable=False),
+    sa.Column('arguments_jsonb', postgresql.JSONB(astext_type=Text()), nullable=False),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('full_result_text', sa.Text(), nullable=True),
+    sa.Column('structured_result_jsonb', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('error_text', sa.Text(), nullable=True),
+    sa.Column('error_jsonb', postgresql.JSONB(astext_type=Text()), nullable=True),
+    sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+    sa.Column('duration_ms', sa.BigInteger(), nullable=True),
+    sa.ForeignKeyConstraint(['ai_call_id', 'generation_id'], ['reporting.ai_calls.id', 'reporting.ai_calls.generation_id'], name='fk_tool_calls_ai_call_same_generation', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['generation_id'], ['reporting.generations.id'], name=op.f('fk_tool_calls_generation_id_generations'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_tool_calls')),
+    sa.UniqueConstraint('ai_call_id', 'tool_ordinal', name='uq_tool_calls_ai_call_ordinal'),
+    sa.UniqueConstraint('id', 'generation_id', name='uq_tool_calls_id_generation'),
+    schema='reporting'
+    )
+    op.create_index('ix_tool_calls_generation_ai_ordinal', 'tool_calls', ['generation_id', 'ai_call_id', 'tool_ordinal'], unique=False, schema='reporting')
+    op.create_index('ix_tool_calls_name_started', 'tool_calls', ['tool_name', 'started_at'], unique=False, schema='reporting')
+    op.create_table('artifacts',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('generation_id', sa.UUID(), nullable=False),
+    sa.Column('kind', sa.Text(), nullable=False),
+    sa.Column('name', sa.Text(), nullable=False),
+    sa.Column('format', sa.Text(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['generation_id'], ['reporting.generations.id'], name=op.f('fk_artifacts_generation_id_generations'), ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_artifacts')),
+    sa.UniqueConstraint('generation_id', 'kind', 'name', name='uq_artifacts_generation_kind_name'),
+    sa.UniqueConstraint('id', 'generation_id', name='uq_artifacts_id_generation'),
+    schema='reporting'
+    )
+    op.create_index('ix_artifacts_generation_kind', 'artifacts', ['generation_id', 'kind'], unique=False, schema='reporting')
+    op.create_table('artifact_versions',
+    sa.Column('id', sa.UUID(), nullable=False),
+    sa.Column('artifact_id', sa.UUID(), nullable=False),
+    sa.Column('generation_id', sa.UUID(), nullable=False),
+    sa.Column('revision_number', sa.SmallInteger(), nullable=False),
+    sa.Column('content', sa.Text(), nullable=False),
+    sa.Column('content_hash', sa.Text(), nullable=False),
+    sa.Column('source_ai_call_id', sa.UUID(), nullable=True),
+    sa.Column('source_tool_call_id', sa.UUID(), nullable=True),
+    sa.Column('status', sa.Text(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['artifact_id', 'generation_id'], ['reporting.artifacts.id', 'reporting.artifacts.generation_id'], name='fk_artifact_versions_artifact_same_generation', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_ai_call_id', 'generation_id'], ['reporting.ai_calls.id', 'reporting.ai_calls.generation_id'], name='fk_artifact_versions_ai_call_same_generation', ondelete='RESTRICT'),
+    sa.ForeignKeyConstraint(['source_tool_call_id', 'generation_id'], ['reporting.tool_calls.id', 'reporting.tool_calls.generation_id'], name='fk_artifact_versions_tool_call_same_generation', ondelete='RESTRICT'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_artifact_versions')),
+    sa.UniqueConstraint('artifact_id', 'revision_number', name='uq_artifact_versions_artifact_revision'),
+    sa.UniqueConstraint('id', 'generation_id', name='uq_artifact_versions_id_generation'),
+    schema='reporting'
+    )
+    op.create_index('ix_artifact_versions_artifact_revision_desc', 'artifact_versions', ['artifact_id', sa.literal_column('revision_number DESC')], unique=False, schema='reporting')
+    op.create_index('ix_artifact_versions_final', 'artifact_versions', ['artifact_id'], unique=False, schema='reporting', postgresql_where=sa.text("status = 'final'"))
+    op.create_index('uq_artifact_versions_one_final', 'artifact_versions', ['artifact_id'], unique=True, schema='reporting', postgresql_where=sa.text("status = 'final'"))
+    _create_reporting_history_triggers()
+
+
+def downgrade() -> None:
+    _drop_reporting_history_triggers()
+    op.drop_index('uq_artifact_versions_one_final', table_name='artifact_versions', schema='reporting', postgresql_where=sa.text("status = 'final'"))
+    op.drop_index('ix_artifact_versions_final', table_name='artifact_versions', schema='reporting', postgresql_where=sa.text("status = 'final'"))
+    op.drop_index('ix_artifact_versions_artifact_revision_desc', table_name='artifact_versions', schema='reporting')
+    op.drop_table('artifact_versions', schema='reporting')
+    op.drop_index('ix_artifacts_generation_kind', table_name='artifacts', schema='reporting')
+    op.drop_table('artifacts', schema='reporting')
+    op.drop_index('ix_tool_calls_name_started', table_name='tool_calls', schema='reporting')
+    op.drop_index('ix_tool_calls_generation_ai_ordinal', table_name='tool_calls', schema='reporting')
+    op.drop_table('tool_calls', schema='reporting')
+    op.drop_index('uq_ai_calls_one_success_per_turn', table_name='ai_calls', schema='reporting', postgresql_where=sa.text("status = 'succeeded'"))
+    op.drop_index('ix_ai_calls_generation_turn_attempt', table_name='ai_calls', schema='reporting')
+    op.drop_index('ix_ai_calls_actual_model_completed', table_name='ai_calls', schema='reporting')
+    op.drop_table('ai_calls', schema='reporting')
+    op.drop_index('ix_generations_workspace_sequence', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_status_progress', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_requested_model', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_memory_revision', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_data_snapshot', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_competition_season', table_name='generations', schema='reporting')
+    op.drop_index('ix_generations_competition_created', table_name='generations', schema='reporting')
+    op.drop_table('generations', schema='reporting')
+    op.drop_index('uq_evaluation_workspaces_one_active', table_name='evaluation_workspaces', schema='reporting', postgresql_where=sa.text("status = 'active'"))
+    op.drop_index('ix_evaluation_workspaces_competition_status', table_name='evaluation_workspaces', schema='reporting')
+    op.drop_index('ix_evaluation_workspaces_base_revision', table_name='evaluation_workspaces', schema='reporting')
+    op.drop_table('evaluation_workspaces', schema='reporting')

--- a/backend/tests/database/constraints/test_reporting_constraints.py
+++ b/backend/tests/database/constraints/test_reporting_constraints.py
@@ -1,0 +1,664 @@
+from collections.abc import Mapping
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.memory import MemoryRevision
+from backend.database.models.reporting import (
+    AICall,
+    Artifact,
+    ArtifactVersion,
+    EvaluationWorkspace,
+    Generation,
+    ToolCall,
+)
+
+
+def _seed_domain(connection: Connection, label: str) -> dict[str, UUID]:
+    competition_id = uuid4()
+    season_id = uuid4()
+    revision_id = uuid4()
+    connection.execute(
+        sa.insert(Competition),
+        {"id": competition_id, "display_name": f"{label} Competition"},
+    )
+    connection.execute(
+        sa.insert(CompetitionSeason),
+        {
+            "id": season_id,
+            "competition_id": competition_id,
+            "season_year": 2026,
+            "sequence_number": 1,
+            "sleeper_league_id": f"league-{uuid4()}",
+        },
+    )
+    connection.execute(
+        sa.insert(MemoryRevision),
+        {
+            "id": revision_id,
+            "competition_id": competition_id,
+            "sequence_number": 0,
+            "competition_season_id": season_id,
+            "state_content_hash": f"state-{uuid4()}",
+        },
+    )
+    return {
+        "competition": competition_id,
+        "season": season_id,
+        "revision": revision_id,
+    }
+
+
+def _generation_values(
+    domain: Mapping[str, UUID],
+    *,
+    status: str = "pending",
+    generation_id: UUID | None = None,
+    **overrides: object,
+) -> dict[str, object]:
+    values: dict[str, object] = {
+        "id": generation_id or uuid4(),
+        "competition_id": domain["competition"],
+        "competition_season_id": domain["season"],
+        "kind": "live",
+        "status": status,
+        "request_text": "write the report",
+        "requested_primary_model": "test-model",
+        "settings_jsonb": {},
+        "current_turn": 0,
+    }
+    values.update(overrides)
+    return values
+
+
+def _ai_call_values(
+    generation_id: UUID,
+    *,
+    status: str = "started",
+    call_id: UUID | None = None,
+    turn_number: int = 1,
+    attempt_number: int = 0,
+) -> dict[str, object]:
+    return {
+        "id": call_id or uuid4(),
+        "generation_id": generation_id,
+        "turn_number": turn_number,
+        "attempt_number": attempt_number,
+        "requested_model": "test-model",
+        "input_messages": [],
+        "tool_definitions": [],
+        "request_parameters": {},
+        "status": status,
+    }
+
+
+def _tool_call_values(
+    generation_id: UUID,
+    ai_call_id: UUID,
+    *,
+    status: str = "started",
+    tool_call_id: UUID | None = None,
+    ordinal: int = 0,
+) -> dict[str, object]:
+    return {
+        "id": tool_call_id or uuid4(),
+        "generation_id": generation_id,
+        "ai_call_id": ai_call_id,
+        "tool_ordinal": ordinal,
+        "tool_name": "lookup",
+        "implementation_version": "v1",
+        "arguments_jsonb": {},
+        "status": status,
+    }
+
+
+def _artifact_values(
+    generation_id: UUID,
+    *,
+    artifact_id: UUID | None = None,
+    name: str = "article",
+) -> dict[str, object]:
+    return {
+        "id": artifact_id or uuid4(),
+        "generation_id": generation_id,
+        "kind": "article",
+        "name": name,
+        "format": "markdown",
+    }
+
+
+def _artifact_version_values(
+    artifact_id: UUID,
+    generation_id: UUID,
+    *,
+    version_id: UUID | None = None,
+    revision_number: int = 1,
+    status: str = "working",
+    source_ai_call_id: UUID | None = None,
+    source_tool_call_id: UUID | None = None,
+) -> dict[str, object]:
+    return {
+        "id": version_id or uuid4(),
+        "artifact_id": artifact_id,
+        "generation_id": generation_id,
+        "revision_number": revision_number,
+        "content": "report body",
+        "content_hash": f"hash-{uuid4()}",
+        "source_ai_call_id": source_ai_call_id,
+        "source_tool_call_id": source_tool_call_id,
+        "status": status,
+    }
+
+
+def _assert_integrity_error(engine: Engine, statement: sa.Executable) -> None:
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def _assert_database_error(engine: Engine, statement: sa.Executable) -> None:
+    with pytest.raises(DBAPIError), engine.begin() as connection:
+        connection.execute(statement)
+
+
+def test_reporting_schema_has_only_structural_checks_and_history_guards(
+    database_engine: Engine,
+) -> None:
+    expected_tables = {
+        "generations",
+        "evaluation_workspaces",
+        "ai_calls",
+        "tool_calls",
+        "artifacts",
+        "artifact_versions",
+    }
+    expected_checks = {
+        "ck_generations_workspace_shape",
+        "ck_generations_unambiguous_memory_input",
+    }
+    expected_partial_uniques = {
+        "uq_evaluation_workspaces_one_active",
+        "uq_ai_calls_one_success_per_turn",
+        "uq_artifact_versions_one_final",
+    }
+    expected_triggers = {
+        "generations_protect_terminal",
+        "generations_protect_workspace_membership",
+        "evaluation_workspaces_protect_history",
+        "ai_calls_protect_terminal",
+        "tool_calls_protect_terminal",
+        "artifact_versions_append_only",
+    }
+
+    with database_engine.connect() as connection:
+        tables = set(
+            connection.execute(
+                sa.text(
+                    "SELECT tablename FROM pg_tables WHERE schemaname = 'reporting'"
+                )
+            ).scalars()
+        )
+        checks = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT constraint_record.conname
+                    FROM pg_catalog.pg_constraint AS constraint_record
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = constraint_record.connamespace
+                    WHERE namespace.nspname = 'reporting'
+                      AND constraint_record.contype = 'c'
+                    """
+                )
+            ).scalars()
+        )
+        partial_uniques = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = 'reporting'
+                      AND indexdef LIKE 'CREATE UNIQUE INDEX%WHERE%'
+                    """
+                )
+            ).scalars()
+        )
+        triggers = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT trigger_name
+                    FROM information_schema.triggers
+                    WHERE trigger_schema = 'reporting'
+                    """
+                )
+            ).scalars()
+        )
+        delete_rules = set(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT delete_rule
+                    FROM information_schema.referential_constraints
+                    WHERE constraint_schema = 'reporting'
+                    """
+                )
+            ).scalars()
+        )
+        identifiers = list(
+            connection.execute(
+                sa.text(
+                    """
+                    SELECT constraint_name
+                    FROM information_schema.table_constraints
+                    WHERE constraint_schema = 'reporting'
+                    UNION ALL
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = 'reporting'
+                    """
+                )
+            ).scalars()
+        )
+
+    assert tables == expected_tables
+    assert checks == expected_checks
+    assert expected_partial_uniques <= partial_uniques
+    assert expected_triggers <= triggers
+    assert delete_rules == {"RESTRICT"}
+    assert all(len(identifier) <= 63 for identifier in identifiers)
+    assert not any("ck_generations_ck_generations" in name for name in checks)
+
+
+def test_generation_scope_and_memory_input_shape_are_enforced(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        first = _seed_domain(connection, "First")
+        second = _seed_domain(connection, "Second")
+        workspace_id = uuid4()
+        connection.execute(
+            sa.insert(EvaluationWorkspace),
+            {
+                "id": workspace_id,
+                "competition_id": first["competition"],
+                "base_memory_revision_id": first["revision"],
+                "status": "active",
+            },
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(Generation).values(
+            **_generation_values(
+                first,
+                competition_season_id=second["season"],
+            )
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(Generation).values(
+            **_generation_values(
+                second,
+                evaluation_workspace_id=workspace_id,
+                workspace_sequence_number=1,
+            )
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(Generation).values(
+            **_generation_values(first, workspace_sequence_number=1)
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(Generation).values(
+            **_generation_values(
+                first,
+                input_memory_revision_id=first["revision"],
+                input_memory_artifact_version_id=uuid4(),
+            )
+        ),
+    )
+
+
+def test_reporting_accepts_application_owned_semantics(
+    database_engine: Engine,
+) -> None:
+    generation_id = uuid4()
+    call_id = uuid4()
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Semantic Boundary")
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(
+                domain,
+                generation_id=generation_id,
+                status="future_generation_status",
+                kind="future_kind",
+                current_turn=-10,
+                week_start=-4,
+                week_end=-99,
+                manifest_hash="",
+            ),
+        )
+        connection.execute(
+            sa.insert(AICall),
+            _ai_call_values(
+                generation_id,
+                call_id=call_id,
+                status="future_call_status",
+                turn_number=-3,
+                attempt_number=-2,
+            ),
+        )
+        connection.execute(
+            sa.insert(ToolCall),
+            _tool_call_values(
+                generation_id,
+                call_id,
+                status="future_tool_status",
+                ordinal=-1,
+            ),
+        )
+
+
+def test_partial_unique_indexes_and_natural_identity(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Concurrency")
+        first_workspace = uuid4()
+        connection.execute(
+            sa.insert(EvaluationWorkspace),
+            {
+                "id": first_workspace,
+                "competition_id": domain["competition"],
+                "base_memory_revision_id": domain["revision"],
+                "status": "active",
+            },
+        )
+        generation_id = uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(domain, generation_id=generation_id),
+        )
+        connection.execute(
+            sa.insert(AICall),
+            _ai_call_values(
+                generation_id,
+                status="succeeded",
+                turn_number=1,
+                attempt_number=0,
+            ),
+        )
+        artifact_id = uuid4()
+        connection.execute(
+            sa.insert(Artifact),
+            _artifact_values(generation_id, artifact_id=artifact_id),
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            _artifact_version_values(
+                artifact_id,
+                generation_id,
+                status="final",
+                revision_number=1,
+            ),
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(EvaluationWorkspace).values(
+            id=uuid4(),
+            competition_id=domain["competition"],
+            base_memory_revision_id=domain["revision"],
+            status="active",
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(AICall).values(
+            **_ai_call_values(
+                generation_id,
+                status="succeeded",
+                turn_number=1,
+                attempt_number=1,
+            )
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(ArtifactVersion).values(
+            **_artifact_version_values(
+                artifact_id,
+                generation_id,
+                status="final",
+                revision_number=2,
+            )
+        ),
+    )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(EvaluationWorkspace),
+            {
+                "id": uuid4(),
+                "competition_id": domain["competition"],
+                "base_memory_revision_id": domain["revision"],
+                "status": "discarded",
+            },
+        )
+        connection.execute(
+            sa.insert(AICall),
+            _ai_call_values(
+                generation_id,
+                status="retryable_error",
+                turn_number=1,
+                attempt_number=1,
+            ),
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            _artifact_version_values(
+                artifact_id,
+                generation_id,
+                status="working",
+                revision_number=2,
+            ),
+        )
+
+
+def test_tool_and_artifact_provenance_cannot_cross_generations(
+    database_engine: Engine,
+) -> None:
+    first_generation = uuid4()
+    second_generation = uuid4()
+    first_ai_call = uuid4()
+    second_artifact = uuid4()
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Provenance")
+        connection.execute(
+            sa.insert(Generation),
+            [
+                _generation_values(domain, generation_id=first_generation),
+                _generation_values(domain, generation_id=second_generation),
+            ],
+        )
+        connection.execute(
+            sa.insert(AICall),
+            _ai_call_values(first_generation, call_id=first_ai_call),
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            _artifact_values(second_generation, artifact_id=second_artifact),
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(ToolCall).values(
+            **_tool_call_values(second_generation, first_ai_call)
+        ),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.insert(ArtifactVersion).values(
+            **_artifact_version_values(
+                second_artifact,
+                second_generation,
+                source_ai_call_id=first_ai_call,
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("table", "status"),
+    [
+        (Generation, "succeeded"),
+        (AICall, "succeeded"),
+        (ToolCall, "succeeded"),
+    ],
+)
+def test_terminal_execution_history_is_immutable(
+    database_engine: Engine,
+    table: type[Generation] | type[AICall] | type[ToolCall],
+    status: str,
+) -> None:
+    row_id = uuid4()
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, f"Terminal {table.__name__}")
+        generation_id = row_id if table is Generation else uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(
+                domain,
+                generation_id=generation_id,
+                status=status if table is Generation else "pending",
+            ),
+        )
+        if table is AICall:
+            connection.execute(
+                sa.insert(AICall),
+                _ai_call_values(generation_id, call_id=row_id, status=status),
+            )
+        elif table is ToolCall:
+            ai_call_id = uuid4()
+            connection.execute(
+                sa.insert(AICall),
+                _ai_call_values(generation_id, call_id=ai_call_id),
+            )
+            connection.execute(
+                sa.insert(ToolCall),
+                _tool_call_values(
+                    generation_id,
+                    ai_call_id,
+                    tool_call_id=row_id,
+                    status=status,
+                ),
+            )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(table).where(table.id == row_id).values(status="reopened"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(table).where(table.id == row_id),
+    )
+
+
+def test_artifact_versions_are_append_only(database_engine: Engine) -> None:
+    version_id = uuid4()
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Append Only")
+        generation_id = uuid4()
+        artifact_id = uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(domain, generation_id=generation_id),
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            _artifact_values(generation_id, artifact_id=artifact_id),
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            _artifact_version_values(
+                artifact_id,
+                generation_id,
+                version_id=version_id,
+            ),
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(ArtifactVersion)
+        .where(ArtifactVersion.id == version_id)
+        .values(content="rewritten"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(ArtifactVersion).where(ArtifactVersion.id == version_id),
+    )
+
+
+def test_closed_workspace_and_generation_membership_are_immutable(
+    database_engine: Engine,
+) -> None:
+    workspace_id = uuid4()
+    generation_id = uuid4()
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Closed Workspace")
+        connection.execute(
+            sa.insert(EvaluationWorkspace),
+            {
+                "id": workspace_id,
+                "competition_id": domain["competition"],
+                "base_memory_revision_id": domain["revision"],
+                "status": "active",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(
+                domain,
+                generation_id=generation_id,
+                evaluation_workspace_id=workspace_id,
+                workspace_sequence_number=1,
+            ),
+        )
+        connection.execute(
+            sa.update(EvaluationWorkspace)
+            .where(EvaluationWorkspace.id == workspace_id)
+            .values(status="discarded")
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(EvaluationWorkspace)
+        .where(EvaluationWorkspace.id == workspace_id)
+        .values(status="active"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(Generation)
+        .where(Generation.id == generation_id)
+        .values(evaluation_workspace_id=None, workspace_sequence_number=None),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.insert(Generation).values(
+            **_generation_values(
+                domain,
+                evaluation_workspace_id=workspace_id,
+                workspace_sequence_number=2,
+            )
+        ),
+    )

--- a/docs/database/status.md
+++ b/docs/database/status.md
@@ -79,7 +79,7 @@ agent takes over the same scope.
 | 2. Core identity | `core_agent` | Complete | `backend/database/models/core/`; core migration; core constraint tests |
 | 3. Sleeper persistence | `sleeper_agent` | Complete | `backend/database/models/sleeper/`; Sleeper migration; Sleeper constraint tests |
 | 4. Memory state | `core_agent` | Complete | `backend/database/models/memory/`; memory migration; memory constraint tests |
-| 5. Reporting history | `sleeper_agent` | In progress | `backend/database/models/reporting/`; reporting migration; reporting constraint tests |
+| 5. Reporting history | `sleeper_agent` | Complete | `backend/database/models/reporting/`; reporting migration; reporting constraint tests |
 | 6. Cross-namespace integrity | `root` | Pending | integration migration; immutability/scope/leakage tests |
 | 7. Supabase hardening | `foundation_agent` | Complete | CI and deployment/restore/role/TLS runbooks |
 
@@ -105,6 +105,13 @@ Coordination notes:
 - `sleeper_agent`: added all 19 request/current/snapshot ORM tables, revision
   `0003`, and DB-028-focused relational/concurrency/storage-shape/immutability
   tests. Live PostgreSQL tests pass and migrated schema matches ORM metadata.
+- `sleeper_agent` layer 5: completed the six reporting ORM tables, revision
+  `0005`, and DB-028-focused scope, concurrency, provenance, and immutable-history
+  tests. The full live PostgreSQL database suite passes (53 tests), reporting
+  migration/metadata drift is empty, and offline upgrade/downgrade DDL compiles.
+  Layer `0006` must add the deferred artifact/workspace pointer scope rules,
+  memory-to-reporting provenance FKs, and cross-namespace final-history guards;
+  `root` must also import reporting models into the shared metadata registry.
 - `foundation_agent` layer 7: added a role-only hosted bootstrap, manual
   preview/staging verification workflow, mandatory verify-full operator checks,
   credential-free schema reporting, guarded logical backup/restore-drill


### PR DESCRIPTION
## Summary

- adds generations, AI calls, tool calls, artifacts, artifact versions, and evaluation workspaces
- adds Alembic revision `0005` with exact request/response history, token telemetry, versioned artifacts, terminal-record immutability, and active/final concurrency constraints
- registers reporting metadata and adds PostgreSQL scope/history tests

## Design decisions

Reporting history is generation-centered and append-oriented. Cost is derived from stored model/token identity rather than persisted pricing catalogs, and articles/briefs remain generic versioned artifacts.

## Verification

- reporting scope, provenance, concurrency, and history tests: passed
- reporting metadata comparison: zero drift
- final stacked database suite: 66 passed

## Stack

5 of 7. Previous: #89. Next: #91
