### PR TITLE
feat(memory): add canonical reads and search

### DIFF
--- a/backend/resources/memory/manager.py
+++ b/backend/resources/memory/manager.py
@@ -1,0 +1,1007 @@
+"""Canonical memory persistence and revision-grounded read operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session, aliased
+
+from backend.database.models.memory import (
+    ContextNote,
+    ContextNoteVersion,
+    CurrentRevision,
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.memory.errors import (
+    MemoryNotFound,
+    MemoryScopeViolation,
+    SearchProjectionUnavailable,
+)
+from backend.resources.memory.objects import (
+    DEFAULT_EXPANSION,
+    ExpansionPolicy,
+    HydratedMemoryVersion,
+    ItemHistory,
+    MemoryListQuery,
+    MemoryPage,
+    MemoryQuery,
+    MemoryRevision as MemoryRevisionResource,
+    MemoryRevisionRef,
+    MemoryKind,
+    RebuildResult,
+    RevisionPage,
+    SearchIndexStatus,
+    TypedMemoryVersion,
+    decode_memory_content,
+)
+from backend.resources.memory.search_documents import (
+    SEARCH_DOCUMENT_BUILDER_VERSION,
+    SearchDocument,
+    build_search_document,
+    entity_search_key,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryCandidate:
+    """One compact projection match returned to retrieval policy."""
+
+    version_id: UUID
+    kind: str
+    match_reasons: tuple[str, ...]
+    rank_components: Mapping[str, float]
+    matched_entities: tuple[str, ...]
+
+
+class MemoryManager:
+    """Deep persistence boundary for the canonical memory aggregate."""
+
+    def __init__(self, session_factory: SessionFactory) -> None:
+        self._session_factory = session_factory
+
+    def current_revision(self, competition_id: UUID) -> MemoryRevisionRef:
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(
+                sa.select(MemoryRevision)
+                .join(
+                    CurrentRevision,
+                    sa.and_(
+                        CurrentRevision.current_revision_id == MemoryRevision.id,
+                        CurrentRevision.competition_id
+                        == MemoryRevision.competition_id,
+                    ),
+                )
+                .where(CurrentRevision.competition_id == competition_id)
+            ).scalar_one_or_none()
+            if row is None:
+                raise MemoryNotFound(
+                    f"current memory revision not found for {competition_id}"
+                )
+            return _revision_ref(row)
+
+    def get_revision(
+        self,
+        revision_id: UUID,
+        competition_id: UUID | None = None,
+    ) -> MemoryRevisionRef:
+        with read_only_session(self._session_factory) as session:
+            row = session.get(MemoryRevision, revision_id)
+            if row is None:
+                raise MemoryNotFound(f"memory revision not found: {revision_id}")
+            if competition_id is not None and row.competition_id != competition_id:
+                raise MemoryScopeViolation(
+                    f"memory revision is outside competition scope: {revision_id}"
+                )
+            return _revision_ref(row)
+
+    def get_visible_item(
+        self,
+        revision: MemoryRevisionRef,
+        item_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion:
+        with read_only_session(self._session_factory) as session:
+            item = session.get(MemoryItem, item_id)
+            if item is None:
+                raise MemoryNotFound(f"memory item not found: {item_id}")
+            if item.competition_id != revision.competition_id:
+                raise MemoryScopeViolation(
+                    f"memory item is outside competition scope: {item_id}"
+                )
+            version_id = session.scalar(
+                _visible_versions(revision)
+                .with_only_columns(MemoryVersion.id)
+                .where(MemoryVersion.item_id == item_id)
+            )
+            if version_id is None:
+                raise MemoryScopeViolation(
+                    f"memory item is not visible at revision {revision.id}: {item_id}"
+                )
+            return _hydrate_visible_versions(
+                session, revision, [version_id], expansion
+            )[version_id]
+
+    def get_visible_version(
+        self,
+        revision: MemoryRevisionRef,
+        version_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion:
+        with read_only_session(self._session_factory) as session:
+            return _hydrate_visible_versions(
+                session, revision, [version_id], expansion
+            )[version_id]
+
+    def hydrate_visible_versions(
+        self,
+        revision: MemoryRevisionRef,
+        version_ids: Sequence[UUID],
+        expansion: ExpansionPolicy,
+    ) -> Mapping[UUID, HydratedMemoryVersion]:
+        if not version_ids:
+            return {}
+        with read_only_session(self._session_factory) as session:
+            return _hydrate_visible_versions(session, revision, version_ids, expansion)
+
+    def list_visible_items(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryListQuery,
+    ) -> MemoryPage:
+        if query.competition_id != revision.competition_id:
+            raise MemoryScopeViolation(
+                "list query competition does not match the pinned revision"
+            )
+        statement = _visible_versions(revision).join(
+            MemoryItem,
+            MemoryItem.id == MemoryVersion.item_id,
+        )
+        if query.kinds:
+            statement = statement.where(
+                MemoryItem.kind.in_([kind.value for kind in query.kinds])
+            )
+        if query.statuses:
+            statement = statement.where(
+                sa.or_(*(_status_matches(status.value) for status in query.statuses))
+            )
+        if query.cursor is not None:
+            statement = statement.where(MemoryItem.id > _uuid_cursor(query.cursor))
+        statement = statement.order_by(MemoryItem.id).limit(query.limit + 1)
+
+        with read_only_session(self._session_factory) as session:
+            rows = list(
+                session.execute(
+                    statement.with_only_columns(MemoryItem.id, MemoryVersion.id)
+                )
+            )
+            page_rows = rows[: query.limit]
+            page_ids = [row[1] for row in page_rows]
+            hydrated = _hydrate_visible_versions(
+                session,
+                revision,
+                page_ids,
+                DEFAULT_EXPANSION,
+            )
+        next_cursor = str(page_rows[-1][0]) if len(rows) > query.limit else None
+        return MemoryPage(
+            revision=revision,
+            items=tuple(hydrated[version_id] for version_id in page_ids),
+            next_cursor=next_cursor,
+        )
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory:
+        with read_only_session(self._session_factory) as session:
+            item = session.get(MemoryItem, item_id)
+            if item is None:
+                raise MemoryNotFound(f"memory item not found: {item_id}")
+            if item.competition_id != competition_id:
+                raise MemoryScopeViolation(
+                    f"memory item is outside competition scope: {item_id}"
+                )
+            version_ids = list(
+                session.scalars(
+                    sa.select(MemoryVersion.id)
+                    .where(
+                        MemoryVersion.item_id == item_id,
+                        MemoryVersion.competition_id == competition_id,
+                    )
+                    .order_by(MemoryVersion.revision_number)
+                )
+            )
+            versions = _load_typed_versions(session, version_ids)
+        return ItemHistory(
+            competition_id=competition_id,
+            item_id=item_id,
+            versions=tuple(versions[version_id] for version_id in version_ids),
+        )
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None,
+        limit: int,
+    ) -> RevisionPage:
+        if not 1 <= limit <= 100:
+            raise ValueError("revision page limit must be between 1 and 100")
+        statement = sa.select(MemoryRevision).where(
+            MemoryRevision.competition_id == competition_id
+        )
+        if cursor is not None:
+            statement = statement.where(
+                MemoryRevision.sequence_number < _sequence_cursor(cursor)
+            )
+        statement = statement.order_by(MemoryRevision.sequence_number.desc()).limit(
+            limit + 1
+        )
+        with read_only_session(self._session_factory) as session:
+            rows = list(session.scalars(statement))
+        page_rows = rows[:limit]
+        next_cursor = (
+            str(page_rows[-1].sequence_number) if len(rows) > limit else None
+        )
+        return RevisionPage(
+            competition_id=competition_id,
+            revisions=tuple(_revision_resource(row) for row in page_rows),
+            next_cursor=next_cursor,
+        )
+
+    def find_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> Sequence[MemoryCandidate]:
+        """Find compact candidates only when the current projection is complete."""
+
+        visible = _visible_versions(revision).with_only_columns(
+            MemoryVersion.id
+        ).subquery()
+        with read_only_session(self._session_factory) as session:
+            projection_incomplete = session.scalar(
+                sa.select(
+                    sa.exists(
+                        sa.select(1)
+                        .select_from(visible)
+                        .outerjoin(
+                            MemorySearchDocument,
+                            MemorySearchDocument.version_id == visible.c.id,
+                        )
+                        .where(
+                            sa.or_(
+                                MemorySearchDocument.version_id.is_(None),
+                                MemorySearchDocument.builder_version
+                                != SEARCH_DOCUMENT_BUILDER_VERSION,
+                            )
+                        )
+                    )
+                )
+            )
+            if projection_incomplete:
+                raise SearchProjectionUnavailable
+
+            entity_keys = tuple(
+                sorted({entity_search_key(entity) for entity in query.entities})
+            )
+            text_query = (
+                sa.func.plainto_tsquery("english", query.text)
+                if query.text is not None
+                else None
+            )
+            lexical_rank = (
+                sa.func.ts_rank_cd(
+                    MemorySearchDocument.search_vector,
+                    text_query,
+                )
+                if text_query is not None
+                else sa.literal(0.0)
+            ).label("lexical_rank")
+            statement = (
+                sa.select(MemorySearchDocument, lexical_rank)
+                .join(visible, visible.c.id == MemorySearchDocument.version_id)
+                .where(
+                    MemorySearchDocument.builder_version
+                    == SEARCH_DOCUMENT_BUILDER_VERSION
+                )
+            )
+            if query.kinds:
+                statement = statement.where(
+                    MemorySearchDocument.kind.in_(
+                        [kind.value for kind in query.kinds]
+                    )
+                )
+            if query.statuses:
+                statement = statement.where(
+                    MemorySearchDocument.status.in_(
+                        [status.value for status in query.statuses]
+                    )
+                )
+            if query.season_id is not None:
+                statement = statement.where(
+                    MemorySearchDocument.competition_season_id == query.season_id
+                )
+            if query.week is not None:
+                statement = statement.where(MemorySearchDocument.week == query.week)
+            signals: list[sa.ColumnElement[bool]] = []
+            if text_query is not None:
+                signals.append(
+                    MemorySearchDocument.search_vector.op("@@")(text_query)
+                )
+            if entity_keys:
+                signals.append(MemorySearchDocument.entity_keys.overlap(entity_keys))
+            if signals:
+                statement = statement.where(sa.or_(*signals))
+            statement = statement.order_by(
+                lexical_rank.desc(),
+                MemorySearchDocument.salience.desc().nullslast(),
+                MemorySearchDocument.version_id,
+            ).limit(min(query.limit * 4, 400))
+            rows = session.execute(statement).all()
+
+        return tuple(
+            _candidate_from_document(
+                document,
+                float(lexical_score),
+                entity_keys,
+                has_text=query.text is not None,
+            )
+            for document, lexical_score in rows
+        )
+
+    def scan_visible_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+        limit: int,
+    ) -> Sequence[MemoryCandidate]:
+        """Bounded canonical fallback used only while the projection needs repair."""
+
+        statement = _visible_versions(revision).join(
+            MemoryItem,
+            MemoryItem.id == MemoryVersion.item_id,
+        )
+        if query.kinds:
+            statement = statement.where(
+                MemoryItem.kind.in_([kind.value for kind in query.kinds])
+            )
+        if query.season_id is not None:
+            statement = statement.where(
+                MemoryVersion.competition_season_id == query.season_id
+            )
+        if query.week is not None:
+            statement = statement.where(MemoryVersion.week == query.week)
+        statement = statement.order_by(
+            MemoryVersion.recorded_at.desc(), MemoryVersion.id
+        ).limit(500)
+
+        with read_only_session(self._session_factory) as session:
+            version_ids = list(
+                session.scalars(statement.with_only_columns(MemoryVersion.id))
+            )
+            versions = _load_typed_versions(session, version_ids)
+
+        entity_keys = tuple(
+            sorted({entity_search_key(entity) for entity in query.entities})
+        )
+        candidates: list[MemoryCandidate] = []
+        for version_id in version_ids:
+            document = build_search_document(versions[version_id])
+            if query.statuses and document.status not in {
+                status.value for status in query.statuses
+            }:
+                continue
+            lexical_match = _fallback_text_matches(query.text, document.document_text)
+            entity_match = bool(set(entity_keys) & set(document.entity_keys))
+            if (query.text is not None or entity_keys) and not (
+                lexical_match or entity_match
+            ):
+                continue
+            candidates.append(
+                _candidate_from_document(
+                    document,
+                    0.5 if lexical_match else 0.0,
+                    entity_keys,
+                    has_text=query.text is not None,
+                )
+            )
+            if len(candidates) >= limit:
+                break
+        return tuple(candidates)
+
+    def search_index_status(self, competition_id: UUID) -> SearchIndexStatus:
+        with read_only_session(self._session_factory) as session:
+            total = session.scalar(
+                sa.select(sa.func.count())
+                .select_from(MemoryVersion)
+                .where(MemoryVersion.competition_id == competition_id)
+            ) or 0
+            indexed = session.scalar(
+                sa.select(sa.func.count())
+                .select_from(MemorySearchDocument)
+                .where(
+                    MemorySearchDocument.competition_id == competition_id,
+                    MemorySearchDocument.builder_version
+                    == SEARCH_DOCUMENT_BUILDER_VERSION,
+                )
+            ) or 0
+            missing = session.scalar(
+                sa.select(sa.func.count())
+                .select_from(MemoryVersion)
+                .outerjoin(
+                    MemorySearchDocument,
+                    MemorySearchDocument.version_id == MemoryVersion.id,
+                )
+                .where(
+                    MemoryVersion.competition_id == competition_id,
+                    MemorySearchDocument.version_id.is_(None),
+                )
+            ) or 0
+            stale = session.scalar(
+                sa.select(sa.func.count())
+                .select_from(MemorySearchDocument)
+                .where(
+                    MemorySearchDocument.competition_id == competition_id,
+                    MemorySearchDocument.builder_version
+                    != SEARCH_DOCUMENT_BUILDER_VERSION,
+                )
+            ) or 0
+        return SearchIndexStatus(
+            competition_id=competition_id,
+            builder_version=SEARCH_DOCUMENT_BUILDER_VERSION,
+            canonical_version_count=total,
+            indexed_document_count=indexed,
+            missing_document_count=missing,
+            stale_document_count=stale,
+        )
+
+    def rebuild_search_index(
+        self,
+        competition_id: UUID,
+        *,
+        batch_size: int = 200,
+    ) -> RebuildResult:
+        """Rebuild projection rows from immutable canonical versions in batches."""
+
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        rebuilt = 0
+        cursor: UUID | None = None
+        while True:
+            with read_only_session(self._session_factory) as session:
+                statement = (
+                    sa.select(MemoryVersion.id)
+                    .where(MemoryVersion.competition_id == competition_id)
+                    .order_by(MemoryVersion.id)
+                    .limit(batch_size)
+                )
+                if cursor is not None:
+                    statement = statement.where(MemoryVersion.id > cursor)
+                version_ids = list(session.scalars(statement))
+                versions = _load_typed_versions(session, version_ids)
+            if not version_ids:
+                break
+            self._write_search_documents(
+                [
+                    build_search_document(versions[version_id])
+                    for version_id in version_ids
+                ]
+            )
+            rebuilt += len(version_ids)
+            cursor = version_ids[-1]
+        return RebuildResult(
+            competition_id=competition_id,
+            builder_version=SEARCH_DOCUMENT_BUILDER_VERSION,
+            rebuilt_document_count=rebuilt,
+        )
+
+    def _write_search_documents(self, documents: Sequence[SearchDocument]) -> None:
+        """Atomically install deterministic projection rows for exact versions."""
+
+        if not documents:
+            return
+        with transaction_session(self._session_factory) as session:
+            _persist_search_documents(session, documents)
+
+
+def _revision_ref(revision: MemoryRevision) -> MemoryRevisionRef:
+    return MemoryRevisionRef(
+        id=revision.id,
+        competition_id=revision.competition_id,
+        sequence_number=revision.sequence_number,
+        state_content_hash=revision.state_content_hash,
+    )
+
+
+def _revision_resource(revision: MemoryRevision) -> MemoryRevisionResource:
+    return MemoryRevisionResource(
+        id=revision.id,
+        competition_id=revision.competition_id,
+        sequence_number=revision.sequence_number,
+        state_content_hash=revision.state_content_hash,
+        previous_revision_id=revision.previous_revision_id,
+        producing_generation_id=revision.producing_generation_id,
+        competition_season_id=revision.competition_season_id,
+        week=revision.week,
+        knowledge_cutoff_at=revision.knowledge_cutoff_at,
+        created_at=revision.created_at,
+    )
+
+
+def _visible_versions(revision: MemoryRevisionRef) -> sa.Select[Any]:
+    introduced = aliased(MemoryRevision, name="introduced_revision")
+    retired = aliased(MemoryRevision, name="retired_revision")
+    return (
+        sa.select(MemoryVersion)
+        .join(
+            introduced,
+            sa.and_(
+                introduced.id == MemoryVersion.introduced_revision_id,
+                introduced.competition_id == MemoryVersion.competition_id,
+            ),
+        )
+        .outerjoin(
+            retired,
+            sa.and_(
+                retired.id == MemoryVersion.retired_revision_id,
+                retired.competition_id == MemoryVersion.competition_id,
+            ),
+        )
+        .where(
+            MemoryVersion.competition_id == revision.competition_id,
+            introduced.sequence_number <= revision.sequence_number,
+            sa.or_(
+                MemoryVersion.retired_revision_id.is_(None),
+                retired.sequence_number > revision.sequence_number,
+            ),
+        )
+    )
+
+
+def _hydrate_visible_versions(
+    session: Session,
+    revision: MemoryRevisionRef,
+    version_ids: Sequence[UUID],
+    expansion: ExpansionPolicy,
+) -> dict[UUID, HydratedMemoryVersion]:
+    unique_ids = tuple(dict.fromkeys(version_ids))
+    if not unique_ids:
+        return {}
+    visible_ids = set(
+        session.scalars(
+            _visible_versions(revision)
+            .with_only_columns(MemoryVersion.id)
+            .where(MemoryVersion.id.in_(unique_ids))
+        )
+    )
+    missing = [version_id for version_id in unique_ids if version_id not in visible_ids]
+    if missing:
+        _raise_invisible_version(session, revision, missing[0])
+
+    versions = _load_typed_versions(session, unique_ids)
+    evidence_ids: set[UUID] = set()
+    related_item_ids: set[UUID] = set()
+    if expansion.include_evidence:
+        for version in versions.values():
+            if version.kind == MemoryKind.STORYLINE:
+                evidence_ids.update(
+                    reference.version_id for reference in version.content.evidence
+                )
+            elif version.kind == MemoryKind.FACT:
+                evidence_ids.update(version.content.originating_event_version_ids)
+    if expansion.include_related_items:
+        for version in versions.values():
+            if version.kind == MemoryKind.STORYLINE:
+                related_item_ids.update(
+                    reference.item_id
+                    for reference in version.content.related_storylines
+                )
+            elif version.kind == MemoryKind.TRIGGER:
+                related_item_ids.update(
+                    item_id
+                    for item_id in (
+                        version.content.target_storyline_item_id,
+                        version.content.origin_event_item_id,
+                    )
+                    if item_id is not None
+                )
+
+    evidence = _load_evidence_versions(session, revision, evidence_ids)
+    related = _load_visible_items(session, revision, related_item_ids)
+    hydrated: dict[UUID, HydratedMemoryVersion] = {}
+    for version_id in unique_ids:
+        version = versions[version_id]
+        hydrated[version_id] = HydratedMemoryVersion(
+            version=version,
+            evidence=tuple(
+                evidence[evidence_id]
+                for evidence_id in _evidence_ids(version)
+                if evidence_id in evidence
+            ),
+            related_items=tuple(
+                related[item_id]
+                for item_id in _related_item_ids(version)
+                if item_id in related
+            ),
+        )
+    return hydrated
+
+
+def _load_typed_versions(
+    session: Session,
+    version_ids: Sequence[UUID],
+) -> dict[UUID, TypedMemoryVersion]:
+    if not version_ids:
+        return {}
+    rows = session.execute(
+        sa.select(MemoryVersion, MemoryItem)
+        .join(MemoryItem, MemoryItem.id == MemoryVersion.item_id)
+        .where(MemoryVersion.id.in_(version_ids))
+    ).all()
+    envelopes = {version.id: (version, item) for version, item in rows}
+    if len(envelopes) != len(set(version_ids)):
+        missing = next(
+            version_id for version_id in version_ids if version_id not in envelopes
+        )
+        raise MemoryNotFound(f"memory version not found: {missing}")
+
+    ids_by_kind: dict[MemoryKind, list[UUID]] = {}
+    for version, item in envelopes.values():
+        try:
+            kind = MemoryKind(item.kind)
+        except ValueError as error:
+            raise ValueError(f"unsupported stored memory kind: {item.kind}") from error
+        ids_by_kind.setdefault(kind, []).append(version.id)
+
+    typed_rows: dict[UUID, object] = {}
+    table_by_kind = {
+        MemoryKind.STORYLINE: StorylineVersion,
+        MemoryKind.FACT: FactVersion,
+        MemoryKind.EVENT: EventVersion,
+        MemoryKind.TRIGGER: TriggerVersion,
+        MemoryKind.CONTEXT_NOTE: ContextNoteVersion,
+    }
+    for kind, ids in ids_by_kind.items():
+        typed_rows.update(
+            {
+                row.version_id: row
+                for row in session.scalars(
+                    sa.select(table_by_kind[kind]).where(
+                        table_by_kind[kind].version_id.in_(ids)
+                    )
+                )
+            }
+        )
+
+    context_identities = {
+        row.item_id: row
+        for row in session.scalars(
+            sa.select(ContextNote).where(
+                ContextNote.item_id.in_(
+                    [
+                        item.id
+                        for _, item in envelopes.values()
+                        if item.kind == MemoryKind.CONTEXT_NOTE.value
+                    ]
+                )
+            )
+        )
+    }
+    decoded: dict[UUID, TypedMemoryVersion] = {}
+    for version_id, (envelope, item) in envelopes.items():
+        typed_row = typed_rows.get(version_id)
+        if typed_row is None:
+            raise MemoryNotFound(f"typed memory content not found: {version_id}")
+        kind = MemoryKind(item.kind)
+        content = decode_memory_content(
+            kind,
+            envelope.content_schema_version,
+            _content_payload(kind, typed_row),
+        )
+        identity_row = context_identities.get(item.id)
+        decoded[version_id] = TypedMemoryVersion(
+            version_id=envelope.id,
+            item_id=envelope.item_id,
+            competition_id=envelope.competition_id,
+            kind=kind,
+            revision_number=envelope.revision_number,
+            content_schema_version=envelope.content_schema_version,
+            introduced_revision_id=envelope.introduced_revision_id,
+            retired_revision_id=envelope.retired_revision_id,
+            competition_season_id=envelope.competition_season_id,
+            week=envelope.week,
+            occurred_at=envelope.occurred_at,
+            creating_generation_id=envelope.creating_generation_id,
+            creating_tool_call_id=envelope.creating_tool_call_id,
+            change_reason=envelope.change_reason,
+            recorded_at=envelope.recorded_at,
+            content=content,
+            context_note_identity=(
+                {
+                    "scope": identity_row.scope,
+                    "note_key": identity_row.note_key,
+                    "competition_season_id": identity_row.competition_season_id,
+                    "franchise_id": identity_row.franchise_id,
+                }
+                if identity_row is not None
+                else None
+            ),
+        )
+    return decoded
+
+
+def _content_payload(kind: MemoryKind, row: object) -> dict[str, Any]:
+    if kind == MemoryKind.STORYLINE:
+        return {
+            "headline": row.headline,
+            "summary": row.summary,
+            "status": row.status,
+            "arc_type": row.arc_type,
+            "salience": row.salience,
+            "tags": row.tags,
+            "subjects": row.subjects,
+            "evidence": row.evidence,
+            "related_storylines": row.related_storylines,
+            "callback_condition": row.callback_condition,
+            "resolution_summary": row.resolution_summary,
+        }
+    if kind == MemoryKind.FACT:
+        return {
+            "claim": row.claim,
+            "category": row.category,
+            "numbers": row.structured_numbers or {},
+            "confidence": row.confidence,
+            "status": row.status,
+            "subjects": row.subjects,
+            "originating_event_version_ids": row.originating_event_version_ids,
+            "primary_tool_call_id": row.primary_tool_call_id,
+            "primary_api_request_id": row.primary_api_request_id,
+            "source_hints": row.additional_source_hints,
+        }
+    if kind == MemoryKind.EVENT:
+        return {
+            "event_type": row.event_type,
+            "headline": row.headline,
+            "summary": row.summary,
+            "salience": row.salience,
+            "confidence": row.confidence,
+            "status": row.status,
+            "details": row.details,
+            "primary_tool_call_id": row.primary_tool_call_id,
+            "primary_api_request_id": row.primary_api_request_id,
+            "source_hints": row.additional_source_hints,
+        }
+    if kind == MemoryKind.TRIGGER:
+        return {
+            "trigger_type": row.trigger_type,
+            "status": row.status,
+            "fire_policy": row.fire_policy,
+            "target_storyline_item_id": row.target_storyline_item_id,
+            "origin_event_item_id": row.origin_event_item_id,
+            "target_competition_season_id": row.target_competition_season_id,
+            "target_week": row.target_week,
+            "target_at": row.target_at,
+            "condition": row.condition,
+            "resolution_reason": row.resolution_reason,
+        }
+    return {
+        "narrative": row.narrative_text,
+        "outlook": row.outlook,
+        "status": row.status,
+        "tags": row.tags,
+    }
+
+
+def _load_evidence_versions(
+    session: Session,
+    revision: MemoryRevisionRef,
+    version_ids: set[UUID],
+) -> dict[UUID, TypedMemoryVersion]:
+    if not version_ids:
+        return {}
+    introduced = aliased(MemoryRevision)
+    eligible_ids = set(
+        session.scalars(
+            sa.select(MemoryVersion.id)
+            .join(introduced, introduced.id == MemoryVersion.introduced_revision_id)
+            .where(
+                MemoryVersion.id.in_(version_ids),
+                MemoryVersion.competition_id == revision.competition_id,
+                introduced.sequence_number <= revision.sequence_number,
+            )
+        )
+    )
+    return _load_typed_versions(session, tuple(eligible_ids))
+
+
+def _load_visible_items(
+    session: Session,
+    revision: MemoryRevisionRef,
+    item_ids: set[UUID],
+) -> dict[UUID, TypedMemoryVersion]:
+    if not item_ids:
+        return {}
+    rows = session.execute(
+        _visible_versions(revision)
+        .with_only_columns(MemoryVersion.item_id, MemoryVersion.id)
+        .where(MemoryVersion.item_id.in_(item_ids))
+    ).all()
+    version_by_item = {item_id: version_id for item_id, version_id in rows}
+    versions = _load_typed_versions(session, tuple(version_by_item.values()))
+    return {
+        item_id: versions[version_id]
+        for item_id, version_id in version_by_item.items()
+    }
+
+
+def _evidence_ids(version: TypedMemoryVersion) -> tuple[UUID, ...]:
+    if version.kind == MemoryKind.STORYLINE:
+        return tuple(reference.version_id for reference in version.content.evidence)
+    if version.kind == MemoryKind.FACT:
+        return tuple(version.content.originating_event_version_ids)
+    return ()
+
+
+def _related_item_ids(version: TypedMemoryVersion) -> tuple[UUID, ...]:
+    if version.kind == MemoryKind.STORYLINE:
+        return tuple(
+            reference.item_id for reference in version.content.related_storylines
+        )
+    if version.kind == MemoryKind.TRIGGER:
+        return tuple(
+            item_id
+            for item_id in (
+                version.content.target_storyline_item_id,
+                version.content.origin_event_item_id,
+            )
+            if item_id is not None
+        )
+    return ()
+
+
+def _raise_invisible_version(
+    session: Session,
+    revision: MemoryRevisionRef,
+    version_id: UUID,
+) -> None:
+    stored = session.get(MemoryVersion, version_id)
+    if stored is None:
+        raise MemoryNotFound(f"memory version not found: {version_id}")
+    if stored.competition_id != revision.competition_id:
+        raise MemoryScopeViolation(
+            f"memory version is outside competition scope: {version_id}"
+        )
+    raise MemoryScopeViolation(
+        f"memory version is not visible at revision {revision.id}: {version_id}"
+    )
+
+
+def _status_matches(status: str) -> sa.ColumnElement[bool]:
+    tables = (
+        StorylineVersion,
+        FactVersion,
+        EventVersion,
+        TriggerVersion,
+        ContextNoteVersion,
+    )
+    return sa.or_(
+        *(
+            sa.exists(
+                sa.select(1).where(
+                    table.version_id == MemoryVersion.id,
+                    table.status == status,
+                )
+            )
+            for table in tables
+        )
+    )
+
+
+def _uuid_cursor(cursor: str) -> UUID:
+    try:
+        return UUID(cursor)
+    except ValueError as error:
+        raise ValueError("invalid memory item cursor") from error
+
+
+def _sequence_cursor(cursor: str) -> int:
+    try:
+        sequence = int(cursor)
+    except ValueError as error:
+        raise ValueError("invalid memory revision cursor") from error
+    if sequence < 0:
+        raise ValueError("invalid memory revision cursor")
+    return sequence
+
+
+def _candidate_from_document(
+    document: MemorySearchDocument | SearchDocument,
+    lexical_score: float,
+    query_entity_keys: Sequence[str],
+    *,
+    has_text: bool,
+) -> MemoryCandidate:
+    matched_entities = tuple(
+        sorted(set(query_entity_keys) & set(document.entity_keys))
+    )
+    reasons: list[str] = []
+    components: dict[str, float] = {}
+    if lexical_score > 0:
+        reasons.append("lexical_match")
+        components["lexical"] = lexical_score
+    if matched_entities:
+        reasons.append("entity_overlap")
+        components["entity"] = 1.0
+    if document.salience is not None:
+        components["salience"] = document.salience / 25
+    if not reasons and not has_text and not query_entity_keys:
+        reasons.append("filter_match")
+        components["baseline"] = 0.0
+    return MemoryCandidate(
+        version_id=document.version_id,
+        kind=document.kind,
+        match_reasons=tuple(reasons),
+        rank_components=components,
+        matched_entities=matched_entities,
+    )
+
+
+def _fallback_text_matches(query_text: str | None, document_text: str) -> bool:
+    if query_text is None:
+        return False
+    terms = query_text.casefold().split()
+    searchable = document_text.casefold()
+    return all(term in searchable for term in terms)
+
+
+def _persist_search_documents(
+    session: Session,
+    documents: Sequence[SearchDocument],
+) -> None:
+    """Persist projections in the transaction already owned by the caller."""
+
+    if not documents:
+        return
+    insert = pg_insert(MemorySearchDocument).values(
+        [document.persistence_values() for document in documents]
+    )
+    mutable_columns = {
+        name: getattr(insert.excluded, name)
+        for name in (
+            "item_id",
+            "competition_id",
+            "kind",
+            "status",
+            "salience",
+            "competition_season_id",
+            "week",
+            "entity_keys",
+            "evidence_version_ids",
+            "related_item_ids",
+            "tags",
+            "document_text",
+            "builder_version",
+            "content_hash",
+        )
+    }
+    mutable_columns["indexed_at"] = sa.func.now()
+    session.execute(
+        insert.on_conflict_do_update(
+            index_elements=[MemorySearchDocument.version_id],
+            set_=mutable_columns,
+        )
+    )

--- a/backend/resources/memory/search_documents.py
+++ b/backend/resources/memory/search_documents.py
@@ -1,0 +1,412 @@
+"""Deterministic search-document construction for canonical memory versions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from backend.resources.memory.objects import TypedMemoryVersion
+
+
+SEARCH_DOCUMENT_BUILDER_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SearchDocument:
+    """Persistence-ready projection of one immutable canonical version."""
+
+    version_id: UUID
+    item_id: UUID
+    competition_id: UUID
+    kind: str
+    status: str | None
+    salience: int | None
+    competition_season_id: UUID | None
+    week: int | None
+    entity_keys: tuple[str, ...]
+    evidence_version_ids: tuple[UUID, ...]
+    related_item_ids: tuple[UUID, ...]
+    tags: tuple[str, ...]
+    document_text: str
+    builder_version: int
+    content_hash: str
+
+    def persistence_values(self) -> dict[str, object]:
+        """Return the exact mutable mapping accepted by the ORM insert."""
+
+        return {
+            "version_id": self.version_id,
+            "item_id": self.item_id,
+            "competition_id": self.competition_id,
+            "kind": self.kind,
+            "status": self.status,
+            "salience": self.salience,
+            "competition_season_id": self.competition_season_id,
+            "week": self.week,
+            "entity_keys": list(self.entity_keys),
+            "evidence_version_ids": list(self.evidence_version_ids),
+            "related_item_ids": list(self.related_item_ids),
+            "tags": list(self.tags),
+            "document_text": self.document_text,
+            "builder_version": self.builder_version,
+            "content_hash": self.content_hash,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _DocumentContent:
+    status: str | None
+    salience: int | None
+    entity_keys: tuple[str, ...]
+    evidence_version_ids: tuple[UUID, ...]
+    related_item_ids: tuple[UUID, ...]
+    tags: tuple[str, ...]
+    text_parts: tuple[str, ...]
+
+
+def build_search_document(version: TypedMemoryVersion) -> SearchDocument:
+    """Build the sole derived search representation for a typed version."""
+
+    kind = _enum_value(version.kind)
+    builder = _BUILDERS.get(kind)
+    if builder is None:
+        raise ValueError(f"unsupported memory kind: {kind}")
+
+    projected = builder(version)
+    return SearchDocument(
+        version_id=version.version_id,
+        item_id=version.item_id,
+        competition_id=version.competition_id,
+        kind=kind,
+        status=projected.status,
+        salience=projected.salience,
+        competition_season_id=version.competition_season_id,
+        week=version.week,
+        entity_keys=projected.entity_keys,
+        evidence_version_ids=projected.evidence_version_ids,
+        related_item_ids=projected.related_item_ids,
+        tags=projected.tags,
+        document_text="\n".join(projected.text_parts),
+        builder_version=SEARCH_DOCUMENT_BUILDER_VERSION,
+        content_hash=_content_hash(
+            kind,
+            version.content,
+            version.context_note_identity,
+            version.competition_season_id,
+            version.week,
+        ),
+    )
+
+
+def _build_storyline(version: TypedMemoryVersion) -> _DocumentContent:
+    content = version.content
+    entity_keys, entity_labels = _entities(content.subjects)
+    evidence_ids = _sorted_uuids(reference.version_id for reference in content.evidence)
+    related_ids = _sorted_uuids(
+        reference.item_id for reference in content.related_storylines
+    )
+    tags = _normalized_strings(content.tags)
+    return _DocumentContent(
+        status=_enum_value(content.status),
+        salience=content.salience,
+        entity_keys=entity_keys,
+        evidence_version_ids=evidence_ids,
+        related_item_ids=related_ids,
+        tags=tags,
+        text_parts=_text_parts(
+            content.headline,
+            content.summary,
+            content.arc_type,
+            _enum_value(content.status),
+            *tags,
+            *entity_labels,
+            content.callback_condition,
+            content.resolution_summary,
+        ),
+    )
+
+
+def _build_fact(version: TypedMemoryVersion) -> _DocumentContent:
+    content = version.content
+    entity_keys, entity_labels = _entities(content.subjects)
+    evidence_ids = _sorted_uuids(content.originating_event_version_ids)
+    return _DocumentContent(
+        status=_enum_value(content.status),
+        salience=None,
+        entity_keys=entity_keys,
+        evidence_version_ids=evidence_ids,
+        related_item_ids=(),
+        tags=(),
+        text_parts=_text_parts(
+            content.claim,
+            content.category,
+            _enum_value(content.confidence),
+            _enum_value(content.status),
+            _canonical_json(content.numbers),
+            *entity_labels,
+        ),
+    )
+
+
+def _build_event(version: TypedMemoryVersion) -> _DocumentContent:
+    content = version.content
+    entity_keys = _event_entity_keys(content.details)
+    return _DocumentContent(
+        status=_enum_value(content.status),
+        salience=content.salience,
+        entity_keys=entity_keys,
+        evidence_version_ids=(),
+        related_item_ids=(),
+        tags=(),
+        text_parts=_text_parts(
+            content.headline,
+            content.summary,
+            _enum_value(content.event_type),
+            _enum_value(content.confidence),
+            _enum_value(content.status),
+            _canonical_json(content.details),
+            *entity_keys,
+        ),
+    )
+
+
+def _build_trigger(version: TypedMemoryVersion) -> _DocumentContent:
+    content = version.content
+    related_ids = _sorted_uuids(
+        item_id
+        for item_id in (
+            content.target_storyline_item_id,
+            content.origin_event_item_id,
+        )
+        if item_id is not None
+    )
+    condition_subject = getattr(content.condition, "subject", None)
+    entity_keys = tuple(
+        sorted(
+            {
+                key
+                for key in (
+                    (
+                        f"season:{content.target_competition_season_id}"
+                        if content.target_competition_season_id is not None
+                        else None
+                    ),
+                    (
+                        entity_search_key(condition_subject)
+                        if condition_subject is not None
+                        else None
+                    ),
+                )
+                if key is not None
+            }
+        )
+    )
+    return _DocumentContent(
+        status=_enum_value(content.status),
+        salience=None,
+        entity_keys=entity_keys,
+        evidence_version_ids=(),
+        related_item_ids=related_ids,
+        tags=(),
+        text_parts=_text_parts(
+            _enum_value(content.trigger_type),
+            _enum_value(content.status),
+            _enum_value(content.fire_policy),
+            content.target_week,
+            content.target_at.isoformat() if content.target_at else None,
+            _canonical_json(content.condition),
+            content.resolution_reason,
+        ),
+    )
+
+
+def _build_context_note(version: TypedMemoryVersion) -> _DocumentContent:
+    content = version.content
+    identity = version.context_note_identity
+    if identity is None:
+        raise ValueError("context-note version is missing its stable identity")
+    tags = _normalized_strings(content.tags)
+    entity_keys = tuple(
+        key
+        for key in (
+            (
+                f"season:{identity.competition_season_id}"
+                if identity.competition_season_id is not None
+                else None
+            ),
+            (
+                f"franchise:{identity.franchise_id}"
+                if identity.franchise_id is not None
+                else None
+            ),
+        )
+        if key is not None
+    )
+    return _DocumentContent(
+        status=_enum_value(content.status),
+        salience=None,
+        entity_keys=entity_keys,
+        evidence_version_ids=(),
+        related_item_ids=(),
+        tags=tags,
+        text_parts=_text_parts(
+            content.narrative,
+            content.outlook,
+            _enum_value(content.status),
+            _enum_value(identity.scope),
+            identity.note_key,
+            *entity_keys,
+            *tags,
+        ),
+    )
+
+
+_BUILDERS = {
+    "storyline": _build_storyline,
+    "fact": _build_fact,
+    "event": _build_event,
+    "trigger": _build_trigger,
+    "context_note": _build_context_note,
+}
+
+
+def _entities(references: Sequence[Any]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    keys = tuple(sorted({entity_search_key(reference) for reference in references}))
+    labels = tuple(
+        reference.display_name or entity_search_key(reference)
+        for reference in references
+    )
+    return keys, labels
+
+
+def entity_search_key(reference: Any) -> str:
+    """Return the stable projection key shared by indexing and query filters."""
+
+    kind = _enum_value(reference.kind)
+    return f"{_entity_prefix(kind)}:{reference.id}"
+
+
+def _event_entity_keys(details: Any) -> tuple[str, ...]:
+    values = details.model_dump(mode="python")
+    keys: set[str] = set()
+    _collect_event_entity_keys(values, keys)
+    return tuple(sorted(keys))
+
+
+def _collect_event_entity_keys(value: object, keys: set[str]) -> None:
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        (str, bytes, bytearray),
+    ):
+        for item in value:
+            _collect_event_entity_keys(item, keys)
+        return
+    if not isinstance(value, dict):
+        return
+
+    kind = value.get("kind")
+    entity_id = value.get("id")
+    if kind in {"franchise", "player", "season_roster", "sleeper_user"} and entity_id:
+        keys.add(_entity_key_from_parts(str(kind), entity_id))
+
+    field_prefixes = {
+        "franchise_id": "franchise",
+        "sender_franchise_id": "franchise",
+        "receiver_franchise_id": "franchise",
+        "winner_franchise_id": "franchise",
+        "loser_franchise_id": "franchise",
+        "season_roster_id": "roster",
+        "original_season_roster_id": "roster",
+        "player_id": "player",
+        "added_player_id": "player",
+        "dropped_player_id": "player",
+        "sleeper_player_id": "player",
+        "sleeper_user_id": "user",
+    }
+    for field, nested in value.items():
+        prefix = field_prefixes.get(field)
+        if prefix is not None and nested is not None:
+            keys.add(f"{prefix}:{nested}")
+        else:
+            _collect_event_entity_keys(nested, keys)
+
+
+def _entity_key_from_parts(kind: str, entity_id: object) -> str:
+    return f"{_entity_prefix(kind)}:{entity_id}"
+
+
+def _entity_prefix(kind: str) -> str:
+    return {
+        "season_roster": "roster",
+        "sleeper_user": "user",
+        "competition_season": "season",
+    }.get(kind, kind)
+
+
+def _content_hash(
+    kind: str,
+    content: Any,
+    identity: Any | None,
+    competition_season_id: UUID | None,
+    week: int | None,
+) -> str:
+    payload = {
+        "kind": kind,
+        "content": content.model_dump(mode="json"),
+        "context_note_identity": (
+            identity.model_dump(mode="json") if identity is not None else None
+        ),
+        "competition_season_id": (
+            str(competition_season_id)
+            if competition_season_id is not None
+            else None
+        ),
+        "week": week,
+    }
+    return sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: object) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
+    elif isinstance(value, Mapping):
+        value = {key: _json_compatible(item) for key, item in value.items()}
+    elif isinstance(value, (list, tuple)):
+        value = [_json_compatible(item) for item in value]
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _json_compatible(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {key: _json_compatible(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_compatible(item) for item in value]
+    return value
+
+
+def _text_parts(*values: object | None) -> tuple[str, ...]:
+    parts: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        normalized = " ".join(str(value).split())
+        if normalized:
+            parts.append(normalized)
+    return tuple(parts)
+
+
+def _normalized_strings(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted({" ".join(value.split()) for value in values if value.strip()}))
+
+
+def _sorted_uuids(values: Any) -> tuple[UUID, ...]:
+    return tuple(sorted(set(values), key=str))
+
+
+def _enum_value(value: object) -> str:
+    return str(getattr(value, "value", value))

--- a/backend/tests/resources/memory/test_manager_reads.py
+++ b/backend/tests/resources/memory/test_manager_reads.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.memory import (
+    CurrentRevision,
+    FactVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+)
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.memory.errors import (
+    MemoryScopeViolation,
+    SearchProjectionUnavailable,
+)
+from backend.resources.memory.manager import MemoryManager
+from backend.resources.memory.objects import (
+    ExpansionPolicy,
+    MemoryKind,
+    MemoryListQuery,
+    MemoryQuery,
+    MemoryStatus,
+)
+from backend.tests.database.conftest import (  # noqa: F401
+    database_engine,
+    migrated_database,
+)
+
+
+@dataclass(frozen=True)
+class _SeededMemory:
+    competition_id: UUID
+    other_competition_id: UUID
+    season_id: UUID
+    root_revision_id: UUID
+    middle_revision_id: UUID
+    current_revision_id: UUID
+    storyline_item_id: UUID
+    first_storyline_version_id: UUID
+    current_storyline_version_id: UUID
+    fact_version_id: UUID
+
+
+def _seed_memory(engine: Engine) -> _SeededMemory:
+    competition_id = uuid4()
+    other_competition_id = uuid4()
+    season_id = uuid4()
+    other_season_id = uuid4()
+    root_revision_id = uuid4()
+    middle_revision_id = uuid4()
+    current_revision_id = uuid4()
+    other_revision_id = uuid4()
+    middle_generation_id = uuid4()
+    current_generation_id = uuid4()
+    storyline_item_id = uuid4()
+    fact_item_id = uuid4()
+    first_storyline_version_id = uuid4()
+    current_storyline_version_id = uuid4()
+    fact_version_id = uuid4()
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": competition_id, "display_name": "Manager Test League"},
+                {"id": other_competition_id, "display_name": "Other League"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                {
+                    "id": season_id,
+                    "competition_id": competition_id,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+                {
+                    "id": other_season_id,
+                    "competition_id": other_competition_id,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            [
+                {
+                    "id": root_revision_id,
+                    "competition_id": competition_id,
+                    "sequence_number": 0,
+                    "previous_revision_id": None,
+                    "competition_season_id": None,
+                    "week": None,
+                    "producing_generation_id": None,
+                    "state_content_hash": "root",
+                },
+                {
+                    "id": other_revision_id,
+                    "competition_id": other_competition_id,
+                    "sequence_number": 0,
+                    "previous_revision_id": None,
+                    "competition_season_id": None,
+                    "week": None,
+                    "producing_generation_id": None,
+                    "state_content_hash": "other-root",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": middle_generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "input_memory_revision_id": root_revision_id,
+                "kind": "test",
+                "status": "complete",
+                "request_text": "manager read fixture",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": middle_revision_id,
+                "competition_id": competition_id,
+                "sequence_number": 1,
+                "previous_revision_id": root_revision_id,
+                "producing_generation_id": middle_generation_id,
+                "competition_season_id": season_id,
+                "week": 7,
+                "state_content_hash": "middle",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": current_generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "input_memory_revision_id": middle_revision_id,
+                "kind": "test",
+                "status": "complete",
+                "request_text": "manager replacement fixture",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": current_revision_id,
+                "competition_id": competition_id,
+                "sequence_number": 2,
+                "previous_revision_id": middle_revision_id,
+                "producing_generation_id": current_generation_id,
+                "competition_season_id": season_id,
+                "week": 8,
+                "state_content_hash": "current",
+            },
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            [
+                {
+                    "competition_id": competition_id,
+                    "current_revision_id": current_revision_id,
+                    "lock_version": 2,
+                },
+                {
+                    "competition_id": other_competition_id,
+                    "current_revision_id": other_revision_id,
+                    "lock_version": 0,
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                {
+                    "id": storyline_item_id,
+                    "competition_id": competition_id,
+                    "kind": "storyline",
+                    "agent_key": "collapse-arc",
+                },
+                {
+                    "id": fact_item_id,
+                    "competition_id": competition_id,
+                    "kind": "fact",
+                    "agent_key": "loss-streak",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryVersion),
+            [
+                {
+                    "id": first_storyline_version_id,
+                    "item_id": storyline_item_id,
+                    "competition_id": competition_id,
+                    "revision_number": 1,
+                    "introduced_revision_id": middle_revision_id,
+                    "retired_revision_id": current_revision_id,
+                    "competition_season_id": season_id,
+                    "week": 7,
+                    "creating_generation_id": middle_generation_id,
+                    "change_reason": None,
+                },
+                {
+                    "id": current_storyline_version_id,
+                    "item_id": storyline_item_id,
+                    "competition_id": competition_id,
+                    "revision_number": 2,
+                    "introduced_revision_id": current_revision_id,
+                    "retired_revision_id": None,
+                    "competition_season_id": season_id,
+                    "week": 8,
+                    "creating_generation_id": current_generation_id,
+                    "change_reason": "The arc resolved",
+                },
+                {
+                    "id": fact_version_id,
+                    "item_id": fact_item_id,
+                    "competition_id": competition_id,
+                    "revision_number": 1,
+                    "introduced_revision_id": middle_revision_id,
+                    "retired_revision_id": None,
+                    "competition_season_id": season_id,
+                    "week": 7,
+                    "creating_generation_id": middle_generation_id,
+                    "change_reason": None,
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(StorylineVersion),
+            [
+                {
+                    "version_id": first_storyline_version_id,
+                    "headline": "The Collapse Begins",
+                    "summary": "The Sharks keep losing.",
+                    "status": "active",
+                    "arc_type": "collapse",
+                    "salience": 4,
+                    "tags": ["playoffs"],
+                    "subjects": [],
+                    "evidence": [],
+                    "related_storylines": [],
+                    "resolution_summary": None,
+                },
+                {
+                    "version_id": current_storyline_version_id,
+                    "headline": "The Collapse Is Complete",
+                    "summary": "The Sharks missed the playoffs.",
+                    "status": "resolved",
+                    "arc_type": "collapse",
+                    "salience": 5,
+                    "tags": ["playoffs"],
+                    "subjects": [],
+                    "evidence": [
+                        {
+                            "kind": "fact",
+                            "version_id": str(fact_version_id),
+                            "role": "payoff",
+                        }
+                    ],
+                    "related_storylines": [],
+                    "resolution_summary": "The late-season slide ended the run.",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(FactVersion),
+            {
+                "version_id": fact_version_id,
+                "competition_id": competition_id,
+                "claim": "The Sharks lost three straight games.",
+                "category": "streak",
+                "structured_numbers": {"losses": 3},
+                "confidence": "source_backed",
+                "status": "active",
+                "subjects": [],
+                "originating_event_version_ids": [],
+            },
+        )
+
+    return _SeededMemory(
+        competition_id=competition_id,
+        other_competition_id=other_competition_id,
+        season_id=season_id,
+        root_revision_id=root_revision_id,
+        middle_revision_id=middle_revision_id,
+        current_revision_id=current_revision_id,
+        storyline_item_id=storyline_item_id,
+        first_storyline_version_id=first_storyline_version_id,
+        current_storyline_version_id=current_storyline_version_id,
+        fact_version_id=fact_version_id,
+    )
+
+
+def _manager(engine: Engine) -> MemoryManager:
+    return MemoryManager(create_session_factory(engine))
+
+
+def test_revision_resolution_is_competition_scoped(database_engine: Engine) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+
+    current = manager.current_revision(seeded.competition_id)
+
+    assert current.id == seeded.current_revision_id
+    assert current.sequence_number == 2
+    with pytest.raises(MemoryScopeViolation):
+        manager.get_revision(current.id, seeded.other_competition_id)
+
+
+def test_visible_reads_pin_versions_and_batch_expand_exact_evidence(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    root = manager.get_revision(seeded.root_revision_id)
+    middle = manager.get_revision(seeded.middle_revision_id)
+    current = manager.get_revision(seeded.current_revision_id)
+
+    with pytest.raises(MemoryScopeViolation):
+        manager.get_visible_item(
+            root,
+            seeded.storyline_item_id,
+            ExpansionPolicy(),
+        )
+    historical = manager.get_visible_item(
+        middle,
+        seeded.storyline_item_id,
+        ExpansionPolicy(),
+    )
+    current_item = manager.get_visible_item(
+        current,
+        seeded.storyline_item_id,
+        ExpansionPolicy(),
+    )
+    hydrated = manager.hydrate_visible_versions(
+        current,
+        [seeded.current_storyline_version_id],
+        ExpansionPolicy(include_evidence=True),
+    )
+
+    assert historical.version.version_id == seeded.first_storyline_version_id
+    assert current_item.version.version_id == seeded.current_storyline_version_id
+    assert hydrated[seeded.current_storyline_version_id].evidence[0].version_id == (
+        seeded.fact_version_id
+    )
+    with pytest.raises(MemoryScopeViolation):
+        manager.get_visible_version(
+            middle,
+            seeded.current_storyline_version_id,
+            ExpansionPolicy(),
+        )
+    with pytest.raises(MemoryScopeViolation):
+        manager.get_visible_version(
+            current,
+            seeded.first_storyline_version_id,
+            ExpansionPolicy(),
+        )
+
+
+def test_history_and_pages_return_typed_canonical_resources(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    current = manager.current_revision(seeded.competition_id)
+
+    history = manager.item_history(seeded.competition_id, seeded.storyline_item_id)
+    page = manager.list_visible_items(
+        current,
+        MemoryListQuery(
+            competition_id=seeded.competition_id,
+            kinds={MemoryKind.STORYLINE},
+            statuses={MemoryStatus.RESOLVED},
+        ),
+    )
+    revisions = manager.list_revisions(seeded.competition_id, None, 2)
+
+    assert [version.revision_number for version in history.versions] == [1, 2]
+    assert [item.version.version_id for item in page.items] == [
+        seeded.current_storyline_version_id
+    ]
+    assert [revision.sequence_number for revision in revisions.revisions] == [2, 1]
+    assert revisions.next_cursor == "1"
+
+
+def test_projection_rebuild_restores_search_without_changing_canonical_state(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    current = manager.current_revision(seeded.competition_id)
+    query = MemoryQuery(text="missed playoffs", limit=5)
+
+    with pytest.raises(SearchProjectionUnavailable):
+        manager.find_candidates(current, query)
+    fallback = manager.scan_visible_candidates(current, query, 5)
+    rebuilt = manager.rebuild_search_index(seeded.competition_id, batch_size=2)
+    candidates = manager.find_candidates(current, query)
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(MemorySearchDocument)
+            .where(MemorySearchDocument.version_id == seeded.fact_version_id)
+            .values(builder_version=99)
+        )
+    stale_status = manager.search_index_status(seeded.competition_id)
+    with pytest.raises(SearchProjectionUnavailable):
+        manager.find_candidates(current, query)
+    mixed_fallback = manager.scan_visible_candidates(current, query, 5)
+    manager.rebuild_search_index(seeded.competition_id, batch_size=2)
+    repaired_candidates = manager.find_candidates(current, query)
+    repaired_status = manager.search_index_status(seeded.competition_id)
+
+    assert [candidate.version_id for candidate in fallback] == [
+        seeded.current_storyline_version_id
+    ]
+    assert [candidate.version_id for candidate in candidates] == [
+        seeded.current_storyline_version_id
+    ]
+    assert stale_status.stale_document_count == 1
+    assert [candidate.version_id for candidate in mixed_fallback] == [
+        seeded.current_storyline_version_id
+    ]
+    assert [candidate.version_id for candidate in repaired_candidates] == [
+        seeded.current_storyline_version_id
+    ]
+    assert rebuilt.rebuilt_document_count == 3
+    assert repaired_status.missing_document_count == 0
+    assert repaired_status.stale_document_count == 0
+    assert manager.current_revision(seeded.competition_id) == current

--- a/backend/tests/resources/memory/test_search_documents.py
+++ b/backend/tests/resources/memory/test_search_documents.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+
+from backend.resources.memory.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+    DraftPickTradeAsset,
+    EventContent,
+    EvidenceRef,
+    FactContent,
+    FranchiseRef,
+    MemoryContent,
+    MemoryKind,
+    PlayerTradeAsset,
+    RelatedStorylineRef,
+    StorylineContent,
+    TradeEventPayload,
+    TriggerContent,
+    TypedMemoryVersion,
+    WeekTriggerCondition,
+)
+from backend.resources.memory.search_documents import (
+    SEARCH_DOCUMENT_BUILDER_VERSION,
+    build_search_document,
+)
+
+
+COMPETITION_ID = UUID("00000000-0000-0000-0000-000000000001")
+SEASON_ID = UUID("00000000-0000-0000-0000-000000000002")
+OTHER_SEASON_ID = UUID("00000000-0000-0000-0000-000000000008")
+ITEM_ID = UUID("00000000-0000-0000-0000-000000000003")
+VERSION_ID = UUID("00000000-0000-0000-0000-000000000004")
+FRANCHISE_ID = UUID("00000000-0000-0000-0000-000000000005")
+EVIDENCE_ID = UUID("00000000-0000-0000-0000-000000000006")
+RELATED_ID = UUID("00000000-0000-0000-0000-000000000007")
+ROSTER_ID = UUID("00000000-0000-0000-0000-000000000009")
+
+
+def _version(
+    content: MemoryContent,
+    *,
+    identity: ContextNoteIdentity | None = None,
+    competition_season_id: UUID | None = SEASON_ID,
+    week: int | None = 8,
+) -> TypedMemoryVersion:
+    return TypedMemoryVersion(
+        version_id=VERSION_ID,
+        item_id=ITEM_ID,
+        competition_id=COMPETITION_ID,
+        kind=MemoryKind(content.kind),
+        content=content,
+        content_schema_version=content.schema_version,
+        revision_number=1,
+        introduced_revision_id=RELATED_ID,
+        competition_season_id=competition_season_id,
+        week=week,
+        creating_generation_id=EVIDENCE_ID,
+        recorded_at=datetime(2026, 8, 9, tzinfo=timezone.utc),
+        context_note_identity=identity,
+    )
+
+
+STORYLINE_VERSION = _version(
+    StorylineContent(
+        headline="The Long Collapse",
+        summary="The Sharks lost again.",
+        status="active",
+        arc_type="collapse",
+        salience=4,
+        tags=("playoffs", "collapse"),
+        subjects=(
+            FranchiseRef(
+                id=FRANCHISE_ID,
+                role="focus",
+                display_name="Old Sharks",
+            ),
+        ),
+        evidence=(
+            EvidenceRef(kind="fact", version_id=EVIDENCE_ID, role="support"),
+        ),
+        related_storylines=(
+            RelatedStorylineRef(item_id=RELATED_ID, role="counterpoint"),
+        ),
+        callback_condition="If the slide continues",
+    )
+)
+
+FACT_VERSION = _version(
+    FactContent(
+        claim="The Sharks have lost three straight.",
+        category="streak",
+        numbers={"losses": 3},
+        confidence="source_backed",
+        status="active",
+        subjects=(FranchiseRef(id=FRANCHISE_ID, role="subject"),),
+        originating_event_version_ids=(EVIDENCE_ID,),
+    )
+)
+
+TRADE_VERSION = _version(
+    EventContent(
+        event_type="trade",
+        headline="A blockbuster trade",
+        summary="The Sharks acquired a quarterback and a first-round pick.",
+        salience=5,
+        confidence="source_backed",
+        status="active",
+        details=TradeEventPayload(
+            sender_franchise_id=FRANCHISE_ID,
+            receiver_franchise_id=RELATED_ID,
+            assets=(
+                PlayerTradeAsset(player_id="player-1", display_name="QB One"),
+                DraftPickTradeAsset(
+                    season=2027,
+                    round=1,
+                    original_season_roster_id=ROSTER_ID,
+                ),
+            ),
+            sleeper_transaction_id="txn-42",
+        ),
+    )
+)
+
+TRIGGER_VERSION = _version(
+    TriggerContent(
+        trigger_type="week",
+        status="open",
+        fire_policy="one_shot",
+        target_competition_season_id=SEASON_ID,
+        target_storyline_item_id=RELATED_ID,
+        origin_event_item_id=ITEM_ID,
+        target_week=9,
+        condition=WeekTriggerCondition(week=9),
+    )
+)
+
+CONTEXT_VERSION = _version(
+    ContextNoteContent(
+        narrative="The league rewards patient roster building.",
+        outlook="Expect contenders to hoard picks.",
+        status="active",
+        tags=("dynasty", "strategy"),
+    ),
+    identity=ContextNoteIdentity(
+        scope="franchise",
+        note_key="identity",
+        franchise_id=FRANCHISE_ID,
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        (
+            STORYLINE_VERSION,
+            {
+                "status": "active",
+                "salience": 4,
+                "entity_keys": (f"franchise:{FRANCHISE_ID}",),
+                "evidence_version_ids": (EVIDENCE_ID,),
+                "related_item_ids": (RELATED_ID,),
+                "tags": ("collapse", "playoffs"),
+                "document_text": "\n".join(
+                    (
+                        "The Long Collapse",
+                        "The Sharks lost again.",
+                        "collapse",
+                        "active",
+                        "collapse",
+                        "playoffs",
+                        "Old Sharks",
+                        "If the slide continues",
+                    )
+                ),
+            },
+        ),
+        (
+            FACT_VERSION,
+            {
+                "status": "active",
+                "salience": None,
+                "entity_keys": (f"franchise:{FRANCHISE_ID}",),
+                "evidence_version_ids": (EVIDENCE_ID,),
+                "related_item_ids": (),
+                "tags": (),
+                "document_text": "\n".join(
+                    (
+                        "The Sharks have lost three straight.",
+                        "streak",
+                        "source_backed",
+                        "active",
+                        '{"losses":3}',
+                        f"franchise:{FRANCHISE_ID}",
+                    )
+                ),
+            },
+        ),
+        (
+            TRADE_VERSION,
+            {
+                "status": "active",
+                "salience": 5,
+                "entity_keys": (
+                    f"franchise:{FRANCHISE_ID}",
+                    f"franchise:{RELATED_ID}",
+                    "player:player-1",
+                    f"roster:{ROSTER_ID}",
+                ),
+                "evidence_version_ids": (),
+                "related_item_ids": (),
+                "tags": (),
+                "document_text": "\n".join(
+                    (
+                        "A blockbuster trade",
+                        "The Sharks acquired a quarterback and a first-round pick.",
+                        "trade",
+                        "source_backed",
+                        "active",
+                        (
+                            '{"assets":[{"display_name":"QB One","kind":"player",'
+                            '"player_id":"player-1"},{"kind":"draft_pick",'
+                            f'"original_season_roster_id":"{ROSTER_ID}",'
+                            '"round":1,"season":2027}],"kind":"trade",'
+                            f'"receiver_franchise_id":"{RELATED_ID}",'
+                            f'"sender_franchise_id":"{FRANCHISE_ID}",'
+                            '"sleeper_transaction_id":"txn-42"}'
+                        ),
+                        f"franchise:{FRANCHISE_ID}",
+                        f"franchise:{RELATED_ID}",
+                        "player:player-1",
+                        f"roster:{ROSTER_ID}",
+                    )
+                ),
+            },
+        ),
+        (
+            TRIGGER_VERSION,
+            {
+                "status": "open",
+                "salience": None,
+                "entity_keys": (f"season:{SEASON_ID}",),
+                "evidence_version_ids": (),
+                "related_item_ids": tuple(sorted((ITEM_ID, RELATED_ID), key=str)),
+                "tags": (),
+                "document_text": "\n".join(
+                    (
+                        "week",
+                        "open",
+                        "one_shot",
+                        "9",
+                        '{"kind":"week","week":9}',
+                    )
+                ),
+            },
+        ),
+        (
+            CONTEXT_VERSION,
+            {
+                "status": "active",
+                "salience": None,
+                "entity_keys": (f"franchise:{FRANCHISE_ID}",),
+                "evidence_version_ids": (),
+                "related_item_ids": (),
+                "tags": ("dynasty", "strategy"),
+                "document_text": "\n".join(
+                    (
+                        "The league rewards patient roster building.",
+                        "Expect contenders to hoard picks.",
+                        "active",
+                        "franchise",
+                        "identity",
+                        f"franchise:{FRANCHISE_ID}",
+                        "dynasty",
+                        "strategy",
+                    )
+                ),
+            },
+        ),
+    ],
+)
+def test_build_search_document_has_golden_output(
+    version: TypedMemoryVersion,
+    expected: dict[str, object],
+) -> None:
+    document = build_search_document(version)
+
+    for field, value in expected.items():
+        assert getattr(document, field) == value
+    assert document.version_id == VERSION_ID
+    assert document.item_id == ITEM_ID
+    assert document.competition_id == COMPETITION_ID
+    assert document.builder_version == SEARCH_DOCUMENT_BUILDER_VERSION
+    assert len(document.content_hash) == 64
+    assert document == build_search_document(version)
+
+
+def test_typed_trade_flattens_tuple_assets_to_player_and_roster_keys() -> None:
+    document = build_search_document(TRADE_VERSION)
+
+    assert "player:player-1" in document.entity_keys
+    assert f"roster:{ROSTER_ID}" in document.entity_keys
+
+
+def test_builder_uses_immutable_label_snapshot() -> None:
+    document = build_search_document(STORYLINE_VERSION)
+
+    assert "Old Sharks" in document.document_text
+    assert document.entity_keys == (f"franchise:{FRANCHISE_ID}",)
+
+
+def test_projection_hash_covers_output_driving_envelope_fields() -> None:
+    original = build_search_document(FACT_VERSION)
+    different_week = build_search_document(FACT_VERSION.model_copy(update={"week": 9}))
+    different_season = build_search_document(
+        FACT_VERSION.model_copy(update={"competition_season_id": OTHER_SEASON_ID})
+    )
+
+    assert original.content_hash != different_week.content_hash
+    assert original.content_hash != different_season.content_hash

--- a/docs/memory/log.md
+++ b/docs/memory/log.md
@@ -313,8 +313,8 @@ the manager persists its output and retrieval never rebuilds documents.
 - Builder inputs come only from immutable version content. Stored display-name
   snapshots may be indexed; current external names are never resolved during a
   rebuild.
-- The builder version and canonical content hash fully identify deterministic
-  output.
+- The builder version and projection-input hash, including immutable content,
+  context-note identity, season, and week, fully identify deterministic output.
 - Golden tests invoke the same dispatcher through mutation and rebuild paths.
 
 ### MEM-016 — Derive mutation context and use one concurrency token
@@ -359,9 +359,8 @@ an actual scoped capability because it carries an enforced revision invariant.
 - The initial implementation does not add one forwarding class per port.
 - Search-index maintenance uses explicit `search_index_status` and
   `rebuild_search_index` names rather than generic projection verbs.
-- Ordinary retrieval masks missing/stale index rows with the last valid builder
-  version or a bounded canonical fallback. `ProjectionUnavailable` is not a
-  caller-facing error.
+- Ordinary retrieval masks missing or stale index rows with a bounded canonical
+  fallback. `ProjectionUnavailable` is not a caller-facing error.
 
 ### MEM-018 — Implement the service as a six-layer GitHub PR stack
 

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -169,11 +169,11 @@ A projection rebuild:
 Rebuilding changes retrieval behavior, not canonical history, and therefore does
 not create memory revisions.
 
-If current projection rows are missing or stale, ordinary retrieval keeps using
-the last valid builder version when possible. Otherwise it degrades internally
-to exact entity/reference signals and a bounded scan of visible canonical
-versions while surfacing the repair need through search-index status. Reporter
-callers do not handle a projection-administration error.
+If current projection rows are missing, stale, or use mixed builder versions,
+ordinary retrieval degrades internally to exact entity/reference signals and a
+bounded scan of visible canonical versions. Mixed-version index state is never
+used for ranking. Search-index status surfaces the repair need; reporter callers
+do not handle a projection-administration error.
 
 Hydrated immutable typed versions may be cached by exact `version_id`. A pinned
 revision determines which IDs are visible; the cached aggregate itself never

--- a/docs/memory/service-architecture.md
+++ b/docs/memory/service-architecture.md
@@ -515,9 +515,9 @@ rows in bounded transactions and avoid deleting a valid old projection before
 its replacement is ready.
 
 Ordinary retrieval does not expose a repairable search-index failure to callers.
-It continues with the last valid builder version when present, otherwise falls
-back to exact entity/reference signals and a bounded scan of visible canonical
-versions. The service records degraded operation for the status/rebuild path.
+When visible rows are missing or use mixed builder versions, it falls back to
+exact entity/reference signals and a bounded scan of visible canonical versions.
+The service records degraded operation for the status/rebuild path.
 
 ## Error Contract
 

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -17,9 +17,9 @@ are not preserved
 | Service boundaries and public contracts | Designed | `service-architecture.md` |
 | Resource objects and schema converters | Implemented | `backend/resources/memory/objects.py` |
 | Stable application errors | Implemented | `backend/resources/memory/errors.py` |
-| Memory resource manager and canonical reads | Pending | `backend/resources/memory/manager.py` |
+| Memory resource manager and canonical reads | Implemented | `backend/resources/memory/manager.py` |
 | Complete-bundle mutation transaction | Pending | Generation-derived context plus `MemoryManager` transaction |
-| Authoritative search-document builder | Pending | `backend/resources/memory/search_documents.py` |
+| Authoritative search-document builder | Implemented | `backend/resources/memory/search_documents.py` |
 | Revision-pinned retrieval and hydration | Pending | `MemoryService.at_revision` plus internal retrieval pipeline |
 | Service facade and consumer protocols | Pending | `backend/services/memory/` |
 | Basic canonical viewing and item history | Pending | `MemoryInspector` capability on `MemoryService` |
@@ -69,8 +69,8 @@ are not preserved
 | Slice | State | Completion signal |
 | --- | --- | --- |
 | 1. Contracts, errors, and schema converters | Complete | All initial typed payloads decode and validate with unit coverage |
-| 2. Canonical reads and hydration manager | In progress | Revision-pinned item/version/history queries pass PostgreSQL tests |
-| 3. Search-document builder | In progress | One dispatcher produces identical mutation/rebuild output for every kind |
+| 2. Canonical reads and hydration manager | Complete | Revision-pinned item/version/history queries pass PostgreSQL tests |
+| 3. Search-document builder | Complete | One dispatcher produces identical mutation/rebuild output for every kind |
 | 4. Canonical mutation transaction | Not started | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
 | 5. Pinned retrieval pipeline | Not started | Entity, evidence, related-item, lexical, and historical-leakage tests pass |
 | 6. Basic viewing, promotion integration, reporter/generation, and rebuild CLI | Not started | Narrow capabilities work without UI-specific business logic |
@@ -103,9 +103,9 @@ decision-log entry before expanding the baseline.
 
 ## Next Milestone
 
-Complete slice 2 revision-pinned canonical reads and slice 3 deterministic
-search-document construction, including real PostgreSQL manager coverage. Then
-implement canonical mutation before adding public adapters.
+Implement slice 4 canonical mutation with one generation-derived transaction,
+including no-op, retry, concurrency, reference, and atomic projection coverage.
+Then add the already-designed pinned retrieval service without public adapters.
 
 ## PR Stack Coordination
 
@@ -116,7 +116,7 @@ integrated by `root` after the owning agent reports completion.
 | Stack layer | Branch | Owner | State | Assigned paths |
 | --- | --- | --- | --- | --- |
 | 1. Design and resource contracts | `codex/memory-service-contracts` | `contracts_agent` | Complete | `docs/memory/`; `backend/resources/memory/objects.py`; `errors.py`; resource contract tests |
-| 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | In progress | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
+| 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | Complete | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
 | 3. Canonical mutation | `codex/memory-service-mutations` | Unassigned | Pending | mutation methods and transaction tests; no public adapters |
 | 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `service_agent` | In progress | `backend/services/memory/`; retrieval/inspection tests |
 | 5. Composition and adapters | `codex/memory-service-integration` | `root` | Pending | composition, reporter tools, minimal API/CLI adapters, legacy-path removal, integration tests |


### PR DESCRIPTION
## Summary

- add revision-pinned canonical reads, hydration, item history, and revision listing
- add the single authoritative search-document dispatcher used by both mutations and rebuilds
- add bounded raw candidate discovery and real PostgreSQL manager coverage

## Design

The private manager is the deep persistence boundary: it hides ORM/query mechanics and returns typed canonical data or raw retrieval signals. Search policy remains outside persistence.

## Verification

- full-stack workspace suite: 310 passed, 70 PostgreSQL-only skips
- memory PostgreSQL read/mutation suite on disposable PostgreSQL 17: 22 passed

Stack 2/5. Depends on #96.
