### PR TITLE
chore(database): harden Supabase operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ REPORTER_TRACING=true
 
 # Product database (runtime and migration credentials must be distinct)
 AIDAM_DATABASE_URL=postgresql+psycopg://aidam_api:password@localhost:54329/aidam
+AIDAM_WORKER_DATABASE_URL=postgresql+psycopg://aidam_worker:password@localhost:54329/aidam
 AIDAM_MIGRATION_DATABASE_URL=postgresql+psycopg://aidam_migrator:password@localhost:54329/aidam
 AIDAM_DATABASE_CA_FILE=/path/to/supabase-root.crt
 AIDAM_DATABASE_POOL_SIZE=5

--- a/.github/workflows/database-hosted-verify.yml
+++ b/.github/workflows/database-hosted-verify.yml
@@ -1,0 +1,92 @@
+name: Hosted database verification
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Protected GitHub environment containing database secrets
+        required: true
+        type: choice
+        options:
+          - preview
+          - staging
+      expected_database:
+        description: Exact PostgreSQL database name
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: database-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: ${{ inputs.environment }}
+    env:
+      AIDAM_MIGRATION_DATABASE_URL: ${{ secrets.AIDAM_MIGRATION_DATABASE_URL }}
+      AIDAM_DATABASE_URL: ${{ secrets.AIDAM_DATABASE_URL }}
+      AIDAM_WORKER_DATABASE_URL: ${{ secrets.AIDAM_WORKER_DATABASE_URL }}
+      AIDAM_EXPECTED_DATABASE: ${{ inputs.expected_database }}
+      AIDAM_MIGRATION_ROLE: aidam_owner
+      AIDAM_MIGRATION_REQUIRE_TLS: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install project
+        run: python -m pip install --editable '.[dev]'
+      - name: Install trusted database CA
+        env:
+          DATABASE_CA_PEM: ${{ secrets.AIDAM_DATABASE_CA_PEM }}
+        run: |
+          install -m 700 -d "$RUNNER_TEMP/aidam-database"
+          printf '%s' "$DATABASE_CA_PEM" > "$RUNNER_TEMP/aidam-database/root.crt"
+          chmod 600 "$RUNNER_TEMP/aidam-database/root.crt"
+          echo "AIDAM_DATABASE_CA_FILE=$RUNNER_TEMP/aidam-database/root.crt" >> "$GITHUB_ENV"
+      - name: Verify single Alembic head
+        run: test "$(alembic -c backend/migrations/alembic.ini heads | wc -l)" -eq 1
+      - name: Apply migration history
+        run: alembic -c backend/migrations/alembic.ini upgrade head
+      - name: Verify database is at head
+        run: alembic -c backend/migrations/alembic.ini current --check-heads
+      - name: Verify migrator and hosted boundaries
+        run: >-
+          python -m infra.database.verify_database
+          --url-environment AIDAM_MIGRATION_DATABASE_URL
+          --expected-database "$AIDAM_EXPECTED_DATABASE"
+          --expected-role aidam_migrator
+          --profile migrator
+      - name: Verify API role and TLS
+        run: >-
+          python -m infra.database.verify_database
+          --url-environment AIDAM_DATABASE_URL
+          --expected-database "$AIDAM_EXPECTED_DATABASE"
+          --expected-role aidam_api
+          --profile runtime
+      - name: Verify worker role and TLS
+        run: >-
+          python -m infra.database.verify_database
+          --url-environment AIDAM_WORKER_DATABASE_URL
+          --expected-database "$AIDAM_EXPECTED_DATABASE"
+          --expected-role aidam_worker
+          --profile runtime
+      - name: Check ORM and migration drift
+        run: alembic -c backend/migrations/alembic.ini check
+      - name: Write credential-free schema report
+        run: >-
+          python -m infra.database.schema_report
+          --url-environment AIDAM_MIGRATION_DATABASE_URL
+          > "$RUNNER_TEMP/schema-report.json"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: database-schema-report-${{ inputs.environment }}
+          path: ${{ runner.temp }}/schema-report.json
+          if-no-files-found: error
+          retention-days: 30

--- a/backend/tests/database/operations/__init__.py
+++ b/backend/tests/database/operations/__init__.py
@@ -1,0 +1,1 @@
+"""Static operational-hardening tests."""

--- a/backend/tests/database/operations/test_assets.py
+++ b/backend/tests/database/operations/test_assets.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy import Engine
+
+from infra.database import common
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_hosted_role_bootstrap_does_not_duplicate_application_ddl() -> None:
+    bootstrap = (ROOT / "infra" / "database" / "bootstrap_roles.sql").read_text()
+    uppercase = bootstrap.upper()
+
+    assert "CREATE SCHEMA" not in uppercase
+    assert "CREATE TABLE" not in uppercase
+    assert "CREATE ROLE AIDAM_OWNER" in uppercase
+    assert "CREATE ROLE AIDAM_RUNTIME" in uppercase
+    assert "REVOKE CREATE ON SCHEMA PUBLIC FROM PUBLIC" in uppercase
+    assert "GRANT USAGE, CREATE ON SCHEMA PUBLIC TO AIDAM_OWNER" in uppercase
+    assert "SET SEARCH_PATH = PG_CATALOG" in uppercase
+
+
+def test_hosted_workflow_cannot_target_production() -> None:
+    workflow = (
+        ROOT / ".github" / "workflows" / "database-hosted-verify.yml"
+    ).read_text()
+
+    assert "- preview" in workflow
+    assert "- staging" in workflow
+    assert "- production" not in workflow
+    assert "cancel-in-progress: false" in workflow
+    assert "alembic -c backend/migrations/alembic.ini check" in workflow
+    assert "infra.database.verify_database" in workflow
+
+
+def test_database_ci_tracks_all_operational_hardening_paths() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "database.yml").read_text()
+
+    assert '"infra/database/**"' in workflow
+    assert '"docs/database/runbooks/**"' in workflow
+    assert '".github/workflows/database-hosted-verify.yml"' in workflow
+
+
+def test_backup_and_restore_scripts_have_tls_and_target_guards() -> None:
+    backup = (ROOT / "infra" / "database" / "backup.sh").read_text()
+    restore = (ROOT / "infra" / "database" / "restore_drill.sh").read_text()
+
+    assert "PGSSLMODE=verify-full" in backup
+    assert "refusing to overwrite" in backup
+    assert "--role aidam_owner" in backup
+    assert "--schema core" in backup
+    assert "--table public.alembic_version" in backup
+    assert "printf '%s\\n' \"$application_hash\"" in backup
+    assert "PGSSLMODE=verify-full" in restore
+    assert "aidam_restore_*" in restore
+    assert "AIDAM_RESTORE_CONFIRM_DATABASE" in restore
+    assert "restore target is not empty" in restore
+    assert "--single-transaction" in restore
+    assert "shasum -a 256 --check" not in restore
+    assert 'verify_checksum "$backup_path" "$backup_path.sha256"' in restore
+    assert (
+        'verify_checksum "$version_backup_path" '
+        '"$version_backup_path.sha256"'
+    ) in restore
+
+
+def test_foundation_revision_freezes_its_schema_set() -> None:
+    revision = (
+        ROOT / "backend" / "migrations" / "versions" / "0001_database_foundation.py"
+    ).read_text()
+
+    assert "from backend.database.base import APPLICATION_SCHEMAS" not in revision
+    assert '_APPLICATION_SCHEMAS = ("core", "sleeper", "memory", "reporting")' in revision
+
+
+def test_verified_engine_forces_ca_and_verify_full(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    ca_file = tmp_path / "root.crt"
+    _ = ca_file.write_text("test certificate fixture")
+    monkeypatch.setenv(
+        "TEST_DATABASE_URL",
+        "postgresql+psycopg://aidam_api:secret@database.example/aidam",
+    )
+    monkeypatch.setenv("AIDAM_DATABASE_CA_FILE", str(ca_file))
+    captured: dict[str, object] = {}
+    expected_engine = cast(Engine, object())
+
+    def fake_create_engine(url: str, **kwargs: object) -> Engine:
+        captured["url"] = url
+        captured.update(kwargs)
+        return expected_engine
+
+    monkeypatch.setattr(common, "create_engine", fake_create_engine)
+
+    result = common.create_verified_engine("TEST_DATABASE_URL", "aidam-verify")
+
+    assert result is expected_engine
+    connect_args = cast(dict[str, str | int], captured["connect_args"])
+    assert connect_args["sslmode"] == "verify-full"
+    assert connect_args["sslrootcert"] == str(ca_file)
+    assert connect_args["application_name"] == "aidam-verify"
+
+
+def test_verified_engine_rejects_missing_ca(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "TEST_DATABASE_URL",
+        "postgresql+psycopg://aidam_api:secret@database.example/aidam",
+    )
+    monkeypatch.delenv("AIDAM_DATABASE_CA_FILE", raising=False)
+
+    with pytest.raises(RuntimeError, match="AIDAM_DATABASE_CA_FILE is required"):
+        _ = common.create_verified_engine("TEST_DATABASE_URL", "aidam-verify")

--- a/docs/database/infrastructure.md
+++ b/docs/database/infrastructure.md
@@ -714,8 +714,10 @@ observability.
 Health endpoints distinguish:
 
 - **liveness:** process is running; no database round trip required;
-- **readiness:** bounded `SELECT 1`, expected database/role, TLS in hosted env, and
-  Alembic at head;
+- **readiness:** bounded database query plus expected database/role and TLS in
+  hosted environments; runtime roles do not read protected migration history;
+- **deployment readiness:** the migrator verifies Alembic at head before writers
+  are enabled;
 - **dependency detail:** operator-only diagnostics for server version, connection
   mode, pool, and migration revision.
 

--- a/docs/database/runbooks/backup-and-restore.md
+++ b/docs/database/runbooks/backup-and-restore.md
@@ -1,0 +1,56 @@
+# Backup and Restore Drill
+
+A complete AIdam recovery includes PostgreSQL, private object storage, custom
+roles, and rotated login secrets. Supabase database backups do not include
+Storage objects.
+
+## Create an off-project logical backup
+
+1. Confirm the managed backup/PITR state and stop or quiesce writers when the
+   chosen consistency point requires it.
+2. Set `AIDAM_BACKUP_DATABASE_URL` to the migrator's direct or verified
+   session-mode connection and `AIDAM_DATABASE_CA_FILE` to the trusted CA. The
+   dump sets `aidam_owner` and selects only the four application schemas plus
+   `public.alembic_version`.
+3. Choose a new absolute path on an encrypted, access-controlled volume:
+
+   ```bash
+   infra/database/backup.sh /secure/aidam-2026-08-08.dump
+   ```
+
+   The script refuses overwrite, uses `verify-full`, writes separate
+   custom-format application and `public.alembic_version` archives without role
+   passwords/ownership, applies `umask 077`, and creates both SHA-256 checksums.
+   Each checksum file contains only the digest, so a relocated backup is always
+   verified against the exact archive path supplied to the restore script.
+4. Independently copy/version all referenced private Storage objects. Export an
+   inventory containing locator, content hash, and byte length, then verify each
+   object against database metadata. Retain the dump, checksum, and object
+   inventory together but off-project.
+
+## Restore drill
+
+1. Provision a disposable isolated target named `aidam_restore_*`. Bootstrap its
+   roles with `bootstrap_roles.sql`, but do not run Alembic or enable writers.
+2. Set `AIDAM_RESTORE_DATABASE_URL`, the CA file, and
+   `AIDAM_RESTORE_CONFIRM_DATABASE` to the exact target name.
+3. Restore only to the empty drill target:
+
+   ```bash
+   infra/database/restore_drill.sh /secure/aidam-2026-08-08.dump
+   ```
+
+   The script verifies the checksum, exact target name, safety prefix, and empty
+   application schemas before using one `pg_restore` transaction. It never
+   cleans or overwrites a populated database.
+4. Restore the matching Storage inventory and bytes. Verify locator, hash, size,
+   and the absence of both missing and unreferenced retained objects.
+5. Run verified database checks for migrator/API/worker roles,
+   `alembic current --check-heads`, `alembic check`, and the schema report.
+6. Execute representative audit-chain and frozen-SQLite artifact smoke tests.
+   Record elapsed restore time and the recovered consistency point.
+7. Destroy the disposable target and rotate any drill credentials.
+
+For a real incident, stop writers first. Resume workers and then API writes only
+after database, roles, object storage, migration head, and artifact integrity all
+pass. A successful dashboard restore alone is not a completed recovery.

--- a/docs/database/runbooks/observability-and-drift.md
+++ b/docs/database/runbooks/observability-and-drift.md
@@ -1,0 +1,51 @@
+# Database Observability and Drift
+
+## Readiness and deployment evidence
+
+Liveness does not query PostgreSQL. API/worker readiness uses the bounded
+database health check and verifies database name, runtime role, and TLS without
+reading the protected `public.alembic_version` table. The migrator deployment
+gate separately verifies the expected Alembic head before writers are enabled.
+Detailed operator reports may include server version, schema/table sizes,
+connection-pool state, and revision, but never URLs, credentials, prompts,
+payloads, arbitrary SQL binds, or object-store secrets.
+
+Run the following against protected staging/preview secrets after every schema
+change:
+
+```bash
+python -m infra.database.verify_database \
+  --url-environment AIDAM_MIGRATION_DATABASE_URL \
+  --expected-database aidam \
+  --expected-role aidam_migrator \
+  --profile migrator
+alembic -c backend/migrations/alembic.ini current --check-heads
+alembic -c backend/migrations/alembic.ini check
+python -m infra.database.schema_report \
+  --url-environment AIDAM_MIGRATION_DATABASE_URL
+```
+
+Repeat `verify_database` with the API and worker URLs and the `runtime` profile.
+All commands require the trusted CA and `verify-full`. Review the report for the
+expected server version, revision, table counts, size changes, unvalidated
+constraints, and invalid indexes. An Alembic diff is a release blocker; never
+stamp the database merely to hide drift.
+
+## Initial signals and alerts
+
+Collect pool checked-out/available/overflow counts and wait time by process;
+connection/reconnect failures; transaction and normalized-query duration;
+statement, lock, deadlock, serialization, and constraint errors; long or idle
+transactions; table/storage growth; ingestion failures; artifact-integrity
+failures; current code/Alembic revisions; and migration duration.
+
+Alert on database unreachability, migration failure, sustained pool exhaustion,
+long transactions, repeated timeouts/deadlocks, storage approaching the plan
+limit, and artifact-integrity failure. Use Supabase query insights and
+`pg_stat_statements` when available, but do not make that operational extension
+an application migration prerequisite.
+
+Review the credential-free schema report with every hosted migration and retain
+it with deployment evidence. Any unexpected object, owner, grant, invalid index,
+unvalidated constraint, multiple head, or metadata diff stops promotion until a
+reviewed Alembic forward fix explains it.

--- a/docs/database/runbooks/roles-and-deployment.md
+++ b/docs/database/runbooks/roles-and-deployment.md
@@ -1,0 +1,69 @@
+# Roles and Hosted Deployment
+
+Use this runbook only for a new Supabase preview/staging project or an approved
+production release. FastAPI and workers never use `postgres`, `service_role`, or
+the migrator login. Alembic remains the only application DDL authority.
+
+## One-time role bootstrap
+
+1. Confirm the project, database name, PostgreSQL version, region, connection
+   limit, direct IPv6 or session-pool endpoint, backup tier, and PITR status.
+2. Configure `psql` with a protected service/password file. Set
+   `PGSSLMODE=verify-full` and `PGSSLROOTCERT` to the project CA. Do not place an
+   administrative URL or password in shell history.
+3. Connect as the Supabase administrative database role and run:
+
+   ```bash
+   psql --no-psqlrc --file infra/database/bootstrap_roles.sql
+   ```
+
+4. In the same interactive `psql` session, set fresh secrets without exposing
+   them in command arguments, then enable each login:
+
+   ```text
+   \password aidam_migrator
+   ALTER ROLE aidam_migrator LOGIN;
+   \password aidam_api
+   ALTER ROLE aidam_api LOGIN;
+   \password aidam_worker
+   ALTER ROLE aidam_worker LOGIN;
+   ```
+
+5. Store the three resulting connection URLs in separate protected secrets.
+   Rotate them independently. Re-run the bootstrap file to repair memberships,
+   database privileges, timeouts, or restricted search paths; it never creates
+   application schemas or tables.
+
+## Preview/staging verification
+
+The manual `Hosted database verification` GitHub workflow accepts only protected
+`preview` or `staging` environments. Each environment must define:
+
+- `AIDAM_MIGRATION_DATABASE_URL` for `aidam_migrator`;
+- `AIDAM_DATABASE_URL` for `aidam_api`;
+- `AIDAM_WORKER_DATABASE_URL` for `aidam_worker`;
+- `AIDAM_DATABASE_CA_PEM`, copied from the project's connection settings.
+
+The workflow serializes by environment, requires `verify-full`, upgrades through
+Alembic, verifies the single head, roles, private-schema ownership, Data API
+isolation, invalid indexes, runtime privileges, and ORM drift, then uploads a
+credential-free schema report. It does not seed or clone production data.
+
+## Production release gate
+
+Before adding a production-capable workflow environment, record approval for:
+
+- exact starting and target Alembic revisions;
+- recent managed backup plus an encrypted off-project logical backup;
+- matching private object-storage backup and integrity inventory;
+- successful restore drill and staging verification from an empty database;
+- lock review and rollback choice: safe downgrade, forward fix, or restore;
+- one migration owner/job and confirmed connection budget headroom.
+
+During the release, stop competing deploys, run `alembic upgrade head` as
+`aidam_migrator`, and retain migration output without connection URLs or bind
+values. Afterward run `current --check-heads`, all three role verifications,
+`alembic check`, and the schema report before enabling writers.
+
+Never use Supabase Studio, `supabase db push`, or a Supabase migration directory
+to alter AIdam application objects.

--- a/infra/__init__.py
+++ b/infra/__init__.py
@@ -1,0 +1,1 @@
+"""Operational tooling that is not part of the application runtime."""

--- a/infra/database/__init__.py
+++ b/infra/database/__init__.py
@@ -1,0 +1,1 @@
+"""Database deployment and recovery tooling."""

--- a/infra/database/backup.sh
+++ b/infra/database/backup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: backup.sh /absolute/path/to/new-backup.dump" >&2
+  exit 2
+fi
+
+backup_path=$1
+version_backup_path="$backup_path.alembic"
+if [[ ${backup_path:0:1} != "/" ]]; then
+  echo "backup path must be absolute" >&2
+  exit 2
+fi
+if [[ -e "$backup_path" || -e "$version_backup_path" || \
+      -e "$backup_path.sha256" || -e "$version_backup_path.sha256" ]]; then
+  echo "refusing to overwrite an existing backup or checksum" >&2
+  exit 2
+fi
+: "${AIDAM_BACKUP_DATABASE_URL:?AIDAM_BACKUP_DATABASE_URL is required}"
+: "${AIDAM_DATABASE_CA_FILE:?AIDAM_DATABASE_CA_FILE is required}"
+if [[ ! -f "$AIDAM_DATABASE_CA_FILE" ]]; then
+  echo "database CA file does not exist" >&2
+  exit 2
+fi
+
+export PGSSLMODE=verify-full
+export PGSSLROOTCERT="$AIDAM_DATABASE_CA_FILE"
+export PGDATABASE="$AIDAM_BACKUP_DATABASE_URL"
+umask 077
+pg_dump \
+  --format custom \
+  --role aidam_owner \
+  --no-owner \
+  --no-privileges \
+  --schema core \
+  --schema sleeper \
+  --schema memory \
+  --schema reporting \
+  --file "$backup_path"
+pg_dump \
+  --format custom \
+  --role aidam_owner \
+  --no-owner \
+  --no-privileges \
+  --table public.alembic_version \
+  --file "$version_backup_path"
+application_hash=$(shasum -a 256 "$backup_path" | awk '{print $1}')
+version_hash=$(shasum -a 256 "$version_backup_path" | awk '{print $1}')
+printf '%s\n' "$application_hash" > "$backup_path.sha256"
+printf '%s\n' "$version_hash" > "$version_backup_path.sha256"
+echo "backup and checksum created; verify private object storage separately"

--- a/infra/database/bootstrap_roles.sql
+++ b/infra/database/bootstrap_roles.sql
@@ -1,0 +1,60 @@
+-- Run once as the Supabase administrative database role through verified TLS.
+-- This owns cluster/database roles only. Alembic remains the sole application
+-- schema/table/function/trigger migration authority.
+\set ON_ERROR_STOP on
+
+SELECT 'CREATE ROLE aidam_owner NOLOGIN NOINHERIT'
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aidam_owner'
+) \gexec
+
+SELECT 'CREATE ROLE aidam_runtime NOLOGIN NOINHERIT'
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aidam_runtime'
+) \gexec
+
+SELECT 'CREATE ROLE aidam_migrator NOLOGIN NOINHERIT'
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aidam_migrator'
+) \gexec
+
+SELECT 'CREATE ROLE aidam_api NOLOGIN INHERIT'
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aidam_api'
+) \gexec
+
+SELECT 'CREATE ROLE aidam_worker NOLOGIN INHERIT'
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aidam_worker'
+) \gexec
+
+GRANT aidam_owner TO aidam_migrator;
+GRANT aidam_runtime TO aidam_api, aidam_worker;
+
+SELECT format(
+    'GRANT CONNECT, CREATE ON DATABASE %I TO aidam_owner',
+    pg_catalog.current_database()
+) \gexec
+SELECT format(
+    'GRANT CONNECT ON DATABASE %I TO aidam_migrator, aidam_api, aidam_worker',
+    pg_catalog.current_database()
+) \gexec
+
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+GRANT USAGE, CREATE ON SCHEMA public TO aidam_owner;
+
+ALTER ROLE aidam_owner SET search_path = pg_catalog;
+ALTER ROLE aidam_migrator SET search_path = pg_catalog;
+ALTER ROLE aidam_runtime SET search_path = pg_catalog;
+ALTER ROLE aidam_api SET search_path = pg_catalog;
+ALTER ROLE aidam_worker SET search_path = pg_catalog;
+
+ALTER ROLE aidam_api SET statement_timeout = '30s';
+ALTER ROLE aidam_api SET lock_timeout = '5s';
+ALTER ROLE aidam_api SET idle_in_transaction_session_timeout = '30s';
+ALTER ROLE aidam_worker SET statement_timeout = '30s';
+ALTER ROLE aidam_worker SET lock_timeout = '5s';
+ALTER ROLE aidam_worker SET idle_in_transaction_session_timeout = '30s';
+
+-- Login passwords are intentionally not accepted by this file. Set them with
+-- psql's interactive \password command, then enable each login explicitly.

--- a/infra/database/common.py
+++ b/infra/database/common.py
@@ -1,0 +1,39 @@
+"""Shared verified-connection helpers for operator-only database checks."""
+
+import os
+from pathlib import Path
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.engine import make_url
+from sqlalchemy.pool import NullPool
+
+
+def required_environment(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def create_verified_engine(url_environment: str, application_name: str) -> Engine:
+    """Create a one-connection engine with mandatory full TLS verification."""
+
+    database_url = required_environment(url_environment)
+    url = make_url(database_url)
+    if url.drivername != "postgresql+psycopg":
+        raise RuntimeError(f"{url_environment} must use postgresql+psycopg")
+
+    ca_file = Path(required_environment("AIDAM_DATABASE_CA_FILE"))
+    if not ca_file.is_file():
+        raise RuntimeError("AIDAM_DATABASE_CA_FILE does not exist")
+
+    return create_engine(
+        database_url,
+        poolclass=NullPool,
+        connect_args={
+            "application_name": application_name,
+            "connect_timeout": 10,
+            "sslmode": "verify-full",
+            "sslrootcert": str(ca_file),
+        },
+    )

--- a/infra/database/restore_drill.sh
+++ b/infra/database/restore_drill.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: restore_drill.sh /absolute/path/to/backup.dump" >&2
+  exit 2
+fi
+
+backup_path=$1
+version_backup_path="$backup_path.alembic"
+if [[ ${backup_path:0:1} != "/" || ! -f "$backup_path" ]]; then
+  echo "backup must be an existing absolute path" >&2
+  exit 2
+fi
+if [[ ! -f "$backup_path.sha256" || ! -f "$version_backup_path" || \
+      ! -f "$version_backup_path.sha256" ]]; then
+  echo "application/Alembic archives and matching checksums are required" >&2
+  exit 2
+fi
+: "${AIDAM_RESTORE_DATABASE_URL:?AIDAM_RESTORE_DATABASE_URL is required}"
+: "${AIDAM_RESTORE_CONFIRM_DATABASE:?AIDAM_RESTORE_CONFIRM_DATABASE is required}"
+: "${AIDAM_DATABASE_CA_FILE:?AIDAM_DATABASE_CA_FILE is required}"
+if [[ ! -f "$AIDAM_DATABASE_CA_FILE" ]]; then
+  echo "database CA file does not exist" >&2
+  exit 2
+fi
+
+export PGSSLMODE=verify-full
+export PGSSLROOTCERT="$AIDAM_DATABASE_CA_FILE"
+export PGDATABASE="$AIDAM_RESTORE_DATABASE_URL"
+
+verify_checksum() {
+  local file_path=$1
+  local checksum_path=$2
+  local expected_hash
+  local extra_content
+  local actual_hash
+
+  read -r expected_hash extra_content < "$checksum_path"
+  if [[ ! "$expected_hash" =~ ^[0-9a-fA-F]{64}$ || -n "$extra_content" ]]; then
+    echo "invalid checksum manifest: $checksum_path" >&2
+    exit 2
+  fi
+  actual_hash=$(shasum -a 256 "$file_path" | awk '{print $1}')
+  if [[ "$actual_hash" != "$expected_hash" ]]; then
+    echo "checksum mismatch for exact restore input: $file_path" >&2
+    exit 2
+  fi
+}
+
+verify_checksum "$backup_path" "$backup_path.sha256"
+verify_checksum "$version_backup_path" "$version_backup_path.sha256"
+
+actual_database=$(psql --no-psqlrc --tuples-only \
+  --no-align --command "SELECT pg_catalog.current_database()")
+if [[ "$actual_database" != aidam_restore_* ]]; then
+  echo "refusing restore outside an aidam_restore_* database" >&2
+  exit 2
+fi
+if [[ "$actual_database" != "$AIDAM_RESTORE_CONFIRM_DATABASE" ]]; then
+  echo "restore confirmation does not match target database" >&2
+  exit 2
+fi
+
+existing_relations=$(psql --no-psqlrc \
+  --tuples-only --no-align --command \
+  "SELECT count(*) FROM pg_catalog.pg_class AS c JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace WHERE n.nspname IN ('core', 'sleeper', 'memory', 'reporting') AND c.relkind IN ('r', 'm')")
+if [[ "$existing_relations" != "0" ]]; then
+  echo "restore target is not empty" >&2
+  exit 2
+fi
+
+pg_restore \
+  --exit-on-error \
+  --single-transaction \
+  --role aidam_owner \
+  --no-owner \
+  --no-privileges \
+  "$version_backup_path"
+pg_restore \
+  --exit-on-error \
+  --single-transaction \
+  --role aidam_owner \
+  --no-owner \
+  --no-privileges \
+  "$backup_path"
+
+echo "database restore completed; roles, Alembic head, Storage, and audit chains still require verification"

--- a/infra/database/schema_report.py
+++ b/infra/database/schema_report.py
@@ -1,0 +1,101 @@
+"""Emit a credential-free operational schema report as JSON."""
+
+from argparse import ArgumentParser
+import json
+from typing import cast
+
+from sqlalchemy import text
+
+from backend.database.base import APPLICATION_SCHEMAS
+from backend.database.health import read_database_health
+from infra.database.common import create_verified_engine
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    _ = parser.add_argument(
+        "--url-environment",
+        choices=("AIDAM_MIGRATION_DATABASE_URL",),
+        required=True,
+    )
+    arguments = parser.parse_args()
+    url_environment = cast(str, arguments.url_environment)
+    engine = create_verified_engine(url_environment, "aidam-schema-report")
+    try:
+        health = read_database_health(engine, include_migration_revision=True)
+        with engine.connect() as connection:
+            tables = connection.execute(
+                text(
+                    """
+                    SELECT schemaname, count(*) AS table_count
+                    FROM pg_catalog.pg_tables
+                    WHERE schemaname = ANY(:schemas)
+                    GROUP BY schemaname
+                    ORDER BY schemaname
+                    """
+                ),
+                {"schemas": list(APPLICATION_SCHEMAS)},
+            ).mappings()
+            table_counts = {
+                cast(str, row["schemaname"]): cast(int, row["table_count"])
+                for row in tables
+            }
+            sizes = connection.execute(
+                text(
+                    """
+                    SELECT namespace.nspname AS schema_name,
+                           pg_catalog.sum(pg_catalog.pg_total_relation_size(relation.oid))
+                               AS bytes
+                    FROM pg_catalog.pg_class AS relation
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = relation.relnamespace
+                    WHERE namespace.nspname = ANY(:schemas)
+                      AND relation.relkind IN ('r', 'm')
+                    GROUP BY namespace.nspname
+                    ORDER BY namespace.nspname
+                    """
+                ),
+                {"schemas": list(APPLICATION_SCHEMAS)},
+            ).mappings()
+            schema_sizes = {
+                cast(str, row["schema_name"]): cast(int, row["bytes"])
+                for row in sizes
+            }
+            unvalidated_constraints = cast(
+                int,
+                connection.execute(
+                    text(
+                        """
+                        SELECT count(*)
+                        FROM pg_catalog.pg_constraint AS constraint_state
+                        JOIN pg_catalog.pg_namespace AS namespace
+                          ON namespace.oid = constraint_state.connamespace
+                        WHERE namespace.nspname = ANY(:schemas)
+                          AND NOT constraint_state.convalidated
+                        """
+                    ),
+                    {"schemas": list(APPLICATION_SCHEMAS)},
+                ).scalar_one(),
+            )
+
+        print(
+            json.dumps(
+                {
+                    "alembic_revision": health.alembic_revision,
+                    "database": health.database,
+                    "schema_sizes_bytes": schema_sizes,
+                    "server_version": health.server_version,
+                    "table_counts": table_counts,
+                    "tls": health.tls,
+                    "unvalidated_constraint_count": unvalidated_constraints,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/database/verify_database.py
+++ b/infra/database/verify_database.py
@@ -1,0 +1,253 @@
+"""Verify hosted database identity, TLS, roles, grants, and migration state."""
+
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Literal, cast
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import Engine, text
+
+from backend.database.base import APPLICATION_SCHEMAS
+from backend.database.health import assert_database_ready, read_database_health
+from infra.database.common import create_verified_engine
+
+_DATA_API_ROLES = ("anon", "authenticated", "service_role")
+UrlEnvironment = Literal[
+    "AIDAM_MIGRATION_DATABASE_URL",
+    "AIDAM_DATABASE_URL",
+    "AIDAM_WORKER_DATABASE_URL",
+]
+VerificationProfile = Literal["migrator", "runtime"]
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationArguments:
+    url_environment: UrlEnvironment
+    expected_database: str
+    expected_role: str
+    profile: VerificationProfile
+
+
+def _arguments() -> VerificationArguments:
+    parser = ArgumentParser()
+    _ = parser.add_argument(
+        "--url-environment",
+        choices=(
+            "AIDAM_MIGRATION_DATABASE_URL",
+            "AIDAM_DATABASE_URL",
+            "AIDAM_WORKER_DATABASE_URL",
+        ),
+        required=True,
+    )
+    _ = parser.add_argument("--expected-database", required=True)
+    _ = parser.add_argument(
+        "--expected-role",
+        choices=("aidam_migrator", "aidam_api", "aidam_worker"),
+        required=True,
+    )
+    _ = parser.add_argument(
+        "--profile",
+        choices=("migrator", "runtime"),
+        required=True,
+    )
+    parsed: Namespace = parser.parse_args()
+    return VerificationArguments(
+        url_environment=cast(UrlEnvironment, parsed.url_environment),
+        expected_database=cast(str, parsed.expected_database),
+        expected_role=cast(str, parsed.expected_role),
+        profile=cast(VerificationProfile, parsed.profile),
+    )
+
+
+def _expected_head() -> str:
+    root = Path(__file__).resolve().parents[2]
+    config = Config(str(root / "backend" / "migrations" / "alembic.ini"))
+    heads = ScriptDirectory.from_config(config).get_heads()
+    if len(heads) != 1:
+        raise RuntimeError(f"expected one Alembic head, found {len(heads)}")
+    return heads[0]
+
+
+def _verify_common(engine: Engine) -> dict[str, object]:
+    with engine.connect() as connection:
+        schema_rows = connection.execute(
+            text(
+                """
+                SELECT nspname, pg_catalog.pg_get_userbyid(nspowner) AS owner
+                FROM pg_catalog.pg_namespace
+                WHERE nspname = ANY(:schemas)
+                ORDER BY nspname
+                """
+            ),
+            {"schemas": list(APPLICATION_SCHEMAS)},
+        ).mappings()
+        schema_owners = {
+            cast(str, row["nspname"]): cast(str, row["owner"])
+            for row in schema_rows
+        }
+        if set(schema_owners) != set(APPLICATION_SCHEMAS):
+            raise RuntimeError("one or more private application schemas are missing")
+        if set(schema_owners.values()) != {"aidam_owner"}:
+            raise RuntimeError("private application schema ownership is incorrect")
+
+        search_path = cast(
+            str,
+            connection.execute(text("SHOW search_path")).scalar_one(),
+        )
+        if search_path.replace(" ", "") != "pg_catalog":
+            raise RuntimeError("database role search_path is not restricted")
+
+        public_create = cast(
+            bool,
+            connection.execute(
+                text("SELECT has_schema_privilege('public', 'public', 'CREATE')")
+            ).scalar_one(),
+        )
+        if public_create:
+            raise RuntimeError("PUBLIC retains CREATE on schema public")
+
+        invalid_indexes = cast(
+            int,
+            connection.execute(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM pg_catalog.pg_index AS index_state
+                    JOIN pg_catalog.pg_class AS relation
+                      ON relation.oid = index_state.indexrelid
+                    JOIN pg_catalog.pg_namespace AS namespace
+                      ON namespace.oid = relation.relnamespace
+                    WHERE namespace.nspname = ANY(:schemas)
+                      AND NOT index_state.indisvalid
+                    """
+                ),
+                {"schemas": list(APPLICATION_SCHEMAS)},
+            ).scalar_one(),
+        )
+        if invalid_indexes:
+            raise RuntimeError("invalid application indexes exist")
+
+        data_api_access: dict[str, list[str]] = {}
+        for role in _DATA_API_ROLES:
+            role_exists = cast(
+                bool,
+                connection.execute(
+                    text(
+                        """
+                        SELECT EXISTS (
+                            SELECT 1
+                            FROM pg_catalog.pg_roles
+                            WHERE rolname = :role
+                        )
+                        """
+                    ),
+                    {"role": role},
+                ).scalar_one(),
+            )
+            if not role_exists:
+                continue
+            visible = [
+                schema
+                for schema in APPLICATION_SCHEMAS
+                if cast(
+                    bool,
+                    connection.execute(
+                        text("SELECT has_schema_privilege(:role, :schema, 'USAGE')"),
+                        {"role": role, "schema": schema},
+                    ).scalar_one(),
+                )
+            ]
+            if visible:
+                raise RuntimeError(f"Data API role {role} can use private schemas")
+            data_api_access[role] = visible
+
+    return {
+        "application_schemas": sorted(schema_owners),
+        "data_api_schema_access": data_api_access,
+        "invalid_index_count": invalid_indexes,
+        "search_path": search_path,
+    }
+
+
+def _verify_profile(engine: Engine, profile: str, expected_role: str) -> None:
+    with engine.connect() as connection:
+        if profile == "migrator":
+            owner_member = cast(
+                bool,
+                connection.execute(
+                    text(
+                        """
+                        SELECT pg_catalog.pg_has_role(
+                            :role, 'aidam_owner', 'MEMBER'
+                        )
+                        """
+                    ),
+                    {"role": expected_role},
+                ).scalar_one(),
+            )
+            if not owner_member:
+                raise RuntimeError("migrator cannot SET ROLE aidam_owner")
+            return
+
+        with connection.begin():
+            for schema in APPLICATION_SCHEMAS:
+                privileges = connection.execute(
+                    text(
+                        """
+                        SELECT
+                            has_schema_privilege(:schema, 'USAGE') AS can_use,
+                            has_schema_privilege(:schema, 'CREATE') AS can_create
+                        """
+                    ),
+                    {"schema": schema},
+                ).mappings().one()
+                if not cast(bool, privileges["can_use"]) or cast(
+                    bool, privileges["can_create"]
+                ):
+                    raise RuntimeError("runtime schema privileges are incorrect")
+
+
+def main() -> None:
+    arguments = _arguments()
+    engine = create_verified_engine(
+        arguments.url_environment,
+        f"aidam-verify-{arguments.profile}",
+    )
+    try:
+        verifies_revision = arguments.profile == "migrator"
+        health = read_database_health(
+            engine,
+            include_migration_revision=verifies_revision,
+        )
+        expected_head = _expected_head() if verifies_revision else None
+        assert_database_ready(
+            health,
+            expected_database=arguments.expected_database,
+            expected_role=arguments.expected_role,
+            expected_revision=expected_head,
+            require_tls=True,
+        )
+        report = _verify_common(engine)
+        _verify_profile(engine, arguments.profile, arguments.expected_role)
+        report.update(
+            {
+                "database": health.database,
+                "migration_revision_checked": verifies_revision,
+                "role": health.role,
+                "server_version": health.server_version,
+                "tls": health.tls,
+                "verified": True,
+            }
+        )
+        if verifies_revision:
+            report["alembic_revision"] = health.alembic_revision
+        print(json.dumps(report, indent=2, sort_keys=True))
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- adds hosted role bootstrap and manual preview/staging verification for Supabase PostgreSQL
- adds TLS/role/grant/drift/schema-report checks plus guarded logical backup and restore-drill tooling
- adds deployment, backup/restore, and observability runbooks and extends database CI coverage to all operational assets

## Design decisions

Layer 7 contains operational hardening only, so the Alembic history intentionally ends at `0006` rather than adding an empty marker revision. Runtime readiness does not require protected migration-history access; migrator verification does.

## Verification

- operational asset tests: passed
- shell syntax, Python compilation, Compose validation, and basedpyright: passed
- full stacked database suite: 66 passed
- no hosted environment was contacted; preview/staging verification and restore drills remain explicit operator gates

## Stack

7 of 7. Previous: #91
