### PR TITLE
feat(memory): add canonical mutation transaction

### DIFF
--- a/backend/resources/memory/content_codec.py
+++ b/backend/resources/memory/content_codec.py
@@ -1,0 +1,275 @@
+"""Schema-version-aware conversion between typed memory content and ORM rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+from uuid import UUID
+
+from backend.database.models.memory import (
+    ContextNoteVersion,
+    EventVersion,
+    FactVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+from backend.resources.memory.objects import (
+    MemoryContent,
+    MemoryKind,
+    decode_memory_content,
+)
+from backend.resources.memory.errors import UnsupportedMemorySchema
+
+
+@dataclass(frozen=True, slots=True)
+class _ContentCodec:
+    model: type[Any]
+    encode: Callable[[UUID, UUID, UUID, Any], dict[str, Any]]
+    decode: Callable[[Any], dict[str, Any]]
+
+
+def typed_content_model(kind: MemoryKind) -> type[Any]:
+    """Return the canonical typed table for one memory kind."""
+
+    return _CODECS[(kind, 1)].model
+
+
+def typed_content_models() -> tuple[type[Any], ...]:
+    """Return the typed tables that own cross-kind status vocabulary."""
+
+    return tuple(codec.model for codec in _CODECS.values())
+
+
+def decode_stored_content(
+    kind: MemoryKind,
+    schema_version: int,
+    row: Any,
+) -> MemoryContent:
+    """Decode one complete typed ORM row through the matching schema codec."""
+
+    codec = _codec(kind, schema_version)
+    return decode_memory_content(kind, schema_version, codec.decode(row))
+
+
+def encode_stored_content(
+    version_id: UUID,
+    competition_id: UUID,
+    generation_id: UUID,
+    content: MemoryContent,
+) -> Any:
+    """Build one complete typed ORM row through the matching schema codec."""
+
+    kind = MemoryKind(content.kind)
+    codec = _codec(kind, content.schema_version)
+    return codec.model(
+        **codec.encode(version_id, competition_id, generation_id, content)
+    )
+
+
+def _codec(kind: MemoryKind, schema_version: int) -> _ContentCodec:
+    try:
+        return _CODECS[(kind, schema_version)]
+    except KeyError as error:
+        raise UnsupportedMemorySchema(
+            f"unsupported stored memory schema: {kind.value} v{schema_version}"
+        ) from error
+
+
+def _encode_storyline(
+    version_id: UUID,
+    _competition_id: UUID,
+    _generation_id: UUID,
+    content: Any,
+) -> dict[str, Any]:
+    values = content.model_dump(mode="json")
+    return {
+        "version_id": version_id,
+        "headline": content.headline,
+        "summary": content.summary,
+        "status": content.status.value,
+        "arc_type": content.arc_type,
+        "salience": content.salience,
+        "tags": list(content.tags),
+        "subjects": values["subjects"],
+        "evidence": values["evidence"],
+        "related_storylines": values["related_storylines"],
+        "callback_condition": content.callback_condition,
+        "resolution_summary": content.resolution_summary,
+    }
+
+
+def _decode_storyline(row: Any) -> dict[str, Any]:
+    return {
+        "headline": row.headline,
+        "summary": row.summary,
+        "status": row.status,
+        "arc_type": row.arc_type,
+        "salience": row.salience,
+        "tags": row.tags,
+        "subjects": row.subjects,
+        "evidence": row.evidence,
+        "related_storylines": row.related_storylines,
+        "callback_condition": row.callback_condition,
+        "resolution_summary": row.resolution_summary,
+    }
+
+
+def _encode_fact(
+    version_id: UUID,
+    competition_id: UUID,
+    generation_id: UUID,
+    content: Any,
+) -> dict[str, Any]:
+    values = content.model_dump(mode="json")
+    return {
+        "version_id": version_id,
+        "competition_id": competition_id,
+        "claim": content.claim,
+        "category": content.category,
+        "structured_numbers": values["numbers"],
+        "confidence": content.confidence.value,
+        "subjects": values["subjects"],
+        "originating_event_version_ids": list(
+            content.originating_event_version_ids
+        ),
+        "primary_tool_call_id": content.primary_tool_call_id,
+        "primary_tool_call_generation_id": (
+            generation_id if content.primary_tool_call_id is not None else None
+        ),
+        "primary_api_request_id": content.primary_api_request_id,
+        "additional_source_hints": values["source_hints"],
+        "status": content.status.value,
+    }
+
+
+def _decode_fact(row: Any) -> dict[str, Any]:
+    return {
+        "claim": row.claim,
+        "category": row.category,
+        "numbers": row.structured_numbers or {},
+        "confidence": row.confidence,
+        "status": row.status,
+        "subjects": row.subjects,
+        "originating_event_version_ids": row.originating_event_version_ids,
+        "primary_tool_call_id": row.primary_tool_call_id,
+        "primary_api_request_id": row.primary_api_request_id,
+        "source_hints": row.additional_source_hints,
+    }
+
+
+def _encode_event(
+    version_id: UUID,
+    competition_id: UUID,
+    generation_id: UUID,
+    content: Any,
+) -> dict[str, Any]:
+    values = content.model_dump(mode="json")
+    return {
+        "version_id": version_id,
+        "competition_id": competition_id,
+        "event_type": content.event_type.value,
+        "headline": content.headline,
+        "summary": content.summary,
+        "salience": content.salience,
+        "confidence": content.confidence.value,
+        "status": content.status.value,
+        "details": values["details"],
+        "additional_source_hints": values["source_hints"],
+        "primary_tool_call_id": content.primary_tool_call_id,
+        "primary_tool_call_generation_id": (
+            generation_id if content.primary_tool_call_id is not None else None
+        ),
+        "primary_api_request_id": content.primary_api_request_id,
+    }
+
+
+def _decode_event(row: Any) -> dict[str, Any]:
+    return {
+        "event_type": row.event_type,
+        "headline": row.headline,
+        "summary": row.summary,
+        "salience": row.salience,
+        "confidence": row.confidence,
+        "status": row.status,
+        "details": row.details,
+        "primary_tool_call_id": row.primary_tool_call_id,
+        "primary_api_request_id": row.primary_api_request_id,
+        "source_hints": row.additional_source_hints,
+    }
+
+
+def _encode_trigger(
+    version_id: UUID,
+    competition_id: UUID,
+    _generation_id: UUID,
+    content: Any,
+) -> dict[str, Any]:
+    values = content.model_dump(mode="json")
+    return {
+        "version_id": version_id,
+        "competition_id": competition_id,
+        "trigger_type": content.trigger_type.value,
+        "status": content.status.value,
+        "fire_policy": content.fire_policy.value,
+        "target_competition_season_id": content.target_competition_season_id,
+        "target_storyline_item_id": content.target_storyline_item_id,
+        "origin_event_item_id": content.origin_event_item_id,
+        "target_week": content.target_week,
+        "target_at": content.target_at,
+        "condition": values["condition"],
+        "resolution_reason": content.resolution_reason,
+    }
+
+
+def _decode_trigger(row: Any) -> dict[str, Any]:
+    return {
+        "trigger_type": row.trigger_type,
+        "status": row.status,
+        "fire_policy": row.fire_policy,
+        "target_storyline_item_id": row.target_storyline_item_id,
+        "origin_event_item_id": row.origin_event_item_id,
+        "target_competition_season_id": row.target_competition_season_id,
+        "target_week": row.target_week,
+        "target_at": row.target_at,
+        "condition": row.condition,
+        "resolution_reason": row.resolution_reason,
+    }
+
+
+def _encode_context_note(
+    version_id: UUID,
+    _competition_id: UUID,
+    _generation_id: UUID,
+    content: Any,
+) -> dict[str, Any]:
+    return {
+        "version_id": version_id,
+        "narrative_text": content.narrative,
+        "outlook": content.outlook,
+        "status": content.status.value,
+        "tags": list(content.tags),
+    }
+
+
+def _decode_context_note(row: Any) -> dict[str, Any]:
+    return {
+        "narrative": row.narrative_text,
+        "outlook": row.outlook,
+        "status": row.status,
+        "tags": row.tags,
+    }
+
+
+_CODECS = {
+    (MemoryKind.STORYLINE, 1): _ContentCodec(
+        StorylineVersion, _encode_storyline, _decode_storyline
+    ),
+    (MemoryKind.FACT, 1): _ContentCodec(FactVersion, _encode_fact, _decode_fact),
+    (MemoryKind.EVENT, 1): _ContentCodec(EventVersion, _encode_event, _decode_event),
+    (MemoryKind.TRIGGER, 1): _ContentCodec(
+        TriggerVersion, _encode_trigger, _decode_trigger
+    ),
+    (MemoryKind.CONTEXT_NOTE, 1): _ContentCodec(
+        ContextNoteVersion, _encode_context_note, _decode_context_note
+    ),
+}

--- a/backend/resources/memory/errors.py
+++ b/backend/resources/memory/errors.py
@@ -54,3 +54,11 @@ class StaleCanonicalRevision(MemoryError):
 
 class SearchProjectionUnavailable(Exception):
     """Internal signal that retrieval must use its bounded canonical fallback."""
+
+
+class CanonicalStateHashMismatch(RuntimeError):
+    """Internal invariant failure between prepared and stored canonical state."""
+
+
+class UnsupportedMemorySchema(RuntimeError):
+    """Internal signal that persisted content has no installed schema codec."""

--- a/backend/resources/memory/manager.py
+++ b/backend/resources/memory/manager.py
@@ -4,52 +4,72 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+import json
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, aliased
 
+from backend.database.models.core import CompetitionSeason, Franchise, SeasonRoster
 from backend.database.models.memory import (
     ContextNote,
-    ContextNoteVersion,
     CurrentRevision,
-    EventVersion,
-    FactVersion,
     MemoryItem,
     MemoryRevision,
     MemorySearchDocument,
     MemoryVersion,
-    StorylineVersion,
-    TriggerVersion,
 )
+from backend.database.models.reporting import Generation, ToolCall
+from backend.database.models.sleeper import ApiRequest, LeagueUser, Player, User
 from backend.database.sessions import (
     SessionFactory,
     read_only_session,
     transaction_session,
 )
 from backend.resources.memory.errors import (
+    CanonicalStateHashMismatch,
+    InvalidMemoryContent,
+    InvalidMemoryReference,
     MemoryNotFound,
     MemoryScopeViolation,
     SearchProjectionUnavailable,
+    StaleCanonicalRevision,
+)
+from backend.resources.memory.content_codec import (
+    decode_stored_content,
+    encode_stored_content,
+    typed_content_model,
+    typed_content_models,
 )
 from backend.resources.memory.objects import (
+    CreateItem,
+    ContextNoteIdentity,
     DEFAULT_EXPANSION,
     ExpansionPolicy,
     HydratedMemoryVersion,
     ItemHistory,
+    MemoryContent,
     MemoryListQuery,
     MemoryPage,
     MemoryQuery,
     MemoryRevision as MemoryRevisionResource,
     MemoryRevisionRef,
     MemoryKind,
+    MemoryMutationBundle,
     RebuildResult,
+    ReplaceItem,
+    RevisionCommitted,
     RevisionPage,
     SearchIndexStatus,
     TypedMemoryVersion,
-    decode_memory_content,
+    MutationItemResult,
+    MutationResult,
+    NoChange,
 )
 from backend.resources.memory.search_documents import (
     SEARCH_DOCUMENT_BUILDER_VERSION,
@@ -70,11 +90,215 @@ class MemoryCandidate:
     matched_entities: tuple[str, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedVersion:
+    operation_index: int
+    client_key: str | None
+    item_id: UUID
+    version_id: UUID
+    content: MemoryContent
+    context_note_identity: ContextNoteIdentity | None
+    revision_number: int
+    replaced_version_id: UUID | None
+    change_reason: str | None
+
+
+_EXPECTED_IDENTITY_CONSTRAINTS = frozenset(
+    {
+        "pk_memory_items",
+        "pk_memory_versions",
+        "uq_memory_items_id_competition",
+        "uq_memory_versions_id_competition",
+        "uq_memory_versions_item_revision",
+        "uq_context_notes_competition_key",
+        "uq_context_notes_season_key",
+        "uq_context_notes_franchise_key",
+    }
+)
+
+
 class MemoryManager:
     """Deep persistence boundary for the canonical memory aggregate."""
 
     def __init__(self, session_factory: SessionFactory) -> None:
         self._session_factory = session_factory
+
+    def apply(self, bundle: MemoryMutationBundle) -> MutationResult:
+        """Validate and atomically commit one complete canonical mutation bundle."""
+
+        try:
+            with transaction_session(self._session_factory) as session:
+                generation = session.get(Generation, bundle.producing_generation_id)
+                if generation is None:
+                    raise MemoryNotFound(
+                        f"producing generation not found: {bundle.producing_generation_id}"
+                    )
+                existing = _revision_for_generation(session, generation.id)
+                if existing is not None:
+                    return _committed_result(session, existing)
+
+                current = session.scalar(
+                    sa.select(CurrentRevision)
+                    .where(CurrentRevision.competition_id == generation.competition_id)
+                    .with_for_update()
+                )
+                if current is None:
+                    raise MemoryNotFound(
+                        "current memory revision not found for producing generation"
+                    )
+
+                # A concurrent retry may have committed while this transaction waited
+                # for the competition pointer lock.
+                existing = _revision_for_generation(session, generation.id)
+                if existing is not None:
+                    return _committed_result(session, existing)
+
+                current_revision = session.get(
+                    MemoryRevision, current.current_revision_id
+                )
+                if current_revision is None:
+                    raise MemoryNotFound(
+                        f"current memory revision not found: {current.current_revision_id}"
+                    )
+                if generation.input_memory_revision_id is None:
+                    if not bundle.operations:
+                        return NoChange(
+                            revision=_revision_ref(current_revision),
+                            reason="mutation bundle contains no operations",
+                        )
+                    raise InvalidMemoryReference(
+                        "producing generation does not have a canonical memory input",
+                        details={"generation_id": str(generation.id)},
+                    )
+                pinned_base = session.get(
+                    MemoryRevision, generation.input_memory_revision_id
+                )
+                if pinned_base is None:
+                    raise MemoryNotFound(
+                        "generation input memory revision was not found"
+                    )
+                if pinned_base.competition_id != generation.competition_id:
+                    raise MemoryScopeViolation(
+                        "generation input memory revision is outside its competition"
+                    )
+                base_ref = _revision_ref(pinned_base)
+                if not bundle.operations:
+                    return NoChange(
+                        revision=base_ref,
+                        reason="mutation bundle contains no operations",
+                    )
+
+                prepared = _prepare_mutation(
+                    session,
+                    bundle,
+                    generation,
+                    base_ref,
+                )
+                if not prepared:
+                    return NoChange(
+                        revision=base_ref,
+                        reason="mutation bundle does not change canonical memory",
+                    )
+                if current.current_revision_id != generation.input_memory_revision_id:
+                    current_ref = _revision_ref(current_revision)
+                    surviving_indexes = {
+                        item.operation_index for item in prepared
+                    }
+                    surviving_bundle = MemoryMutationBundle(
+                        producing_generation_id=bundle.producing_generation_id,
+                        operations=tuple(
+                            operation
+                            for index, operation in enumerate(bundle.operations)
+                            if index in surviving_indexes
+                        ),
+                    )
+                    current_prepared = _prepare_mutation(
+                        session,
+                        surviving_bundle,
+                        generation,
+                        current_ref,
+                    )
+                    if not current_prepared:
+                        return NoChange(
+                            revision=current_ref,
+                            reason="mutation transitions are already represented",
+                        )
+                    raise StaleCanonicalRevision(
+                        "canonical memory advanced after the generation was pinned",
+                        details={
+                            "generation_id": str(generation.id),
+                            "expected_revision_id": str(
+                                generation.input_memory_revision_id
+                            ),
+                            "current_revision_id": str(current.current_revision_id),
+                        },
+                    )
+
+                revision_id = uuid4()
+                recorded_at = datetime.now(UTC)
+                revision = MemoryRevision(
+                    id=revision_id,
+                    competition_id=generation.competition_id,
+                    sequence_number=pinned_base.sequence_number + 1,
+                    previous_revision_id=pinned_base.id,
+                    producing_generation_id=generation.id,
+                    competition_season_id=generation.competition_season_id,
+                    week=generation.domain_cutoff_week,
+                    knowledge_cutoff_at=generation.knowledge_cutoff_at,
+                    state_content_hash=_resulting_state_hash(
+                        session,
+                        base_ref,
+                        prepared,
+                    ),
+                    created_at=recorded_at,
+                )
+                session.add(revision)
+                session.flush()
+
+                _persist_prepared_versions(
+                    session,
+                    prepared,
+                    generation,
+                    revision_id,
+                    recorded_at,
+                )
+                stored_hash = _stored_state_hash(
+                    session,
+                    MemoryRevisionRef(
+                        id=revision_id,
+                        competition_id=generation.competition_id,
+                        sequence_number=revision.sequence_number,
+                        state_content_hash=revision.state_content_hash,
+                    ),
+                )
+                if stored_hash != revision.state_content_hash:
+                    raise CanonicalStateHashMismatch(
+                        "stored canonical memory does not match its resulting-state hash",
+                    )
+                typed_versions = _typed_prepared_versions(
+                    prepared,
+                    generation,
+                    revision_id,
+                    recorded_at,
+                )
+                _persist_search_documents(
+                    session,
+                    [build_search_document(version) for version in typed_versions],
+                )
+
+                current.current_revision_id = revision_id
+                current.lock_version += 1
+                current.updated_at = recorded_at
+                session.flush()
+
+                return _committed_result(session, revision)
+        except IntegrityError as error:
+            if _integrity_constraint(error) not in _EXPECTED_IDENTITY_CONSTRAINTS:
+                raise
+            raise InvalidMemoryReference(
+                "memory mutation conflicts with a persisted canonical identity",
+                details={"generation_id": str(bundle.producing_generation_id)},
+            ) from error
 
     def current_revision(self, competition_id: UUID) -> MemoryRevisionRef:
         with read_only_session(self._session_factory) as session:
@@ -518,6 +742,896 @@ class MemoryManager:
             _persist_search_documents(session, documents)
 
 
+def _revision_for_generation(
+    session: Session,
+    generation_id: UUID,
+) -> MemoryRevision | None:
+    return session.scalar(
+        sa.select(MemoryRevision).where(
+            MemoryRevision.producing_generation_id == generation_id
+        )
+    )
+
+
+def _committed_result(
+    session: Session,
+    revision: MemoryRevision,
+) -> RevisionCommitted:
+    rows = session.execute(
+        sa.select(MemoryVersion, MemoryItem)
+        .join(MemoryItem, MemoryItem.id == MemoryVersion.item_id)
+        .where(MemoryVersion.introduced_revision_id == revision.id)
+        .order_by(MemoryVersion.item_id, MemoryVersion.id)
+    )
+    return RevisionCommitted(
+        revision=_revision_ref(revision),
+        items=tuple(
+            MutationItemResult(
+                client_key=(item.agent_key if version.revision_number == 1 else None),
+                item_id=version.item_id,
+                version_id=version.id,
+            )
+            for version, item in rows
+        )
+    )
+
+
+def _prepare_mutation(
+    session: Session,
+    bundle: MemoryMutationBundle,
+    generation: Generation,
+    base: MemoryRevisionRef,
+) -> tuple[_PreparedVersion, ...]:
+    creates = [
+        (index, operation)
+        for index, operation in enumerate(bundle.operations)
+        if isinstance(operation, CreateItem)
+    ]
+    replacements = [
+        (index, operation)
+        for index, operation in enumerate(bundle.operations)
+        if isinstance(operation, ReplaceItem)
+    ]
+    _reject_duplicate_values(
+        "client key",
+        [operation.client_key for _, operation in creates],
+    )
+    _reject_duplicate_values(
+        "generated item ID",
+        [operation.item_id for _, operation in creates],
+    )
+    _reject_duplicate_values(
+        "generated version ID",
+        [operation.version_id for _, operation in creates],
+    )
+    _reject_duplicate_values(
+        "replacement target",
+        [operation.item_id for _, operation in replacements],
+    )
+    create_item_ids = {operation.item_id for _, operation in creates}
+    replaced_item_ids = {operation.item_id for _, operation in replacements}
+    overlap = create_item_ids & replaced_item_ids
+    if overlap:
+        _invalid_reference(
+            "an item cannot be created and replaced in the same bundle",
+            next(iter(overlap)),
+        )
+
+    represented_creates = _represented_create_indexes(
+        session,
+        creates,
+        generation.competition_id,
+        base,
+    )
+
+    stored_targets = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(MemoryItem).where(MemoryItem.id.in_(replaced_item_ids))
+        )
+    }
+    for _, operation in replacements:
+        target = stored_targets.get(operation.item_id)
+        if target is None:
+            _invalid_reference("replacement target does not exist", operation.item_id)
+        if target.competition_id != generation.competition_id:
+            raise MemoryScopeViolation(
+                "replacement target is outside the producing competition",
+                details={"item_id": str(operation.item_id)},
+            )
+        if target.kind != operation.content.kind:
+            raise InvalidMemoryContent(
+                "replacement content kind does not match its stable item",
+                details={
+                    "item_id": str(operation.item_id),
+                    "target_kind": target.kind,
+                    "content_kind": operation.content.kind,
+                },
+            )
+
+    visible_rows = session.execute(
+        _visible_versions(base)
+        .with_only_columns(MemoryVersion.item_id, MemoryVersion.id)
+        .where(MemoryVersion.item_id.in_(replaced_item_ids))
+    ).all()
+    visible_by_item = {item_id: version_id for item_id, version_id in visible_rows}
+    for item_id in replaced_item_ids:
+        if item_id not in visible_by_item:
+            _invalid_reference(
+                "replacement target is not visible at the generation input revision",
+                item_id,
+            )
+    current_versions = _load_typed_versions(
+        session,
+        tuple(visible_by_item.values()),
+    )
+
+    prepared: list[_PreparedVersion] = [
+        _PreparedVersion(
+            operation_index=index,
+            client_key=operation.client_key,
+            item_id=operation.item_id,
+            version_id=operation.version_id,
+            content=operation.content,
+            context_note_identity=operation.context_note_identity,
+            revision_number=1,
+            replaced_version_id=None,
+            change_reason=None,
+        )
+        for index, operation in creates
+        if index not in represented_creates
+    ]
+    for index, operation in replacements:
+        previous = current_versions[visible_by_item[operation.item_id]]
+        if _canonical_content(previous.content) == _canonical_content(
+            operation.content
+        ):
+            continue
+        prepared.append(
+            _PreparedVersion(
+                operation_index=index,
+                client_key=None,
+                item_id=operation.item_id,
+                version_id=uuid4(),
+                content=operation.content,
+                context_note_identity=previous.context_note_identity,
+                revision_number=previous.revision_number + 1,
+                replaced_version_id=previous.version_id,
+                change_reason=operation.change_reason,
+            )
+        )
+
+    prepared.sort(key=lambda item: item.operation_index)
+    _validate_memory_references(
+        session,
+        generation.competition_id,
+        base,
+        prepared,
+    )
+    _validate_scoped_resources(session, generation, prepared)
+    _validate_context_note_keys(
+        session,
+        generation.competition_id,
+        base,
+        prepared,
+    )
+    return tuple(prepared)
+
+
+def _represented_create_indexes(
+    session: Session,
+    creates: Sequence[tuple[int, CreateItem]],
+    competition_id: UUID,
+    revision: MemoryRevisionRef,
+) -> set[int]:
+    if not creates:
+        return set()
+    item_ids = {operation.item_id for _, operation in creates}
+    version_ids = {operation.version_id for _, operation in creates}
+    stored_items = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(MemoryItem).where(MemoryItem.id.in_(item_ids))
+        )
+    }
+    stored_versions = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(MemoryVersion).where(MemoryVersion.id.in_(version_ids))
+        )
+    }
+    visible_rows = session.execute(
+        _visible_versions(revision)
+        .with_only_columns(MemoryVersion.item_id, MemoryVersion.id)
+        .where(
+            sa.or_(
+                MemoryVersion.item_id.in_(item_ids),
+                MemoryVersion.id.in_(version_ids),
+            )
+        )
+    ).all()
+    visible_item_ids = {item_id for item_id, _ in visible_rows}
+    visible_version_ids = {version_id for _, version_id in visible_rows}
+    represented: set[int] = set()
+    for index, operation in creates:
+        item = stored_items.get(operation.item_id)
+        version = stored_versions.get(operation.version_id)
+        for stored in (item, version):
+            if stored is not None and stored.competition_id != competition_id:
+                raise MemoryScopeViolation(
+                    "generated memory identity exists in another competition",
+                    details={"reference_id": str(operation.item_id)},
+                )
+        item_visible = operation.item_id in visible_item_ids
+        version_visible = operation.version_id in visible_version_ids
+        if not item_visible and not version_visible:
+            continue
+        if (
+            item is None
+            or version is None
+            or not item_visible
+            or not version_visible
+            or version.item_id != operation.item_id
+            or item.kind != operation.content.kind
+        ):
+            _invalid_reference(
+                "generated memory identity conflicts with canonical state",
+                operation.item_id,
+            )
+        stored_content = _load_typed_versions(session, [version.id])[version.id]
+        if (
+            _canonical_content(stored_content.content)
+            != _canonical_content(operation.content)
+            or stored_content.context_note_identity != operation.context_note_identity
+        ):
+            _invalid_reference(
+                "generated memory identity has different canonical content",
+                operation.item_id,
+            )
+        represented.add(index)
+    return represented
+
+
+def _reject_duplicate_values(label: str, values: Sequence[object]) -> None:
+    seen: set[object] = set()
+    for value in values:
+        if value in seen:
+            raise InvalidMemoryReference(
+                f"duplicate {label} in mutation bundle",
+                details={"value": str(value)},
+            )
+        seen.add(value)
+
+
+def _invalid_reference(message: str, reference_id: UUID) -> None:
+    raise InvalidMemoryReference(
+        message,
+        details={"reference_id": str(reference_id)},
+    )
+
+
+def _validate_memory_references(
+    session: Session,
+    competition_id: UUID,
+    base: MemoryRevisionRef,
+    prepared: Sequence[_PreparedVersion],
+) -> None:
+    new_version_kinds = {
+        item.version_id: MemoryKind(item.content.kind) for item in prepared
+    }
+    new_item_kinds = {item.item_id: MemoryKind(item.content.kind) for item in prepared}
+    exact_references: dict[UUID, MemoryKind] = {}
+    item_references: dict[UUID, MemoryKind] = {}
+    for item in prepared:
+        content = item.content
+        if content.kind == MemoryKind.STORYLINE.value:
+            for reference in content.evidence:
+                _register_expected_kind(
+                    exact_references,
+                    reference.version_id,
+                    MemoryKind(reference.kind),
+                )
+            for reference in content.related_storylines:
+                _register_expected_kind(
+                    item_references,
+                    reference.item_id,
+                    MemoryKind.STORYLINE,
+                )
+        elif content.kind == MemoryKind.FACT.value:
+            for version_id in content.originating_event_version_ids:
+                _register_expected_kind(
+                    exact_references,
+                    version_id,
+                    MemoryKind.EVENT,
+                )
+        elif content.kind == MemoryKind.TRIGGER.value:
+            if content.target_storyline_item_id is not None:
+                _register_expected_kind(
+                    item_references,
+                    content.target_storyline_item_id,
+                    MemoryKind.STORYLINE,
+                )
+            if content.origin_event_item_id is not None:
+                _register_expected_kind(
+                    item_references,
+                    content.origin_event_item_id,
+                    MemoryKind.EVENT,
+                )
+
+    persisted_version_ids = set(exact_references) - set(new_version_kinds)
+    persisted_versions = {
+        row.id: (row, memory_item)
+        for row, memory_item in session.execute(
+            sa.select(MemoryVersion, MemoryItem)
+            .join(MemoryItem, MemoryItem.id == MemoryVersion.item_id)
+            .where(MemoryVersion.id.in_(persisted_version_ids))
+        )
+    }
+    introduced = aliased(MemoryRevision)
+    available_version_ids = set(
+        session.scalars(
+            sa.select(MemoryVersion.id)
+            .join(introduced, introduced.id == MemoryVersion.introduced_revision_id)
+            .where(
+                MemoryVersion.id.in_(persisted_version_ids),
+                introduced.sequence_number <= base.sequence_number,
+            )
+        )
+    )
+    for version_id, expected_kind in exact_references.items():
+        if version_id in new_version_kinds:
+            actual_kind = new_version_kinds[version_id]
+        else:
+            stored = persisted_versions.get(version_id)
+            if stored is None:
+                _invalid_reference("referenced memory version does not exist", version_id)
+            envelope, memory_item = stored
+            if envelope.competition_id != competition_id:
+                raise MemoryScopeViolation(
+                    "referenced memory version is outside the producing competition",
+                    details={"version_id": str(version_id)},
+                )
+            if version_id not in available_version_ids:
+                _invalid_reference(
+                    "referenced memory version was not available at the generation input",
+                    version_id,
+                )
+            actual_kind = MemoryKind(memory_item.kind)
+        if actual_kind is not expected_kind:
+            raise InvalidMemoryReference(
+                "referenced memory version has the wrong kind",
+                details={
+                    "version_id": str(version_id),
+                    "expected_kind": expected_kind.value,
+                    "actual_kind": actual_kind.value,
+                },
+            )
+
+    persisted_item_ids = set(item_references) - set(new_item_kinds)
+    persisted_items = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(MemoryItem).where(MemoryItem.id.in_(persisted_item_ids))
+        )
+    }
+    visible_item_ids = set(
+        session.scalars(
+            _visible_versions(base)
+            .with_only_columns(MemoryVersion.item_id)
+            .where(MemoryVersion.item_id.in_(persisted_item_ids))
+        )
+    )
+    for item_id, expected_kind in item_references.items():
+        if item_id in new_item_kinds:
+            actual_kind = new_item_kinds[item_id]
+        else:
+            stored = persisted_items.get(item_id)
+            if stored is None:
+                _invalid_reference("referenced memory item does not exist", item_id)
+            if stored.competition_id != competition_id:
+                raise MemoryScopeViolation(
+                    "referenced memory item is outside the producing competition",
+                    details={"item_id": str(item_id)},
+                )
+            if item_id not in visible_item_ids:
+                _invalid_reference(
+                    "referenced memory item is not visible at the generation input",
+                    item_id,
+                )
+            actual_kind = MemoryKind(stored.kind)
+        if actual_kind is not expected_kind:
+            raise InvalidMemoryReference(
+                "referenced memory item has the wrong kind",
+                details={
+                    "item_id": str(item_id),
+                    "expected_kind": expected_kind.value,
+                    "actual_kind": actual_kind.value,
+                },
+            )
+
+
+def _register_expected_kind(
+    references: dict[UUID, MemoryKind],
+    reference_id: UUID,
+    expected_kind: MemoryKind,
+) -> None:
+    previous = references.get(reference_id)
+    if previous is not None and previous is not expected_kind:
+        raise InvalidMemoryReference(
+            "memory reference has contradictory kind expectations",
+            details={
+                "reference_id": str(reference_id),
+                "first_kind": previous.value,
+                "second_kind": expected_kind.value,
+            },
+        )
+    references[reference_id] = expected_kind
+
+
+def _validate_scoped_resources(
+    session: Session,
+    generation: Generation,
+    prepared: Sequence[_PreparedVersion],
+) -> None:
+    ids_by_model: dict[type[Any], set[UUID]] = {
+        CompetitionSeason: {generation.competition_season_id},
+        Franchise: set(),
+        SeasonRoster: set(),
+    }
+    player_ids: set[str] = set()
+    user_ids: set[str] = set()
+    tool_call_ids: set[UUID] = set()
+    api_request_ids: set[UUID] = set()
+    for item in prepared:
+        subjects = getattr(item.content, "subjects", ())
+        for subject in subjects:
+            if subject.kind == "franchise":
+                ids_by_model[Franchise].add(subject.id)
+            elif subject.kind == "season_roster":
+                ids_by_model[SeasonRoster].add(subject.id)
+            elif subject.kind == "competition_season":
+                ids_by_model[CompetitionSeason].add(subject.id)
+            elif subject.kind == "player":
+                player_ids.add(subject.id)
+            elif subject.kind == "sleeper_user":
+                user_ids.add(subject.id)
+        if item.content.kind == MemoryKind.EVENT.value:
+            details = item.content.details
+            for name in (
+                "sender_franchise_id",
+                "receiver_franchise_id",
+                "winner_franchise_id",
+                "loser_franchise_id",
+                "franchise_id",
+            ):
+                value = getattr(details, name, None)
+                if value is not None:
+                    ids_by_model[Franchise].add(value)
+            for asset in getattr(details, "assets", ()):
+                player_id = getattr(asset, "player_id", None)
+                if player_id is not None:
+                    player_ids.add(player_id)
+                roster_id = getattr(asset, "original_season_roster_id", None)
+                if roster_id is not None:
+                    ids_by_model[SeasonRoster].add(roster_id)
+            for name in ("added_player_id", "dropped_player_id"):
+                player_id = getattr(details, name, None)
+                if player_id is not None:
+                    player_ids.add(player_id)
+        if item.content.kind == MemoryKind.TRIGGER.value:
+            season_id = item.content.target_competition_season_id
+            if season_id is not None:
+                ids_by_model[CompetitionSeason].add(season_id)
+            subject = getattr(item.content.condition, "subject", None)
+            if subject is not None:
+                if subject.kind == "franchise":
+                    ids_by_model[Franchise].add(subject.id)
+                elif subject.kind == "season_roster":
+                    ids_by_model[SeasonRoster].add(subject.id)
+                elif subject.kind == "competition_season":
+                    ids_by_model[CompetitionSeason].add(subject.id)
+                elif subject.kind == "player":
+                    player_ids.add(subject.id)
+                elif subject.kind == "sleeper_user":
+                    user_ids.add(subject.id)
+        tool_call_id = getattr(item.content, "primary_tool_call_id", None)
+        if tool_call_id is not None:
+            tool_call_ids.add(tool_call_id)
+        api_request_id = getattr(item.content, "primary_api_request_id", None)
+        if api_request_id is not None:
+            api_request_ids.add(api_request_id)
+        identity = item.context_note_identity
+        if identity is not None:
+            if identity.competition_season_id is not None:
+                ids_by_model[CompetitionSeason].add(identity.competition_season_id)
+            if identity.franchise_id is not None:
+                ids_by_model[Franchise].add(identity.franchise_id)
+
+    for model, resource_ids in ids_by_model.items():
+        if not resource_ids:
+            continue
+        stored = {
+            row.id: row
+            for row in session.scalars(sa.select(model).where(model.id.in_(resource_ids)))
+        }
+        for resource_id in resource_ids:
+            row = stored.get(resource_id)
+            if row is None:
+                _invalid_reference("referenced scoped resource does not exist", resource_id)
+            if row.competition_id != generation.competition_id:
+                raise MemoryScopeViolation(
+                    "referenced resource is outside the producing competition",
+                    details={"reference_id": str(resource_id)},
+                )
+    _validate_player_references(session, player_ids)
+    _validate_user_references(
+        session,
+        generation.competition_season_id,
+        user_ids,
+    )
+    _validate_source_receipts(
+        session,
+        generation,
+        tool_call_ids,
+        api_request_ids,
+    )
+    for item in prepared:
+        identity = item.context_note_identity
+        if (
+            identity is not None
+            and identity.competition_season_id is not None
+            and identity.competition_season_id != generation.competition_season_id
+        ):
+            raise InvalidMemoryReference(
+                "context-note season must match the producing generation season",
+                details={"item_id": str(item.item_id)},
+            )
+
+
+def _validate_player_references(session: Session, player_ids: set[str]) -> None:
+    if not player_ids:
+        return
+    stored_ids = set(
+        session.scalars(
+            sa.select(Player.sleeper_player_id).where(
+                Player.sleeper_player_id.in_(player_ids)
+            )
+        )
+    )
+    missing = player_ids - stored_ids
+    if missing:
+        raise InvalidMemoryReference(
+            "referenced Sleeper player does not exist",
+            details={"player_id": min(missing)},
+        )
+
+
+def _validate_user_references(
+    session: Session,
+    competition_season_id: UUID,
+    user_ids: set[str],
+) -> None:
+    if not user_ids:
+        return
+    stored_ids = set(
+        session.scalars(
+            sa.select(User.sleeper_user_id).where(
+                User.sleeper_user_id.in_(user_ids)
+            )
+        )
+    )
+    missing = user_ids - stored_ids
+    if missing:
+        raise InvalidMemoryReference(
+            "referenced Sleeper user does not exist",
+            details={"sleeper_user_id": min(missing)},
+        )
+    member_ids = set(
+        session.scalars(
+            sa.select(LeagueUser.sleeper_user_id).where(
+                LeagueUser.competition_season_id == competition_season_id,
+                LeagueUser.sleeper_user_id.in_(user_ids),
+            )
+        )
+    )
+    outside_scope = user_ids - member_ids
+    if outside_scope:
+        raise MemoryScopeViolation(
+            "referenced Sleeper user is outside the producing season",
+            details={"sleeper_user_id": min(outside_scope)},
+        )
+
+
+def _validate_source_receipts(
+    session: Session,
+    generation: Generation,
+    tool_call_ids: set[UUID],
+    api_request_ids: set[UUID],
+) -> None:
+    tool_calls = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(ToolCall).where(ToolCall.id.in_(tool_call_ids))
+        )
+    }
+    for tool_call_id in tool_call_ids:
+        tool_call = tool_calls.get(tool_call_id)
+        if tool_call is None:
+            _invalid_reference("primary tool-call receipt does not exist", tool_call_id)
+        if tool_call.generation_id != generation.id:
+            raise MemoryScopeViolation(
+                "primary tool-call receipt belongs to another generation",
+                details={"tool_call_id": str(tool_call_id)},
+            )
+
+    api_requests = {
+        row.id: row
+        for row in session.scalars(
+            sa.select(ApiRequest).where(ApiRequest.id.in_(api_request_ids))
+        )
+    }
+    for api_request_id in api_request_ids:
+        api_request = api_requests.get(api_request_id)
+        if api_request is None:
+            _invalid_reference("primary API-request receipt does not exist", api_request_id)
+        if api_request.competition_season_id != generation.competition_season_id:
+            raise MemoryScopeViolation(
+                "primary API-request receipt is outside the producing season",
+                details={"api_request_id": str(api_request_id)},
+            )
+
+
+def _validate_context_note_keys(
+    session: Session,
+    competition_id: UUID,
+    revision: MemoryRevisionRef,
+    prepared: Sequence[_PreparedVersion],
+) -> None:
+    identities = [
+        (item.item_id, item.context_note_identity)
+        for item in prepared
+        if item.replaced_version_id is None and item.context_note_identity is not None
+    ]
+    keys: list[tuple[object, ...]] = []
+    for _, identity in identities:
+        keys.append(
+            (
+                identity.scope.value,
+                identity.competition_season_id,
+                identity.franchise_id,
+                identity.note_key,
+            )
+        )
+    _reject_duplicate_values("context-note identity", keys)
+    for item_id, identity in identities:
+        statement = sa.select(ContextNote.item_id).where(
+            ContextNote.competition_id == competition_id,
+            ContextNote.scope == identity.scope.value,
+            ContextNote.note_key == identity.note_key,
+        )
+        if identity.competition_season_id is not None:
+            statement = statement.where(
+                ContextNote.competition_season_id == identity.competition_season_id
+            )
+        if identity.franchise_id is not None:
+            statement = statement.where(ContextNote.franchise_id == identity.franchise_id)
+        existing_item_id = session.scalar(statement)
+        if existing_item_id is not None and session.scalar(
+            sa.select(
+                sa.exists(
+                    _visible_versions(revision)
+                    .with_only_columns(MemoryVersion.id)
+                    .where(MemoryVersion.item_id == existing_item_id)
+                )
+            )
+        ):
+            _invalid_reference("context-note identity already exists", item_id)
+
+
+def _resulting_state_hash(
+    session: Session,
+    base: MemoryRevisionRef,
+    prepared: Sequence[_PreparedVersion],
+) -> str:
+    visible_ids = list(
+        session.scalars(_visible_versions(base).with_only_columns(MemoryVersion.id))
+    )
+    current: dict[UUID, tuple[MemoryContent, ContextNoteIdentity | None]] = {
+        version.item_id: (version.content, version.context_note_identity)
+        for version in _load_typed_versions(session, visible_ids).values()
+    }
+    for item in prepared:
+        current[item.item_id] = (item.content, item.context_note_identity)
+    return _state_hash(current)
+
+
+def _stored_state_hash(session: Session, revision: MemoryRevisionRef) -> str:
+    visible_ids = list(
+        session.scalars(_visible_versions(revision).with_only_columns(MemoryVersion.id))
+    )
+    stored = {
+        version.item_id: (version.content, version.context_note_identity)
+        for version in _load_typed_versions(session, visible_ids).values()
+    }
+    return _state_hash(stored)
+
+
+def _state_hash(
+    state_by_item: Mapping[
+        UUID,
+        tuple[MemoryContent, ContextNoteIdentity | None],
+    ],
+) -> str:
+    state = [
+        {
+            "item_id": str(item_id),
+            "content": content.model_dump(mode="json"),
+            "context_note_identity": (
+                identity.model_dump(mode="json")
+                if identity is not None
+                else None
+            ),
+        }
+        for item_id, (content, identity) in sorted(
+            state_by_item.items(), key=lambda pair: pair[0].hex
+        )
+    ]
+    return sha256(_canonical_json_bytes(state)).hexdigest()
+
+
+def _persist_prepared_versions(
+    session: Session,
+    prepared: Sequence[_PreparedVersion],
+    generation: Generation,
+    revision_id: UUID,
+    recorded_at: datetime,
+) -> None:
+    creates = [item for item in prepared if item.replaced_version_id is None]
+    session.add_all(
+        [
+            MemoryItem(
+                id=item.item_id,
+                competition_id=generation.competition_id,
+                kind=item.content.kind,
+                agent_key=item.client_key,
+                created_at=recorded_at,
+            )
+            for item in creates
+        ]
+    )
+    # The context-note FK is composite and has no ORM relationship edge; make the
+    # stable items visible before adding their one-to-one identities.
+    session.flush()
+    session.add_all(
+        [
+            ContextNote(
+                item_id=item.item_id,
+                competition_id=generation.competition_id,
+                scope=item.context_note_identity.scope.value,
+                competition_season_id=item.context_note_identity.competition_season_id,
+                franchise_id=item.context_note_identity.franchise_id,
+                note_key=item.context_note_identity.note_key,
+            )
+            for item in creates
+            if item.context_note_identity is not None
+        ]
+    )
+    replaced_ids = [
+        item.replaced_version_id
+        for item in prepared
+        if item.replaced_version_id is not None
+    ]
+    if replaced_ids:
+        session.execute(
+            sa.update(MemoryVersion)
+            .where(
+                MemoryVersion.id.in_(replaced_ids),
+                MemoryVersion.retired_revision_id.is_(None),
+            )
+            .values(retired_revision_id=revision_id)
+        )
+    session.add_all(
+        [
+            MemoryVersion(
+                id=item.version_id,
+                item_id=item.item_id,
+                competition_id=generation.competition_id,
+                revision_number=item.revision_number,
+                content_schema_version=item.content.schema_version,
+                introduced_revision_id=revision_id,
+                retired_revision_id=None,
+                competition_season_id=generation.competition_season_id,
+                week=generation.domain_cutoff_week,
+                occurred_at=None,
+                creating_generation_id=generation.id,
+                creating_tool_call_id=None,
+                change_reason=item.change_reason,
+                recorded_at=recorded_at,
+            )
+            for item in prepared
+        ]
+    )
+    session.flush()
+    session.add_all(
+        [
+            encode_stored_content(
+                item.version_id,
+                generation.competition_id,
+                generation.id,
+                item.content,
+            )
+            for item in prepared
+        ]
+    )
+    session.flush()
+
+
+def _typed_prepared_versions(
+    prepared: Sequence[_PreparedVersion],
+    generation: Generation,
+    revision_id: UUID,
+    recorded_at: datetime,
+) -> tuple[TypedMemoryVersion, ...]:
+    return tuple(
+        _typed_prepared_version(
+            item,
+            competition_id=generation.competition_id,
+            competition_season_id=generation.competition_season_id,
+            week=generation.domain_cutoff_week,
+            generation_id=generation.id,
+            revision_id=revision_id,
+            recorded_at=recorded_at,
+        )
+        for item in prepared
+    )
+
+
+def _typed_prepared_version(
+    item: _PreparedVersion,
+    *,
+    competition_id: UUID,
+    competition_season_id: UUID | None,
+    week: int | None,
+    generation_id: UUID,
+    revision_id: UUID,
+    recorded_at: datetime,
+) -> TypedMemoryVersion:
+    return TypedMemoryVersion(
+        version_id=item.version_id,
+        item_id=item.item_id,
+        competition_id=competition_id,
+        kind=MemoryKind(item.content.kind),
+        content=item.content,
+        content_schema_version=item.content.schema_version,
+        revision_number=item.revision_number,
+        introduced_revision_id=revision_id,
+        competition_season_id=competition_season_id,
+        week=week,
+        creating_generation_id=generation_id,
+        change_reason=item.change_reason,
+        recorded_at=recorded_at,
+        context_note_identity=item.context_note_identity,
+    )
+
+
+def _canonical_content(content: MemoryContent) -> bytes:
+    return _canonical_json_bytes(content.model_dump(mode="json"))
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _integrity_constraint(error: IntegrityError) -> str | None:
+    diagnostic = getattr(error.orig, "diag", None)
+    return getattr(diagnostic, "constraint_name", None)
+
+
 def _revision_ref(revision: MemoryRevision) -> MemoryRevisionRef:
     return MemoryRevisionRef(
         id=revision.id,
@@ -668,21 +1782,13 @@ def _load_typed_versions(
         ids_by_kind.setdefault(kind, []).append(version.id)
 
     typed_rows: dict[UUID, object] = {}
-    table_by_kind = {
-        MemoryKind.STORYLINE: StorylineVersion,
-        MemoryKind.FACT: FactVersion,
-        MemoryKind.EVENT: EventVersion,
-        MemoryKind.TRIGGER: TriggerVersion,
-        MemoryKind.CONTEXT_NOTE: ContextNoteVersion,
-    }
     for kind, ids in ids_by_kind.items():
+        model = typed_content_model(kind)
         typed_rows.update(
             {
                 row.version_id: row
                 for row in session.scalars(
-                    sa.select(table_by_kind[kind]).where(
-                        table_by_kind[kind].version_id.in_(ids)
-                    )
+                    sa.select(model).where(model.version_id.in_(ids))
                 )
             }
         )
@@ -707,10 +1813,10 @@ def _load_typed_versions(
         if typed_row is None:
             raise MemoryNotFound(f"typed memory content not found: {version_id}")
         kind = MemoryKind(item.kind)
-        content = decode_memory_content(
+        content = decode_stored_content(
             kind,
             envelope.content_schema_version,
-            _content_payload(kind, typed_row),
+            typed_row,
         )
         identity_row = context_identities.get(item.id)
         decoded[version_id] = TypedMemoryVersion(
@@ -742,68 +1848,6 @@ def _load_typed_versions(
             ),
         )
     return decoded
-
-
-def _content_payload(kind: MemoryKind, row: object) -> dict[str, Any]:
-    if kind == MemoryKind.STORYLINE:
-        return {
-            "headline": row.headline,
-            "summary": row.summary,
-            "status": row.status,
-            "arc_type": row.arc_type,
-            "salience": row.salience,
-            "tags": row.tags,
-            "subjects": row.subjects,
-            "evidence": row.evidence,
-            "related_storylines": row.related_storylines,
-            "callback_condition": row.callback_condition,
-            "resolution_summary": row.resolution_summary,
-        }
-    if kind == MemoryKind.FACT:
-        return {
-            "claim": row.claim,
-            "category": row.category,
-            "numbers": row.structured_numbers or {},
-            "confidence": row.confidence,
-            "status": row.status,
-            "subjects": row.subjects,
-            "originating_event_version_ids": row.originating_event_version_ids,
-            "primary_tool_call_id": row.primary_tool_call_id,
-            "primary_api_request_id": row.primary_api_request_id,
-            "source_hints": row.additional_source_hints,
-        }
-    if kind == MemoryKind.EVENT:
-        return {
-            "event_type": row.event_type,
-            "headline": row.headline,
-            "summary": row.summary,
-            "salience": row.salience,
-            "confidence": row.confidence,
-            "status": row.status,
-            "details": row.details,
-            "primary_tool_call_id": row.primary_tool_call_id,
-            "primary_api_request_id": row.primary_api_request_id,
-            "source_hints": row.additional_source_hints,
-        }
-    if kind == MemoryKind.TRIGGER:
-        return {
-            "trigger_type": row.trigger_type,
-            "status": row.status,
-            "fire_policy": row.fire_policy,
-            "target_storyline_item_id": row.target_storyline_item_id,
-            "origin_event_item_id": row.origin_event_item_id,
-            "target_competition_season_id": row.target_competition_season_id,
-            "target_week": row.target_week,
-            "target_at": row.target_at,
-            "condition": row.condition,
-            "resolution_reason": row.resolution_reason,
-        }
-    return {
-        "narrative": row.narrative_text,
-        "outlook": row.outlook,
-        "status": row.status,
-        "tags": row.tags,
-    }
 
 
 def _load_evidence_versions(
@@ -891,13 +1935,6 @@ def _raise_invisible_version(
 
 
 def _status_matches(status: str) -> sa.ColumnElement[bool]:
-    tables = (
-        StorylineVersion,
-        FactVersion,
-        EventVersion,
-        TriggerVersion,
-        ContextNoteVersion,
-    )
     return sa.or_(
         *(
             sa.exists(
@@ -906,7 +1943,7 @@ def _status_matches(status: str) -> sa.ColumnElement[bool]:
                     table.status == status,
                 )
             )
-            for table in tables
+            for table in typed_content_models()
         )
     )
 

--- a/backend/resources/memory/objects.py
+++ b/backend/resources/memory/objects.py
@@ -177,6 +177,21 @@ FactConfidence = MemoryConfidence
 EventConfidence = MemoryConfidence
 
 
+def _validate_source_backed_receipt(
+    confidence: MemoryConfidence,
+    primary_tool_call_id: UUID | None,
+    primary_api_request_id: UUID | None,
+) -> None:
+    if (
+        confidence is MemoryConfidence.SOURCE_BACKED
+        and primary_tool_call_id is None
+        and primary_api_request_id is None
+    ):
+        raise ValueError(
+            "source-backed memory requires a primary tool-call or API-request receipt"
+        )
+
+
 class EntityReference(MemoryObject):
     role: NonEmptyStr
     display_name: NonEmptyStr | None = None
@@ -315,6 +330,11 @@ class FactContent(MemoryObject):
             set(self.originating_event_version_ids)
         ):
             raise ValueError("originating event references must be unique")
+        _validate_source_backed_receipt(
+            self.confidence,
+            self.primary_tool_call_id,
+            self.primary_api_request_id,
+        )
         return self
 
 
@@ -424,6 +444,11 @@ class EventContent(MemoryObject):
     def event_type_matches_payload(self) -> EventContent:
         if self.event_type.value != self.details.kind:
             raise ValueError("event_type must match details.kind")
+        _validate_source_backed_receipt(
+            self.confidence,
+            self.primary_tool_call_id,
+            self.primary_api_request_id,
+        )
         return self
 
 
@@ -733,7 +758,6 @@ class MemoryMutationBundle(MemoryObject):
 
 
 class MutationItemResult(MemoryObject):
-    operation_index: int = Field(ge=0)
     client_key: str | None = None
     item_id: UUID
     version_id: UUID

--- a/backend/tests/resources/memory/test_manager_mutations.py
+++ b/backend/tests/resources/memory/test_manager_mutations.py
@@ -1,0 +1,856 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    CurrentRevision,
+    ContextNoteVersion,
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.memory.errors import (
+    CanonicalStateHashMismatch,
+    InvalidMemoryReference,
+    MemoryScopeViolation,
+    StaleCanonicalRevision,
+    UnsupportedMemorySchema,
+)
+from backend.resources.memory.content_codec import decode_stored_content
+from backend.resources.memory.manager import MemoryManager
+from backend.resources.memory.objects import (
+    CreateItem,
+    ContextNoteContent,
+    ContextNoteIdentity,
+    ContextNoteScope,
+    ContextNoteStatus,
+    EvidenceRef,
+    EventCallbackTriggerCondition,
+    EventContent,
+    EventStatus,
+    EventType,
+    ExpansionPolicy,
+    FactContent,
+    FactStatus,
+    MemoryConfidence,
+    MemoryMutationBundle,
+    MemoryKind,
+    MatchupEventPayload,
+    NoChange,
+    PlayerRef,
+    ReplaceItem,
+    RevisionCommitted,
+    FirePolicy,
+    StorylineContent,
+    StorylineStatus,
+    TriggerContent,
+    TriggerStatus,
+    TriggerType,
+)
+from backend.tests.database.conftest import (  # noqa: F401
+    database_engine,
+    migrated_database,
+)
+
+
+@dataclass(frozen=True)
+class _Domain:
+    competition_id: UUID
+    season_id: UUID
+    root_revision_id: UUID
+    first_franchise_id: UUID
+    second_franchise_id: UUID
+
+
+def _seed_domain(engine: Engine) -> _Domain:
+    domain = _Domain(uuid4(), uuid4(), uuid4(), uuid4(), uuid4())
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": domain.competition_id, "display_name": "Mutation Test League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": domain.season_id,
+                "competition_id": domain.competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": domain.first_franchise_id,
+                    "competition_id": domain.competition_id,
+                    "display_name": "Rockets",
+                },
+                {
+                    "id": domain.second_franchise_id,
+                    "competition_id": domain.competition_id,
+                    "display_name": "Owls",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": domain.root_revision_id,
+                "competition_id": domain.competition_id,
+                "sequence_number": 0,
+                "previous_revision_id": None,
+                "producing_generation_id": None,
+                "competition_season_id": None,
+                "week": None,
+                "state_content_hash": "empty",
+            },
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": domain.competition_id,
+                "current_revision_id": domain.root_revision_id,
+                "lock_version": 0,
+            },
+        )
+    return domain
+
+
+def _generation(
+    engine: Engine,
+    domain: _Domain,
+    input_revision_id: UUID,
+    *,
+    week: int = 8,
+) -> UUID:
+    generation_id = uuid4()
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": domain.competition_id,
+                "competition_season_id": domain.season_id,
+                "input_memory_revision_id": input_revision_id,
+                "kind": "article",
+                "status": "running",
+                "request_text": "mutation manager test",
+                "domain_cutoff_week": week,
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+    return generation_id
+
+
+def _manager(engine: Engine) -> MemoryManager:
+    return MemoryManager(create_session_factory(engine))
+
+
+def _fact(claim: str) -> FactContent:
+    return FactContent(
+        claim=claim,
+        category="record",
+        confidence=MemoryConfidence.INFERRED,
+        status=FactStatus.ACTIVE,
+    )
+
+
+def test_codec_rejects_unsupported_schema_with_named_internal_error() -> None:
+    with pytest.raises(UnsupportedMemorySchema, match="fact v99"):
+        decode_stored_content(MemoryKind.FACT, 99, object())
+
+
+def test_create_supports_same_bundle_exact_evidence_and_projection(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    fact = CreateItem(client_key="fact", content=_fact("Rockets are 6-2"))
+    storyline = CreateItem(
+        client_key="arc",
+        content=StorylineContent(
+            headline="Rockets launch",
+            summary="The contender keeps winning.",
+            status=StorylineStatus.ACTIVE,
+            salience=4,
+            evidence=(
+                EvidenceRef(
+                    kind="fact",
+                    version_id=fact.version_id,
+                    role="support",
+                ),
+            ),
+        ),
+    )
+
+    result = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=generation_id,
+            operations=(fact, storyline),
+        )
+    )
+
+    assert isinstance(result, RevisionCommitted)
+    assert result.revision.sequence_number == 1
+    assert {item.version_id for item in result.items} == {
+        fact.version_id,
+        storyline.version_id,
+    }
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemorySearchDocument).where(
+                MemorySearchDocument.version_id.in_(
+                    [fact.version_id, storyline.version_id]
+                )
+            )
+        ) == 2
+        assert connection.scalar(
+            sa.select(CurrentRevision.lock_version).where(
+                CurrentRevision.competition_id == domain.competition_id
+            )
+        ) == 1
+
+
+def test_one_bundle_persists_and_decodes_every_kind_with_stable_references(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    event = CreateItem(
+        client_key="matchup-event",
+        content=EventContent(
+            event_type=EventType.MATCHUP,
+            headline="Rockets beat Owls",
+            summary="The Rockets won the featured matchup.",
+            salience=4,
+            confidence=MemoryConfidence.INFERRED,
+            status=EventStatus.ACTIVE,
+            details=MatchupEventPayload(
+                winner_franchise_id=domain.first_franchise_id,
+                loser_franchise_id=domain.second_franchise_id,
+                sleeper_matchup_id="week-8-matchup-1",
+            ),
+        ),
+    )
+    fact = CreateItem(
+        client_key="record-fact",
+        content=FactContent(
+            claim="Rockets are 6-2",
+            category="record",
+            confidence=MemoryConfidence.INFERRED,
+            status=FactStatus.ACTIVE,
+            originating_event_version_ids=(event.version_id,),
+        ),
+    )
+    storyline = CreateItem(
+        client_key="contender-arc",
+        content=StorylineContent(
+            headline="Rockets launch",
+            summary="The contender keeps winning.",
+            status=StorylineStatus.ACTIVE,
+            salience=4,
+            evidence=(
+                EvidenceRef(
+                    kind="fact",
+                    version_id=fact.version_id,
+                    role="support",
+                ),
+            ),
+        ),
+    )
+    trigger = CreateItem(
+        client_key="callback-trigger",
+        content=TriggerContent(
+            trigger_type=TriggerType.EVENT_CALLBACK,
+            status=TriggerStatus.OPEN,
+            fire_policy=FirePolicy.ONE_SHOT,
+            target_storyline_item_id=storyline.item_id,
+            origin_event_item_id=event.item_id,
+            condition=EventCallbackTriggerCondition(event_type=EventType.MATCHUP),
+        ),
+    )
+    context_note = CreateItem(
+        client_key="league-tone",
+        content=ContextNoteContent(
+            narrative="The league treats the Rockets as the team to beat.",
+            status=ContextNoteStatus.ACTIVE,
+        ),
+        context_note_identity=ContextNoteIdentity(
+            scope=ContextNoteScope.COMPETITION,
+            note_key="team-to-beat",
+        ),
+    )
+    creates = (event, fact, storyline, trigger, context_note)
+
+    result = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=generation_id,
+            operations=creates,
+        )
+    )
+
+    assert isinstance(result, RevisionCommitted)
+    hydrated = _manager(database_engine).hydrate_visible_versions(
+        result.revision,
+        [create.version_id for create in creates],
+        ExpansionPolicy(include_evidence=True, include_related_items=True),
+    )
+    assert set(hydrated) == {create.version_id for create in creates}
+    assert hydrated[fact.version_id].evidence[0].version_id == event.version_id
+    assert hydrated[storyline.version_id].evidence[0].version_id == fact.version_id
+    assert {item.item_id for item in hydrated[trigger.version_id].related_items} == {
+        storyline.item_id,
+        event.item_id,
+    }
+    assert (
+        hydrated[context_note.version_id].version.context_note_identity.note_key
+        == "team-to-beat"
+    )
+    with database_engine.connect() as connection:
+        for table, version_id in (
+            (EventVersion, event.version_id),
+            (FactVersion, fact.version_id),
+            (StorylineVersion, storyline.version_id),
+            (TriggerVersion, trigger.version_id),
+            (ContextNoteVersion, context_note.version_id),
+        ):
+            assert connection.scalar(
+                sa.select(sa.func.count()).select_from(table).where(
+                    table.version_id == version_id
+                )
+            ) == 1
+
+
+def test_replace_retires_exact_visible_version_and_advances_once(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    create_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    first = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=create_generation,
+            operations=(create,),
+        )
+    )
+    assert isinstance(first, RevisionCommitted)
+    replace_generation = _generation(database_engine, domain, first.revision.id)
+
+    replace_bundle = MemoryMutationBundle(
+        producing_generation_id=replace_generation,
+        operations=(
+            ReplaceItem(
+                item_id=create.item_id,
+                content=_fact("Rockets are 7-2"),
+                change_reason="Week 9 win",
+            ),
+        ),
+    )
+    second = _manager(database_engine).apply(replace_bundle)
+    retry = _manager(database_engine).apply(replace_bundle)
+
+    assert isinstance(second, RevisionCommitted)
+    assert second.revision.sequence_number == 2
+    assert second.items[0].version_id != create.version_id
+    assert second.items[0].client_key is None
+    assert retry == second
+    history = _manager(database_engine).item_history(
+        domain.competition_id, create.item_id
+    )
+    assert [version.revision_number for version in history.versions] == [1, 2]
+    assert history.versions[0].retired_revision_id == second.revision.id
+    assert history.versions[1].content.claim == "Rockets are 7-2"
+
+
+def test_empty_and_identical_bundles_are_no_ops(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    empty_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    manager = _manager(database_engine)
+
+    empty = manager.apply(
+        MemoryMutationBundle(producing_generation_id=empty_generation)
+    )
+    assert isinstance(empty, NoChange)
+    assert empty.revision.id == domain.root_revision_id
+
+    create_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    committed = manager.apply(
+        MemoryMutationBundle(
+            producing_generation_id=create_generation,
+            operations=(create,),
+        )
+    )
+    assert isinstance(committed, RevisionCommitted)
+    identical_generation = _generation(
+        database_engine, domain, committed.revision.id
+    )
+    identical = manager.apply(
+        MemoryMutationBundle(
+            producing_generation_id=identical_generation,
+            operations=(
+                ReplaceItem(item_id=create.item_id, content=create.content),
+            ),
+        )
+    )
+
+    assert isinstance(identical, NoChange)
+    assert identical.revision.id == committed.revision.id
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.competition_id == domain.competition_id
+            )
+        ) == 2
+
+
+def test_retry_returns_the_existing_generation_revision(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    bundle = MemoryMutationBundle(
+        producing_generation_id=generation_id,
+        operations=(create,),
+    )
+    manager = _manager(database_engine)
+
+    first = manager.apply(bundle)
+    retry = manager.apply(bundle)
+
+    assert isinstance(first, RevisionCommitted)
+    assert retry == first
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.producing_generation_id == generation_id
+            )
+        ) == 1
+
+
+def test_stale_writer_fails_only_when_a_write_remains(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    first_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    stale_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    committed = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=first_generation,
+            operations=(create,),
+        )
+    )
+    assert isinstance(committed, RevisionCommitted)
+
+    with pytest.raises(StaleCanonicalRevision):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=stale_generation,
+                operations=(
+                    CreateItem(client_key="other", content=_fact("Owls are 5-3")),
+                ),
+            )
+        )
+
+
+
+def test_stale_empty_returns_no_change_at_the_pinned_base(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    stale_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    advancing_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    advanced = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=advancing_generation,
+            operations=(CreateItem(client_key="record", content=_fact("6-2")),),
+        )
+    )
+    assert isinstance(advanced, RevisionCommitted)
+
+    result = _manager(database_engine).apply(
+        MemoryMutationBundle(producing_generation_id=stale_generation)
+    )
+
+    assert isinstance(result, NoChange)
+    assert result.revision.id == domain.root_revision_id
+
+
+def test_stale_identical_to_base_returns_no_change_at_the_pinned_base(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    create_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    base = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=create_generation,
+            operations=(create,),
+        )
+    )
+    assert isinstance(base, RevisionCommitted)
+    stale_generation = _generation(database_engine, domain, base.revision.id)
+    advancing_generation = _generation(database_engine, domain, base.revision.id)
+    advanced = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=advancing_generation,
+            operations=(CreateItem(client_key="other", content=_fact("Owls 5-3")),),
+        )
+    )
+    assert isinstance(advanced, RevisionCommitted)
+
+    result = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=stale_generation,
+            operations=(ReplaceItem(item_id=create.item_id, content=create.content),),
+        )
+    )
+
+    assert isinstance(result, NoChange)
+    assert result.revision.id == base.revision.id
+
+
+def test_stale_already_applied_replace_and_create_return_current_no_change(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    create_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    original = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    base = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=create_generation,
+            operations=(original,),
+        )
+    )
+    assert isinstance(base, RevisionCommitted)
+    stale_replace_generation = _generation(database_engine, domain, base.revision.id)
+    applying_generation = _generation(database_engine, domain, base.revision.id)
+    desired = ReplaceItem(
+        item_id=original.item_id,
+        content=_fact("Rockets are 7-2"),
+    )
+    applied = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=applying_generation,
+            operations=(desired,),
+        )
+    )
+    assert isinstance(applied, RevisionCommitted)
+
+    represented_replace = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=stale_replace_generation,
+            operations=(desired,),
+        )
+    )
+    assert isinstance(represented_replace, NoChange)
+    assert represented_replace.revision.id == applied.revision.id
+
+    other_domain = _seed_domain(database_engine)
+    stale_create_generation = _generation(
+        database_engine, other_domain, other_domain.root_revision_id
+    )
+    applying_create_generation = _generation(
+        database_engine, other_domain, other_domain.root_revision_id
+    )
+    fixed_create = CreateItem(client_key="fixed", content=_fact("Fixed create"))
+    created = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=applying_create_generation,
+            operations=(fixed_create,),
+        )
+    )
+    assert isinstance(created, RevisionCommitted)
+    represented_create = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=stale_create_generation,
+            operations=(fixed_create,),
+        )
+    )
+    assert isinstance(represented_create, NoChange)
+    assert represented_create.revision.id == created.revision.id
+
+
+def test_stale_comparison_keeps_only_transitions_that_survived_pinned_base(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    create_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    first = CreateItem(client_key="first", content=_fact("A at base"))
+    second = CreateItem(client_key="second", content=_fact("B at base"))
+    base = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=create_generation,
+            operations=(first, second),
+        )
+    )
+    assert isinstance(base, RevisionCommitted)
+    stale_generation = _generation(database_engine, domain, base.revision.id)
+    applying_generation = _generation(database_engine, domain, base.revision.id)
+    desired_second = _fact("B desired")
+    advanced = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=applying_generation,
+            operations=(
+                ReplaceItem(item_id=first.item_id, content=_fact("A diverged")),
+                ReplaceItem(item_id=second.item_id, content=desired_second),
+            ),
+        )
+    )
+    assert isinstance(advanced, RevisionCommitted)
+
+    result = _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=stale_generation,
+            operations=(
+                ReplaceItem(item_id=first.item_id, content=first.content),
+                ReplaceItem(item_id=second.item_id, content=desired_second),
+            ),
+        )
+    )
+
+    assert isinstance(result, NoChange)
+    assert result.revision.id == advanced.revision.id
+
+
+def test_rejects_duplicate_and_cross_scope_references(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    other = _seed_domain(database_engine)
+    other_generation = _generation(
+        database_engine, other, other.root_revision_id
+    )
+    other_fact = CreateItem(client_key="other-fact", content=_fact("Owls are 5-3"))
+    _manager(database_engine).apply(
+        MemoryMutationBundle(
+            producing_generation_id=other_generation,
+            operations=(other_fact,),
+        )
+    )
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+
+    with pytest.raises(MemoryScopeViolation):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=generation_id,
+                operations=(
+                    CreateItem(
+                        client_key="arc",
+                        content=StorylineContent(
+                            headline="Foreign evidence",
+                            summary="This should not cross leagues.",
+                            status=StorylineStatus.ACTIVE,
+                            salience=2,
+                            evidence=(
+                                EvidenceRef(
+                                    kind="fact",
+                                    version_id=other_fact.version_id,
+                                    role="support",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+    duplicate_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    with pytest.raises(InvalidMemoryReference, match="duplicate client key"):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=duplicate_generation,
+                operations=(
+                    CreateItem(client_key="same", content=_fact("One")),
+                    CreateItem(client_key="same", content=_fact("Two")),
+                ),
+            )
+        )
+
+
+def test_rejects_missing_player_and_source_receipt_before_persistence(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    player_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    with pytest.raises(InvalidMemoryReference, match="Sleeper player"):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=player_generation,
+                operations=(
+                    CreateItem(
+                        client_key="unknown-player",
+                        content=FactContent(
+                            claim="Unknown player scored twice",
+                            category="performance",
+                            confidence=MemoryConfidence.INFERRED,
+                            status=FactStatus.ACTIVE,
+                            subjects=(
+                                PlayerRef(
+                                    role="subject",
+                                    id="missing-player",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+    receipt_generation = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    with pytest.raises(InvalidMemoryReference, match="tool-call receipt"):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=receipt_generation,
+                operations=(
+                    CreateItem(
+                        client_key="missing-receipt",
+                        content=FactContent(
+                            claim="Rockets are 6-2",
+                            category="record",
+                            confidence=MemoryConfidence.SOURCE_BACKED,
+                            status=FactStatus.ACTIVE,
+                            primary_tool_call_id=uuid4(),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+
+def test_stored_state_hash_mismatch_rolls_back_before_pointer_advance(
+    database_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    domain = _seed_domain(database_engine)
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+    monkeypatch.setattr(
+        "backend.resources.memory.manager._resulting_state_hash",
+        lambda *_args: "incorrect-state-hash",
+    )
+
+    with pytest.raises(CanonicalStateHashMismatch, match="resulting-state hash"):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=generation_id,
+                operations=(create,),
+            )
+        )
+
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(CurrentRevision.current_revision_id).where(
+                CurrentRevision.competition_id == domain.competition_id
+            )
+        ) == domain.root_revision_id
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryItem).where(
+                MemoryItem.id == create.item_id
+            )
+        ) == 0
+
+
+def test_projection_failure_rolls_back_canonical_rows_and_pointer(
+    database_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    domain = _seed_domain(database_engine)
+    generation_id = _generation(
+        database_engine, domain, domain.root_revision_id
+    )
+    create = CreateItem(client_key="record", content=_fact("Rockets are 6-2"))
+
+    def fail_projection(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("projection persistence failed")
+
+    monkeypatch.setattr(
+        "backend.resources.memory.manager._persist_search_documents",
+        fail_projection,
+    )
+    with pytest.raises(RuntimeError, match="projection persistence failed"):
+        _manager(database_engine).apply(
+            MemoryMutationBundle(
+                producing_generation_id=generation_id,
+                operations=(create,),
+            )
+        )
+
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(CurrentRevision.current_revision_id).where(
+                CurrentRevision.competition_id == domain.competition_id
+            )
+        ) == domain.root_revision_id
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryItem).where(
+                MemoryItem.id == create.item_id
+            )
+        ) == 0
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryVersion).where(
+                MemoryVersion.id == create.version_id
+            )
+        ) == 0
+        assert connection.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.producing_generation_id == generation_id
+            )
+        ) == 0

--- a/backend/tests/resources/memory/test_manager_reads.py
+++ b/backend/tests/resources/memory/test_manager_reads.py
@@ -294,7 +294,7 @@ def _seed_memory(engine: Engine) -> _SeededMemory:
                 "claim": "The Sharks lost three straight games.",
                 "category": "streak",
                 "structured_numbers": {"losses": 3},
-                "confidence": "source_backed",
+                "confidence": "inferred",
                 "status": "active",
                 "subjects": [],
                 "originating_event_version_ids": [],

--- a/backend/tests/resources/memory/test_objects.py
+++ b/backend/tests/resources/memory/test_objects.py
@@ -18,6 +18,7 @@ from backend.resources.memory.objects import (
     MemoryMutationBundle,
     MemoryQuery,
     MemoryStatus,
+    MutationItemResult,
     PlayerRef,
     EvidenceRef,
     StorylineContent,
@@ -60,7 +61,7 @@ ID_4 = UUID("00000000-0000-0000-0000-000000000004")
             {
                 "claim": "The roster has won four straight.",
                 "category": "streak",
-                "confidence": "source_backed",
+                "confidence": "inferred",
                 "status": "active",
                 "subjects": [
                     {"kind": "franchise", "id": str(ID_1), "role": "subject"}
@@ -75,7 +76,7 @@ ID_4 = UUID("00000000-0000-0000-0000-000000000004")
                 "headline": "An upset",
                 "summary": "The underdog won.",
                 "salience": 5,
-                "confidence": "source_backed",
+                "confidence": "inferred",
                 "status": "active",
                 "details": {
                     "kind": "matchup",
@@ -138,7 +139,7 @@ def test_decode_validation_details_are_transport_safe() -> None:
                 "headline": "Impossible result",
                 "summary": "One franchise cannot beat itself.",
                 "salience": 3,
-                "confidence": "source_backed",
+                "confidence": "inferred",
                 "status": "active",
                 "details": {
                     "kind": "matchup",
@@ -166,7 +167,7 @@ def test_authored_content_is_deeply_immutable_and_serializes_as_json() -> None:
     fact = FactContent(
         claim="Three consecutive wins.",
         category="streak",
-        confidence="source_backed",
+        confidence="inferred",
         status="active",
         numbers=input_numbers,
         subjects=[{"kind": "player", "id": "p1", "role": "subject"}],
@@ -221,11 +222,53 @@ def test_content_discriminators_and_owned_roles_are_validated() -> None:
         FactContent(
             claim="A claim",
             category="general",
-            confidence="source_backed",
+            confidence="inferred",
             status="active",
             subjects=[PlayerRef(id="p1", role="focus")],
         )
 
+
+def test_source_backed_fact_requires_and_accepts_typed_receipt() -> None:
+    with pytest.raises(ValidationError, match="source-backed memory requires"):
+        FactContent(
+            claim="A sourced claim.",
+            category="general",
+            confidence="source_backed",
+            status="active",
+        )
+
+    fact = FactContent(
+        claim="A sourced claim.",
+        category="general",
+        confidence="source_backed",
+        status="active",
+        primary_tool_call_id=ID_1,
+    )
+    assert fact.primary_tool_call_id == ID_1
+
+
+def test_source_backed_event_requires_and_accepts_typed_receipt() -> None:
+    event_fields = {
+        "event_type": "matchup",
+        "headline": "A sourced result",
+        "summary": "The favorite won.",
+        "salience": 3,
+        "confidence": "source_backed",
+        "status": "active",
+        "details": {
+            "kind": "matchup",
+            "winner_franchise_id": ID_1,
+            "loser_franchise_id": ID_2,
+            "sleeper_matchup_id": "5",
+        },
+    }
+    with pytest.raises(ValidationError, match="source-backed memory requires"):
+        EventContent.model_validate(event_fields)
+
+    event = EventContent.model_validate(
+        {**event_fields, "primary_api_request_id": ID_3}
+    )
+    assert event.primary_api_request_id == ID_3
 
 def test_context_note_identity_enforces_scope_shape() -> None:
     ContextNoteIdentity(scope="competition", note_key="league-voice")
@@ -313,7 +356,7 @@ def test_mutation_bundle_derives_context_from_generation() -> None:
                 content=FactContent(
                     claim="Four straight wins.",
                     category="streak",
-                    confidence="source_backed",
+                    confidence="inferred",
                     status="active",
                 ),
             )
@@ -330,7 +373,7 @@ def test_create_ids_support_same_bundle_references() -> None:
         content=FactContent(
             claim="Four straight wins.",
             category="streak",
-            confidence="source_backed",
+            confidence="inferred",
             status="active",
         ),
     )
@@ -357,3 +400,17 @@ def test_create_ids_support_same_bundle_references() -> None:
 
     assert fact.item_id != fact.version_id
     assert bundle.operations[1].content.evidence[0].version_id == fact.version_id
+
+
+def test_mutation_item_result_has_no_request_position() -> None:
+    result = MutationItemResult(
+        client_key="fact:streak",
+        item_id=ID_1,
+        version_id=ID_2,
+    )
+
+    assert result.model_dump() == {
+        "client_key": "fact:streak",
+        "item_id": ID_1,
+        "version_id": ID_2,
+    }

--- a/backend/tests/resources/memory/test_search_documents.py
+++ b/backend/tests/resources/memory/test_search_documents.py
@@ -94,7 +94,7 @@ FACT_VERSION = _version(
         claim="The Sharks have lost three straight.",
         category="streak",
         numbers={"losses": 3},
-        confidence="source_backed",
+        confidence="inferred",
         status="active",
         subjects=(FranchiseRef(id=FRANCHISE_ID, role="subject"),),
         originating_event_version_ids=(EVIDENCE_ID,),
@@ -107,7 +107,7 @@ TRADE_VERSION = _version(
         headline="A blockbuster trade",
         summary="The Sharks acquired a quarterback and a first-round pick.",
         salience=5,
-        confidence="source_backed",
+        confidence="inferred",
         status="active",
         details=TradeEventPayload(
             sender_franchise_id=FRANCHISE_ID,
@@ -192,7 +192,7 @@ CONTEXT_VERSION = _version(
                     (
                         "The Sharks have lost three straight.",
                         "streak",
-                        "source_backed",
+                        "inferred",
                         "active",
                         '{"losses":3}',
                         f"franchise:{FRANCHISE_ID}",
@@ -219,7 +219,7 @@ CONTEXT_VERSION = _version(
                         "A blockbuster trade",
                         "The Sharks acquired a quarterback and a first-round pick.",
                         "trade",
-                        "source_backed",
+                        "inferred",
                         "active",
                         (
                             '{"assets":[{"display_name":"QB One","kind":"player",'

--- a/docs/memory/lifecycle.md
+++ b/docs/memory/lifecycle.md
@@ -55,11 +55,13 @@ Application code:
 1. parses each proposed content object into its Pydantic type;
 2. loads competition, season, cutoffs, and the base revision from the producing
    generation rather than accepting caller-supplied copies;
-3. validates same-bundle keys, references, and contradictions;
-4. removes identical replacements and already-represented transitions;
-5. batch-loads referenced item and version IDs;
-6. validates persisted target kind and competition scope;
-7. constructs search documents through the one authoritative builder registry.
+3. normalizes the bundle against that pinned base revision;
+4. validates same-bundle keys, references, receipts, and contradictions;
+5. removes identical replacements and, after a concurrent advance, transitions
+   already represented by the current revision;
+6. batch-loads referenced item and version IDs;
+7. validates persisted target kind and competition scope;
+8. constructs search documents through the one authoritative builder registry.
 
 Invalid proposals return actionable application errors. They do not rely on raw
 database constraint failures for semantic feedback.
@@ -75,13 +77,16 @@ In one short transaction, the manager:
 5. retires replaced visible versions;
 6. inserts complete `memory_versions` and typed content rows;
 7. inserts their lexical/entity search documents;
-8. verifies the resulting-state hash;
+8. decodes the stored rows through the same versioned content codec and verifies
+   their resulting-state hash;
 9. advances the current pointer and lock version.
 
-If no accepted memory change remains, the transaction creates no revision. If
-canonical memory advanced after the generation started, the mutation fails
-without producing a sibling state or partial projection. Retrying a generation
-that already produced its revision returns that existing committed result.
+If no accepted memory change remains at the pinned base, the transaction creates
+no revision and returns that pinned revision. If canonical memory advanced, the
+manager recognizes a transition already represented by current state; any other
+unresolved transition fails without producing a sibling state or partial
+projection. Retrying a generation that already produced its revision returns
+the same payload-independent committed result.
 
 ### 7. Add optional embeddings
 

--- a/docs/memory/log.md
+++ b/docs/memory/log.md
@@ -452,6 +452,50 @@ role-free entity keys rather than authored entity references.
 - Content-decoder errors contain sanitized JSON-safe validation details rather
   than Pydantic exception objects or documentation URLs.
 
+### MEM-022 — Normalize mutations against their pinned generation input
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent concurrency and error-design review
+
+Mutation intent is first evaluated against the producing generation's pinned
+input revision, never against a newer current pointer. Empty or identical input
+therefore returns that pinned revision. If canonical state advanced, the manager
+evaluates the same unresolved transition against current state: an already
+represented transition is a no-op, while any remaining transition is stale.
+
+**Consequences:**
+
+- A stale generation cannot silently adopt unrelated newer memory as the result
+  of an empty or base-identical bundle.
+- Callers do not supply retry flags or implement race-specific branching.
+- First commits and retries return one payload-independent canonical result,
+  ordered by stable item and version identity.
+- A create result carries its client correlation key; a replacement result does
+  not incorrectly reuse the item's original creation key.
+
+### MEM-023 — Pair one content codec with a stored-state invariant
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent deep-module and information-hiding review
+
+`backend/resources/memory/content_codec.py` owns both directions of every
+schema-versioned typed-content mapping. `MemoryManager` continues to own the
+aggregate transaction, but it decodes the rows it just persisted and verifies
+the resulting visible-state hash before advancing the current pointer.
+
+**Consequences:**
+
+- Adding or retaining a content schema version has one codec registry entry
+  rather than separate manager read and write switch statements.
+- Unsupported stored schemas and state-hash mismatches are named internal
+  operational faults, not caller input errors.
+- Source-backed facts and events require a tool-call or API-request receipt;
+  the manager validates that receipt in the generation or competition scope.
+- Any encoding drift, projection failure, or hash mismatch rolls back the whole
+  canonical mutation.
+
 ## Pending Decisions
 
 - Default retrieval and evidence-expansion limits.

--- a/docs/memory/service-architecture.md
+++ b/docs/memory/service-architecture.md
@@ -219,8 +219,9 @@ rather than an unversioned side effect.
 
 - `NoChange`, retaining the base revision and explaining why no accepted
   operations remained; or
-- `RevisionCommitted`, returning the new revision reference and the item/version
-  IDs produced by each client operation key.
+- `RevisionCommitted`, returning the new revision reference plus a canonical,
+  item-ID-ordered set of produced item/version IDs. Creates retain their client
+  correlation key; replacements do not reuse the item's original create key.
 
 An empty bundle, an identical replacement, or a repeated transition already
 represented by current content returns `NoChange` without creating a revision.
@@ -543,6 +544,7 @@ backend/
 │   ├── __init__.py
 │   ├── objects.py
 │   ├── errors.py
+│   ├── content_codec.py
 │   ├── manager.py
 │   └── search_documents.py
 ├── services/memory/

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -16,9 +16,10 @@ are not preserved
 | Typed content and reference design | Designed | `application-contracts.md` |
 | Service boundaries and public contracts | Designed | `service-architecture.md` |
 | Resource objects and schema converters | Implemented | `backend/resources/memory/objects.py` |
+| Bidirectional typed-content codec | Implemented | `backend/resources/memory/content_codec.py` |
 | Stable application errors | Implemented | `backend/resources/memory/errors.py` |
 | Memory resource manager and canonical reads | Implemented | `backend/resources/memory/manager.py` |
-| Complete-bundle mutation transaction | Pending | Generation-derived context plus `MemoryManager` transaction |
+| Complete-bundle mutation transaction | Implemented | Generation-derived context plus `MemoryManager.apply` |
 | Authoritative search-document builder | Implemented | `backend/resources/memory/search_documents.py` |
 | Revision-pinned retrieval and hydration | Pending | `MemoryService.at_revision` plus internal retrieval pipeline |
 | Service facade and consumer protocols | Pending | `backend/services/memory/` |
@@ -48,8 +49,15 @@ are not preserved
   competition, cutoffs, season, and its one base-revision concurrency token.
 - Empty, identical, already-applied, and retry mutation cases return stable
   no-op/existing results rather than creating revisions or avoidable errors.
+- Mutation intent is normalized against the generation's pinned input first;
+  unresolved stale transitions are then compared with current state before a
+  stale-writer error is returned.
+- Source-backed facts and events require a persisted tool-call or API-request
+  receipt in the correct generation or competition scope.
 - An ordinary mutation creates zero or one revision in one short manager-owned
   transaction.
+- One schema-versioned codec owns both typed-row encoding and decoding. The
+  manager verifies the stored visible-state hash before advancing the pointer.
 - Search documents are derived, synchronously created for new versions, and
   independently rebuildable.
 - Mutation and rebuild use one authoritative deterministic document builder
@@ -71,7 +79,7 @@ are not preserved
 | 1. Contracts, errors, and schema converters | Complete | All initial typed payloads decode and validate with unit coverage |
 | 2. Canonical reads and hydration manager | Complete | Revision-pinned item/version/history queries pass PostgreSQL tests |
 | 3. Search-document builder | Complete | One dispatcher produces identical mutation/rebuild output for every kind |
-| 4. Canonical mutation transaction | Not started | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
+| 4. Canonical mutation transaction | Complete | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
 | 5. Pinned retrieval pipeline | Not started | Entity, evidence, related-item, lexical, and historical-leakage tests pass |
 | 6. Basic viewing, promotion integration, reporter/generation, and rebuild CLI | Not started | Narrow capabilities work without UI-specific business logic |
 | 7. Legacy removal | Not started | No active imports or writes depend on `reporter_memory` |
@@ -103,9 +111,9 @@ decision-log entry before expanding the baseline.
 
 ## Next Milestone
 
-Implement slice 4 canonical mutation with one generation-derived transaction,
-including no-op, retry, concurrency, reference, and atomic projection coverage.
-Then add the already-designed pinned retrieval service without public adapters.
+Refine and land slice 5 pinned retrieval and inspection without public adapters.
+Keep ranking and fallback policy inside the service while the pinned reader
+enforces one fixed competition/revision scope.
 
 ## PR Stack Coordination
 
@@ -117,7 +125,7 @@ integrated by `root` after the owning agent reports completion.
 | --- | --- | --- | --- | --- |
 | 1. Design and resource contracts | `codex/memory-service-contracts` | `contracts_agent` | Complete | `docs/memory/`; `backend/resources/memory/objects.py`; `errors.py`; resource contract tests |
 | 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | Complete | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
-| 3. Canonical mutation | `codex/memory-service-mutations` | Unassigned | Pending | mutation methods and transaction tests; no public adapters |
+| 3. Canonical mutation | `codex/memory-service-mutations` | `persistence_agent` | Complete | mutation methods and transaction tests; no public adapters |
 | 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `service_agent` | In progress | `backend/services/memory/`; retrieval/inspection tests |
 | 5. Composition and adapters | `codex/memory-service-integration` | `root` | Pending | composition, reporter tools, minimal API/CLI adapters, legacy-path removal, integration tests |
 | 6. Workspace promotion | `codex/memory-workspace-promotion` | Unassigned | Pending | reporting-owned promotion workflow and private memory command |


### PR DESCRIPTION
## Summary

- implement one atomic canonical mutation transaction for creates and replacements
- validate persisted scope, provenance, references, concurrency, and post-write state hashes
- define no-op, retry, stale-writer, projection rollback, and all-five-kind behavior

## Design

One manager operation owns the aggregate-wide write invariant. Empty and semantically identical bundles are `NoChange`; projection documents are built by the same dispatcher used for rebuilds.

## Verification

- full-stack workspace suite: 310 passed, 70 PostgreSQL-only skips
- memory PostgreSQL read/mutation suite on disposable PostgreSQL 17: 22 passed

Stack 3/5. Depends on #97.
