### PR TITLE
feat(memory): add pinned retrieval service

### DIFF
--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -2,6 +2,8 @@
 
 from backend.resources.memory.errors import (
     InvalidMemoryContent,
+    InvalidMemoryCursor,
+    InvalidMemoryQuery,
     InvalidMemoryReference,
     MemoryError,
     MemoryNotFound,
@@ -11,6 +13,8 @@ from backend.resources.memory.errors import (
 
 __all__ = [
     "InvalidMemoryContent",
+    "InvalidMemoryCursor",
+    "InvalidMemoryQuery",
     "InvalidMemoryReference",
     "MemoryError",
     "MemoryNotFound",

--- a/backend/resources/memory/cursors.py
+++ b/backend/resources/memory/cursors.py
@@ -1,0 +1,110 @@
+"""Opaque, versioned pagination cursors for memory collections."""
+
+from __future__ import annotations
+
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from binascii import Error as Base64Error
+from dataclasses import dataclass
+import json
+from uuid import UUID
+
+from backend.resources.memory.errors import InvalidMemoryCursor
+
+
+_CURSOR_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryItemCursor:
+    revision_id: UUID
+    item_id: UUID
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRevisionCursor:
+    competition_id: UUID
+    sequence_number: int
+
+
+def encode_item_cursor(revision_id: UUID, item_id: UUID) -> str:
+    return _encode(
+        {
+            "v": _CURSOR_VERSION,
+            "kind": "item",
+            "revision": str(revision_id),
+            "item": str(item_id),
+        }
+    )
+
+
+def decode_item_cursor(value: str) -> MemoryItemCursor:
+    payload = _decode(value, "item")
+    try:
+        return MemoryItemCursor(
+            revision_id=UUID(payload["revision"]),
+            item_id=UUID(payload["item"]),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise _invalid() from error
+
+
+def encode_revision_cursor(competition_id: UUID, sequence_number: int) -> str:
+    return _encode(
+        {
+            "v": _CURSOR_VERSION,
+            "kind": "revision",
+            "competition": str(competition_id),
+            "sequence": sequence_number,
+        }
+    )
+
+
+def decode_revision_cursor(value: str) -> MemoryRevisionCursor:
+    payload = _decode(value, "revision")
+    try:
+        sequence_number = payload["sequence"]
+        if isinstance(sequence_number, bool) or not isinstance(sequence_number, int):
+            raise TypeError
+        cursor = MemoryRevisionCursor(
+            competition_id=UUID(payload["competition"]),
+            sequence_number=sequence_number,
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise _invalid() from error
+    if cursor.sequence_number < 0:
+        raise _invalid()
+    return cursor
+
+
+def _encode(payload: dict[str, object]) -> str:
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return urlsafe_b64encode(serialized).decode("ascii").rstrip("=")
+
+
+def _decode(value: str, kind: str) -> dict[str, object]:
+    try:
+        padding = "=" * (-len(value) % 4)
+        decoded = urlsafe_b64decode(value + padding)
+        payload = json.loads(decoded)
+    except (
+        Base64Error,
+        ValueError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ) as error:
+        raise _invalid() from error
+    if (
+        not isinstance(payload, dict)
+        or payload.get("v") != _CURSOR_VERSION
+        or payload.get("kind") != kind
+    ):
+        raise _invalid()
+    return payload
+
+
+def _invalid() -> InvalidMemoryCursor:
+    return InvalidMemoryCursor("invalid memory pagination cursor")

--- a/backend/resources/memory/errors.py
+++ b/backend/resources/memory/errors.py
@@ -46,6 +46,18 @@ class InvalidMemoryReference(MemoryError):
     code = "invalid_memory_reference"
 
 
+class InvalidMemoryCursor(MemoryError):
+    """A pagination cursor is malformed for the requested memory collection."""
+
+    code = "invalid_memory_cursor"
+
+
+class InvalidMemoryQuery(MemoryError):
+    """A memory read query violates a stable boundary constraint."""
+
+    code = "invalid_memory_query"
+
+
 class StaleCanonicalRevision(MemoryError):
     """Canonical memory advanced beyond a generation's pinned input revision."""
 

--- a/backend/resources/memory/manager.py
+++ b/backend/resources/memory/manager.py
@@ -34,6 +34,8 @@ from backend.database.sessions import (
 from backend.resources.memory.errors import (
     CanonicalStateHashMismatch,
     InvalidMemoryContent,
+    InvalidMemoryCursor,
+    InvalidMemoryQuery,
     InvalidMemoryReference,
     MemoryNotFound,
     MemoryScopeViolation,
@@ -45,6 +47,12 @@ from backend.resources.memory.content_codec import (
     encode_stored_content,
     typed_content_model,
     typed_content_models,
+)
+from backend.resources.memory.cursors import (
+    decode_item_cursor,
+    decode_revision_cursor,
+    encode_item_cursor,
+    encode_revision_cursor,
 )
 from backend.resources.memory.objects import (
     CreateItem,
@@ -81,13 +89,15 @@ from backend.resources.memory.search_documents import (
 
 @dataclass(frozen=True, slots=True)
 class MemoryCandidate:
-    """One compact projection match returned to retrieval policy."""
+    """Raw persistence signals consumed by service-owned retrieval policy."""
 
     version_id: UUID
-    kind: str
-    match_reasons: tuple[str, ...]
-    rank_components: Mapping[str, float]
+    lexical_match: bool
     matched_entities: tuple[str, ...]
+    matched_evidence_version_ids: tuple[UUID, ...]
+    matched_related_item_ids: tuple[UUID, ...]
+    salience: int | None
+    recorded_at: datetime
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,6 +125,12 @@ _EXPECTED_IDENTITY_CONSTRAINTS = frozenset(
         "uq_context_notes_franchise_key",
     }
 )
+
+_MIN_CANDIDATES_PER_SIGNAL = 20
+_MAX_CANDIDATES_PER_SIGNAL = 200
+_CANDIDATES_PER_RESULT = 2
+_MAX_FALLBACK_VISIBLE_SCAN = 5_000
+_MAX_FALLBACK_CANDIDATES = 800
 
 
 class MemoryManager:
@@ -406,7 +422,16 @@ class MemoryManager:
                 sa.or_(*(_status_matches(status.value) for status in query.statuses))
             )
         if query.cursor is not None:
-            statement = statement.where(MemoryItem.id > _uuid_cursor(query.cursor))
+            cursor = decode_item_cursor(query.cursor)
+            if cursor.revision_id != revision.id:
+                raise InvalidMemoryCursor(
+                    "memory item cursor belongs to a different revision",
+                    details={
+                        "cursor_revision_id": str(cursor.revision_id),
+                        "revision_id": str(revision.id),
+                    },
+                )
+            statement = statement.where(MemoryItem.id > cursor.item_id)
         statement = statement.order_by(MemoryItem.id).limit(query.limit + 1)
 
         with read_only_session(self._session_factory) as session:
@@ -423,7 +448,11 @@ class MemoryManager:
                 page_ids,
                 DEFAULT_EXPANSION,
             )
-        next_cursor = str(page_rows[-1][0]) if len(rows) > query.limit else None
+        next_cursor = (
+            encode_item_cursor(revision.id, page_rows[-1][0])
+            if len(rows) > query.limit
+            else None
+        )
         return MemoryPage(
             revision=revision,
             items=tuple(hydrated[version_id] for version_id in page_ids),
@@ -463,13 +492,25 @@ class MemoryManager:
         limit: int,
     ) -> RevisionPage:
         if not 1 <= limit <= 100:
-            raise ValueError("revision page limit must be between 1 and 100")
+            raise InvalidMemoryQuery(
+                "revision page limit must be between 1 and 100",
+                details={"limit": limit},
+            )
         statement = sa.select(MemoryRevision).where(
             MemoryRevision.competition_id == competition_id
         )
         if cursor is not None:
+            decoded_cursor = decode_revision_cursor(cursor)
+            if decoded_cursor.competition_id != competition_id:
+                raise InvalidMemoryCursor(
+                    "memory revision cursor belongs to a different competition",
+                    details={
+                        "cursor_competition_id": str(decoded_cursor.competition_id),
+                        "competition_id": str(competition_id),
+                    },
+                )
             statement = statement.where(
-                MemoryRevision.sequence_number < _sequence_cursor(cursor)
+                MemoryRevision.sequence_number < decoded_cursor.sequence_number
             )
         statement = statement.order_by(MemoryRevision.sequence_number.desc()).limit(
             limit + 1
@@ -478,7 +519,12 @@ class MemoryManager:
             rows = list(session.scalars(statement))
         page_rows = rows[:limit]
         next_cursor = (
-            str(page_rows[-1].sequence_number) if len(rows) > limit else None
+            encode_revision_cursor(
+                competition_id,
+                page_rows[-1].sequence_number,
+            )
+            if len(rows) > limit
+            else None
         )
         return RevisionPage(
             competition_id=competition_id,
@@ -494,7 +540,8 @@ class MemoryManager:
         """Find compact candidates only when the current projection is complete."""
 
         visible = _visible_versions(revision).with_only_columns(
-            MemoryVersion.id
+            MemoryVersion.id,
+            MemoryVersion.recorded_at,
         ).subquery()
         with read_only_session(self._session_factory) as session:
             projection_incomplete = session.scalar(
@@ -522,6 +569,10 @@ class MemoryManager:
             entity_keys = tuple(
                 sorted({entity_search_key(entity) for entity in query.entities})
             )
+            evidence_version_ids = tuple(
+                sorted(query.evidence_version_ids, key=str)
+            )
+            related_item_ids = tuple(sorted(query.related_item_ids, key=str))
             text_query = (
                 sa.func.plainto_tsquery("english", query.text)
                 if query.text is not None
@@ -535,8 +586,37 @@ class MemoryManager:
                 if text_query is not None
                 else sa.literal(0.0)
             ).label("lexical_rank")
+            lexical_match = (
+                MemorySearchDocument.search_vector.op("@@")(text_query)
+                if text_query is not None
+                else sa.false()
+            ).label("lexical_match")
+            entity_match = (
+                MemorySearchDocument.entity_keys.overlap(entity_keys)
+                if entity_keys
+                else sa.false()
+            ).label("entity_match")
+            evidence_match = (
+                MemorySearchDocument.evidence_version_ids.overlap(
+                    evidence_version_ids
+                )
+                if evidence_version_ids
+                else sa.false()
+            ).label("evidence_match")
+            related_match = (
+                MemorySearchDocument.related_item_ids.overlap(related_item_ids)
+                if related_item_ids
+                else sa.false()
+            ).label("related_match")
             statement = (
-                sa.select(MemorySearchDocument, lexical_rank)
+                sa.select(
+                    MemorySearchDocument,
+                    lexical_match,
+                    entity_match,
+                    evidence_match,
+                    related_match,
+                    visible.c.recorded_at,
+                )
                 .join(visible, visible.c.id == MemorySearchDocument.version_id)
                 .where(
                     MemorySearchDocument.builder_version
@@ -561,37 +641,84 @@ class MemoryManager:
                 )
             if query.week is not None:
                 statement = statement.where(MemorySearchDocument.week == query.week)
-            signals: list[sa.ColumnElement[bool]] = []
+            signal_queries: list[
+                tuple[sa.ColumnElement[bool], tuple[sa.ColumnElement[Any], ...]]
+            ] = []
             if text_query is not None:
-                signals.append(
-                    MemorySearchDocument.search_vector.op("@@")(text_query)
+                signal_queries.append(
+                    (
+                        MemorySearchDocument.search_vector.op("@@")(text_query),
+                        (lexical_rank.desc(), visible.c.recorded_at.desc()),
+                    )
                 )
             if entity_keys:
-                signals.append(MemorySearchDocument.entity_keys.overlap(entity_keys))
-            if signals:
-                statement = statement.where(sa.or_(*signals))
-            statement = statement.order_by(
-                lexical_rank.desc(),
-                MemorySearchDocument.salience.desc().nullslast(),
-                MemorySearchDocument.version_id,
-            ).limit(min(query.limit * 4, 400))
-            rows = session.execute(statement).all()
+                signal_queries.append(
+                    (entity_match, (visible.c.recorded_at.desc(),))
+                )
+            if evidence_version_ids:
+                signal_queries.append(
+                    (evidence_match, (visible.c.recorded_at.desc(),))
+                )
+            if related_item_ids:
+                signal_queries.append(
+                    (related_match, (visible.c.recorded_at.desc(),))
+                )
+
+            if signal_queries:
+                per_signal_limit = min(
+                    max(
+                        query.limit * _CANDIDATES_PER_RESULT,
+                        _MIN_CANDIDATES_PER_SIGNAL,
+                    ),
+                    _MAX_CANDIDATES_PER_SIGNAL,
+                )
+                candidate_ids: set[UUID] = set()
+                for condition, ordering in signal_queries:
+                    candidate_ids.update(
+                        session.scalars(
+                            statement.where(condition)
+                            .with_only_columns(MemorySearchDocument.version_id)
+                            .order_by(*ordering, MemorySearchDocument.version_id)
+                            .limit(per_signal_limit)
+                        )
+                    )
+                if not candidate_ids:
+                    return ()
+                statement = statement.where(
+                    MemorySearchDocument.version_id.in_(candidate_ids)
+                )
+            else:
+                statement = statement.order_by(
+                    visible.c.recorded_at.desc(),
+                    MemorySearchDocument.version_id,
+                ).limit(_MAX_CANDIDATES_PER_SIGNAL)
+            rows = session.execute(
+                statement.order_by(MemorySearchDocument.version_id)
+            ).all()
 
         return tuple(
             _candidate_from_document(
                 document,
-                float(lexical_score),
+                bool(lexical_matched),
                 entity_keys,
-                has_text=query.text is not None,
+                evidence_version_ids,
+                related_item_ids,
+                recorded_at,
             )
-            for document, lexical_score in rows
+            for (
+                document,
+                lexical_matched,
+                _entity_match,
+                _evidence_match,
+                _related_match,
+                recorded_at,
+            ) in rows
         )
 
     def scan_visible_candidates(
         self,
         revision: MemoryRevisionRef,
         query: MemoryQuery,
-        limit: int,
     ) -> Sequence[MemoryCandidate]:
         """Bounded canonical fallback used only while the projection needs repair."""
 
@@ -609,9 +736,13 @@ class MemoryManager:
             )
         if query.week is not None:
             statement = statement.where(MemoryVersion.week == query.week)
+        if query.statuses:
+            statement = statement.where(
+                sa.or_(*(_status_matches(status.value) for status in query.statuses))
+            )
         statement = statement.order_by(
             MemoryVersion.recorded_at.desc(), MemoryVersion.id
-        ).limit(500)
+        ).limit(_MAX_FALLBACK_VISIBLE_SCAN)
 
         with read_only_session(self._session_factory) as session:
             version_ids = list(
@@ -622,30 +753,68 @@ class MemoryManager:
         entity_keys = tuple(
             sorted({entity_search_key(entity) for entity in query.entities})
         )
-        candidates: list[MemoryCandidate] = []
+        evidence_version_ids = tuple(sorted(query.evidence_version_ids, key=str))
+        related_item_ids = tuple(sorted(query.related_item_ids, key=str))
+        candidates: dict[UUID, MemoryCandidate] = {}
+        selected_per_signal = {
+            "lexical": 0,
+            "entity": 0,
+            "evidence": 0,
+            "related": 0,
+        }
+        has_retrieval_signal = bool(
+            query.text is not None
+            or entity_keys
+            or evidence_version_ids
+            or related_item_ids
+        )
         for version_id in version_ids:
-            document = build_search_document(versions[version_id])
-            if query.statuses and document.status not in {
-                status.value for status in query.statuses
-            }:
-                continue
+            version = versions[version_id]
+            document = build_search_document(version)
             lexical_match = _fallback_text_matches(query.text, document.document_text)
             entity_match = bool(set(entity_keys) & set(document.entity_keys))
-            if (query.text is not None or entity_keys) and not (
-                lexical_match or entity_match
+            evidence_match = bool(
+                set(evidence_version_ids) & set(document.evidence_version_ids)
+            )
+            related_match = bool(
+                set(related_item_ids) & set(document.related_item_ids)
+            )
+            if (
+                query.text is not None
+                or entity_keys
+                or evidence_version_ids
+                or related_item_ids
+            ) and not (
+                lexical_match or entity_match or evidence_match or related_match
             ):
                 continue
-            candidates.append(
-                _candidate_from_document(
-                    document,
-                    0.5 if lexical_match else 0.0,
-                    entity_keys,
-                    has_text=query.text is not None,
+            matched_signals = tuple(
+                name
+                for name, matched in (
+                    ("lexical", lexical_match),
+                    ("entity", entity_match),
+                    ("evidence", evidence_match),
+                    ("related", related_match),
                 )
+                if matched
             )
-            if len(candidates) >= limit:
-                break
-        return tuple(candidates)
+            selected = not has_retrieval_signal and (
+                len(candidates) < _MAX_FALLBACK_CANDIDATES
+            )
+            for signal in matched_signals:
+                if selected_per_signal[signal] < _MAX_CANDIDATES_PER_SIGNAL:
+                    selected_per_signal[signal] += 1
+                    selected = True
+            if selected:
+                candidates[version_id] = _candidate_from_document(
+                    document,
+                    lexical_match,
+                    entity_keys,
+                    evidence_version_ids,
+                    related_item_ids,
+                    version.recorded_at,
+                )
+        return tuple(candidates.values())
 
     def search_index_status(self, competition_id: UUID) -> SearchIndexStatus:
         with read_only_session(self._session_factory) as session:
@@ -1948,52 +2117,37 @@ def _status_matches(status: str) -> sa.ColumnElement[bool]:
     )
 
 
-def _uuid_cursor(cursor: str) -> UUID:
-    try:
-        return UUID(cursor)
-    except ValueError as error:
-        raise ValueError("invalid memory item cursor") from error
-
-
-def _sequence_cursor(cursor: str) -> int:
-    try:
-        sequence = int(cursor)
-    except ValueError as error:
-        raise ValueError("invalid memory revision cursor") from error
-    if sequence < 0:
-        raise ValueError("invalid memory revision cursor")
-    return sequence
-
-
 def _candidate_from_document(
     document: MemorySearchDocument | SearchDocument,
-    lexical_score: float,
+    lexical_match: bool,
     query_entity_keys: Sequence[str],
-    *,
-    has_text: bool,
+    query_evidence_version_ids: Sequence[UUID],
+    query_related_item_ids: Sequence[UUID],
+    recorded_at: datetime,
 ) -> MemoryCandidate:
     matched_entities = tuple(
         sorted(set(query_entity_keys) & set(document.entity_keys))
     )
-    reasons: list[str] = []
-    components: dict[str, float] = {}
-    if lexical_score > 0:
-        reasons.append("lexical_match")
-        components["lexical"] = lexical_score
-    if matched_entities:
-        reasons.append("entity_overlap")
-        components["entity"] = 1.0
-    if document.salience is not None:
-        components["salience"] = document.salience / 25
-    if not reasons and not has_text and not query_entity_keys:
-        reasons.append("filter_match")
-        components["baseline"] = 0.0
+    matched_evidence = tuple(
+        sorted(
+            set(query_evidence_version_ids) & set(document.evidence_version_ids),
+            key=str,
+        )
+    )
+    matched_related = tuple(
+        sorted(
+            set(query_related_item_ids) & set(document.related_item_ids),
+            key=str,
+        )
+    )
     return MemoryCandidate(
         version_id=document.version_id,
-        kind=document.kind,
-        match_reasons=tuple(reasons),
-        rank_components=components,
+        lexical_match=lexical_match,
         matched_entities=matched_entities,
+        matched_evidence_version_ids=matched_evidence,
+        matched_related_item_ids=matched_related,
+        salience=document.salience,
+        recorded_at=recorded_at,
     )
 
 

--- a/backend/resources/memory/objects.py
+++ b/backend/resources/memory/objects.py
@@ -604,6 +604,8 @@ DEFAULT_EXPANSION = ExpansionPolicy()
 class MemoryQuery(MemoryObject):
     text: NonEmptyStr | None = None
     entities: tuple[EntityKey, ...] = ()
+    evidence_version_ids: frozenset[UUID] = frozenset()
+    related_item_ids: frozenset[UUID] = frozenset()
     kinds: frozenset[MemoryKind] = frozenset()
     statuses: frozenset[MemoryStatus] = frozenset()
     season_id: UUID | None = None
@@ -666,10 +668,7 @@ class RetrievedMemoryEntry(MemoryObject):
     memory: HydratedMemoryVersion
     score: float
     match_reasons: tuple[NonEmptyStr, ...] = ()
-    rank_components: FrozenJsonObject = Field(
-        default_factory=lambda: FrozenJsonObject({})
-    )
-    matched_entities: tuple[NonEmptyStr, ...] = ()
+    matched_entities: tuple[EntityKey, ...] = ()
 
 
 class RetrievedMemory(MemoryObject):

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application services for backend capabilities."""

--- a/backend/services/memory/__init__.py
+++ b/backend/services/memory/__init__.py
@@ -1,0 +1,19 @@
+"""Revision-safe canonical memory service contracts."""
+
+from backend.services.memory.contracts import (
+    MemoryInspector,
+    MemoryReader,
+    MemorySearchIndexAdmin,
+    MemoryWriter,
+    PinnedMemoryReader,
+)
+from backend.services.memory.service import MemoryService
+
+__all__ = [
+    "MemoryInspector",
+    "MemoryReader",
+    "MemorySearchIndexAdmin",
+    "MemoryService",
+    "MemoryWriter",
+    "PinnedMemoryReader",
+]

--- a/backend/services/memory/contracts.py
+++ b/backend/services/memory/contracts.py
@@ -1,0 +1,98 @@
+"""Narrow consumer ports for canonical memory reads.
+
+The protocols describe capabilities granted to callers.  They deliberately do
+not mirror ``MemoryManager``: persistence search and hydration primitives stay
+behind ``MemoryService``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+from uuid import UUID
+
+from backend.resources.memory.objects import (
+    DEFAULT_EXPANSION,
+    ExpansionPolicy,
+    HydratedMemoryVersion,
+    ItemHistory,
+    MemoryListQuery,
+    MemoryMutationBundle,
+    MemoryPage,
+    MemoryQuery,
+    MemoryRevisionRef,
+    MutationResult,
+    RebuildResult,
+    RetrievedMemory,
+    RevisionPage,
+    SearchIndexStatus,
+)
+
+
+class PinnedMemoryReader(Protocol):
+    """Revision-bound memory capability supplied to reporter execution."""
+
+    @property
+    def revision(self) -> MemoryRevisionRef: ...
+
+    def retrieve(self, query: MemoryQuery) -> RetrievedMemory: ...
+
+    def get_version(
+        self,
+        version_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion: ...
+
+    def get_item(
+        self,
+        item_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion: ...
+
+
+class MemoryReader(Protocol):
+    """Capability for resolving and pinning canonical memory revisions."""
+
+    def pin_current(self, competition_id: UUID) -> PinnedMemoryReader: ...
+
+    def at_revision(self, revision_id: UUID) -> PinnedMemoryReader: ...
+
+
+class MemoryWriter(Protocol):
+    """Canonical mutation capability implemented directly by persistence."""
+
+    def apply(self, bundle: MemoryMutationBundle) -> MutationResult: ...
+
+
+class MemoryInspector(Protocol):
+    """Basic canonical viewing and history capability for trusted adapters."""
+
+    def list_items(self, query: MemoryListQuery) -> MemoryPage: ...
+
+    def get_item(
+        self,
+        competition_id: UUID,
+        item_id: UUID,
+        revision_id: UUID | None = None,
+    ) -> HydratedMemoryVersion: ...
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory: ...
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None = None,
+        limit: int = 50,
+    ) -> RevisionPage: ...
+
+
+class MemorySearchIndexAdmin(Protocol):
+    """Narrow maintenance capability implemented directly by persistence."""
+
+    def search_index_status(self, competition_id: UUID) -> SearchIndexStatus: ...
+
+    def rebuild_search_index(
+        self,
+        competition_id: UUID,
+        *,
+        batch_size: int = 200,
+    ) -> RebuildResult: ...

--- a/backend/services/memory/service.py
+++ b/backend/services/memory/service.py
@@ -1,0 +1,355 @@
+"""Revision-safe retrieval policy and canonical memory read facade."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+from backend.resources.memory.cursors import decode_item_cursor
+from backend.resources.memory.errors import (
+    InvalidMemoryCursor,
+    MemoryNotFound,
+    MemoryScopeViolation,
+    SearchProjectionUnavailable,
+)
+from backend.resources.memory.objects import (
+    DEFAULT_EXPANSION,
+    EntityKey,
+    ExpansionPolicy,
+    HydratedMemoryVersion,
+    ItemHistory,
+    MemoryListQuery,
+    MemoryPage,
+    MemoryQuery,
+    MemoryRevisionRef,
+    RetrievedMemory,
+    RetrievedMemoryEntry,
+    RevisionPage,
+)
+from backend.resources.memory.search_documents import entity_search_key
+from backend.services.memory.contracts import PinnedMemoryReader
+
+
+class CandidateMatch(Protocol):
+    """Raw persistence signals accepted by service-owned ranking policy."""
+
+    version_id: UUID
+    lexical_match: bool
+    matched_entities: Sequence[str]
+    matched_evidence_version_ids: Sequence[UUID]
+    matched_related_item_ids: Sequence[UUID]
+    salience: int | None
+    recorded_at: datetime
+
+
+class MemoryReadManager(Protocol):
+    """Persistence capabilities needed by the cohesive memory service."""
+
+    def current_revision(self, competition_id: UUID) -> MemoryRevisionRef: ...
+
+    def get_revision(
+        self,
+        revision_id: UUID,
+        competition_id: UUID | None = None,
+    ) -> MemoryRevisionRef: ...
+
+    def get_visible_item(
+        self,
+        revision: MemoryRevisionRef,
+        item_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion: ...
+
+    def get_visible_version(
+        self,
+        revision: MemoryRevisionRef,
+        version_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion: ...
+
+    def list_visible_items(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryListQuery,
+    ) -> MemoryPage: ...
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory: ...
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None,
+        limit: int,
+    ) -> RevisionPage: ...
+
+    def find_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> Sequence[CandidateMatch]: ...
+
+    def scan_visible_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> Sequence[CandidateMatch]: ...
+
+    def hydrate_visible_versions(
+        self,
+        revision: MemoryRevisionRef,
+        version_ids: Sequence[UUID],
+        expansion: ExpansionPolicy,
+    ) -> Mapping[UUID, HydratedMemoryVersion]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _RankedCandidate:
+    version_id: UUID
+    score: float
+    match_reasons: tuple[str, ...]
+    matched_entities: tuple[EntityKey, ...]
+
+
+@dataclass(slots=True)
+class _CandidateSignals:
+    recorded_at: datetime
+    lexical_match: bool = False
+    entities: set[str] = field(default_factory=set)
+    evidence: set[UUID] = field(default_factory=set)
+    related: set[UUID] = field(default_factory=set)
+    salience: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PinnedMemoryReader:
+    """Immutable capability that prevents competition or revision drift."""
+
+    _manager: MemoryReadManager
+    _service: MemoryService
+    revision: MemoryRevisionRef
+
+    def retrieve(self, query: MemoryQuery) -> RetrievedMemory:
+        return self._service._retrieve_at(self.revision, query)
+
+    def get_version(
+        self,
+        version_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion:
+        return self._manager.get_visible_version(self.revision, version_id, expansion)
+
+    def get_item(
+        self,
+        item_id: UUID,
+        expansion: ExpansionPolicy = DEFAULT_EXPANSION,
+    ) -> HydratedMemoryVersion:
+        return self._manager.get_visible_item(self.revision, item_id, expansion)
+
+
+class MemoryService:
+    """One cohesive facade for revision-safe retrieval and basic inspection."""
+
+    _EXACT_EVIDENCE_WEIGHT = 4.0
+    _RELATED_ITEM_WEIGHT = 3.0
+    _ENTITY_WEIGHT = 2.0
+    _LEXICAL_WEIGHT = 1.5
+    _SALIENCE_WEIGHT = 0.5
+    _RECENCY_WEIGHT = 0.25
+    _RECENCY_WINDOW_SECONDS = 365 * 24 * 60 * 60
+
+    def __init__(self, manager: MemoryReadManager) -> None:
+        self._manager = manager
+
+    def pin_current(self, competition_id: UUID) -> PinnedMemoryReader:
+        return _PinnedMemoryReader(
+            self._manager,
+            self,
+            self._manager.current_revision(competition_id),
+        )
+
+    def at_revision(self, revision_id: UUID) -> PinnedMemoryReader:
+        return _PinnedMemoryReader(
+            self._manager,
+            self,
+            self._manager.get_revision(revision_id),
+        )
+
+    def list_items(self, query: MemoryListQuery) -> MemoryPage:
+        revision_id = query.revision_id
+        if query.cursor is not None:
+            cursor = decode_item_cursor(query.cursor)
+            if revision_id is not None and revision_id != cursor.revision_id:
+                raise InvalidMemoryCursor(
+                    "memory item cursor conflicts with the requested revision",
+                    details={
+                        "cursor_revision_id": str(cursor.revision_id),
+                        "revision_id": str(revision_id),
+                    },
+                )
+            revision_id = cursor.revision_id
+        try:
+            revision = self._resolve_revision(query.competition_id, revision_id)
+        except (MemoryNotFound, MemoryScopeViolation) as error:
+            if query.cursor is None:
+                raise
+            raise InvalidMemoryCursor(
+                "memory item cursor references an unavailable revision"
+            ) from error
+        return self._manager.list_visible_items(revision, query)
+
+    def get_item(
+        self,
+        competition_id: UUID,
+        item_id: UUID,
+        revision_id: UUID | None = None,
+    ) -> HydratedMemoryVersion:
+        revision = self._resolve_revision(competition_id, revision_id)
+        return self._manager.get_visible_item(revision, item_id, DEFAULT_EXPANSION)
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory:
+        return self._manager.item_history(competition_id, item_id)
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None = None,
+        limit: int = 50,
+    ) -> RevisionPage:
+        return self._manager.list_revisions(competition_id, cursor, limit)
+
+    def _resolve_revision(
+        self,
+        competition_id: UUID,
+        revision_id: UUID | None,
+    ) -> MemoryRevisionRef:
+        if revision_id is None:
+            return self._manager.current_revision(competition_id)
+        return self._manager.get_revision(revision_id, competition_id)
+
+    def _retrieve_at(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> RetrievedMemory:
+        degraded = False
+        try:
+            candidates = self._manager.find_candidates(revision, query)
+        except SearchProjectionUnavailable:
+            degraded = True
+            candidates = self._manager.scan_visible_candidates(
+                revision,
+                query,
+            )
+
+        ranked = self._rank_candidates(candidates, query.entities)[: query.limit]
+        hydrated = self._manager.hydrate_visible_versions(
+            revision,
+            [candidate.version_id for candidate in ranked],
+            query.expansion,
+        )
+        entries = tuple(
+            RetrievedMemoryEntry(
+                memory=hydrated[candidate.version_id],
+                score=candidate.score,
+                match_reasons=candidate.match_reasons,
+                matched_entities=candidate.matched_entities,
+            )
+            for candidate in ranked
+        )
+        return RetrievedMemory(
+            revision=revision,
+            entries=entries,
+            degraded=degraded,
+        )
+
+    def _rank_candidates(
+        self,
+        candidates: Sequence[CandidateMatch],
+        query_entities: Sequence[EntityKey],
+    ) -> tuple[_RankedCandidate, ...]:
+        """Merge raw signals and apply one deterministic ranking policy."""
+
+        merged: dict[UUID, _CandidateSignals] = {}
+        for candidate in candidates:
+            signals = merged.setdefault(
+                candidate.version_id,
+                _CandidateSignals(recorded_at=candidate.recorded_at),
+            )
+            signals.lexical_match = (
+                signals.lexical_match or candidate.lexical_match
+            )
+            signals.entities.update(candidate.matched_entities)
+            signals.evidence.update(candidate.matched_evidence_version_ids)
+            signals.related.update(candidate.matched_related_item_ids)
+            if candidate.salience is not None:
+                signals.salience = max(
+                    candidate.salience,
+                    signals.salience or 0,
+                )
+            if candidate.recorded_at > signals.recorded_at:
+                signals.recorded_at = candidate.recorded_at
+
+        newest = max(
+            (signals.recorded_at for signals in merged.values()),
+            default=None,
+        )
+        ranked: list[_RankedCandidate] = []
+        typed_entities = {
+            entity_search_key(entity): entity for entity in query_entities
+        }
+        for version_id, signals in merged.items():
+            components: dict[str, float] = {}
+            reasons: list[str] = []
+            if signals.evidence:
+                reasons.append("exact_evidence")
+                components["exact_evidence"] = self._EXACT_EVIDENCE_WEIGHT
+            if signals.related:
+                reasons.append("related_item")
+                components["related_item"] = self._RELATED_ITEM_WEIGHT
+            if signals.entities:
+                reasons.append("entity_overlap")
+                components["entity"] = self._ENTITY_WEIGHT
+            if signals.lexical_match:
+                reasons.append("lexical_match")
+                components["lexical"] = self._LEXICAL_WEIGHT
+            if signals.salience is not None:
+                components["salience"] = (
+                    signals.salience / 5 * self._SALIENCE_WEIGHT
+                )
+            if newest is not None:
+                age_seconds = max(
+                    0.0,
+                    (newest - signals.recorded_at).total_seconds(),
+                )
+                recency = max(
+                    0.0,
+                    1.0 - age_seconds / self._RECENCY_WINDOW_SECONDS,
+                )
+                if recency > 0:
+                    components["recency"] = recency * self._RECENCY_WEIGHT
+            if not reasons:
+                reasons.append("filter_match")
+            ranked.append(
+                _RankedCandidate(
+                    version_id=version_id,
+                    score=sum(components.values()),
+                    match_reasons=tuple(reasons),
+                    matched_entities=tuple(
+                        sorted(
+                            (
+                                typed_entities[key]
+                                for key in signals.entities
+                                if key in typed_entities
+                            ),
+                            key=lambda entity: (entity.kind, str(entity.id)),
+                        )
+                    ),
+                )
+            )
+
+        return tuple(
+            sorted(ranked, key=lambda item: (-item.score, str(item.version_id)))
+        )

--- a/backend/tests/resources/memory/test_manager_reads.py
+++ b/backend/tests/resources/memory/test_manager_reads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
@@ -20,16 +21,27 @@ from backend.database.models.memory import (
 from backend.database.models.reporting import Generation
 from backend.database.sessions import create_session_factory
 from backend.resources.memory.errors import (
+    InvalidMemoryCursor,
     MemoryScopeViolation,
     SearchProjectionUnavailable,
 )
 from backend.resources.memory.manager import MemoryManager
+from backend.resources.memory.cursors import (
+    decode_item_cursor,
+    decode_revision_cursor,
+    encode_revision_cursor,
+)
 from backend.resources.memory.objects import (
     ExpansionPolicy,
+    FranchiseKey,
     MemoryKind,
     MemoryListQuery,
     MemoryQuery,
     MemoryStatus,
+)
+from backend.resources.memory.search_documents import (
+    SEARCH_DOCUMENT_BUILDER_VERSION,
+    entity_search_key,
 )
 from backend.tests.database.conftest import (  # noqa: F401
     database_engine,
@@ -281,7 +293,12 @@ def _seed_memory(engine: Engine) -> _SeededMemory:
                             "role": "payoff",
                         }
                     ],
-                    "related_storylines": [],
+                    "related_storylines": [
+                        {
+                            "item_id": str(storyline_item_id),
+                            "role": "continuation",
+                        }
+                    ],
                     "resolution_summary": "The late-season slide ended the run.",
                 },
             ],
@@ -404,7 +421,53 @@ def test_history_and_pages_return_typed_canonical_resources(
         seeded.current_storyline_version_id
     ]
     assert [revision.sequence_number for revision in revisions.revisions] == [2, 1]
-    assert revisions.next_cursor == "1"
+    assert revisions.next_cursor is not None
+    assert decode_revision_cursor(revisions.next_cursor).sequence_number == 1
+
+
+def test_item_and_revision_cursors_are_opaque_scoped_and_revision_safe(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    current = manager.current_revision(seeded.competition_id)
+    other_revision = manager.current_revision(seeded.other_competition_id)
+
+    page = manager.list_visible_items(
+        current,
+        MemoryListQuery(competition_id=seeded.competition_id, limit=1),
+    )
+    assert page.next_cursor is not None
+    decoded_item = decode_item_cursor(page.next_cursor)
+    assert decoded_item.revision_id == current.id
+    with pytest.raises(InvalidMemoryCursor):
+        manager.list_visible_items(
+            other_revision,
+            MemoryListQuery(
+                competition_id=seeded.other_competition_id,
+                cursor=page.next_cursor,
+            ),
+        )
+    with pytest.raises(InvalidMemoryCursor):
+        manager.list_visible_items(
+            current,
+            MemoryListQuery(
+                competition_id=seeded.competition_id,
+                cursor="not-a-cursor",
+            ),
+        )
+
+    revision_cursor = encode_revision_cursor(seeded.competition_id, 2)
+    revisions = manager.list_revisions(seeded.competition_id, revision_cursor, 1)
+    assert revisions.revisions[0].sequence_number == 1
+    with pytest.raises(InvalidMemoryCursor):
+        manager.list_revisions(
+            seeded.other_competition_id,
+            revision_cursor,
+            1,
+        )
+    with pytest.raises(InvalidMemoryCursor):
+        manager.list_revisions(seeded.competition_id, "not-a-cursor", 1)
 
 
 def test_projection_rebuild_restores_search_without_changing_canonical_state(
@@ -417,7 +480,7 @@ def test_projection_rebuild_restores_search_without_changing_canonical_state(
 
     with pytest.raises(SearchProjectionUnavailable):
         manager.find_candidates(current, query)
-    fallback = manager.scan_visible_candidates(current, query, 5)
+    fallback = manager.scan_visible_candidates(current, query)
     rebuilt = manager.rebuild_search_index(seeded.competition_id, batch_size=2)
     candidates = manager.find_candidates(current, query)
     with database_engine.begin() as connection:
@@ -429,10 +492,22 @@ def test_projection_rebuild_restores_search_without_changing_canonical_state(
     stale_status = manager.search_index_status(seeded.competition_id)
     with pytest.raises(SearchProjectionUnavailable):
         manager.find_candidates(current, query)
-    mixed_fallback = manager.scan_visible_candidates(current, query, 5)
+    mixed_fallback = manager.scan_visible_candidates(current, query)
     manager.rebuild_search_index(seeded.competition_id, batch_size=2)
     repaired_candidates = manager.find_candidates(current, query)
     repaired_status = manager.search_index_status(seeded.competition_id)
+    exact_evidence = manager.find_candidates(
+        current,
+        MemoryQuery(evidence_version_ids={seeded.fact_version_id}),
+    )
+    exact_related = manager.find_candidates(
+        current,
+        MemoryQuery(related_item_ids={seeded.storyline_item_id}),
+    )
+    historical = manager.find_candidates(
+        manager.get_revision(seeded.middle_revision_id),
+        query,
+    )
 
     assert [candidate.version_id for candidate in fallback] == [
         seeded.current_storyline_version_id
@@ -447,7 +522,131 @@ def test_projection_rebuild_restores_search_without_changing_canonical_state(
     assert [candidate.version_id for candidate in repaired_candidates] == [
         seeded.current_storyline_version_id
     ]
+    assert [candidate.version_id for candidate in exact_evidence] == [
+        seeded.current_storyline_version_id
+    ]
+    assert exact_evidence[0].matched_evidence_version_ids == (
+        seeded.fact_version_id,
+    )
+    assert [candidate.version_id for candidate in exact_related] == [
+        seeded.current_storyline_version_id
+    ]
+    assert exact_related[0].matched_related_item_ids == (
+        seeded.storyline_item_id,
+    )
+    assert historical == ()
     assert rebuilt.rebuilt_document_count == 3
     assert repaired_status.missing_document_count == 0
     assert repaired_status.stale_document_count == 0
     assert manager.current_revision(seeded.competition_id) == current
+
+
+def test_candidate_pool_reserves_capacity_for_each_independent_signal(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    manager.rebuild_search_index(seeded.competition_id)
+    entity = FranchiseKey(id=uuid4())
+    entity_version_id = uuid4()
+    lexical_version_ids = [uuid4() for _ in range(25)]
+    version_ids = [*lexical_version_ids, entity_version_id]
+    item_ids = [uuid4() for _ in version_ids]
+
+    with database_engine.begin() as connection:
+        generation_id = connection.scalar(
+            sa.select(MemoryRevision.producing_generation_id).where(
+                MemoryRevision.id == seeded.current_revision_id
+            )
+        )
+        assert generation_id is not None
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                {
+                    "id": item_id,
+                    "competition_id": seeded.competition_id,
+                    "kind": "fact",
+                    "agent_key": f"pool-{index}",
+                }
+                for index, item_id in enumerate(item_ids)
+            ],
+        )
+        newest = datetime(2026, 8, 9, tzinfo=UTC)
+        connection.execute(
+            sa.insert(MemoryVersion),
+            [
+                {
+                    "id": version_id,
+                    "item_id": item_id,
+                    "competition_id": seeded.competition_id,
+                    "revision_number": 1,
+                    "introduced_revision_id": seeded.current_revision_id,
+                    "competition_season_id": seeded.season_id,
+                    "week": 8,
+                    "creating_generation_id": generation_id,
+                    "recorded_at": newest - timedelta(seconds=index),
+                }
+                for index, (item_id, version_id) in enumerate(
+                    zip(item_ids, version_ids, strict=True)
+                )
+            ],
+        )
+        connection.execute(
+            sa.insert(MemorySearchDocument),
+            [
+                {
+                    "version_id": version_id,
+                    "item_id": item_id,
+                    "competition_id": seeded.competition_id,
+                    "kind": "fact",
+                    "status": "active",
+                    "competition_season_id": seeded.season_id,
+                    "week": 8,
+                    "entity_keys": [],
+                    "evidence_version_ids": [],
+                    "related_item_ids": [],
+                    "tags": [],
+                    "document_text": f"crowded lexical result {index}",
+                    "builder_version": SEARCH_DOCUMENT_BUILDER_VERSION,
+                    "content_hash": f"lexical-{index}",
+                }
+                for index, (item_id, version_id) in enumerate(
+                    zip(item_ids[:-1], lexical_version_ids, strict=True)
+                )
+            ]
+            + [
+                {
+                    "version_id": entity_version_id,
+                    "item_id": item_ids[-1],
+                    "competition_id": seeded.competition_id,
+                    "kind": "fact",
+                    "status": "active",
+                    "competition_season_id": seeded.season_id,
+                    "week": 8,
+                    "entity_keys": [entity_search_key(entity)],
+                    "evidence_version_ids": [],
+                    "related_item_ids": [],
+                    "tags": [],
+                    "document_text": "entity only",
+                    "builder_version": SEARCH_DOCUMENT_BUILDER_VERSION,
+                    "content_hash": "entity",
+                }
+            ],
+        )
+
+    query = MemoryQuery(text="crowded", entities=(entity,), limit=1)
+    candidates = manager.find_candidates(
+        manager.current_revision(seeded.competition_id),
+        query,
+    )
+
+    assert entity_version_id in {candidate.version_id for candidate in candidates}
+    assert len(candidates) > query.limit
+
+    filter_query = MemoryQuery(kinds={MemoryKind.FACT}, limit=1)
+    filter_candidates = manager.find_candidates(
+        manager.current_revision(seeded.competition_id),
+        filter_query,
+    )
+    assert len(filter_candidates) > filter_query.limit

--- a/backend/tests/services/__init__.py
+++ b/backend/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application service tests."""

--- a/backend/tests/services/memory/__init__.py
+++ b/backend/tests/services/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical memory service tests."""

--- a/backend/tests/services/memory/test_search.py
+++ b/backend/tests/services/memory/test_search.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+
+from backend.resources.memory.errors import SearchProjectionUnavailable
+from backend.resources.memory.objects import (
+    ExpansionPolicy,
+    FactContent,
+    FactConfidence,
+    FactStatus,
+    FranchiseKey,
+    HydratedMemoryVersion,
+    MemoryKind,
+    MemoryQuery,
+    MemoryRevisionRef,
+    TypedMemoryVersion,
+)
+from backend.resources.memory.search_documents import entity_search_key
+from backend.services.memory.service import MemoryService
+
+
+REVISION = MemoryRevisionRef(
+    id=UUID("00000000-0000-0000-0000-000000000010"),
+    competition_id=UUID("00000000-0000-0000-0000-000000000020"),
+    sequence_number=3,
+    state_content_hash="revision-three",
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    version_id: UUID
+    lexical_match: bool = False
+    matched_entities: tuple[str, ...] = ()
+    matched_evidence_version_ids: tuple[UUID, ...] = ()
+    matched_related_item_ids: tuple[UUID, ...] = ()
+    salience: int | None = None
+    recorded_at: datetime = datetime(2026, 8, 9, tzinfo=UTC)
+
+
+def _memory(version_id: UUID) -> HydratedMemoryVersion:
+    return HydratedMemoryVersion(
+        version=TypedMemoryVersion(
+            version_id=version_id,
+            item_id=UUID(int=version_id.int + 100),
+            competition_id=REVISION.competition_id,
+            kind=MemoryKind.FACT,
+            revision_number=1,
+            content_schema_version=1,
+            introduced_revision_id=REVISION.id,
+            creating_generation_id=UUID(int=version_id.int + 200),
+            recorded_at=datetime(2026, 8, 9, tzinfo=UTC),
+            content=FactContent(
+                claim="The Sharks have won three straight.",
+                category="streak",
+                confidence=FactConfidence.INFERRED,
+                status=FactStatus.ACTIVE,
+            ),
+        )
+    )
+
+
+class RetrievalManager:
+    def __init__(
+        self,
+        primary: tuple[Candidate, ...],
+        fallback: tuple[Candidate, ...] = (),
+        *,
+        projection_available: bool = True,
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self.projection_available = projection_available
+        self.find_revisions: list[MemoryRevisionRef] = []
+        self.scan_revisions: list[MemoryRevisionRef] = []
+        all_candidates = {candidate.version_id for candidate in primary + fallback}
+        self.memories = {version_id: _memory(version_id) for version_id in all_candidates}
+
+    def get_revision(self, revision_id, competition_id=None):
+        assert revision_id == REVISION.id
+        assert competition_id is None
+        return REVISION
+
+    def find_candidates(self, revision, query):
+        self.find_revisions.append(revision)
+        if not self.projection_available:
+            raise SearchProjectionUnavailable
+        return self.primary
+
+    def scan_visible_candidates(self, revision, query):
+        self.scan_revisions.append(revision)
+        return self.fallback
+
+    def hydrate_visible_versions(self, revision, version_ids, expansion):
+        assert revision is REVISION
+        return {version_id: self.memories[version_id] for version_id in version_ids}
+
+
+def test_service_applies_deterministic_policy_to_raw_signals() -> None:
+    lexical_id = UUID("00000000-0000-0000-0000-000000000001")
+    exact_id = UUID("00000000-0000-0000-0000-000000000002")
+    evidence_id = UUID("00000000-0000-0000-0000-000000000003")
+    franchise = FranchiseKey(id=UUID("00000000-0000-0000-0000-000000000004"))
+    manager = RetrievalManager(
+        (
+            Candidate(
+                lexical_id,
+                lexical_match=True,
+                matched_entities=(entity_search_key(franchise),),
+            ),
+            Candidate(
+                exact_id,
+                matched_evidence_version_ids=(evidence_id,),
+                recorded_at=datetime(2025, 8, 9, tzinfo=UTC),
+            ),
+        )
+    )
+
+    result = MemoryService(manager).at_revision(REVISION.id).retrieve(
+        MemoryQuery(entities=(franchise,), evidence_version_ids={evidence_id})
+    )
+
+    assert [entry.memory.version.version_id for entry in result.entries] == [
+        exact_id,
+        lexical_id,
+    ]
+    assert result.entries[0].match_reasons == ("exact_evidence",)
+    assert result.entries[1].matched_entities == (franchise,)
+    assert not hasattr(result.entries[0], "rank_components")
+
+
+def test_fallback_ranks_its_full_bounded_pool_before_applying_result_limit() -> None:
+    weaker_id = UUID("00000000-0000-0000-0000-000000000001")
+    stronger_id = UUID("00000000-0000-0000-0000-000000000002")
+    evidence_id = UUID("00000000-0000-0000-0000-000000000003")
+    manager = RetrievalManager(
+        (),
+        (
+            Candidate(weaker_id, lexical_match=True),
+            Candidate(
+                stronger_id,
+                matched_evidence_version_ids=(evidence_id,),
+            ),
+        ),
+        projection_available=False,
+    )
+
+    result = MemoryService(manager).at_revision(REVISION.id).retrieve(
+        MemoryQuery(evidence_version_ids={evidence_id}, limit=1)
+    )
+
+    assert result.degraded is True
+    assert result.entries[0].memory.version.version_id == stronger_id
+    assert manager.scan_revisions == [REVISION]
+
+
+def test_primary_and_fallback_paths_report_the_same_stable_reasons() -> None:
+    version_id = UUID("00000000-0000-0000-0000-000000000001")
+    related_item_id = UUID("00000000-0000-0000-0000-000000000002")
+    candidate = Candidate(
+        version_id,
+        lexical_match=True,
+        matched_related_item_ids=(related_item_id,),
+    )
+    query = MemoryQuery(text="sharks", related_item_ids={related_item_id})
+    primary = MemoryService(RetrievalManager((candidate,))).at_revision(
+        REVISION.id
+    ).retrieve(query)
+    fallback = MemoryService(
+        RetrievalManager((), (candidate,), projection_available=False)
+    ).at_revision(REVISION.id).retrieve(query)
+
+    assert primary.entries[0].match_reasons == fallback.entries[0].match_reasons
+    assert primary.entries[0].score == fallback.entries[0].score
+
+
+def test_pinned_retrieval_uses_the_resolved_revision_for_both_stages() -> None:
+    version_id = UUID("00000000-0000-0000-0000-000000000001")
+    manager = RetrievalManager((Candidate(version_id),))
+
+    result = MemoryService(manager).at_revision(REVISION.id).retrieve(MemoryQuery())
+
+    assert result.revision is REVISION
+    assert manager.find_revisions == [REVISION]
+
+
+class UnexpectedFailureManager(RetrievalManager):
+    def find_candidates(self, revision, query):
+        raise RuntimeError("database unavailable")
+
+
+def test_retrieval_does_not_mask_unexpected_manager_failures() -> None:
+    manager = UnexpectedFailureManager(())
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        MemoryService(manager).at_revision(REVISION.id).retrieve(MemoryQuery())
+
+    assert manager.scan_revisions == []

--- a/backend/tests/services/memory/test_service_reads.py
+++ b/backend/tests/services/memory/test_service_reads.py
@@ -1,0 +1,321 @@
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from backend.resources.memory.cursors import (
+    decode_revision_cursor,
+    encode_item_cursor,
+    encode_revision_cursor,
+)
+from backend.resources.memory.errors import (
+    InvalidMemoryCursor,
+    InvalidMemoryQuery,
+    MemoryNotFound,
+    MemoryScopeViolation,
+)
+from backend.resources.memory.manager import MemoryManager
+from backend.resources.memory.objects import (
+    ExpansionPolicy,
+    HydratedMemoryVersion,
+    ItemHistory,
+    MemoryListQuery,
+    MemoryPage,
+    MemoryQuery,
+    MemoryRevisionRef,
+    RevisionPage,
+)
+from backend.services.memory.service import CandidateMatch, MemoryService
+
+
+COMPETITION_ID = UUID("00000000-0000-0000-0000-000000000010")
+REVISION_ID = UUID("00000000-0000-0000-0000-000000000020")
+ITEM_ID = UUID("00000000-0000-0000-0000-000000000030")
+VERSION_ID = UUID("00000000-0000-0000-0000-000000000040")
+
+
+class FakeMemoryManager:
+    """Purpose-built boundary fake; it models no ORM or transaction behavior."""
+
+    def __init__(self, revision: MemoryRevisionRef) -> None:
+        self.current = revision
+        self.revisions = {revision.id: revision}
+        self.revision_requests: list[tuple[UUID, UUID | None]] = []
+        self.visible_item_requests: list[
+            tuple[MemoryRevisionRef, UUID, ExpansionPolicy]
+        ] = []
+        self.visible_version_requests: list[
+            tuple[MemoryRevisionRef, UUID, ExpansionPolicy]
+        ] = []
+        self.list_item_requests: list[tuple[MemoryRevisionRef, MemoryListQuery]] = []
+        self.history_requests: list[tuple[UUID, UUID]] = []
+        self.list_revision_requests: list[tuple[UUID, str | None, int]] = []
+        self.item_result = cast(HydratedMemoryVersion, object())
+        self.version_result = cast(HydratedMemoryVersion, object())
+        self.page_result = cast(MemoryPage, object())
+        self.history_result = cast(ItemHistory, object())
+        self.revisions_result = cast(RevisionPage, object())
+
+    def current_revision(self, competition_id: UUID) -> MemoryRevisionRef:
+        assert competition_id == self.current.competition_id
+        return self.current
+
+    def get_revision(
+        self,
+        revision_id: UUID,
+        competition_id: UUID | None = None,
+    ) -> MemoryRevisionRef:
+        self.revision_requests.append((revision_id, competition_id))
+        revision = self.revisions.get(revision_id)
+        if revision is None:
+            raise MemoryNotFound("revision unavailable")
+        if (
+            competition_id is not None
+            and competition_id != revision.competition_id
+        ):
+            raise MemoryScopeViolation("revision outside competition")
+        return revision
+
+    def get_visible_item(
+        self,
+        revision: MemoryRevisionRef,
+        item_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion:
+        self.visible_item_requests.append((revision, item_id, expansion))
+        return self.item_result
+
+    def get_visible_version(
+        self,
+        revision: MemoryRevisionRef,
+        version_id: UUID,
+        expansion: ExpansionPolicy,
+    ) -> HydratedMemoryVersion:
+        self.visible_version_requests.append((revision, version_id, expansion))
+        return self.version_result
+
+    def list_visible_items(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryListQuery,
+    ) -> MemoryPage:
+        self.list_item_requests.append((revision, query))
+        return self.page_result
+
+    def item_history(self, competition_id: UUID, item_id: UUID) -> ItemHistory:
+        self.history_requests.append((competition_id, item_id))
+        return self.history_result
+
+    def list_revisions(
+        self,
+        competition_id: UUID,
+        cursor: str | None,
+        limit: int,
+    ) -> RevisionPage:
+        self.list_revision_requests.append((competition_id, cursor, limit))
+        return self.revisions_result
+
+    def find_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> Sequence[CandidateMatch]:
+        return ()
+
+    def scan_visible_candidates(
+        self,
+        revision: MemoryRevisionRef,
+        query: MemoryQuery,
+    ) -> Sequence[CandidateMatch]:
+        return ()
+
+    def hydrate_visible_versions(
+        self,
+        revision: MemoryRevisionRef,
+        version_ids: Sequence[UUID],
+        expansion: ExpansionPolicy,
+    ) -> Mapping[UUID, HydratedMemoryVersion]:
+        return {}
+
+
+def revision_ref() -> MemoryRevisionRef:
+    return MemoryRevisionRef(
+        id=REVISION_ID,
+        competition_id=COMPETITION_ID,
+        sequence_number=7,
+        state_content_hash="revision-seven",
+    )
+
+
+def test_pinned_reader_keeps_one_resolved_revision_for_every_direct_read() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+
+    reader = service.at_revision(REVISION_ID)
+    manager.current = MemoryRevisionRef(
+        id=UUID("00000000-0000-0000-0000-000000000021"),
+        competition_id=COMPETITION_ID,
+        sequence_number=8,
+        state_content_hash="revision-eight",
+    )
+
+    assert reader.revision is revision
+    assert reader.get_item(ITEM_ID) is manager.item_result
+    assert reader.get_version(VERSION_ID) is manager.version_result
+    assert manager.revision_requests == [(REVISION_ID, None)]
+    assert manager.visible_item_requests[0][:2] == (revision, ITEM_ID)
+    assert manager.visible_version_requests[0][:2] == (revision, VERSION_ID)
+
+
+def test_pin_current_binds_the_exact_revision_resolved_once() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+
+    reader = service.pin_current(COMPETITION_ID)
+    manager.current = MemoryRevisionRef(
+        id=UUID("00000000-0000-0000-0000-000000000021"),
+        competition_id=COMPETITION_ID,
+        sequence_number=8,
+        state_content_hash="revision-eight",
+    )
+
+    assert reader.revision is revision
+    assert reader.get_item(ITEM_ID) is manager.item_result
+    assert manager.visible_item_requests[0][:2] == (revision, ITEM_ID)
+    assert manager.revision_requests == []
+
+
+def test_inspection_get_item_scopes_an_explicit_revision_to_competition() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+
+    result = service.get_item(COMPETITION_ID, ITEM_ID, revision_id=REVISION_ID)
+
+    assert result is manager.item_result
+    assert manager.revision_requests == [(REVISION_ID, COMPETITION_ID)]
+    assert manager.visible_item_requests[0][:2] == (revision, ITEM_ID)
+
+
+def test_inspection_get_item_resolves_current_revision_once() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+
+    result = service.get_item(COMPETITION_ID, ITEM_ID)
+
+    assert result is manager.item_result
+    assert manager.revision_requests == []
+    assert manager.visible_item_requests[0][:2] == (revision, ITEM_ID)
+
+
+def test_list_items_resolves_and_returns_one_revision_scoped_page() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+    query = MemoryListQuery(competition_id=COMPETITION_ID)
+
+    result = service.list_items(query)
+
+    assert result is manager.page_result
+    assert manager.list_item_requests == [(revision, query)]
+    assert manager.revision_requests == []
+
+
+def test_list_items_cursor_keeps_the_first_pages_revision_after_current_moves() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+    cursor = encode_item_cursor(revision.id, ITEM_ID)
+    manager.current = MemoryRevisionRef(
+        id=UUID("00000000-0000-0000-0000-000000000021"),
+        competition_id=COMPETITION_ID,
+        sequence_number=8,
+        state_content_hash="revision-eight",
+    )
+
+    result = service.list_items(
+        MemoryListQuery(competition_id=COMPETITION_ID, cursor=cursor)
+    )
+
+    assert result is manager.page_result
+    assert manager.revision_requests == [(REVISION_ID, COMPETITION_ID)]
+    assert manager.list_item_requests[0][0] is revision
+
+
+def test_list_items_rejects_cursor_and_explicit_revision_conflict() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+    cursor = encode_item_cursor(revision.id, ITEM_ID)
+
+    with pytest.raises(InvalidMemoryCursor):
+        service.list_items(
+            MemoryListQuery(
+                competition_id=COMPETITION_ID,
+                revision_id=UUID("00000000-0000-0000-0000-000000000021"),
+                cursor=cursor,
+            )
+        )
+
+    assert manager.revision_requests == []
+
+
+def test_list_items_translates_unavailable_cursor_revision() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+    unavailable_revision_id = UUID("00000000-0000-0000-0000-000000000099")
+
+    with pytest.raises(InvalidMemoryCursor):
+        service.list_items(
+            MemoryListQuery(
+                competition_id=COMPETITION_ID,
+                cursor=encode_item_cursor(unavailable_revision_id, ITEM_ID),
+            )
+        )
+
+
+def test_list_items_translates_cross_competition_cursor_revision() -> None:
+    revision = revision_ref()
+    manager = FakeMemoryManager(revision)
+    service = MemoryService(manager)
+    other_competition_id = UUID("00000000-0000-0000-0000-000000000011")
+
+    with pytest.raises(InvalidMemoryCursor):
+        service.list_items(
+            MemoryListQuery(
+                competition_id=other_competition_id,
+                cursor=encode_item_cursor(revision.id, ITEM_ID),
+            )
+        )
+
+
+def test_revision_cursor_requires_a_json_integer_sequence() -> None:
+    cursor = encode_revision_cursor(COMPETITION_ID, True)
+
+    with pytest.raises(InvalidMemoryCursor):
+        decode_revision_cursor(cursor)
+
+
+def test_revision_list_limit_uses_a_stable_query_error() -> None:
+    manager = MemoryManager(cast(Any, object()))
+
+    with pytest.raises(InvalidMemoryQuery):
+        manager.list_revisions(COMPETITION_ID, None, 0)
+
+
+def test_basic_history_and_revision_inspection_stays_competition_scoped() -> None:
+    manager = FakeMemoryManager(revision_ref())
+    service = MemoryService(manager)
+
+    history = service.item_history(COMPETITION_ID, ITEM_ID)
+    revisions = service.list_revisions(COMPETITION_ID, cursor="next", limit=12)
+
+    assert history is manager.history_result
+    assert revisions is manager.revisions_result
+    assert manager.history_requests == [(COMPETITION_ID, ITEM_ID)]
+    assert manager.list_revision_requests == [(COMPETITION_ID, "next", 12)]

--- a/docs/memory/log.md
+++ b/docs/memory/log.md
@@ -496,6 +496,38 @@ the resulting visible-state hash before advancing the current pointer.
 - Any encoding drift, projection failure, or hash mismatch rolls back the whole
   canonical mutation.
 
+### MEM-024 — Keep retrieval policy cohesive and pagination revision-safe
+
+**Date:** 2026-08-09
+**Status:** Settled
+**Source:** Independent deep-module and caller-complexity review
+
+`MemoryService` is the single owner of retrieval weighting, reason vocabulary,
+deduplication, hydration order, and the final result limit. `MemoryManager`
+returns bounded raw candidate signals, reserving capacity independently for
+lexical, entity, evidence-version, and related-item matches. Primary and bounded
+fallback discovery feed the same service policy.
+
+`MemoryService` also creates the immutable pinned reader. The reader retains one
+validated revision, delegates ranked retrieval to the service, and performs
+exact visible-item/version reads through the captured narrow manager. It is a
+scope capability, not a retrieval coordinator.
+
+**Consequences:**
+
+- No `RetrievalCoordinator`, forwarding-only admin class, or duplicate retrieval
+  protocol/module is introduced.
+- Search-index status/rebuild and canonical mutation are structural ports
+  satisfied directly by the deep manager; inspection remains a narrow service
+  view limited to viewing, history, and revisions.
+- Exact evidence and related-item signals work in both primary and degraded
+  paths without kind-specific service methods.
+- Result contracts expose typed matched entities and stable reasons, not search
+  key strings or internal score-component maps.
+- Opaque item cursors contain the resolved revision; later pages cannot drift to
+  a newer current state, and invalid cursor/query inputs use stable memory
+  errors.
+
 ## Pending Decisions
 
 - Default retrieval and evidence-expansion limits.

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -111,17 +111,17 @@ Candidate discovery combines independent signals:
 5. optional vector similarity;
 6. status, salience, event fit, and light recency policy.
 
-The system should retain named score components or use rank fusion rather than
-pretending raw full-text and vector scores have the same scale.
+The service owns one deterministic weighting policy. Persistence returns raw
+match signals and reserves bounded candidate capacity for each independent
+signal; it does not assign application weights or apply the final result limit.
 
 Search returns compact leads:
 
 ```json
 {
   "version_id": "...",
-  "kind": "storyline",
   "score": 0.87,
-  "matched_entities": ["franchise:..."],
+  "matched_entities": [{"kind": "franchise", "id": "..."}],
   "match_reasons": ["entity_overlap", "lexical_match"]
 }
 ```
@@ -171,7 +171,9 @@ not create memory revisions.
 
 If current projection rows are missing, stale, or use mixed builder versions,
 ordinary retrieval degrades internally to exact entity/reference signals and a
-bounded scan of visible canonical versions. Mixed-version index state is never
+bounded scan of visible canonical versions. Primary and fallback paths produce
+the same stable reason vocabulary and lexical-presence signal; the service owns
+ranking in both cases. Mixed-version index state is never
 used for ranking. Search-index status surfaces the repair need; reporter callers
 do not handle a projection-administration error.
 

--- a/docs/memory/service-architecture.md
+++ b/docs/memory/service-architecture.md
@@ -1,6 +1,6 @@
 # Memory Service Architecture
 
-**Status:** Accepted application design; implementation pending
+**Status:** Accepted application design; baseline implemented through pinned retrieval
 
 **Scope:** Application components, caller-facing contracts, dependency direction,
 and transaction boundaries for canonical reporter memory
@@ -41,11 +41,12 @@ flowchart LR
     CLI["Maintenance CLI"] --> Admin["Search-index admin consumer port"]
     Generation["Generation service"] --> Facade["MemoryService"]
     Inspector --> Facade
-    Admin --> Facade
+    Admin --> Manager
 
     Facade -- "at_revision(id) creates" --> Pinned["PinnedMemoryReader"]
     Tools["Reporter memory tools"] --> Pinned
-    Pinned -- "delegates with fixed scope" --> Facade
+    Pinned -- "retrieval with fixed scope" --> Facade
+    Pinned -- "exact reads with fixed scope" --> Manager
 
     Facade --> Retrieval["Internal retrieval pipeline"]
     Facade --> Manager["MemoryManager"]
@@ -72,8 +73,10 @@ classes. The baseline needs only two coordinating application objects:
 - `MemoryService`, which exposes the supported operations and owns orchestration;
 - `MemoryManager`, which owns persistence and ordinary memory transactions.
 
-`PinnedMemoryReader` is a small immutable wrapper containing a `MemoryService`
-read delegate and one validated `MemoryRevisionRef`. Retrieval, mutation,
+`PinnedMemoryReader` is a small immutable wrapper created by `MemoryService`
+with one validated `MemoryRevisionRef` and the narrow read manager. Retrieval,
+which owns ranking and fallback policy, delegates to the service; exact visible
+item/version reads use the same fixed revision through the manager. Mutation,
 inspection, and projection behavior may begin as methods or internal functions.
 They should become separate coordinator classes only if they later acquire
 independent dependencies or substantial state.
@@ -112,6 +115,8 @@ class MemoryRevisionRef:
 class MemoryQuery(BaseModel):
     text: str | None = None
     entities: tuple[EntityKey, ...] = ()
+    evidence_version_ids: frozenset[UUID] = frozenset()
+    related_item_ids: frozenset[UUID] = frozenset()
     kinds: set[MemoryKind] = Field(default_factory=set)
     statuses: set[MemoryStatus] = Field(default_factory=set)
     season_id: UUID | None = None
@@ -131,7 +136,7 @@ A retrieved entry contains:
 - the exact stable item and immutable version identifiers;
 - the decoded kind-specific current resource object;
 - requested exact evidence and visible stable-item expansions;
-- named match reasons and rank components;
+- stable match reasons, a score, and typed matched entity keys;
 - the pinned revision used for visibility.
 
 Search-document text and ORM rows are never part of this result.
@@ -140,8 +145,6 @@ Search-document text and ORM rows are never part of this result.
 
 ```python
 class MemoryReader(Protocol):
-    def current_revision(self, competition_id: UUID) -> MemoryRevisionRef: ...
-
     def pin_current(self, competition_id: UUID) -> PinnedMemoryReader: ...
 
     def at_revision(self, revision_id: UUID) -> PinnedMemoryReader: ...
@@ -170,12 +173,16 @@ class PinnedMemoryReader(Protocol):
 lightweight capability-bound reader in one service operation. `at_revision`
 does the same for an exact persisted revision ID. The internal retrieval
 pipeline does not create the reader. Calls on the reader delegate back to
-`MemoryService` with the fixed revision reference:
+`MemoryService` for ranked retrieval and use the captured narrow manager for
+exact reads, always with the fixed revision reference:
 
 ```python
 class _PinnedMemoryReader:
     def retrieve(self, query: MemoryQuery) -> RetrievedMemory:
         return self._memory_service._retrieve_at(self._revision, query)
+
+    def get_item(self, item_id: UUID) -> HydratedMemoryVersion:
+        return self._manager.get_visible_item(self._revision, item_id)
 ```
 
 The wrapper is not an open database session. The reporter receives it so its
@@ -270,6 +277,9 @@ requires them.
 filters. If no revision is supplied, the service resolves current state once and
 returns that `MemoryRevisionRef` on `MemoryPage`; the caller does not need to
 coordinate current-revision lookup with pagination.
+Opaque item cursors carry that resolved revision, so later pages remain on it
+even if current state advances. Malformed, cross-scope, or unavailable cursor
+targets produce the stable `InvalidMemoryCursor` boundary error.
 
 ### Search-index administration contract
 
@@ -286,6 +296,9 @@ revisions and versions. `search_index_status` reports only actionable basics
 such as builder version and missing or stale document counts.
 `rebuild_search_index` deterministically recreates those documents from canonical
 versions.
+
+`MemoryManager` satisfies this structural maintenance port directly; there is no
+two-method forwarding admin class.
 
 Search-index administration never creates a canonical memory revision. The normal
 mutation path synchronously inserts lexical/entity search documents; it does not
@@ -369,16 +382,17 @@ states.
 
 ### 3. Memory service and pinned read view
 
-`backend/services/memory/service.py` is the composition root visible to other
-backend capabilities. One concrete `MemoryService` implements the initial
-reader, writer, inspector, and search-index-administration operations, while each
-consumer is typed against only the narrow protocol it needs.
+`backend/services/memory/service.py` is the read composition root visible to
+other backend capabilities. One concrete `MemoryService` implements reader and
+inspector operations. `MemoryManager` directly satisfies the structural writer
+and search-index-administration ports so those deep operations are not wrapped
+by forwarding service methods. Each consumer is typed against only the narrow
+protocol it needs.
 
 The facade owns:
 
 - revision validation and creation of `PinnedMemoryReader` values;
-- coordination of retrieval, mutation, basic inspection, and rebuild operations;
-- normalization of bundle-level no-ops and stable service outcomes;
+- coordination of retrieval and basic inspection;
 - explicit resource context and correlation propagation;
 - operation-level observability;
 - exposing narrow consumer ports for composition to inject.
@@ -386,22 +400,23 @@ The facade owns:
 The facade does not contain SQL and does not make memory a global service
 locator.
 
-The pinned reader has no policy of its own beyond retaining its validated scope.
-It delegates retrieval and direct visible-item reads to the same service. It
-exists because preventing scope drift during reporter execution is a real safety
-boundary, not because retrieval needs another orchestration layer.
+The pinned reader has no ranking policy of its own beyond retaining its validated
+scope. It delegates retrieval to the service and direct visible-item reads to
+the narrow manager captured when the service creates it. It exists because
+preventing scope drift during reporter execution is a real safety boundary, not
+because retrieval needs another orchestration layer.
 
 ### 4. Mutation path
 
-The baseline mutation path may live directly in `MemoryService.apply`. It owns
-workflow policy around a submitted bundle:
+The baseline mutation path lives directly in the deep `MemoryManager.apply`
+operation, which satisfies the structural writer port. It owns workflow policy
+around a submitted bundle:
 
 - decode and validate complete typed operations;
 - validate unique client keys and generated IDs, including same-batch references;
 - return `NoChange` for an empty plan;
 - reject only internally contradictory plans before opening a transaction;
-- call the manager once to apply the complete bundle;
-- propagate the manager's typed persisted-reference and stale-write outcomes.
+- return typed persisted-reference, no-op, retry, and stale-write outcomes.
 
 Within the manager-owned transaction, the implementation locks the current
 revision, requires it to equal the producing generation's input revision,
@@ -419,12 +434,13 @@ acquires substantial independent policy or dependencies.
 
 ### 5. Internal retrieval pipeline
 
-`backend/services/memory/search.py` owns internal candidate policy rather than
-canonical state:
+The private functions and values in `backend/services/memory/service.py` own
+internal candidate policy rather than canonical state:
 
 - translate a `MemoryQuery` into exact filters and signal queries;
 - search, deduplicate, rank, hydrate, expand, and cap results;
-- retain named candidate and score-component values.
+- retain raw persistence signals internally and expose only stable match reasons,
+  typed matched entities, and the final score.
 
 Candidate discovery and hydration are separate steps. The manager applies
 competition and pinned-revision visibility before a candidate is eligible.
@@ -530,6 +546,8 @@ Stable error categories are part of the service boundary:
 | `MemoryScopeViolation` | A target belongs to another competition or is outside caller scope |
 | `InvalidMemoryContent` | Typed content, role, discriminator, or reference policy is invalid |
 | `InvalidMemoryReference` | Referenced target is missing, duplicated, or the wrong kind |
+| `InvalidMemoryCursor` | Pagination state is malformed, unavailable, or outside its requested scope |
+| `InvalidMemoryQuery` | A read parameter violates a stable query boundary |
 | `StaleCanonicalRevision` | The competition advanced beyond the submitted base revision |
 
 Adapters translate these errors for their transports. Callers never inspect
@@ -545,13 +563,13 @@ backend/
 │   ├── objects.py
 │   ├── errors.py
 │   ├── content_codec.py
+│   ├── cursors.py
 │   ├── manager.py
 │   └── search_documents.py
 ├── services/memory/
 │   ├── __init__.py
 │   ├── contracts.py
-│   ├── service.py
-│   └── search.py
+│   └── service.py
 ├── api/routes/memory.py
 └── services/reporter/tools/memory.py
 ```

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -21,10 +21,11 @@ are not preserved
 | Memory resource manager and canonical reads | Implemented | `backend/resources/memory/manager.py` |
 | Complete-bundle mutation transaction | Implemented | Generation-derived context plus `MemoryManager.apply` |
 | Authoritative search-document builder | Implemented | `backend/resources/memory/search_documents.py` |
-| Revision-pinned retrieval and hydration | Pending | `MemoryService.at_revision` plus internal retrieval pipeline |
-| Service facade and consumer protocols | Pending | `backend/services/memory/` |
-| Basic canonical viewing and item history | Pending | `MemoryInspector` capability on `MemoryService` |
-| Search-index status and rebuild CLI | Pending | `MemorySearchIndexAdmin` consumer port on `MemoryService` |
+| Revision-pinned retrieval and hydration | Implemented | `MemoryService.at_revision` plus service-owned retrieval policy |
+| Service facade and consumer protocols | Implemented | `backend/services/memory/` |
+| Basic canonical viewing and item history | Implemented | `MemoryInspector` capability on `MemoryService` |
+| Search-index status and rebuild contract | Implemented | `MemorySearchIndexAdmin` port satisfied directly by `MemoryManager` |
+| Search-index maintenance CLI | Pending | Thin adapter over the existing admin port |
 | Evaluation-workspace promotion integration | Pending | Evaluation-workspace manager-owned cross-resource transaction |
 | Reporter/generation adapters | Pending | Reporter service memory tools |
 | UI-specific memory API | Deferred | Shape after initial memory UX is designed |
@@ -44,6 +45,12 @@ are not preserved
 - Generation-time reads use a capability-bound pinned reader.
 - `MemoryService` creates the pinned reader; its methods delegate to the same
   internal retrieval pipeline with a fixed scope.
+- Persistence returns bounded raw candidate signals; `MemoryService` alone owns
+  ranking weights, reason vocabulary, deduplication, and the final result limit.
+- Exact evidence-version and related stable-item queries use the same primary
+  and bounded canonical-fallback paths.
+- Opaque item cursors retain their resolved revision across pages; malformed or
+  cross-scope cursors return stable memory errors.
 - The reporter proposes memory changes but cannot commit canonical state.
 - A mutation bundle names its producing generation; the memory manager derives
   competition, cutoffs, season, and its one base-revision concurrency token.
@@ -80,8 +87,8 @@ are not preserved
 | 2. Canonical reads and hydration manager | Complete | Revision-pinned item/version/history queries pass PostgreSQL tests |
 | 3. Search-document builder | Complete | One dispatcher produces identical mutation/rebuild output for every kind |
 | 4. Canonical mutation transaction | Complete | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
-| 5. Pinned retrieval pipeline | Not started | Entity, evidence, related-item, lexical, and historical-leakage tests pass |
-| 6. Basic viewing, promotion integration, reporter/generation, and rebuild CLI | Not started | Narrow capabilities work without UI-specific business logic |
+| 5. Pinned retrieval pipeline | Complete | Entity, evidence, related-item, lexical, cursor, fallback, and historical-leakage tests pass |
+| 6. Composition, reporter/generation adapters, promotion, and rebuild CLI | Not started | Narrow adapters work without UI-specific business logic |
 | 7. Legacy removal | Not started | No active imports or writes depend on `reporter_memory` |
 
 ## Remaining Decisions
@@ -111,9 +118,10 @@ decision-log entry before expanding the baseline.
 
 ## Next Milestone
 
-Refine and land slice 5 pinned retrieval and inspection without public adapters.
-Keep ranking and fallback policy inside the service while the pinned reader
-enforces one fixed competition/revision scope.
+Compose the implemented reader, writer, inspector, and search-index-admin ports
+into the FastAPI/reporting application. Add only the minimal reporter tools and
+maintenance adapter needed for behavior parity; keep UI-specific inspection and
+promotion on their separately reviewed boundaries.
 
 ## PR Stack Coordination
 
@@ -126,7 +134,7 @@ integrated by `root` after the owning agent reports completion.
 | 1. Design and resource contracts | `codex/memory-service-contracts` | `contracts_agent` | Complete | `docs/memory/`; `backend/resources/memory/objects.py`; `errors.py`; resource contract tests |
 | 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | Complete | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
 | 3. Canonical mutation | `codex/memory-service-mutations` | `persistence_agent` | Complete | mutation methods and transaction tests; no public adapters |
-| 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `service_agent` | In progress | `backend/services/memory/`; retrieval/inspection tests |
+| 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `retrieval_implementation` | Complete | `backend/services/memory/`; retrieval/inspection tests |
 | 5. Composition and adapters | `codex/memory-service-integration` | `root` | Pending | composition, reporter tools, minimal API/CLI adapters, legacy-path removal, integration tests |
 | 6. Workspace promotion | `codex/memory-workspace-promotion` | Unassigned | Pending | reporting-owned promotion workflow and private memory command |
 


### PR DESCRIPTION
## Summary

- add one external `MemoryService` and an immutable revision-bound `PinnedMemoryReader`
- implement retrieval fusion, exact evidence/related signals, hydration, and bounded projection fallback
- add revision-safe opaque cursors plus narrow reader, inspector, writer, and admin ports

## Design

The service creates the pinned reader; retrieval does not create another coordinator. Ranking has one owner, persistence exposes raw signals, and inspection remains limited to viewing/history rather than restore or transformation workflows.

## Verification

- full-stack workspace suite: 310 passed, 70 PostgreSQL-only skips
- memory PostgreSQL read/mutation suite on disposable PostgreSQL 17: 22 passed

Stack 4/5. Depends on #98.
