### PR TITLE
feat(memory): define service contracts

### DIFF
--- a/backend/resources/__init__.py
+++ b/backend/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Application resource objects and persistence managers."""

--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -1,0 +1,19 @@
+"""Canonical memory resource contracts."""
+
+from backend.resources.memory.errors import (
+    InvalidMemoryContent,
+    InvalidMemoryReference,
+    MemoryError,
+    MemoryNotFound,
+    MemoryScopeViolation,
+    StaleCanonicalRevision,
+)
+
+__all__ = [
+    "InvalidMemoryContent",
+    "InvalidMemoryReference",
+    "MemoryError",
+    "MemoryNotFound",
+    "MemoryScopeViolation",
+    "StaleCanonicalRevision",
+]

--- a/backend/resources/memory/errors.py
+++ b/backend/resources/memory/errors.py
@@ -1,0 +1,56 @@
+"""Stable application errors exposed by the canonical memory boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class MemoryError(Exception):
+    """Base class for expected memory application failures."""
+
+    code = "memory_error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = dict(details or {})
+
+
+class MemoryNotFound(MemoryError):
+    """A resource does not exist in the requested memory scope."""
+
+    code = "memory_not_found"
+
+
+class MemoryScopeViolation(MemoryError):
+    """A resource exists but is outside the caller's competition or revision."""
+
+    code = "memory_scope_violation"
+
+
+class InvalidMemoryContent(MemoryError):
+    """A typed memory payload violates its content contract."""
+
+    code = "invalid_memory_content"
+
+
+class InvalidMemoryReference(MemoryError):
+    """A memory reference is missing, duplicated, or targets the wrong kind."""
+
+    code = "invalid_memory_reference"
+
+
+class StaleCanonicalRevision(MemoryError):
+    """Canonical memory advanced beyond a generation's pinned input revision."""
+
+    code = "stale_canonical_revision"
+
+
+class SearchProjectionUnavailable(Exception):
+    """Internal signal that retrieval must use its bounded canonical fallback."""

--- a/backend/resources/memory/objects.py
+++ b/backend/resources/memory/objects.py
@@ -1,0 +1,795 @@
+"""Typed public resource objects for canonical reporter memory."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from enum import StrEnum
+from math import isfinite
+from types import MappingProxyType
+from typing import Annotated, Any, Literal, TypeAlias
+from uuid import UUID, uuid4
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import core_schema
+
+from backend.resources.memory.errors import InvalidMemoryContent
+
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+
+
+class FrozenJsonObject(Mapping[str, Any]):
+    """Recursively immutable JSON object with ordinary JSON serialization."""
+
+    __slots__ = ("_values",)
+
+    def __init__(self, value: Mapping[str, Any]) -> None:
+        self._values = MappingProxyType(
+            {key: _freeze_json(item) for key, item in value.items()}
+        )
+
+    def __getitem__(self, key: str) -> FrozenJsonValue:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __repr__(self) -> str:
+        return f"FrozenJsonObject({_thaw_json(self)!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Mapping) and dict(self) == dict(other)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: Any,
+        _handler: Any,
+    ) -> core_schema.CoreSchema:
+        dictionary_schema = core_schema.dict_schema(
+            keys_schema=core_schema.str_schema(),
+            values_schema=core_schema.any_schema(),
+        )
+        return core_schema.no_info_after_validator_function(
+            cls,
+            dictionary_schema,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                _thaw_json,
+                return_schema=dictionary_schema,
+            ),
+        )
+
+
+FrozenJsonValue: TypeAlias = (
+    JsonScalar | tuple["FrozenJsonValue", ...] | FrozenJsonObject
+)
+
+
+def _freeze_json(value: Any) -> FrozenJsonValue:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not isfinite(value):
+            raise ValueError("JSON numbers must be finite")
+        return value
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise ValueError("JSON object keys must be strings")
+        return FrozenJsonObject(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    raise ValueError(f"value is not JSON serializable: {type(value).__name__}")
+
+
+def _thaw_json(value: FrozenJsonValue) -> Any:
+    if isinstance(value, FrozenJsonObject):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+class MemoryObject(BaseModel):
+    """Immutable, closed resource value used across application boundaries."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class MemoryKind(StrEnum):
+    STORYLINE = "storyline"
+    FACT = "fact"
+    EVENT = "event"
+    TRIGGER = "trigger"
+    CONTEXT_NOTE = "context_note"
+
+
+class StorylineStatus(StrEnum):
+    ACTIVE = "active"
+    DORMANT = "dormant"
+    RESOLVED = "resolved"
+    ARCHIVED = "archived"
+
+
+class FactStatus(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+class EventStatus(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+class TriggerStatus(StrEnum):
+    OPEN = "open"
+    FIRED = "fired"
+    SATISFIED = "satisfied"
+    EXPIRED = "expired"
+    ARCHIVED = "archived"
+
+
+class ContextNoteStatus(StrEnum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class MemoryStatus(StrEnum):
+    """Cross-kind status vocabulary used only for retrieval filtering."""
+
+    ACTIVE = "active"
+    DORMANT = "dormant"
+    RESOLVED = "resolved"
+    ARCHIVED = "archived"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    OPEN = "open"
+    FIRED = "fired"
+    SATISFIED = "satisfied"
+    EXPIRED = "expired"
+
+
+class MemoryConfidence(StrEnum):
+    UNVERIFIED = "unverified"
+    INFERRED = "inferred"
+    SOURCE_BACKED = "source_backed"
+
+
+FactConfidence = MemoryConfidence
+EventConfidence = MemoryConfidence
+
+
+class EntityReference(MemoryObject):
+    role: NonEmptyStr
+    display_name: NonEmptyStr | None = None
+
+
+class FranchiseRef(EntityReference):
+    kind: Literal["franchise"] = "franchise"
+    id: UUID
+
+
+class PlayerRef(EntityReference):
+    kind: Literal["player"] = "player"
+    id: NonEmptyStr
+
+
+class SeasonRosterRef(EntityReference):
+    kind: Literal["season_roster"] = "season_roster"
+    id: UUID
+
+
+class SeasonRef(EntityReference):
+    kind: Literal["competition_season"] = "competition_season"
+    id: UUID
+
+
+class SleeperUserRef(EntityReference):
+    kind: Literal["sleeper_user"] = "sleeper_user"
+    id: NonEmptyStr
+
+
+EntityRef: TypeAlias = Annotated[
+    FranchiseRef | PlayerRef | SeasonRosterRef | SeasonRef | SleeperUserRef,
+    Field(discriminator="kind"),
+]
+
+
+class FranchiseKey(MemoryObject):
+    kind: Literal["franchise"] = "franchise"
+    id: UUID
+
+
+class PlayerKey(MemoryObject):
+    kind: Literal["player"] = "player"
+    id: NonEmptyStr
+
+
+class SeasonRosterKey(MemoryObject):
+    kind: Literal["season_roster"] = "season_roster"
+    id: UUID
+
+
+class SeasonKey(MemoryObject):
+    kind: Literal["competition_season"] = "competition_season"
+    id: UUID
+
+
+class SleeperUserKey(MemoryObject):
+    kind: Literal["sleeper_user"] = "sleeper_user"
+    id: NonEmptyStr
+
+
+EntityKey: TypeAlias = Annotated[
+    FranchiseKey | PlayerKey | SeasonRosterKey | SeasonKey | SleeperUserKey,
+    Field(discriminator="kind"),
+]
+
+
+class EvidenceRef(MemoryObject):
+    kind: Literal["fact", "event"]
+    version_id: UUID
+    role: Literal["origin", "support", "update", "payoff"]
+
+
+class RelatedStorylineRef(MemoryObject):
+    item_id: UUID
+    role: Literal["related_arc", "continuation", "counterpoint"]
+
+
+class StorylineContent(MemoryObject):
+    kind: Literal["storyline"] = "storyline"
+    schema_version: Literal[1] = 1
+    headline: NonEmptyStr
+    summary: NonEmptyStr
+    status: StorylineStatus
+    arc_type: NonEmptyStr | None = None
+    salience: int = Field(ge=1, le=5)
+    tags: tuple[NonEmptyStr, ...] = ()
+    subjects: tuple[EntityRef, ...] = ()
+    evidence: tuple[EvidenceRef, ...] = ()
+    related_storylines: tuple[RelatedStorylineRef, ...] = ()
+    callback_condition: NonEmptyStr | None = None
+    resolution_summary: NonEmptyStr | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def tags_are_unique(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(value) != len(set(value)):
+            raise ValueError("tags must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def validates_owned_references(self) -> StorylineContent:
+        allowed_roles = {"focus", "counterparty"}
+        invalid_roles = sorted({ref.role for ref in self.subjects} - allowed_roles)
+        if invalid_roles:
+            raise ValueError(f"invalid storyline subject roles: {invalid_roles}")
+        evidence_keys = [(ref.kind, ref.version_id, ref.role) for ref in self.evidence]
+        if len(evidence_keys) != len(set(evidence_keys)):
+            raise ValueError("storyline evidence references must be unique")
+        related_keys = [(ref.item_id, ref.role) for ref in self.related_storylines]
+        if len(related_keys) != len(set(related_keys)):
+            raise ValueError("related storyline references must be unique")
+        return self
+
+
+class FactContent(MemoryObject):
+    kind: Literal["fact"] = "fact"
+    schema_version: Literal[1] = 1
+    claim: NonEmptyStr
+    category: NonEmptyStr
+    numbers: FrozenJsonObject = Field(default_factory=lambda: FrozenJsonObject({}))
+    confidence: FactConfidence
+    status: FactStatus
+    subjects: tuple[EntityRef, ...] = ()
+    originating_event_version_ids: tuple[UUID, ...] = ()
+    primary_tool_call_id: UUID | None = None
+    primary_api_request_id: UUID | None = None
+    source_hints: FrozenJsonObject | None = None
+
+    @model_validator(mode="after")
+    def validates_owned_references(self) -> FactContent:
+        invalid_roles = sorted({ref.role for ref in self.subjects} - {"subject"})
+        if invalid_roles:
+            raise ValueError(f"invalid fact subject roles: {invalid_roles}")
+        if len(self.originating_event_version_ids) != len(
+            set(self.originating_event_version_ids)
+        ):
+            raise ValueError("originating event references must be unique")
+        return self
+
+
+class PlayerTradeAsset(MemoryObject):
+    kind: Literal["player"] = "player"
+    player_id: NonEmptyStr
+    display_name: NonEmptyStr | None = None
+
+
+class DraftPickTradeAsset(MemoryObject):
+    kind: Literal["draft_pick"] = "draft_pick"
+    season: int = Field(ge=2000, le=2200)
+    round: int = Field(ge=1)
+    original_season_roster_id: UUID | None = None
+
+
+class FaabTradeAsset(MemoryObject):
+    kind: Literal["faab"] = "faab"
+    amount: int = Field(gt=0)
+
+
+TradeAsset: TypeAlias = Annotated[
+    PlayerTradeAsset | DraftPickTradeAsset | FaabTradeAsset,
+    Field(discriminator="kind"),
+]
+
+
+class TradeEventPayload(MemoryObject):
+    kind: Literal["trade"] = "trade"
+    sender_franchise_id: UUID
+    receiver_franchise_id: UUID
+    assets: tuple[TradeAsset, ...] = Field(min_length=1)
+    sleeper_transaction_id: NonEmptyStr | None = None
+
+    @model_validator(mode="after")
+    def has_distinct_participants(self) -> TradeEventPayload:
+        if self.sender_franchise_id == self.receiver_franchise_id:
+            raise ValueError("trade sender and receiver must differ")
+        return self
+
+
+class MatchupEventPayload(MemoryObject):
+    kind: Literal["matchup"] = "matchup"
+    winner_franchise_id: UUID
+    loser_franchise_id: UUID
+    sleeper_matchup_id: NonEmptyStr
+
+    @model_validator(mode="after")
+    def has_distinct_participants(self) -> MatchupEventPayload:
+        if self.winner_franchise_id == self.loser_franchise_id:
+            raise ValueError("matchup winner and loser must differ")
+        return self
+
+
+class WaiverEventPayload(MemoryObject):
+    kind: Literal["waiver"] = "waiver"
+    franchise_id: UUID
+    added_player_id: NonEmptyStr
+    dropped_player_id: NonEmptyStr | None = None
+    sleeper_transaction_id: NonEmptyStr | None = None
+
+
+class StandingsEventPayload(MemoryObject):
+    kind: Literal["standings"] = "standings"
+    franchise_id: UUID
+    previous_rank: int = Field(ge=1)
+    current_rank: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def rank_changed(self) -> StandingsEventPayload:
+        if self.previous_rank == self.current_rank:
+            raise ValueError("standings event must describe a rank change")
+        return self
+
+
+EventPayload: TypeAlias = Annotated[
+    TradeEventPayload
+    | MatchupEventPayload
+    | WaiverEventPayload
+    | StandingsEventPayload,
+    Field(discriminator="kind"),
+]
+
+
+class EventType(StrEnum):
+    TRADE = "trade"
+    MATCHUP = "matchup"
+    WAIVER = "waiver"
+    STANDINGS = "standings"
+
+
+class EventContent(MemoryObject):
+    kind: Literal["event"] = "event"
+    schema_version: Literal[1] = 1
+    event_type: EventType
+    headline: NonEmptyStr
+    summary: NonEmptyStr
+    salience: int = Field(ge=1, le=5)
+    confidence: EventConfidence
+    status: EventStatus
+    details: EventPayload
+    primary_tool_call_id: UUID | None = None
+    primary_api_request_id: UUID | None = None
+    source_hints: FrozenJsonObject | None = None
+
+    @model_validator(mode="after")
+    def event_type_matches_payload(self) -> EventContent:
+        if self.event_type.value != self.details.kind:
+            raise ValueError("event_type must match details.kind")
+        return self
+
+
+class TriggerType(StrEnum):
+    WEEK = "week"
+    DATETIME = "datetime"
+    EVENT_CALLBACK = "event_callback"
+
+
+class FirePolicy(StrEnum):
+    ONE_SHOT = "one_shot"
+    RECURRING = "recurring"
+    UNTIL_RESOLVED = "until_resolved"
+
+
+class WeekTriggerCondition(MemoryObject):
+    kind: Literal["week"] = "week"
+    week: int = Field(ge=0)
+
+
+class TimeTriggerCondition(MemoryObject):
+    kind: Literal["datetime"] = "datetime"
+    at: AwareDatetime
+
+
+class EventCallbackTriggerCondition(MemoryObject):
+    kind: Literal["event_callback"] = "event_callback"
+    event_type: EventType
+    subject: EntityRef | None = None
+
+    @model_validator(mode="after")
+    def validates_subject_role(self) -> EventCallbackTriggerCondition:
+        if self.subject is not None and self.subject.role != "subject":
+            raise ValueError("event callback subject role must be 'subject'")
+        return self
+
+
+TriggerCondition: TypeAlias = Annotated[
+    WeekTriggerCondition | TimeTriggerCondition | EventCallbackTriggerCondition,
+    Field(discriminator="kind"),
+]
+
+
+class TriggerContent(MemoryObject):
+    kind: Literal["trigger"] = "trigger"
+    schema_version: Literal[1] = 1
+    trigger_type: TriggerType
+    status: TriggerStatus
+    fire_policy: FirePolicy
+    target_competition_season_id: UUID | None = None
+    target_storyline_item_id: UUID | None = None
+    origin_event_item_id: UUID | None = None
+    target_week: int | None = Field(default=None, ge=0)
+    target_at: AwareDatetime | None = None
+    condition: TriggerCondition
+    resolution_reason: NonEmptyStr | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def derives_time_target_from_condition(cls, value: Any) -> Any:
+        if not isinstance(value, dict) or not isinstance(value.get("condition"), dict):
+            return value
+        normalized = dict(value)
+        condition = value["condition"]
+        if condition.get("kind") == "week" and "target_week" not in normalized:
+            normalized["target_week"] = condition.get("week")
+        elif condition.get("kind") == "datetime" and "target_at" not in normalized:
+            normalized["target_at"] = condition.get("at")
+        return normalized
+
+    @model_validator(mode="after")
+    def trigger_type_matches_condition(self) -> TriggerContent:
+        if self.trigger_type.value != self.condition.kind:
+            raise ValueError("trigger_type must match condition.kind")
+        if isinstance(self.condition, WeekTriggerCondition):
+            if self.target_week != self.condition.week or self.target_at is not None:
+                raise ValueError("week trigger target must match its condition")
+        elif isinstance(self.condition, TimeTriggerCondition):
+            if self.target_at != self.condition.at or self.target_week is not None:
+                raise ValueError("datetime trigger target must match its condition")
+        elif self.target_at is not None or self.target_week is not None:
+            raise ValueError("event callback triggers do not have a time target")
+        return self
+
+
+class ContextNoteContent(MemoryObject):
+    kind: Literal["context_note"] = "context_note"
+    schema_version: Literal[1] = 1
+    narrative: NonEmptyStr
+    outlook: NonEmptyStr | None = None
+    status: ContextNoteStatus
+    tags: tuple[NonEmptyStr, ...] = ()
+
+
+MemoryContent: TypeAlias = Annotated[
+    StorylineContent | FactContent | EventContent | TriggerContent | ContextNoteContent,
+    Field(discriminator="kind"),
+]
+
+
+class ContextNoteScope(StrEnum):
+    COMPETITION = "competition"
+    COMPETITION_SEASON = "competition_season"
+    FRANCHISE = "franchise"
+
+
+class ContextNoteIdentity(MemoryObject):
+    scope: ContextNoteScope
+    note_key: NonEmptyStr
+    competition_season_id: UUID | None = None
+    franchise_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def scope_matches_target(self) -> ContextNoteIdentity:
+        expected = {
+            ContextNoteScope.COMPETITION: (False, False),
+            ContextNoteScope.COMPETITION_SEASON: (True, False),
+            ContextNoteScope.FRANCHISE: (False, True),
+        }[self.scope]
+        actual = (
+            self.competition_season_id is not None,
+            self.franchise_id is not None,
+        )
+        if actual != expected:
+            raise ValueError("context-note target must match its scope")
+        return self
+
+
+class MemoryRevisionRef(MemoryObject):
+    id: UUID
+    competition_id: UUID
+    sequence_number: int = Field(ge=0)
+    state_content_hash: NonEmptyStr
+
+
+class MemoryRevision(MemoryRevisionRef):
+    previous_revision_id: UUID | None = None
+    producing_generation_id: UUID | None = None
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0)
+    knowledge_cutoff_at: AwareDatetime | None = None
+    created_at: AwareDatetime
+
+
+class ExpansionPolicy(MemoryObject):
+    include_evidence: bool = False
+    include_related_items: bool = False
+
+
+DEFAULT_EXPANSION = ExpansionPolicy()
+
+
+class MemoryQuery(MemoryObject):
+    text: NonEmptyStr | None = None
+    entities: tuple[EntityKey, ...] = ()
+    kinds: frozenset[MemoryKind] = frozenset()
+    statuses: frozenset[MemoryStatus] = frozenset()
+    season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0)
+    limit: int = Field(default=20, ge=1, le=100)
+    expansion: ExpansionPolicy = Field(default_factory=ExpansionPolicy)
+
+
+class TypedMemoryVersion(MemoryObject):
+    version_id: UUID
+    item_id: UUID
+    competition_id: UUID
+    kind: MemoryKind
+    content: MemoryContent
+    content_schema_version: int = Field(ge=1)
+    revision_number: int = Field(ge=1)
+    introduced_revision_id: UUID
+    retired_revision_id: UUID | None = None
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0)
+    occurred_at: AwareDatetime | None = None
+    creating_generation_id: UUID
+    creating_tool_call_id: UUID | None = None
+    change_reason: NonEmptyStr | None = None
+    recorded_at: AwareDatetime
+    context_note_identity: ContextNoteIdentity | None = None
+
+    @model_validator(mode="after")
+    def envelope_matches_content(self) -> TypedMemoryVersion:
+        if self.kind.value != self.content.kind:
+            raise ValueError("version kind must match content kind")
+        if self.content_schema_version != self.content.schema_version:
+            raise ValueError("content schema version must match decoded content")
+        if (self.context_note_identity is not None) != (
+            self.kind is MemoryKind.CONTEXT_NOTE
+        ):
+            raise ValueError(
+                "context_note_identity is required exactly for context-note versions"
+            )
+        if (
+            self.context_note_identity is not None
+            and self.context_note_identity.scope
+            is ContextNoteScope.COMPETITION_SEASON
+            and self.context_note_identity.competition_season_id
+            != self.competition_season_id
+        ):
+            raise ValueError(
+                "context-note season identity must match the version envelope"
+            )
+        return self
+
+
+class HydratedMemoryVersion(MemoryObject):
+    version: TypedMemoryVersion
+    evidence: tuple[TypedMemoryVersion, ...] = ()
+    related_items: tuple[TypedMemoryVersion, ...] = ()
+
+
+class RetrievedMemoryEntry(MemoryObject):
+    memory: HydratedMemoryVersion
+    score: float
+    match_reasons: tuple[NonEmptyStr, ...] = ()
+    rank_components: FrozenJsonObject = Field(
+        default_factory=lambda: FrozenJsonObject({})
+    )
+    matched_entities: tuple[NonEmptyStr, ...] = ()
+
+
+class RetrievedMemory(MemoryObject):
+    revision: MemoryRevisionRef
+    entries: tuple[RetrievedMemoryEntry, ...] = ()
+    degraded: bool = False
+
+
+class MemoryListQuery(MemoryObject):
+    competition_id: UUID
+    revision_id: UUID | None = None
+    kinds: frozenset[MemoryKind] = frozenset()
+    statuses: frozenset[MemoryStatus] = frozenset()
+    cursor: NonEmptyStr | None = None
+    limit: int = Field(default=50, ge=1, le=100)
+
+
+class MemoryPage(MemoryObject):
+    revision: MemoryRevisionRef
+    items: tuple[HydratedMemoryVersion, ...] = ()
+    next_cursor: str | None = None
+
+
+class ItemHistory(MemoryObject):
+    competition_id: UUID
+    item_id: UUID
+    versions: tuple[TypedMemoryVersion, ...] = ()
+
+
+class RevisionPage(MemoryObject):
+    competition_id: UUID
+    revisions: tuple[MemoryRevision, ...] = ()
+    next_cursor: str | None = None
+
+
+class SearchIndexStatus(MemoryObject):
+    competition_id: UUID
+    builder_version: int = Field(ge=1)
+    canonical_version_count: int = Field(ge=0)
+    indexed_document_count: int = Field(ge=0)
+    missing_document_count: int = Field(ge=0)
+    stale_document_count: int = Field(ge=0)
+
+
+class RebuildResult(MemoryObject):
+    competition_id: UUID
+    builder_version: int = Field(ge=1)
+    rebuilt_document_count: int = Field(ge=0)
+
+
+class CreateItem(MemoryObject):
+    operation: Literal["create"] = "create"
+    item_id: UUID = Field(default_factory=uuid4)
+    version_id: UUID = Field(default_factory=uuid4)
+    client_key: NonEmptyStr
+    content: MemoryContent
+    context_note_identity: ContextNoteIdentity | None = None
+
+    @model_validator(mode="after")
+    def validates_context_note_identity(self) -> CreateItem:
+        if (self.context_note_identity is not None) != (
+            self.content.kind == MemoryKind.CONTEXT_NOTE.value
+        ):
+            raise ValueError(
+                "context_note_identity is required exactly for context-note creates"
+            )
+        return self
+
+
+class ReplaceItem(MemoryObject):
+    operation: Literal["replace"] = "replace"
+    item_id: UUID
+    content: MemoryContent
+    change_reason: NonEmptyStr | None = None
+
+
+MemoryMutation: TypeAlias = Annotated[
+    CreateItem | ReplaceItem,
+    Field(discriminator="operation"),
+]
+
+
+class MemoryMutationBundle(MemoryObject):
+    producing_generation_id: UUID
+    operations: tuple[MemoryMutation, ...] = ()
+
+
+class MutationItemResult(MemoryObject):
+    operation_index: int = Field(ge=0)
+    client_key: str | None = None
+    item_id: UUID
+    version_id: UUID
+
+
+class NoChange(MemoryObject):
+    outcome: Literal["no_change"] = "no_change"
+    revision: MemoryRevisionRef
+    reason: NonEmptyStr
+
+
+class RevisionCommitted(MemoryObject):
+    outcome: Literal["revision_committed"] = "revision_committed"
+    revision: MemoryRevisionRef
+    items: tuple[MutationItemResult, ...] = ()
+
+
+MutationResult: TypeAlias = Annotated[
+    NoChange | RevisionCommitted,
+    Field(discriminator="outcome"),
+]
+
+
+_CONTENT_ADAPTER = TypeAdapter(MemoryContent)
+
+
+def decode_memory_content(
+    kind: MemoryKind | str,
+    schema_version: int,
+    payload: dict[str, Any],
+) -> MemoryContent:
+    """Decode one retained storage shape into the current typed contract."""
+
+    try:
+        normalized_kind = MemoryKind(kind)
+    except ValueError as exc:
+        raise InvalidMemoryContent(
+            f"unsupported memory kind: {kind}", details={"kind": str(kind)}
+        ) from exc
+    if schema_version != 1:
+        raise InvalidMemoryContent(
+            f"unsupported {normalized_kind.value} content schema version {schema_version}",
+            details={"kind": normalized_kind.value, "schema_version": schema_version},
+        )
+    candidate = {**payload, "kind": normalized_kind.value, "schema_version": 1}
+    try:
+        return _CONTENT_ADAPTER.validate_python(candidate)
+    except ValidationError as exc:
+        raise InvalidMemoryContent(
+            f"invalid {normalized_kind.value} content",
+            details={
+                "kind": normalized_kind.value,
+                "errors": exc.errors(
+                    include_url=False,
+                    include_context=False,
+                    include_input=False,
+                ),
+            },
+        ) from exc

--- a/backend/tests/resources/__init__.py
+++ b/backend/tests/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Application resource contract tests."""

--- a/backend/tests/resources/memory/__init__.py
+++ b/backend/tests/resources/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical memory resource tests."""

--- a/backend/tests/resources/memory/test_objects.py
+++ b/backend/tests/resources/memory/test_objects.py
@@ -1,0 +1,359 @@
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.memory.errors import InvalidMemoryContent
+from backend.resources.memory.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+    CreateItem,
+    DEFAULT_EXPANSION,
+    EventContent,
+    FactContent,
+    FranchiseKey,
+    MemoryKind,
+    MemoryMutationBundle,
+    MemoryQuery,
+    MemoryStatus,
+    PlayerRef,
+    EvidenceRef,
+    StorylineContent,
+    StandingsEventPayload,
+    TriggerContent,
+    TypedMemoryVersion,
+    decode_memory_content,
+)
+
+
+ID_1 = UUID("00000000-0000-0000-0000-000000000001")
+ID_2 = UUID("00000000-0000-0000-0000-000000000002")
+ID_3 = UUID("00000000-0000-0000-0000-000000000003")
+ID_4 = UUID("00000000-0000-0000-0000-000000000004")
+
+
+@pytest.mark.parametrize(
+    ("kind", "payload", "expected_type"),
+    [
+        (
+            "storyline",
+            {
+                "headline": "The comeback",
+                "summary": "A contender recovered from a slow start.",
+                "status": "active",
+                "salience": 4,
+                "subjects": [
+                    {
+                        "kind": "player",
+                        "id": "player-1",
+                        "role": "focus",
+                        "display_name": "A. Player",
+                    }
+                ],
+            },
+            StorylineContent,
+        ),
+        (
+            "fact",
+            {
+                "claim": "The roster has won four straight.",
+                "category": "streak",
+                "confidence": "source_backed",
+                "status": "active",
+                "subjects": [
+                    {"kind": "franchise", "id": str(ID_1), "role": "subject"}
+                ],
+            },
+            FactContent,
+        ),
+        (
+            "event",
+            {
+                "event_type": "matchup",
+                "headline": "An upset",
+                "summary": "The underdog won.",
+                "salience": 5,
+                "confidence": "source_backed",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": str(ID_1),
+                    "loser_franchise_id": str(ID_2),
+                    "sleeper_matchup_id": "7",
+                },
+            },
+            EventContent,
+        ),
+        (
+            "trigger",
+            {
+                "trigger_type": "week",
+                "status": "open",
+                "fire_policy": "one_shot",
+                "target_week": 9,
+                "condition": {"kind": "week", "week": 9},
+            },
+            TriggerContent,
+        ),
+        (
+            "context_note",
+            {
+                "narrative": "The league values running backs highly.",
+                "status": "active",
+                "tags": ["league culture"],
+            },
+            ContextNoteContent,
+        ),
+    ],
+)
+def test_decode_v1_content(
+    kind: str,
+    payload: dict[str, object],
+    expected_type: type,
+) -> None:
+    decoded = decode_memory_content(kind, 1, payload)
+
+    assert isinstance(decoded, expected_type)
+    assert decoded.kind == kind
+    assert decoded.schema_version == 1
+
+
+def test_decode_rejects_unknown_schema_version_with_stable_error() -> None:
+    with pytest.raises(InvalidMemoryContent) as error:
+        decode_memory_content("fact", 2, {})
+
+    assert error.value.code == "invalid_memory_content"
+    assert error.value.details == {"kind": "fact", "schema_version": 2}
+
+
+def test_decode_validation_details_are_transport_safe() -> None:
+    with pytest.raises(InvalidMemoryContent) as error:
+        decode_memory_content(
+            "event",
+            1,
+            {
+                "event_type": "matchup",
+                "headline": "Impossible result",
+                "summary": "One franchise cannot beat itself.",
+                "salience": 3,
+                "confidence": "source_backed",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": ID_1,
+                    "loser_franchise_id": ID_1,
+                    "sleeper_matchup_id": "7",
+                },
+            },
+        )
+
+    json.dumps(error.value.details)
+    serialized_error = error.value.details["errors"][0]
+    assert "input" not in serialized_error
+    assert "ctx" not in serialized_error
+    assert "url" not in serialized_error
+
+
+def test_default_expansion_is_narrow_and_general() -> None:
+    assert DEFAULT_EXPANSION.include_evidence is False
+    assert DEFAULT_EXPANSION.include_related_items is False
+
+
+def test_authored_content_is_deeply_immutable_and_serializes_as_json() -> None:
+    input_numbers = {"streak": [1, {"wins": 3}]}
+    fact = FactContent(
+        claim="Three consecutive wins.",
+        category="streak",
+        confidence="source_backed",
+        status="active",
+        numbers=input_numbers,
+        subjects=[{"kind": "player", "id": "p1", "role": "subject"}],
+    )
+    input_numbers["streak"][1]["wins"] = 99
+
+    assert fact.numbers["streak"][1]["wins"] == 3
+    assert isinstance(fact.subjects, tuple)
+    with pytest.raises(TypeError):
+        fact.numbers["new"] = 1  # type: ignore[index]
+    assert json.loads(fact.model_dump_json())["numbers"] == {
+        "streak": [1, {"wins": 3}]
+    }
+
+
+def test_query_entities_are_role_free_keys() -> None:
+    query = MemoryQuery(
+        entities=[{"kind": "franchise", "id": ID_1}],
+        kinds={"storyline"},
+        statuses={"resolved"},
+    )
+
+    assert query.entities == (FranchiseKey(id=ID_1),)
+    assert query.kinds == frozenset({MemoryKind.STORYLINE})
+    assert query.statuses == frozenset({MemoryStatus.RESOLVED})
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        MemoryQuery(
+            entities=[{"kind": "franchise", "id": ID_1, "role": "focus"}]
+        )
+
+
+def test_content_discriminators_and_owned_roles_are_validated() -> None:
+    with pytest.raises(ValidationError, match="event_type must match details.kind"):
+        EventContent.model_validate(
+            {
+                "event_type": "trade",
+                "headline": "Mismatch",
+                "summary": "Wrong payload.",
+                "salience": 2,
+                "confidence": "unverified",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": str(ID_1),
+                    "loser_franchise_id": str(ID_2),
+                    "sleeper_matchup_id": "1",
+                },
+            }
+        )
+
+    with pytest.raises(ValidationError, match="invalid fact subject roles"):
+        FactContent(
+            claim="A claim",
+            category="general",
+            confidence="source_backed",
+            status="active",
+            subjects=[PlayerRef(id="p1", role="focus")],
+        )
+
+
+def test_context_note_identity_enforces_scope_shape() -> None:
+    ContextNoteIdentity(scope="competition", note_key="league-voice")
+
+    with pytest.raises(ValidationError, match="target must match its scope"):
+        ContextNoteIdentity(
+            scope="franchise",
+            note_key="team-outlook",
+            competition_season_id=ID_1,
+        )
+
+
+def test_v1_standings_and_event_callback_shapes_are_typed() -> None:
+    standings = StandingsEventPayload(
+        franchise_id=ID_1,
+        previous_rank=6,
+        current_rank=3,
+    )
+    trigger = TriggerContent(
+        trigger_type="event_callback",
+        status="open",
+        fire_policy="one_shot",
+        target_competition_season_id=ID_2,
+        condition={
+            "kind": "event_callback",
+            "event_type": "standings",
+            "subject": {
+                "kind": "franchise",
+                "id": ID_1,
+                "role": "subject",
+            },
+        },
+    )
+
+    assert standings.kind == "standings"
+    assert trigger.condition.event_type == "standings"
+
+
+def test_trigger_derives_redundant_storage_target_from_condition() -> None:
+    trigger = TriggerContent(
+        trigger_type="week",
+        status="open",
+        fire_policy="one_shot",
+        condition={"kind": "week", "week": 0},
+    )
+
+    assert trigger.target_week == 0
+
+
+def test_typed_version_requires_context_identity_exactly_for_context_notes() -> None:
+    content = ContextNoteContent(
+        narrative="A durable league convention.", status="active"
+    )
+    common = {
+        "version_id": ID_1,
+        "item_id": ID_2,
+        "competition_id": ID_3,
+        "kind": MemoryKind.CONTEXT_NOTE,
+        "content": content,
+        "content_schema_version": 1,
+        "revision_number": 1,
+        "introduced_revision_id": ID_4,
+        "creating_generation_id": ID_1,
+        "recorded_at": datetime(2026, 8, 9, tzinfo=UTC),
+    }
+
+    with pytest.raises(ValidationError, match="context_note_identity is required"):
+        TypedMemoryVersion(**common)
+
+    version = TypedMemoryVersion(
+        **common,
+        context_note_identity=ContextNoteIdentity(
+            scope="competition", note_key="league-voice"
+        ),
+    )
+    assert version.context_note_identity.note_key == "league-voice"
+
+
+def test_mutation_bundle_derives_context_from_generation() -> None:
+    bundle = MemoryMutationBundle(
+        producing_generation_id=ID_1,
+        operations=[
+            CreateItem(
+                client_key="fact:streak",
+                content=FactContent(
+                    claim="Four straight wins.",
+                    category="streak",
+                    confidence="source_backed",
+                    status="active",
+                ),
+            )
+        ],
+    )
+
+    assert bundle.model_dump().keys() == {"producing_generation_id", "operations"}
+    assert "expected_item_revision" not in bundle.model_dump_json()
+
+
+def test_create_ids_support_same_bundle_references() -> None:
+    fact = CreateItem(
+        client_key="fact:streak",
+        content=FactContent(
+            claim="Four straight wins.",
+            category="streak",
+            confidence="source_backed",
+            status="active",
+        ),
+    )
+    storyline = CreateItem(
+        client_key="storyline:streak",
+        content=StorylineContent(
+            headline="The winning streak",
+            summary="A run worth following.",
+            status="active",
+            salience=4,
+            evidence=[
+                EvidenceRef(
+                    kind="fact",
+                    version_id=fact.version_id,
+                    role="origin",
+                )
+            ],
+        ),
+    )
+    bundle = MemoryMutationBundle(
+        producing_generation_id=ID_1,
+        operations=(fact, storyline),
+    )
+
+    assert fact.item_id != fact.version_id
+    assert bundle.operations[1].content.evidence[0].version_id == fact.version_id

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -96,12 +96,24 @@ storylines involving this franchise.”
   version boundaries, and reference rules.
 - [`application-contracts.md`](application-contracts.md) — Pydantic content
   models, validation ownership, and mutation APIs.
+- [`service-architecture.md`](service-architecture.md) — application components,
+  public service contracts, dependency direction, and transaction boundaries.
 - [`retrieval.md`](retrieval.md) — persistent search documents, full-text search,
   vector search, filtering, and hydration.
 - [`lifecycle.md`](lifecycle.md) — end-to-end generation, search, mutation, and
   projection-maintenance pipeline.
 - [`transition.md`](transition.md) — concrete changes from the implemented
   baseline and recommended implementation order.
+- [`status.md`](status.md) — implementation state, milestones, and remaining
+  decisions.
+- [`log.md`](log.md) — append-only memory-service decision record.
+
+The owning design document is authoritative for its subject: application content
+shapes live in `application-contracts.md`, service boundaries in
+`service-architecture.md`, and search mechanics in `retrieval.md`. `status.md` is
+tracking only. When a later decision-log entry supersedes earlier prose, update
+the owning document in the same change so domain rules are not maintained in two
+implementations or two competing specifications.
 
 ## Non-Goals
 

--- a/docs/memory/application-contracts.md
+++ b/docs/memory/application-contracts.md
@@ -7,6 +7,8 @@
 Callers should know the complete legal shape of a mutation without understanding
 ORM association rows. Routes, tools, services, and the reporter operate on typed
 resource objects; only the memory manager translates those objects into storage.
+The caller-facing capability boundaries and orchestration ownership are defined
+in [`service-architecture.md`](service-architecture.md).
 
 The examples below are illustrative Pydantic-style contracts, not final code.
 
@@ -34,6 +36,15 @@ EntityRef = Annotated[
     Field(discriminator="kind"),
 ]
 ```
+
+Retrieval filters use the corresponding role-free `EntityKey` union. Roles and
+display-name snapshots describe how authored memory uses an entity; asking for
+memory about an entity should not require the caller to invent either value.
+
+`display_name` is an optional immutable label snapshot for this memory version,
+not a pointer to a current name. Search-document rebuilds may use the stored
+snapshot but never resolve a newer external label. The stable ID remains
+authoritative.
 
 Each owning content type narrows the roles it accepts. A trade event may accept
 `sender`, `receiver`, and `asset`; a fact may accept `subject`; a storyline may
@@ -167,36 +178,68 @@ The note's scope and key are loaded from its stable typed identity.
 
 ## Mutation Contract
 
-Public mutations create or replace complete typed content:
+The public service accepts one general bundle of discriminated create and
+replace operations:
 
 ```python
-create_storyline(content: StorylineContent, ...)
+class CreateItem(BaseModel):
+    item_id: UUID = Field(default_factory=uuid4)
+    version_id: UUID = Field(default_factory=uuid4)
+    client_key: str
+    content: MemoryContent
 
-replace_storyline(
-    item_id: UUID,
-    expected_item_revision: int,
-    content: StorylineContent,
-    ...,
-)
+
+class ReplaceItem(BaseModel):
+    item_id: UUID
+    content: MemoryContent
+    change_reason: str | None = None
+
+
+class MemoryMutationBundle(BaseModel):
+    producing_generation_id: UUID
+    operations: list[CreateItem | ReplaceItem]
 ```
+
+`MemoryContent` is the discriminated union of the five complete content types.
+There are no separate `create_storyline`, `replace_fact`, or similar service
+methods. Small kind-specific constructors may improve call-site typing, but they
+only construct these general operations and do not add service layers.
+
+Create IDs are generated when the immutable operation is constructed. A later
+operation in the same bundle can therefore reference the exact version or stable
+item of an earlier create without introducing a parallel client-key reference
+vocabulary. The service rejects duplicate generated IDs and duplicate client
+keys before persistence.
 
 A patch-oriented UI may edit individual fields locally, but the manager validates
 and persists one complete replacement. This prevents a caller from accidentally
 creating a partial version whose omitted relationships have ambiguous meaning.
 
-Before opening the canonical write transaction, the service performs all model
-or external work. Inside the short transaction, the manager:
+The manager derives competition, season, week, knowledge cutoff, and the pinned
+base revision from the producing generation inside the mutation operation. The
+base revision is the only optimistic concurrency token; the version visible for
+a replacement item is determined under that locked base.
 
-1. validates Pydantic content and schema version;
-2. loads every referenced item/version in one scoped batch;
-3. requires the expected kinds and same competition;
-4. validates references created in the same mutation bundle;
-5. locks and verifies the current canonical revision;
-6. writes the complete replacement and its search projection atomically.
+Before opening the canonical write transaction, all model or external work is
+complete. Validation ownership is split once:
+
+1. Pydantic resource objects validate content shape, schema version,
+   discriminators, and pure per-object invariants.
+2. The service validates same-bundle client keys and references, rejects
+   contradictions, and returns `NoChange` for an empty bundle.
+3. Inside the short transaction, the manager loads the generation and persisted
+   references, checks kinds and competition, resolves identical-content no-ops,
+   locks the current canonical revision, and writes complete replacements with
+   search documents atomically.
 
 Failures return typed application errors such as target-not-found,
-wrong-target-kind, cross-competition-reference, stale-item-version, or
-stale-canonical-revision. Callers do not interpret database constraint names.
+wrong-target-kind, cross-competition-reference, or stale-canonical-revision.
+The manager translates expected constraint failures while it still has database
+context; callers do not interpret constraint names.
+
+An empty bundle, identical replacement, or already-represented transition is a
+`NoChange` result and creates no revision. Retrying a producing generation that
+already committed returns its existing committed result.
 
 ## Schema Evolution
 

--- a/docs/memory/lifecycle.md
+++ b/docs/memory/lifecycle.md
@@ -53,11 +53,13 @@ tool work finish before the canonical memory transaction begins.
 Application code:
 
 1. parses each proposed content object into its Pydantic type;
-2. verifies expected item versions;
-3. batch-loads referenced item and version IDs;
-4. validates target kind and competition scope;
-5. validates event/trigger discriminators, roles, and evidence policy;
-6. constructs deterministic resulting content and search documents.
+2. loads competition, season, cutoffs, and the base revision from the producing
+   generation rather than accepting caller-supplied copies;
+3. validates same-bundle keys, references, and contradictions;
+4. removes identical replacements and already-represented transitions;
+5. batch-loads referenced item and version IDs;
+6. validates persisted target kind and competition scope;
+7. constructs search documents through the one authoritative builder registry.
 
 Invalid proposals return actionable application errors. They do not rely on raw
 database constraint failures for semantic feedback.
@@ -78,7 +80,8 @@ In one short transaction, the manager:
 
 If no accepted memory change remains, the transaction creates no revision. If
 canonical memory advanced after the generation started, the mutation fails
-without producing a sibling state or partial projection.
+without producing a sibling state or partial projection. Retrying a generation
+that already produced its revision returns that existing committed result.
 
 ### 7. Add optional embeddings
 

--- a/docs/memory/log.md
+++ b/docs/memory/log.md
@@ -1,0 +1,458 @@
+# Memory Service Decision Log
+
+This is an append-only record for decisions that constrain the application
+memory service, its caller-facing contracts, or its implementation boundaries.
+Canonical storage decisions remain in [`../database/log.md`](../database/log.md).
+
+## Entry Format
+
+Each entry records:
+
+- a stable decision identifier;
+- the date and status;
+- the source and decision;
+- consequences for implementation and downstream consumers.
+
+When a later entry explicitly supersedes an earlier one, the later entry is the
+implementation contract. Earlier entries remain to preserve the reasoning
+history.
+
+## Decisions
+
+### MEM-001 — Implement memory as a modular-monolith service
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Platform architecture and service-boundary review
+
+Memory is a cohesive backend service inside the existing AIdam deployment. It
+uses the shared PostgreSQL database and migration history. It is not a separate
+network service, database, or deployable.
+
+**Consequences:**
+
+- The primary service boundary is a typed Python contract.
+- FastAPI, reporter tools, worker, and CLI code are adapters.
+- Do not introduce HTTP calls or serialization between backend services.
+- Preserve package boundaries so a future extraction remains possible only if
+  operational evidence justifies it.
+
+### MEM-002 — Expose narrow reader, writer, inspector, and admin capabilities
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Service-contract review
+
+One concrete `MemoryService` may compose the memory capability, but consumers
+depend on the narrow contract they require: revision-pinned reading, canonical
+writing, historical inspection, or projection administration.
+
+**Consequences:**
+
+- Reporter tools receive only a pinned reader.
+- Generation finalization receives the canonical writer.
+- UI/audit surfaces may receive the inspector.
+- Maintenance commands receive projection administration.
+- A broad service facade must not become ambient global state or a service
+  locator.
+
+### MEM-003 — Make generation-time revision scope capability-bound
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Historical-leakage review
+
+The generation service resolves an exact canonical revision and constructs a
+lightweight `PinnedMemoryReader` for the reporter. Reporter tool arguments do not
+accept competition or revision overrides.
+
+**Consequences:**
+
+- Every candidate query, exact-version read, and stable-item read enforces the
+  same competition and revision.
+- The pinned reader carries identifiers only; it does not hold a database
+  session open during reporter execution.
+- Historical visibility cannot depend on the current revision pointer or on
+  search-document contents alone.
+
+### MEM-004 — Keep resource objects as the public application representation
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Application-contract review
+
+Routes, services, reporter tools, and workers exchange typed memory resource
+objects and stable result types. ORM rows, SQLAlchemy sessions, database JSON
+shapes, and search-document records remain internal to the resource manager and
+retrieval implementation.
+
+**Consequences:**
+
+- API schemas may wrap or present resource objects but do not replace them as
+  the backend contract.
+- Content-schema conversion is centralized with memory resource objects.
+- Storage changes that preserve the resource contract do not require caller
+  changes.
+
+### MEM-005 — Persist complete typed replacements
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** DB-031 and application mutation review
+
+Creates and replacements contain one complete kind-specific content object.
+Archiving, resolving, firing, and superseding create new complete versions. The
+canonical mutation contract does not expose partial patches or generic
+relationship operations.
+
+**Consequences:**
+
+- Omitted owned subjects, evidence, or relationships mean an empty collection,
+  not “leave unchanged.”
+- Patch-oriented user interfaces must assemble and validate a complete
+  replacement before calling the service.
+- Adding a new event type extends a discriminated content union rather than a
+  generic event bag.
+
+### MEM-006 — Let the memory manager own the canonical transaction
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Transaction-boundary review
+
+The memory resource manager owns the single short transaction that locks the
+current revision, validates persisted references and optimistic expectations,
+creates one revision, writes complete versions, retires replaced versions,
+inserts search documents, verifies resulting state, and advances the pointer.
+
+**Consequences:**
+
+- Services do not receive or pass SQLAlchemy sessions.
+- No table-by-table public CRUD or generic repository is introduced.
+- Cross-resource validation inside the transaction uses narrow helpers that do
+  not open or commit sessions.
+- Model calls, provider calls, embeddings, filesystem work, and reporter
+  execution finish outside the transaction.
+
+### MEM-007 — Separate candidate discovery from canonical hydration
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** DB-031 and retrieval review
+
+Search documents produce compact, revision-eligible candidate version IDs and
+named match reasons. Selected candidates are then batch-hydrated from canonical
+typed versions before crossing the service boundary.
+
+**Consequences:**
+
+- Search documents are never returned as authoritative memory.
+- Competition and pinned-revision visibility are applied before ranking.
+- Ranking uses named components or rank fusion rather than combining unrelated
+  scores as if they shared one scale.
+- Projection corruption can be repaired without changing canonical history.
+
+### MEM-008 — Keep canonical commit authority outside reporter tools
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Generation-lifecycle review
+
+The reporter may emit a typed mutation proposal. Only the generation service,
+after reporter execution and proposal acceptance, invokes the canonical writer
+with the pinned base revision and producing-generation provenance.
+
+**Consequences:**
+
+- Reporter tools cannot mutate memory mid-run or change what the same generation
+  is allowed to retrieve.
+- All model work completes before the canonical transaction.
+- Stale canonical state causes a typed failure and rerun; it never creates a
+  sibling state.
+
+### MEM-009 — Treat projection rebuild as an administrative operation
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Projection lifecycle review
+
+Normal canonical mutations build search documents synchronously and atomically.
+Inspection and full rebuild are separate operator capabilities that read
+canonical versions and rewrite only derived state.
+
+**Consequences:**
+
+- Rebuild does not create canonical revisions.
+- The baseline can expose rebuild through a synchronous CLI.
+- Durable jobs, leases, and embedding backfill orchestration remain deferred.
+- Rebuild must decode every retained content-schema version and be deterministic
+  for a fixed builder version.
+
+### MEM-010 — Keep factual verification outside the memory service
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Service ownership review
+
+Memory retrieval returns narrative context and provenance. It does not decide
+that a remembered claim is true for the current article. The generation and
+reporter workflow verifies claims against its frozen, cutoff-safe Sleeper
+snapshot.
+
+**Consequences:**
+
+- The memory service does not depend on or query the reporter's SQLite factual
+  snapshot.
+- Retrieval ranking may use memory metadata but cannot promote memory to
+  canonical football truth.
+- Verification evidence remains visible to article generation and audit through
+  reporting tool calls and artifacts.
+
+### MEM-011 — Treat capability contracts as views, not mandatory classes
+
+**Date:** 2026-08-09
+**Status:** Settled; clarifies MEM-002 and MEM-003
+**Source:** User feedback on implementation fragmentation
+
+Reader, writer, inspector, and projection-admin protocols describe which
+operations a consumer may use. They do not each require a separate concrete
+coordinator. The baseline uses one `MemoryService`, one `MemoryManager`, and a
+small immutable `PinnedMemoryReader` that the service creates for a validated
+revision scope.
+
+The pinned reader delegates back to the service's internal retrieval pipeline
+with that fixed scope. The retrieval pipeline does not create or own pinned
+readers and does not begin as a stateful class.
+
+**Consequences:**
+
+- Do not pre-create coordinator classes or empty packages for retrieval,
+  mutation, inspection, or projection administration.
+- Begin with service methods and small internal functions; split them only when
+  they acquire distinct state, dependencies, or substantial complexity.
+- Keep the pinned reader because revision-scope safety justifies that wrapper.
+- Protocols remain useful for dependency typing and tests without dictating
+  runtime object count.
+
+### MEM-012 — Keep inspection and projection administration intentionally small
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** User feedback on unknown UI and user experience
+
+The baseline inspector supports only canonical viewing: listing items at the
+current or selected revision, viewing an item, viewing item history, and listing
+revisions with basic provenance. Projection administration supports only status
+and deterministic rebuild of the derived search-document index.
+
+**Consequences:**
+
+- Do not build advanced diffs, analytics, bulk editing, restoration, ranking
+  tuning, or transformative memory operations before a concrete UX requires
+  them.
+- Projection status reports only actionable builder-version and missing/stale
+  document information.
+- Rebuild is initially a synchronous CLI operation; a projection API and durable
+  job workflow are deferred.
+- The inspector and projection-admin protocols may be capability views on the
+  same `MemoryService` rather than concrete classes.
+
+### MEM-013 — Keep workspace promotion outside inspection and projection admin
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Boundary clarification
+
+Promotion means fast-forwarding a reporting-owned evaluation workspace into one
+new canonical memory revision. It does not mean search-projection rebuild or
+historical restoration.
+
+**Consequences:**
+
+- The evaluation service owns promotion because it validates and updates the
+  workspace and its final artifact.
+- The memory module supplies a narrow same-transaction helper for applying the
+  validated final diff when the workspace base remains current.
+- Promotion supports no merge, rebase, arbitrary historical restore, or content
+  transformation modes.
+
+### MEM-014 — Give promotion one cross-resource transaction owner
+
+**Date:** 2026-08-09
+**Status:** Settled; clarifies MEM-006 and MEM-013
+**Source:** Independent strategic-programming review
+
+`EvaluationService.promote_workspace` owns the public workflow, while the
+evaluation-workspace manager owns its one private transaction. That transaction
+locks and updates the reporting workspace and invokes a session-scoped internal
+memory command to create the fast-forward canonical revision.
+
+**Consequences:**
+
+- `MemoryManager` owns ordinary canonical mutation transactions but does not open
+  or commit the promotion transaction.
+- The session-scoped memory command is private, does not delegate to a public
+  service, and enforces the canonical base/current invariant itself.
+- Public services, routes, and workers never receive or pass database sessions.
+- Retrying an already promoted workspace returns its existing promoted revision.
+
+### MEM-015 — Use one authoritative search-document builder
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent duplication and information-hiding review
+
+`backend/resources/memory/search_documents.py` owns one public dispatcher over
+the discriminated typed memory union. Private per-kind functions implement the
+actual flattening. Canonical mutation and full rebuild call that same dispatcher;
+the manager persists its output and retrieval never rebuilds documents.
+
+**Consequences:**
+
+- Mutation and rebuild cannot drift into separate document policies.
+- Builder inputs come only from immutable version content. Stored display-name
+  snapshots may be indexed; current external names are never resolved during a
+  rebuild.
+- The builder version and canonical content hash fully identify deterministic
+  output.
+- Golden tests invoke the same dispatcher through mutation and rebuild paths.
+
+### MEM-016 — Derive mutation context and use one concurrency token
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent complexity and error-design review
+
+A public mutation bundle supplies only its producing generation ID and typed
+operations. The memory manager derives competition, season, week, knowledge
+cutoff, and the pinned input revision from that generation inside the mutation
+operation. The generation's base revision is the only optimistic concurrency
+token; replacements do not supply an expected item revision.
+
+**Consequences:**
+
+- Callers cannot submit inconsistent copies of persisted generation facts.
+- Under the locked base revision, each target item's visible version is
+  unambiguous.
+- `StaleItemRevision` is removed from the public error contract; a changed
+  canonical base produces `StaleCanonicalRevision`.
+- Empty bundles, identical replacements, and already-represented transitions
+  return `NoChange` without creating a revision.
+- Retrying a generation that already committed returns the existing committed
+  revision rather than a stale-write error.
+
+### MEM-017 — Keep consumer ports static and mask index repair internally
+
+**Date:** 2026-08-09
+**Status:** Settled; clarifies MEM-011 and MEM-012
+**Source:** Independent deep-module review
+
+Reader, writer, inspector, and search-index-admin protocols are static consumer
+ports used for dependency typing. They are not runtime authorization objects.
+Composition decides which port a consumer receives; only `PinnedMemoryReader` is
+an actual scoped capability because it carries an enforced revision invariant.
+
+**Consequences:**
+
+- Do not claim `MemoryService` itself prevents a holder from calling its other
+  methods.
+- The initial implementation does not add one forwarding class per port.
+- Search-index maintenance uses explicit `search_index_status` and
+  `rebuild_search_index` names rather than generic projection verbs.
+- Ordinary retrieval masks missing/stale index rows with the last valid builder
+  version or a bounded canonical fallback. `ProjectionUnavailable` is not a
+  caller-facing error.
+
+### MEM-018 — Implement the service as a six-layer GitHub PR stack
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** User direction and implementation planning
+
+Build the memory application layer as six incremental branches managed by
+`gh stack`: contracts, canonical persistence/search documents, canonical
+mutation, pinned retrieval/inspection, composition/adapters, and reporting-owned
+workspace promotion.
+
+**Consequences:**
+
+- The stack is based on `main@32b2d88`, which includes the FastAPI skeleton.
+- Each PR must remain independently reviewable and testable against its parent.
+- `docs/memory/status.md` is the live path-ownership and completion ledger for
+  parallel agents.
+- Shared files are changed by one assigned owner at a time and integrated by
+  `root`.
+- `gh stack submit --auto` publishes draft PRs after local verification and
+  design review; Graphite commands are not used for this stack.
+
+### MEM-019 — Start with a narrow version-one content vocabulary
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Contract implementation
+
+The first resource contract supports storyline subject roles `focus` and
+`counterparty`, fact subject role `subject`, event payloads for trade, matchup,
+waiver, and standings changes, and trigger conditions for week, datetime, and
+event callbacks.
+
+**Consequences:**
+
+- New roles and discriminators extend the centralized unions and validators in
+  `backend/resources/memory/objects.py`; callers do not submit arbitrary role or
+  payload bags.
+- Entity display names are immutable version-local label snapshots.
+- Context-note typed versions carry their stable scope/key identity so the sole
+  search-document builder can rebuild without current-name or database lookups.
+- This vocabulary is deliberately sufficient for the current reporter behavior,
+  not an exhaustive fantasy-football ontology.
+
+### MEM-020 — Let the service pin current memory in one operation
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent caller-complexity review
+
+`MemoryService.pin_current(competition_id)` resolves the current canonical
+revision and returns its `PinnedMemoryReader` in one service operation.
+`at_revision(revision_id)` remains available when a generation or audit record
+already stores an exact revision.
+
+**Consequences:**
+
+- Callers do not coordinate `current_revision` followed by `at_revision`, which
+  could accidentally pin a different revision after a concurrent write.
+- The service, which owns revision resolution, also owns construction of the
+  invariant-carrying reader.
+- The retrieval pipeline still neither constructs readers nor exposes revision
+  overrides.
+- No generic `shared.py` module is reserved for future promotion code; the
+  private promotion command is named only when its concrete invariant exists.
+
+### MEM-021 — Make boundary values deeply immutable and references directly usable
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent contract and information-hiding review
+
+Typed memory uses tuples, frozen sets, and recursively immutable JSON objects at
+the application boundary. Create operations generate both their stable item ID
+and first immutable version ID when constructed. Retrieval filters use
+role-free entity keys rather than authored entity references.
+
+**Consequences:**
+
+- Deterministic hashes and search documents cannot change because a caller
+  mutates a nested list or JSON object after validation.
+- A create later in the same mutation bundle may use an earlier create's
+  generated version ID for evidence or item ID for a stable relationship.
+- Client keys remain correlation labels and do not become a second domain
+  reference vocabulary.
+- Retrieval callers identify an entity without inventing an authoring role or
+  label snapshot.
+- Content-decoder errors contain sanitized JSON-safe validation details rather
+  than Pydantic exception objects or documentation URLs.
+
+## Pending Decisions
+
+- Default retrieval and evidence-expansion limits.

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -62,23 +62,24 @@ preemptively duplicating every field.
 
 ## Search-Document Building
 
-Each canonical kind has a deterministic builder:
+One authoritative dispatcher accepts the discriminated canonical content union:
 
 ```python
-build_storyline_document(content: StorylineContent) -> SearchDocument
-build_fact_document(content: FactContent) -> SearchDocument
-build_event_document(content: EventContent) -> SearchDocument
-build_trigger_document(content: TriggerContent) -> SearchDocument
-build_context_note_document(content: ContextNoteContent) -> SearchDocument
+build_search_document(version: TypedMemoryVersion) -> SearchDocument
 ```
 
-Builders flatten type-specific structure into a common shape and render useful
-search text from:
+It delegates to private per-kind functions that flatten type-specific structure
+into a common shape and render useful search text from:
 
 - headline, summary, claim, narrative, and outlook;
 - tags, event type, arc type, and status;
 - participant display names and stable keys;
 - concise evidence and relationship labels.
+
+Mutation and rebuild call this exact dispatcher; there is no rebuild-specific
+copy. Display names come only from immutable label snapshots stored on the typed
+version. Builders never resolve current external names. When a label snapshot is
+absent, they index the stable entity key.
 
 The initial lexical/entity document is inserted in the same canonical mutation
 transaction as its source version. A successfully visible memory version is
@@ -167,6 +168,12 @@ A projection rebuild:
 
 Rebuilding changes retrieval behavior, not canonical history, and therefore does
 not create memory revisions.
+
+If current projection rows are missing or stale, ordinary retrieval keeps using
+the last valid builder version when possible. Otherwise it degrades internally
+to exact entity/reference signals and a bounded scan of visible canonical
+versions while surfacing the repair need through search-index status. Reporter
+callers do not handle a projection-administration error.
 
 Hydrated immutable typed versions may be cached by exact `version_id`. A pinned
 revision determines which IDs are visible; the cached aggregate itself never

--- a/docs/memory/service-architecture.md
+++ b/docs/memory/service-architecture.md
@@ -1,0 +1,614 @@
+# Memory Service Architecture
+
+**Status:** Accepted application design; implementation pending
+
+**Scope:** Application components, caller-facing contracts, dependency direction,
+and transaction boundaries for canonical reporter memory
+
+## Purpose
+
+The existing memory documents define canonical data, typed content, retrieval,
+and lifecycle behavior. This document turns those decisions into an application
+service with explicit boundaries.
+
+The memory service is a cohesive module inside the AIdam modular monolith. It is
+not a separately deployed microservice and does not own a separate database. Its
+primary public contract is a typed Python API. FastAPI routes, reporter tools,
+workers, and CLIs are adapters around that contract rather than alternative
+implementations of memory policy.
+
+The service owns narrative memory. It does not own football truth, generation
+lifecycle, model execution, authentication, or evaluation-workspace storage.
+
+## Goals
+
+1. Give every caller a small, typed contract that does not expose SQLAlchemy,
+   PostgreSQL search rows, or storage-shaped JSON.
+2. Make revision pinning unavoidable for generation-time reads.
+3. Keep canonical mutation atomic while keeping model and network work outside
+   database transactions.
+4. Separate authoritative typed memory from rebuildable retrieval projections.
+5. Let API, worker, CLI, and reporter consumers share the same behavior without
+   sharing transport concerns.
+6. Keep the baseline implementation small: introduce a new class only when it
+   owns state, enforces a boundary, or provides a meaningful substitution seam.
+
+## Boundary Map
+
+```mermaid
+flowchart LR
+    API["Memory API routes"] --> Inspector["Inspection consumer port"]
+    CLI["Maintenance CLI"] --> Admin["Search-index admin consumer port"]
+    Generation["Generation service"] --> Facade["MemoryService"]
+    Inspector --> Facade
+    Admin --> Facade
+
+    Facade -- "at_revision(id) creates" --> Pinned["PinnedMemoryReader"]
+    Tools["Reporter memory tools"] --> Pinned
+    Pinned -- "delegates with fixed scope" --> Facade
+
+    Facade --> Retrieval["Internal retrieval pipeline"]
+    Facade --> Manager["MemoryManager"]
+    Retrieval --> Manager
+    Manager --> Builders["One search-document builder registry"]
+    Manager --> DB["PostgreSQL memory schema"]
+
+    Manager -. "persisted reference lookups" .-> Identity["Core, Sleeper, and reporting resource lookups"]
+    Generation -. "verifies remembered claims" .-> Snapshot["Frozen Sleeper snapshot"]
+
+    Evaluation["Evaluation service"] --> Workspace["Evaluation-workspace manager"]
+    Workspace -- "owns promotion transaction" --> PrivateMemory["Private session-scoped memory command"]
+    PrivateMemory --> DB
+```
+
+Dependency direction points inward: adapters depend on service contracts;
+services depend on resource objects and managers; managers depend on ORM models.
+The memory package never imports API schemas, reporter tool definitions, or
+worker code.
+
+The port boxes are static consumer views, not a requirement for separate runtime
+classes. The baseline needs only two coordinating application objects:
+
+- `MemoryService`, which exposes the supported operations and owns orchestration;
+- `MemoryManager`, which owns persistence and ordinary memory transactions.
+
+`PinnedMemoryReader` is a small immutable wrapper containing a `MemoryService`
+read delegate and one validated `MemoryRevisionRef`. Retrieval, mutation,
+inspection, and projection behavior may begin as methods or internal functions.
+They should become separate coordinator classes only if they later acquire
+independent dependencies or substantial state.
+
+### Terms that sound similar
+
+| Term | Reads or changes | Intended caller |
+| --- | --- | --- |
+| Pinned retrieval | Reads relevant canonical memory visible at one fixed revision | Reporter tools |
+| History inspection | Reads canonical items, versions, revisions, and provenance | Basic UI or audit code |
+| Search projection | Derived index used to find candidate canonical versions | Internal retrieval pipeline |
+| Search-index administration | Reports index status or rebuilds that derived projection | Maintenance CLI |
+| Workspace promotion | Creates one canonical revision from an eligible evaluation workspace | Evaluation service |
+
+Inspection and pinned retrieval read the same canonical authority for different
+purposes. Search-index administration operates only on a disposable projection.
+Promotion is a write workflow and is unrelated to the word “projection.”
+
+## Public Contract Model
+
+The signatures below define responsibilities and result shapes. Exact Python
+names may change during implementation, but the scoping and ownership rules are
+contractual.
+
+### Shared values
+
+```python
+@dataclass(frozen=True)
+class MemoryRevisionRef:
+    id: UUID
+    competition_id: UUID
+    sequence_number: int
+    state_content_hash: str
+
+
+class MemoryQuery(BaseModel):
+    text: str | None = None
+    entities: tuple[EntityKey, ...] = ()
+    kinds: set[MemoryKind] = Field(default_factory=set)
+    statuses: set[MemoryStatus] = Field(default_factory=set)
+    season_id: UUID | None = None
+    week: int | None = None
+    limit: int = 20
+    expansion: ExpansionPolicy = Field(default_factory=ExpansionPolicy)
+```
+
+`MemoryRevisionRef` contains the validated semantic replay boundary. Knowledge
+and domain cutoffs remain on the generation manifest; the memory service is
+given the exact revision already selected for that generation. Callers pass only
+the revision ID to `at_revision`; the service loads its competition and sequence
+rather than asking the caller to restate them.
+
+A retrieved entry contains:
+
+- the exact stable item and immutable version identifiers;
+- the decoded kind-specific current resource object;
+- requested exact evidence and visible stable-item expansions;
+- named match reasons and rank components;
+- the pinned revision used for visibility.
+
+Search-document text and ORM rows are never part of this result.
+
+### Read contract
+
+```python
+class MemoryReader(Protocol):
+    def current_revision(self, competition_id: UUID) -> MemoryRevisionRef: ...
+
+    def pin_current(self, competition_id: UUID) -> PinnedMemoryReader: ...
+
+    def at_revision(self, revision_id: UUID) -> PinnedMemoryReader: ...
+
+
+class PinnedMemoryReader(Protocol):
+    @property
+    def revision(self) -> MemoryRevisionRef: ...
+
+    def retrieve(self, query: MemoryQuery) -> RetrievedMemory: ...
+
+    def get_version(
+        self,
+        version_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion: ...
+
+    def get_item(
+        self,
+        item_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion: ...
+```
+
+`MemoryService.pin_current` resolves the current revision and creates the
+lightweight capability-bound reader in one service operation. `at_revision`
+does the same for an exact persisted revision ID. The internal retrieval
+pipeline does not create the reader. Calls on the reader delegate back to
+`MemoryService` with the fixed revision reference:
+
+```python
+class _PinnedMemoryReader:
+    def retrieve(self, query: MemoryQuery) -> RetrievedMemory:
+        return self._memory_service._retrieve_at(self._revision, query)
+```
+
+The wrapper is not an open database session. The reporter receives it so its
+tools cannot silently switch competition or revision. Every delegated operation
+still acquires and closes its own short read session through the manager.
+
+`get_item` resolves the version visible at the pinned revision. `get_version`
+accepts an exact version only when that version is visible in the same scope,
+unless a separate inspection contract is used by an authorized audit surface.
+
+### Mutation contract
+
+```python
+class MemoryMutationBundle(BaseModel):
+    producing_generation_id: UUID
+    operations: list[CreateItem | ReplaceItem]
+
+
+class MemoryWriter(Protocol):
+    def apply(self, bundle: MemoryMutationBundle) -> MutationResult: ...
+```
+
+The memory manager loads the producing generation inside the mutation operation
+and derives its competition, season, domain week, knowledge cutoff, and pinned
+input memory revision. A live canonical mutation is allowed only when that
+generation has a canonical revision input; callers cannot restate or override
+those persisted facts.
+
+Each create operation contains complete typed content. Each replacement contains
+the stable item ID, complete replacement content, and an optional change reason.
+Create operations receive item and version UUIDs when their immutable resource
+object is constructed. Those IDs let later creates in the same bundle use the
+ordinary exact-version and stable-item reference contracts; client keys remain
+result-correlation labels rather than a second reference system.
+The generation's pinned base revision is the only optimistic concurrency token.
+Under the locked base, the visible version of every target item is unambiguous.
+Archiving, resolving, firing, or superseding an item is a typed replacement
+rather than an unversioned side effect.
+
+`MutationResult` is one of:
+
+- `NoChange`, retaining the base revision and explaining why no accepted
+  operations remained; or
+- `RevisionCommitted`, returning the new revision reference and the item/version
+  IDs produced by each client operation key.
+
+An empty bundle, an identical replacement, or a repeated transition already
+represented by current content returns `NoChange` without creating a revision.
+Retrying a generation whose revision was already committed returns the existing
+`RevisionCommitted` result. Contradictory operations and invalid references
+remain errors.
+
+The reporter does not receive `MemoryWriter`. It may produce a typed proposal,
+but the generation service decides whether to accept and commit that proposal.
+This keeps canonical writes tied to generation finalization and provenance.
+
+### Basic inspection contract
+
+UI and audit reads use a narrow read-only contract rather than weakening pinned
+reporter reads. The initial surface supports viewing current or historical state
+and does not attempt to predict a full memory-management UI:
+
+```python
+class MemoryInspector(Protocol):
+    def list_items(self, query: MemoryListQuery) -> MemoryPage: ...
+
+    def get_item(
+        self,
+        competition_id: UUID,
+        item_id: UUID,
+        revision_id: UUID | None = None,
+    ) -> HydratedMemoryVersion: ...
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory: ...
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None = None,
+        limit: int = 50,
+    ) -> RevisionPage: ...
+```
+
+Inspection may expose historical versions and mutation provenance, but it still
+returns resource objects and applies competition scope. It is not available to
+ordinary reporter tools. Advanced diffs, analytics, bulk editing, restoration,
+and UI-specific projections are intentionally absent until a user workflow
+requires them.
+
+`MemoryListQuery` groups the optional kind, typed status, cursor, and limit
+filters. If no revision is supplied, the service resolves current state once and
+returns that `MemoryRevisionRef` on `MemoryPage`; the caller does not need to
+coordinate current-revision lookup with pagination.
+
+### Search-index administration contract
+
+```python
+class MemorySearchIndexAdmin(Protocol):
+    def search_index_status(self, competition_id: UUID) -> SearchIndexStatus: ...
+
+    def rebuild_search_index(self, competition_id: UUID) -> RebuildResult: ...
+```
+
+Here, projection means the derived `memory_search_documents` index. It is
+different from history inspection, which reads authoritative canonical
+revisions and versions. `search_index_status` reports only actionable basics
+such as builder version and missing or stale document counts.
+`rebuild_search_index` deterministically recreates those documents from canonical
+versions.
+
+Search-index administration never creates a canonical memory revision. The normal
+mutation path synchronously inserts lexical/entity search documents; it does not
+invoke this administrative API for each write. It does not edit canonical
+content, tune ranking policy, transform memory, or restore historical state.
+
+The first implementation runs status and rebuild synchronously from a CLI. An
+operator API, durable job system, and embedding backfill are deferred until a UI
+or operational need makes them concrete.
+
+### Promotion boundary
+
+Promotion is unrelated to search-index administration. It means
+fast-forwarding the final state of a reporting-owned evaluation workspace into
+one new canonical memory revision.
+
+`EvaluationService.promote_workspace` owns the public workflow because it must
+validate the workspace and final reporting artifact. The evaluation-workspace
+manager then owns one private cross-resource transaction. Within that
+transaction it locks the workspace and canonical current revision, invokes a
+session-scoped internal memory command to apply the already-validated final
+diff, records the promoted revision, and marks the workspace promoted.
+
+The session-scoped command is not a public memory service and never opens or
+commits a transaction. Promotion has no merge, rebase, historical restoration,
+or transformation modes. Retrying an already promoted workspace returns its
+existing promoted revision.
+
+## Component Responsibilities
+
+### 1. Memory contracts and resource objects
+
+`backend/resources/memory/objects.py` owns:
+
+- typed content and discriminated reference models;
+- revision, item, version, query, result, and pagination objects;
+- mutation commands and outcomes;
+- content-schema decoding and conversion entry points.
+
+`backend/resources/memory/errors.py` owns stable application errors. These
+objects are shared by services and adapters, but contain no HTTP status codes or
+provider-specific errors.
+
+Contracts validate local shape and semantic rules such as legal role values,
+event discriminator agreement, required event participants, and duplicate
+references. They do not query the database.
+
+Validation ownership is deliberately singular:
+
+| Validation | Owner |
+| --- | --- |
+| Content shape, discriminators, and pure per-object invariants | Pydantic resource objects |
+| Same-bundle client keys, generated IDs, references, contradictions, and an empty-bundle no-op | `MemoryService.apply` |
+| Persisted target existence, kind/scope, generation provenance, identical-content no-ops, and concurrency | `MemoryManager` transaction |
+
+The manager translates expected database constraint failures at the point where
+it still has query and transaction context. The service does not use a catch-all
+exception mapper to disguise unexpected operational faults.
+
+### 2. Memory resource manager
+
+`backend/resources/memory/manager.py` is the only ordinary application component
+that reads or writes the memory ORM model. It owns:
+
+- competition-scoped canonical revision, item, and version queries;
+- ORM-to-resource conversion and content-schema decoding;
+- revision visibility queries;
+- candidate search against `memory_search_documents`;
+- batched canonical hydration;
+- the short canonical mutation transaction;
+- atomic search-document insertion with new versions;
+- search-index status and replacement primitives used by the admin view.
+
+The manager returns typed resource objects and internal candidate records, never
+ORM instances. It performs no model calls, HTTP calls, embedding calls, or
+long-running work.
+
+No generic `Repository[T]` sits beneath the manager. Memory is an aggregate with
+revision-wide invariants; table-by-table CRUD would expose invalid intermediate
+states.
+
+### 3. Memory service and pinned read view
+
+`backend/services/memory/service.py` is the composition root visible to other
+backend capabilities. One concrete `MemoryService` implements the initial
+reader, writer, inspector, and search-index-administration operations, while each
+consumer is typed against only the narrow protocol it needs.
+
+The facade owns:
+
+- revision validation and creation of `PinnedMemoryReader` values;
+- coordination of retrieval, mutation, basic inspection, and rebuild operations;
+- normalization of bundle-level no-ops and stable service outcomes;
+- explicit resource context and correlation propagation;
+- operation-level observability;
+- exposing narrow consumer ports for composition to inject.
+
+The facade does not contain SQL and does not make memory a global service
+locator.
+
+The pinned reader has no policy of its own beyond retaining its validated scope.
+It delegates retrieval and direct visible-item reads to the same service. It
+exists because preventing scope drift during reporter execution is a real safety
+boundary, not because retrieval needs another orchestration layer.
+
+### 4. Mutation path
+
+The baseline mutation path may live directly in `MemoryService.apply`. It owns
+workflow policy around a submitted bundle:
+
+- decode and validate complete typed operations;
+- validate unique client keys and generated IDs, including same-batch references;
+- return `NoChange` for an empty plan;
+- reject only internally contradictory plans before opening a transaction;
+- call the manager once to apply the complete bundle;
+- propagate the manager's typed persisted-reference and stale-write outcomes.
+
+Within the manager-owned transaction, the implementation locks the current
+revision, requires it to equal the producing generation's input revision,
+batch-validates stored references and provenance, invokes the authoritative
+search-document builder, inserts the canonical revision and complete versions,
+retires replaced versions, verifies the resulting hash, and advances the current
+pointer.
+
+Reference lookups into core, Sleeper, and reporting resources use narrow
+transaction helpers or scoped lookup adapters. They are internal validation
+ports, not public mutation APIs, and they never open or commit the transaction.
+
+Split this path into a separate coordinator only if mutation preparation later
+acquires substantial independent policy or dependencies.
+
+### 5. Internal retrieval pipeline
+
+`backend/services/memory/search.py` owns internal candidate policy rather than
+canonical state:
+
+- translate a `MemoryQuery` into exact filters and signal queries;
+- search, deduplicate, rank, hydrate, expand, and cap results;
+- retain named candidate and score-component values.
+
+Candidate discovery and hydration are separate steps. The manager applies
+competition and pinned-revision visibility before a candidate is eligible.
+Ranking receives only eligible candidates. The retrieval pipeline then
+batch-hydrates the selected exact versions and returns typed aggregates through
+the pinned reader.
+
+This is an internal pipeline, not a public service and not initially a stateful
+class. `MemoryService` invokes it for a fixed scope; `PinnedMemoryReader` is the
+safe caller-facing handle to that invocation.
+
+Retrieval treats remembered claims as narrative leads. It does not verify them
+against Sleeper data; that remains the generation/reporting workflow's
+responsibility using its frozen factual snapshot.
+
+### 6. Search-document construction and maintenance
+
+`backend/resources/memory/search_documents.py` is the only owner of search-
+document construction. It exposes one general dispatcher over the discriminated
+typed memory union and keeps per-kind builders private. Both canonical mutation
+and full rebuild call this same dispatcher; the manager persists its output.
+
+Builders are pure functions. They use only immutable canonical version content,
+including any display-name snapshot stored on the subject reference. They never
+resolve current external names during rebuild. If a stored label is absent, the
+document uses the stable entity key. Given the same typed version, builder
+version, and normalization rules, they produce the same document text, flattened
+keys, reference IDs, and content hash.
+
+`MemoryService.search_index_status` and
+`MemoryService.rebuild_search_index` apply caller scope, stable result contracts,
+and operation observability around deep manager operations. The manager scans
+canonical versions, decodes every retained content schema, calls the
+authoritative dispatcher, and replaces projection rows in bounded batches.
+There is no second rebuild-specific builder.
+
+Optional embeddings are a later adapter behind a narrow `EmbeddingProvider`
+port. Embedding availability cannot be required for canonical writes or baseline
+retrieval.
+
+### 7. Adapters
+
+- Memory API routes authenticate, parse HTTP schemas, construct resource
+  context, call the facade, and translate stable errors to HTTP responses.
+- Reporter memory tools translate compact model-facing tool arguments into
+  `PinnedMemoryReader` calls and serialize bounded results.
+- The generation service pins the revision, supplies the reader to the reporter,
+  receives any typed mutation proposal, and invokes `MemoryWriter` only during
+  finalization.
+- CLI maintenance commands invoke the basic `MemorySearchIndexAdmin` status and
+  rebuild methods; they do not query ORM models directly.
+- The evaluation service owns workspace promotion and composes its reporting
+  manager transaction with the private session-scoped memory command.
+
+Adapters own presentation limits and transport details. They do not duplicate
+visibility SQL, ranking policy, mutation validation, or transaction logic.
+
+## Transaction and Consistency Boundaries
+
+### Reads
+
+Each service call owns a short read session through the manager. A
+`PinnedMemoryReader` carries IDs, not a live transaction. Revision rows and
+versions are immutable, so separate candidate and hydration reads are safe when
+both explicitly enforce the same pinned revision. Batch hydration should be
+preferred to per-result queries.
+
+### Canonical writes
+
+One ordinary live mutation bundle produces zero or one canonical revision in one
+`MemoryManager` transaction. The current revision lock serializes writers for a
+competition. There are no partial item commits, sibling canonical states, or
+projection rows committed without their source versions.
+
+No model call, Sleeper request, embedding call, filesystem operation, or reporter
+execution occurs inside that transaction.
+
+Workspace promotion is the one documented cross-resource exception. Its
+evaluation-workspace manager owns the transaction and invokes private reporting
+and memory commands with the existing session. Public services and adapters
+still never receive or pass database sessions.
+
+### Projection rebuilds
+
+A rebuild reads immutable canonical versions and writes only derived projection
+rows. It is restartable and idempotent for the same builder version. Normal
+canonical writes remain available; a production implementation must replace
+rows in bounded transactions and avoid deleting a valid old projection before
+its replacement is ready.
+
+Ordinary retrieval does not expose a repairable search-index failure to callers.
+It continues with the last valid builder version when present, otherwise falls
+back to exact entity/reference signals and a bounded scan of visible canonical
+versions. The service records degraded operation for the status/rebuild path.
+
+## Error Contract
+
+Stable error categories are part of the service boundary:
+
+| Error | Meaning |
+| --- | --- |
+| `MemoryNotFound` | Scoped item, version, or revision does not exist |
+| `MemoryScopeViolation` | A target belongs to another competition or is outside caller scope |
+| `InvalidMemoryContent` | Typed content, role, discriminator, or reference policy is invalid |
+| `InvalidMemoryReference` | Referenced target is missing, duplicated, or the wrong kind |
+| `StaleCanonicalRevision` | The competition advanced beyond the submitted base revision |
+
+Adapters translate these errors for their transports. Callers never inspect
+constraint names, SQLAlchemy exceptions, or raw PostgreSQL messages. Unexpected
+database faults remain operational errors and are not mislabeled as user input.
+
+## Proposed Package Shape
+
+```text
+backend/
+├── resources/memory/
+│   ├── __init__.py
+│   ├── objects.py
+│   ├── errors.py
+│   ├── manager.py
+│   └── search_documents.py
+├── services/memory/
+│   ├── __init__.py
+│   ├── contracts.py
+│   ├── service.py
+│   └── search.py
+├── api/routes/memory.py
+└── services/reporter/tools/memory.py
+```
+
+`contracts.py` contains the narrow consumer protocols, not duplicate data
+models. Resource objects stay in `resources/memory/objects.py` so managers,
+services, routes, and tools agree on one application representation.
+
+The private session-scoped promotion command is added only with promotion
+integration and receives a name that describes the invariant it owns. The
+baseline does not reserve a generic `shared.py` module.
+
+This is a starting shape, not a mandate to pre-create empty modules. Keep
+mutation orchestration in `service.py` initially. Split ranking or mutation
+planning into submodules only when their implementation size and dependencies
+justify it. Search-document construction remains singular even if its private
+per-kind functions later move into a subpackage.
+
+## Implementation Slices
+
+1. **Contracts and conversion:** implement content/reference objects, stable
+   errors, schema-version decoders, and contract tests.
+2. **Canonical reads:** implement revision, visible-item, exact-version, history,
+   and batch-hydration manager queries.
+3. **Search-document builder:** implement one deterministic dispatcher with
+   private per-kind builders and golden tests for every initial memory kind.
+4. **Canonical mutation:** implement complete-bundle validation and the single
+   manager-owned transaction, including atomic projection insertion.
+5. **Retrieval:** implement `MemoryService.at_revision`, the pinned reader,
+   pinned filtering, signal queries, named ranking, hydration, and bounded
+   reporter results.
+6. **Basic operational surfaces and replacement:** add canonical viewing and
+   item history, search-index status/rebuild CLI operations, wire generation and
+   reporter consumers, and delete corresponding legacy `reporter_memory`
+   retrieval/ranking paths as each behavior reaches parity. Defer UI-specific
+   API shapes.
+7. **Optional retrieval extensions:** add embeddings only after baseline
+   lexical/entity retrieval is measured.
+
+Each slice should leave one usable abstraction in place. Reporter integration
+should depend on the public reader/writer contracts rather than reaching into an
+incomplete manager or projection implementation.
+
+## Acceptance Boundaries
+
+The service boundary is complete when:
+
+- no concrete reader/writer/inspector/admin wrapper exists unless it enforces an
+  invariant beyond direct delegation;
+- every `MemoryService` method owns at least scope resolution, normalization,
+  stable result/error policy, observability, or multi-step orchestration;
+- a reporter run can retrieve only from its pinned competition and revision;
+- every returned memory is a decoded canonical type with named match reasons;
+- a complete mutation bundle produces zero or one revision atomically;
+- empty, identical, and already-applied mutation bundles do not create revisions;
+- stale canonical writers receive a stable application error;
+- same-batch and stored references are kind- and competition-validated;
+- new canonical versions are immediately available to lexical/entity retrieval;
+- projection rebuild changes no canonical revision or content;
+- API and reporter adapters contain no ORM queries or memory policy;
+- a new event payload type can be added without changing unrelated service
+  contracts.

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -1,0 +1,146 @@
+# Memory Service Implementation Status
+
+## Current Phase
+
+**Phase:** Application memory implementation
+**Architecture:** Modular-monolith service with typed Python contracts
+**Persistence:** Canonical PostgreSQL schema and search-document table implemented
+**Compatibility:** Clean replacement; legacy `reporter_memory` persistence APIs
+are not preserved
+
+## Components
+
+| Component | Status | Output |
+| --- | --- | --- |
+| Canonical revision and typed-version schema | Implemented | `../database/memory.md` |
+| Typed content and reference design | Designed | `application-contracts.md` |
+| Service boundaries and public contracts | Designed | `service-architecture.md` |
+| Resource objects and schema converters | Implemented | `backend/resources/memory/objects.py` |
+| Stable application errors | Implemented | `backend/resources/memory/errors.py` |
+| Memory resource manager and canonical reads | Pending | `backend/resources/memory/manager.py` |
+| Complete-bundle mutation transaction | Pending | Generation-derived context plus `MemoryManager` transaction |
+| Authoritative search-document builder | Pending | `backend/resources/memory/search_documents.py` |
+| Revision-pinned retrieval and hydration | Pending | `MemoryService.at_revision` plus internal retrieval pipeline |
+| Service facade and consumer protocols | Pending | `backend/services/memory/` |
+| Basic canonical viewing and item history | Pending | `MemoryInspector` capability on `MemoryService` |
+| Search-index status and rebuild CLI | Pending | `MemorySearchIndexAdmin` consumer port on `MemoryService` |
+| Evaluation-workspace promotion integration | Pending | Evaluation-workspace manager-owned cross-resource transaction |
+| Reporter/generation adapters | Pending | Reporter service memory tools |
+| UI-specific memory API | Deferred | Shape after initial memory UX is designed |
+| Legacy `reporter_memory` removal | Pending | After behavior parity |
+| Vector embeddings | Deferred | Add only after baseline retrieval measurement |
+| Decision history | Current | `log.md` |
+
+## Settled Baseline
+
+- Canonical memory is one linear revision history per competition.
+- Storyline, fact, event, trigger, and context-note versions own complete typed
+  content.
+- Exact evidence targets immutable version IDs; evolving relationships target
+  stable item IDs.
+- The public application boundary returns resource objects, never ORM rows or
+  search documents.
+- Generation-time reads use a capability-bound pinned reader.
+- `MemoryService` creates the pinned reader; its methods delegate to the same
+  internal retrieval pipeline with a fixed scope.
+- The reporter proposes memory changes but cannot commit canonical state.
+- A mutation bundle names its producing generation; the memory manager derives
+  competition, cutoffs, season, and its one base-revision concurrency token.
+- Empty, identical, already-applied, and retry mutation cases return stable
+  no-op/existing results rather than creating revisions or avoidable errors.
+- An ordinary mutation creates zero or one revision in one short manager-owned
+  transaction.
+- Search documents are derived, synchronously created for new versions, and
+  independently rebuildable.
+- Mutation and rebuild use one authoritative deterministic document builder
+  registry based only on immutable version content.
+- Inspector and search-index-admin contracts are narrow consumer ports on the
+  service, not runtime authorization and not mandatory coordinator classes.
+- Inspection is limited to viewing canonical items/revisions and item history;
+  search-index administration is limited to derived-projection status and
+  rebuild.
+- Evaluation promotion is a fast-forward write owned by the evaluation service,
+  not an inspection or search-projection operation.
+- Remembered claims remain narrative leads and must be verified against the
+  generation's frozen Sleeper snapshot.
+
+## Implementation Sequence
+
+| Slice | State | Completion signal |
+| --- | --- | --- |
+| 1. Contracts, errors, and schema converters | Complete | All initial typed payloads decode and validate with unit coverage |
+| 2. Canonical reads and hydration manager | In progress | Revision-pinned item/version/history queries pass PostgreSQL tests |
+| 3. Search-document builder | In progress | One dispatcher produces identical mutation/rebuild output for every kind |
+| 4. Canonical mutation transaction | Not started | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
+| 5. Pinned retrieval pipeline | Not started | Entity, evidence, related-item, lexical, and historical-leakage tests pass |
+| 6. Basic viewing, promotion integration, reporter/generation, and rebuild CLI | Not started | Narrow capabilities work without UI-specific business logic |
+| 7. Legacy removal | Not started | No active imports or writes depend on `reporter_memory` |
+
+## Remaining Decisions
+
+One non-blocking tuning decision remains:
+
+- maximum default retrieval result and evidence-expansion limits.
+
+These do not block implementation of the shared reference primitives, revision
+objects, stable errors, content-schema conversion framework, or canonical read
+manager.
+
+## Explicitly Deferred
+
+- canonical branches, merges, and sibling histories;
+- a separately deployed memory microservice;
+- a generic graph or generic CRUD repository;
+- embeddings and approximate vector indexes;
+- durable rebuild jobs, leases, and automatic resume;
+- candidate-level access counters and generalized RAG telemetry;
+- advanced inspection, diffing, analytics, bulk editing, and restoration;
+- an operator or user-facing projection API before a concrete UI need;
+- legacy SQLite import or dual-read/dual-write compatibility.
+
+Deferred seams should not become placeholder tables or unused interfaces. Add a
+decision-log entry before expanding the baseline.
+
+## Next Milestone
+
+Complete slice 2 revision-pinned canonical reads and slice 3 deterministic
+search-document construction, including real PostgreSQL manager coverage. Then
+implement canonical mutation before adding public adapters.
+
+## PR Stack Coordination
+
+The application implementation is delivered as a `gh stack` series based on
+`main@32b2d88`. Agents own only the paths assigned below. Shared-path changes are
+integrated by `root` after the owning agent reports completion.
+
+| Stack layer | Branch | Owner | State | Assigned paths |
+| --- | --- | --- | --- | --- |
+| 1. Design and resource contracts | `codex/memory-service-contracts` | `contracts_agent` | Complete | `docs/memory/`; `backend/resources/memory/objects.py`; `errors.py`; resource contract tests |
+| 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | In progress | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
+| 3. Canonical mutation | `codex/memory-service-mutations` | Unassigned | Pending | mutation methods and transaction tests; no public adapters |
+| 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `service_agent` | In progress | `backend/services/memory/`; retrieval/inspection tests |
+| 5. Composition and adapters | `codex/memory-service-integration` | `root` | Pending | composition, reporter tools, minimal API/CLI adapters, legacy-path removal, integration tests |
+| 6. Workspace promotion | `codex/memory-workspace-promotion` | Unassigned | Pending | reporting-owned promotion workflow and private memory command |
+
+Coordination rules:
+
+- A stack layer may be split or combined only with a new `log.md` decision.
+- `objects.py` and `search_documents.py` are the sole authorities for typed
+  content and deterministic search-document construction respectively.
+- Agents do not add alternate repositories, per-kind service methods, or
+  projection-specific builders.
+- Status moves to `Complete` only after the layer's focused tests pass and root
+  reviews the resulting diff.
+- Promotion remains the final layer because it requires the reporting resource
+  boundary; it must not leak sessions into public services.
+
+## Verification Expectations
+
+- Resource-contract tests use no database.
+- Manager and mutation tests use real PostgreSQL; SQLite and mocked ORM sessions
+  are not substitutes for revision and concurrency behavior.
+- Search builders have deterministic golden tests.
+- Retrieval tests prove that revision `R` cannot see versions introduced at
+  `R + 1`.
+- Adapter tests prove that ORM and search-document shapes do not cross the
+  service boundary.

--- a/docs/memory/transition.md
+++ b/docs/memory/transition.md
@@ -33,7 +33,8 @@ retrieval projection.
 - add a content-schema version to immutable typed content;
 - add Pydantic-backed subjects, evidence, thematic references, event payloads,
   and trigger conditions to their owning typed version tables;
-- make manager methods accept complete kind-specific content objects;
+- make public service methods accept complete kind-specific content objects and
+  keep their persistence translation inside the memory manager;
 - move target-kind, role, scope, and payload validation into the application
   mutation boundary;
 - replace type-specific search paths with one search-document manager.
@@ -66,10 +67,12 @@ work should proceed in this order:
    versions.
 3. **Change typed storage.** Add the new typed fields and content-schema version
    while retaining the linear revision envelope.
-4. **Implement complete mutation APIs.** Add transactional reference validation,
-   full replacement, and typed errors.
-5. **Add the search projection.** Build it synchronously for accepted canonical
-   versions and provide a deterministic rebuild command/service operation.
+4. **Implement complete mutation APIs.** Add the public mutation service,
+   manager-owned transactional reference validation, full replacement, and typed
+   errors.
+5. **Add the search projection.** Implement one authoritative search-document
+   dispatcher used by both synchronous canonical writes and deterministic
+   rebuilds.
 6. **Switch reporter retrieval.** Search projection first, then hydrate canonical
    typed aggregates and exact evidence.
 7. **Remove generic graph writes and tables.** Delete the old entity/relationship
@@ -100,9 +103,10 @@ historically safe:
 
 - Pydantic unit tests for each content and reference discriminator;
 - manager tests for complete replacement and application error behavior;
-- transaction tests for stale writers and atomic projection insertion;
+- transaction tests for stale writers, idempotent retries, no-op normalization,
+  and atomic projection insertion;
 - historical-visibility tests for exact revision pinning;
-- search-builder golden tests and deterministic rebuild tests;
+- search-builder golden tests proving mutation and rebuild use identical output;
 - retrieval tests for entity, evidence, full-text, and later vector candidates;
 - hydration tests proving search documents are never returned as canonical
   memory;
@@ -112,5 +116,4 @@ historically safe:
 
 - final role enums and reference cardinalities;
 - which event payload types are required in the first implementation;
-- projection rebuild command/API ownership;
 - embedding provider, model, and retention policy;


### PR DESCRIPTION
## Summary

- define immutable, typed canonical-memory contracts for all five v1 content kinds
- add stable boundary errors, role-free entity keys, references, mutations, and result models
- record the service boundaries, implementation status, and settled decisions in `docs/memory`

## Design

This establishes consumer-facing ports without treating Python protocols as runtime authorization. The contracts use one general discriminated mutation surface instead of kind-specific service methods.

## Verification

- full-stack workspace suite: 310 passed, 70 PostgreSQL-only skips
- focused contract coverage included in `backend/tests/resources/memory/test_objects.py`

Stack 1/5. Base: `main`.
