### PR TITLE
feat(memory): add search index maintenance CLI

### DIFF
--- a/backend/cli/__init__.py
+++ b/backend/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line adapters for trusted backend operations."""

--- a/backend/cli/memory.py
+++ b/backend/cli/memory.py
@@ -1,0 +1,104 @@
+"""Minimal maintenance CLI for the canonical-memory search projection."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from dataclasses import replace
+import json
+import sys
+from uuid import UUID
+
+from backend.config import DatabaseSettings
+from backend.database.engine import build_runtime_engine
+from backend.database.sessions import create_session_factory
+from backend.resources.memory.errors import MemoryError
+from backend.resources.memory.manager import MemoryManager
+from backend.resources.memory.objects import RebuildResult, SearchIndexStatus
+from backend.services.memory import MemorySearchIndexAdmin
+
+
+def _uuid(value: str) -> UUID:
+    try:
+        return UUID(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a valid UUID") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aidam-memory",
+        description="Inspect or rebuild the canonical-memory search index.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    status = commands.add_parser("status", help="Show search-index status.")
+    status.add_argument("competition_id", type=_uuid)
+
+    rebuild = commands.add_parser("rebuild", help="Rebuild the search index.")
+    rebuild.add_argument("competition_id", type=_uuid)
+    return parser
+
+
+def parse_args(args: Sequence[str]) -> argparse.Namespace:
+    """Validate command-line values before constructing database resources."""
+
+    return _build_parser().parse_args(args)
+
+
+def format_result(result: SearchIndexStatus | RebuildResult) -> str:
+    """Serialize the closed admin result contracts without adding CLI fields."""
+
+    return json.dumps(result.model_dump(mode="json"), sort_keys=True)
+
+
+def run(
+    args: argparse.Namespace,
+    admin: MemorySearchIndexAdmin,
+) -> SearchIndexStatus | RebuildResult:
+    """Execute one validated command against the narrow admin capability."""
+
+    if args.command == "status":
+        return admin.search_index_status(args.competition_id)
+    if args.command == "rebuild":
+        return admin.rebuild_search_index(args.competition_id)
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build one process-local admin graph, execute, and release its engine."""
+
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    settings = DatabaseSettings.from_environment("worker")
+    engine_settings = replace(
+        settings.engine_settings("worker"),
+        application_name="aidam-memory",
+    )
+    engine = build_runtime_engine(engine_settings)
+    try:
+        admin = MemoryManager(create_session_factory(engine))
+        try:
+            print(format_result(run(args, admin)))
+        except MemoryError as error:
+            print(
+                json.dumps(
+                    {
+                        "error": {
+                            "code": error.code,
+                            "details": error.details,
+                            "message": error.message,
+                        }
+                    },
+                    default=str,
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+            return 2
+    finally:
+        engine.dispose()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/resources/memory/manager.py
+++ b/backend/resources/memory/manager.py
@@ -131,6 +131,7 @@ _MAX_CANDIDATES_PER_SIGNAL = 200
 _CANDIDATES_PER_RESULT = 2
 _MAX_FALLBACK_VISIBLE_SCAN = 5_000
 _MAX_FALLBACK_CANDIDATES = 800
+_MAX_REBUILD_BATCH_SIZE = 1_000
 
 
 class MemoryManager:
@@ -818,6 +819,7 @@ class MemoryManager:
 
     def search_index_status(self, competition_id: UUID) -> SearchIndexStatus:
         with read_only_session(self._session_factory) as session:
+            _require_memory_competition(session, competition_id)
             total = session.scalar(
                 sa.select(sa.func.count())
                 .select_from(MemoryVersion)
@@ -870,8 +872,13 @@ class MemoryManager:
     ) -> RebuildResult:
         """Rebuild projection rows from immutable canonical versions in batches."""
 
-        if batch_size <= 0:
-            raise ValueError("batch_size must be positive")
+        if not 1 <= batch_size <= _MAX_REBUILD_BATCH_SIZE:
+            raise InvalidMemoryQuery(
+                f"rebuild batch size must be between 1 and {_MAX_REBUILD_BATCH_SIZE}",
+                details={"batch_size": batch_size},
+            )
+        with read_only_session(self._session_factory) as session:
+            _require_memory_competition(session, competition_id)
         rebuilt = 0
         cursor: UUID | None = None
         while True:
@@ -920,6 +927,13 @@ def _revision_for_generation(
             MemoryRevision.producing_generation_id == generation_id
         )
     )
+
+
+def _require_memory_competition(session: Session, competition_id: UUID) -> None:
+    if session.get(CurrentRevision, competition_id) is None:
+        raise MemoryNotFound(
+            f"canonical memory competition not found: {competition_id}"
+        )
 
 
 def _committed_result(

--- a/backend/services/memory/contracts.py
+++ b/backend/services/memory/contracts.py
@@ -90,9 +90,4 @@ class MemorySearchIndexAdmin(Protocol):
 
     def search_index_status(self, competition_id: UUID) -> SearchIndexStatus: ...
 
-    def rebuild_search_index(
-        self,
-        competition_id: UUID,
-        *,
-        batch_size: int = 200,
-    ) -> RebuildResult: ...
+    def rebuild_search_index(self, competition_id: UUID) -> RebuildResult: ...

--- a/backend/tests/cli/__init__.py
+++ b/backend/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for backend command-line adapters."""

--- a/backend/tests/cli/test_memory.py
+++ b/backend/tests/cli/test_memory.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+from unittest.mock import Mock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import Engine
+
+from backend.cli import memory
+from backend.config import DatabaseSettings
+from backend.resources.memory.errors import MemoryNotFound
+from backend.resources.memory.objects import RebuildResult, SearchIndexStatus
+
+
+class FakeAdmin:
+    def __init__(self) -> None:
+        self.status_calls: list[UUID] = []
+        self.rebuild_calls: list[UUID] = []
+
+    def search_index_status(self, competition_id: UUID) -> SearchIndexStatus:
+        self.status_calls.append(competition_id)
+        return SearchIndexStatus(
+            competition_id=competition_id,
+            builder_version=3,
+            canonical_version_count=10,
+            indexed_document_count=8,
+            missing_document_count=1,
+            stale_document_count=1,
+        )
+
+    def rebuild_search_index(self, competition_id: UUID) -> RebuildResult:
+        self.rebuild_calls.append(competition_id)
+        return RebuildResult(
+            competition_id=competition_id,
+            builder_version=3,
+            rebuilt_document_count=10,
+        )
+
+
+def test_status_outputs_only_status_contract_fields() -> None:
+    competition_id = uuid4()
+    admin = FakeAdmin()
+
+    result = memory.run(memory.parse_args(["status", str(competition_id)]), admin)
+    output = memory.format_result(result)
+
+    assert json.loads(output) == {
+        "builder_version": 3,
+        "canonical_version_count": 10,
+        "competition_id": str(competition_id),
+        "indexed_document_count": 8,
+        "missing_document_count": 1,
+        "stale_document_count": 1,
+    }
+    assert admin.status_calls == [competition_id]
+    assert admin.rebuild_calls == []
+
+
+def test_rebuild_uses_manager_owned_batching_and_outputs_result() -> None:
+    competition_id = uuid4()
+    admin = FakeAdmin()
+
+    result = memory.run(
+        memory.parse_args(["rebuild", str(competition_id)]),
+        admin,
+    )
+    output = memory.format_result(result)
+
+    assert json.loads(output) == {
+        "builder_version": 3,
+        "competition_id": str(competition_id),
+        "rebuilt_document_count": 10,
+    }
+    assert admin.rebuild_calls == [competition_id]
+    assert admin.status_calls == []
+
+
+def test_invalid_identifier_fails_at_argparse_boundary() -> None:
+    admin = FakeAdmin()
+
+    with pytest.raises(SystemExit) as exc_info:
+        memory.parse_args(["status", "not-a-uuid"])
+
+    assert exc_info.value.code == 2
+    assert admin.status_calls == []
+    assert admin.rebuild_calls == []
+
+
+def test_main_builds_one_manager_and_disposes_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    competition_id = uuid4()
+    settings = DatabaseSettings(
+        runtime_url="postgresql+psycopg://aidam_runtime:secret@localhost/aidam",
+        migration_url=None,
+        ca_file=None,
+        pool_size=2,
+        max_overflow=2,
+        statement_timeout_ms=30_000,
+        require_tls=False,
+    )
+    engine = Mock(spec=Engine)
+    session_factory = object()
+    admin = FakeAdmin()
+    manager_factory = Mock(return_value=admin)
+    engine_factory = Mock(return_value=engine)
+
+    monkeypatch.setattr(
+        memory.DatabaseSettings,
+        "from_environment",
+        Mock(return_value=settings),
+    )
+    monkeypatch.setattr(memory, "build_runtime_engine", engine_factory)
+    monkeypatch.setattr(
+        memory,
+        "create_session_factory",
+        Mock(return_value=session_factory),
+    )
+    monkeypatch.setattr(memory, "MemoryManager", manager_factory)
+
+    assert memory.main(["status", str(competition_id)]) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "builder_version": 3,
+        "canonical_version_count": 10,
+        "competition_id": str(competition_id),
+        "indexed_document_count": 8,
+        "missing_document_count": 1,
+        "stale_document_count": 1,
+    }
+    engine_settings = engine_factory.call_args.args[0]
+    assert engine_settings.application_name == "aidam-memory"
+    manager_factory.assert_called_once_with(session_factory)
+    cast(Mock, engine.dispose).assert_called_once_with()
+
+
+def test_main_formats_expected_memory_error_and_disposes_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    competition_id = uuid4()
+    settings = DatabaseSettings(
+        runtime_url="postgresql+psycopg://aidam_runtime:secret@localhost/aidam",
+        migration_url=None,
+        ca_file=None,
+        pool_size=2,
+        max_overflow=2,
+        statement_timeout_ms=30_000,
+        require_tls=False,
+    )
+    engine = Mock(spec=Engine)
+    admin = FakeAdmin()
+    admin.search_index_status = Mock(
+        side_effect=MemoryNotFound("canonical memory competition not found")
+    )
+
+    monkeypatch.setattr(
+        memory.DatabaseSettings,
+        "from_environment",
+        Mock(return_value=settings),
+    )
+    monkeypatch.setattr(memory, "build_runtime_engine", Mock(return_value=engine))
+    monkeypatch.setattr(memory, "create_session_factory", Mock(return_value=object()))
+    monkeypatch.setattr(memory, "MemoryManager", Mock(return_value=admin))
+
+    assert memory.main(["status", str(competition_id)]) == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "error": {
+            "code": "memory_not_found",
+            "details": {},
+            "message": "canonical memory competition not found",
+        }
+    }
+    cast(Mock, engine.dispose).assert_called_once_with()

--- a/backend/tests/resources/memory/test_manager_reads.py
+++ b/backend/tests/resources/memory/test_manager_reads.py
@@ -22,6 +22,8 @@ from backend.database.models.reporting import Generation
 from backend.database.sessions import create_session_factory
 from backend.resources.memory.errors import (
     InvalidMemoryCursor,
+    InvalidMemoryQuery,
+    MemoryNotFound,
     MemoryScopeViolation,
     SearchProjectionUnavailable,
 )
@@ -650,3 +652,20 @@ def test_candidate_pool_reserves_capacity_for_each_independent_signal(
         filter_query,
     )
     assert len(filter_candidates) > filter_query.limit
+
+
+def test_projection_admin_rejects_unknown_scope_and_unbounded_batches(
+    database_engine: Engine,
+) -> None:
+    seeded = _seed_memory(database_engine)
+    manager = _manager(database_engine)
+    unknown_competition_id = uuid4()
+
+    with pytest.raises(MemoryNotFound):
+        manager.search_index_status(unknown_competition_id)
+    with pytest.raises(MemoryNotFound):
+        manager.rebuild_search_index(unknown_competition_id)
+    with pytest.raises(InvalidMemoryQuery):
+        manager.rebuild_search_index(seeded.competition_id, batch_size=0)
+    with pytest.raises(InvalidMemoryQuery):
+        manager.rebuild_search_index(seeded.competition_id, batch_size=1_001)

--- a/docs/memory/log.md
+++ b/docs/memory/log.md
@@ -528,6 +528,41 @@ scope capability, not a retrieval coordinator.
   a newer current state, and invalid cursor/query inputs use stable memory
   errors.
 
+### MEM-025 — Compose real ports now and defer adapters without required context
+
+**Date:** 2026-08-09
+**Status:** Settled; narrows stack layer 5 and gates layer 6
+**Source:** Independent adapter-boundary review
+
+`MemoryManager` directly satisfies canonical writer and search-index-admin ports;
+`MemoryService` satisfies reader and inspector ports. The only active external
+adapter added now is `aidam-memory`, with bounded, manager-direct `status` and
+`rebuild` commands.
+
+No memory HTTP handlers are added before the UI, authorization, and transport
+contracts exist. The legacy reporter is not switched to canonical memory before
+a database-backed generation runner can provide an already-pinned reader,
+persisted tool/API receipts, and canonical entity resolution. Existing legacy
+memory remains active until behavior parity; there is no speculative dual-write.
+
+Workspace promotion is gated on a versioned
+`PromotableMemoryWorkspaceArtifactV1`. An opaque artifact string and hash cannot
+prove final item/version identity or preserve exact evidence references.
+
+**Consequences:**
+
+- Stack layer 5 contains the justified maintenance CLI, not an unused FastAPI
+  object graph, placeholder HTTP routes, or unused reporter adapters.
+- A future reporter read adapter accepts `PinnedMemoryReader`; it never resolves
+  current memory itself or reaches through to `MemoryManager`.
+- Canonical writes remain a finalized-generation action, not in-loop model tool
+  side effects.
+- Promotion implementation begins only after the artifact contract defines base
+  identity, deterministic final changes, exact version IDs, reference limits,
+  and canonical hashing.
+- `reporter_memory` deletion remains a parity milestone rather than part of the
+  memory-service foundation stack.
+
 ## Pending Decisions
 
 - Default retrieval and evidence-expansion limits.

--- a/docs/memory/service-architecture.md
+++ b/docs/memory/service-architecture.md
@@ -305,7 +305,9 @@ mutation path synchronously inserts lexical/entity search documents; it does not
 invoke this administrative API for each write. It does not edit canonical
 content, tune ranking policy, transform memory, or restore historical state.
 
-The first implementation runs status and rebuild synchronously from a CLI. An
+The first implementation runs status and rebuild synchronously through
+`aidam-memory status <competition-uuid>` and
+`aidam-memory rebuild <competition-uuid>`. Batching remains manager-owned. An
 operator API, durable job system, and embedding backfill are deferred until a UI
 or operational need makes them concrete.
 
@@ -326,6 +328,24 @@ The session-scoped command is not a public memory service and never opens or
 commits a transaction. Promotion has no merge, rebase, historical restoration,
 or transformation modes. Retrying an already promoted workspace returns its
 existing promoted revision.
+
+Implementation requires one reporting-owned contract that does not yet exist:
+`PromotableMemoryWorkspaceArtifactV1`. The current artifact table stores opaque
+text plus a hash, while the design refers to both a full workspace state and its
+final diff. Before promotion code is added, the versioned artifact contract must
+define:
+
+- competition, base revision, and base state hash;
+- deterministic ordering and canonical JSON/hash rules;
+- explicit stable item and final version IDs for every create or replacement;
+- complete typed content and context-note identity;
+- references limited to versions visible at the base or final versions in the
+  same artifact; and
+- whether deletion exists (it is absent from the baseline mutation contract).
+
+Without those invariants, promotion could not preserve exact evidence identity
+or prove that the promoted revision matches the verified artifact. The workspace
+transaction is therefore intentionally not implemented from an opaque string.
 
 ## Component Responsibilities
 
@@ -470,12 +490,12 @@ document uses the stable entity key. Given the same typed version, builder
 version, and normalization rules, they produce the same document text, flattened
 keys, reference IDs, and content hash.
 
-`MemoryService.search_index_status` and
-`MemoryService.rebuild_search_index` apply caller scope, stable result contracts,
-and operation observability around deep manager operations. The manager scans
-canonical versions, decodes every retained content schema, calls the
-authoritative dispatcher, and replaces projection rows in bounded batches.
-There is no second rebuild-specific builder.
+`MemoryManager.search_index_status` and
+`MemoryManager.rebuild_search_index` enforce competition scope and return stable
+result contracts directly. The manager scans canonical versions, decodes every
+retained content schema, calls the authoritative dispatcher, and replaces
+projection rows in manager-bounded batches. There is no second rebuild-specific
+builder or forwarding service.
 
 Optional embeddings are a later adapter behind a narrow `EmbeddingProvider`
 port. Embedding availability cannot be required for canonical writes or baseline

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -5,8 +5,8 @@
 **Phase:** Application memory implementation
 **Architecture:** Modular-monolith service with typed Python contracts
 **Persistence:** Canonical PostgreSQL schema and search-document table implemented
-**Compatibility:** Clean replacement; legacy `reporter_memory` persistence APIs
-are not preserved
+**Compatibility:** The new canonical layer is a clean replacement contract;
+legacy `reporter_memory` remains active until generation-runner behavior parity
 
 ## Components
 
@@ -25,9 +25,9 @@ are not preserved
 | Service facade and consumer protocols | Implemented | `backend/services/memory/` |
 | Basic canonical viewing and item history | Implemented | `MemoryInspector` capability on `MemoryService` |
 | Search-index status and rebuild contract | Implemented | `MemorySearchIndexAdmin` port satisfied directly by `MemoryManager` |
-| Search-index maintenance CLI | Pending | Thin adapter over the existing admin port |
-| Evaluation-workspace promotion integration | Pending | Evaluation-workspace manager-owned cross-resource transaction |
-| Reporter/generation adapters | Pending | Reporter service memory tools |
+| Search-index maintenance CLI | Implemented | `aidam-memory status` and `aidam-memory rebuild` |
+| Evaluation-workspace promotion integration | Contract blocked | Requires versioned promotable workspace-artifact schema |
+| Reporter/generation adapters | Implementation blocked | Requires database-backed generation runner, pinned input, and receipt/entity resolution |
 | UI-specific memory API | Deferred | Shape after initial memory UX is designed |
 | Legacy `reporter_memory` removal | Pending | After behavior parity |
 | Vector embeddings | Deferred | Add only after baseline retrieval measurement |
@@ -69,8 +69,9 @@ are not preserved
   independently rebuildable.
 - Mutation and rebuild use one authoritative deterministic document builder
   registry based only on immutable version content.
-- Inspector and search-index-admin contracts are narrow consumer ports on the
-  service, not runtime authorization and not mandatory coordinator classes.
+- Inspector and search-index-admin contracts are narrow consumer ports, not
+  runtime authorization and not mandatory coordinator classes. The manager
+  directly satisfies writer/admin ports; the service satisfies reader/inspector.
 - Inspection is limited to viewing canonical items/revisions and item history;
   search-index administration is limited to derived-projection status and
   rebuild.
@@ -88,14 +89,25 @@ are not preserved
 | 3. Search-document builder | Complete | One dispatcher produces identical mutation/rebuild output for every kind |
 | 4. Canonical mutation transaction | Complete | Atomic create/replace, no-op/retry, stale-writer, reference, and projection tests pass |
 | 5. Pinned retrieval pipeline | Complete | Entity, evidence, related-item, lexical, cursor, fallback, and historical-leakage tests pass |
-| 6. Composition, reporter/generation adapters, promotion, and rebuild CLI | Not started | Narrow adapters work without UI-specific business logic |
-| 7. Legacy removal | Not started | No active imports or writes depend on `reporter_memory` |
+| 6. Search-index maintenance CLI | Complete | Narrow manager-direct CLI works without UI-specific business logic |
+| 7. Promotion contract | Contract blocked | Workspace artifact has a promotable v1 schema |
+| 8. Generation/reporter adapter | Implementation blocked | Database-backed runner supplies pinned revisions, provenance, and entity resolution |
+| 9. Legacy removal | Deferred | No active imports or writes depend on `reporter_memory` |
 
 ## Remaining Decisions
 
 One non-blocking tuning decision remains:
 
 - maximum default retrieval result and evidence-expansion limits.
+
+One reporting contract blocks promotion:
+
+- a versioned `PromotableMemoryWorkspaceArtifactV1` with deterministic final
+  item/version identity and exact-reference rules.
+
+Canonical reporter activation is separately blocked on implementation of the
+database-backed generation runner, including pinned revision injection,
+persisted provenance receipts, and canonical entity resolution.
 
 These do not block implementation of the shared reference primitives, revision
 objects, stable errors, content-schema conversion framework, or canonical read
@@ -118,10 +130,10 @@ decision-log entry before expanding the baseline.
 
 ## Next Milestone
 
-Compose the implemented reader, writer, inspector, and search-index-admin ports
-into the FastAPI/reporting application. Add only the minimal reporter tools and
-maintenance adapter needed for behavior parity; keep UI-specific inspection and
-promotion on their separately reviewed boundaries.
+Define and review `PromotableMemoryWorkspaceArtifactV1` with the reporting
+aggregate, then build the database-backed generation runner that can inject an
+already-pinned reader and persist receipts. Do not activate canonical reporter
+writes or delete legacy memory before those inputs exist.
 
 ## PR Stack Coordination
 
@@ -135,8 +147,8 @@ integrated by `root` after the owning agent reports completion.
 | 2. Canonical persistence and search documents | `codex/memory-service-persistence` | `persistence_agent` | Complete | `backend/resources/memory/manager.py`; `search_documents.py`; persistence/builder tests |
 | 3. Canonical mutation | `codex/memory-service-mutations` | `persistence_agent` | Complete | mutation methods and transaction tests; no public adapters |
 | 4. Pinned retrieval and inspection | `codex/memory-service-retrieval` | `retrieval_implementation` | Complete | `backend/services/memory/`; retrieval/inspection tests |
-| 5. Composition and adapters | `codex/memory-service-integration` | `root` | Pending | composition, reporter tools, minimal API/CLI adapters, legacy-path removal, integration tests |
-| 6. Workspace promotion | `codex/memory-workspace-promotion` | Unassigned | Pending | reporting-owned promotion workflow and private memory command |
+| 5. Maintenance adapter | `codex/memory-service-integration` | `root` | Complete | Manager-direct search-index CLI; no premature HTTP/reporter wiring |
+| 6. Workspace promotion | `codex/memory-workspace-promotion` | Unassigned | Contract pending | promotable artifact v1, reporting-owned workflow, private memory command |
 
 Coordination rules:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 sleeperdl = "datalayer.cli.main:main"
 reporter-v2 = "reporter_v2.app.runner:main"
 aidam-api = "backend.api.app:main"
+aidam-memory = "backend.cli.memory:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

- add `aidam-memory status` and `aidam-memory rebuild` over the manager-direct admin port
- keep rebuild batching bounded and manager-owned; reject unknown canonical-memory scopes
- update architecture, status, and decision logs with reviewed integration boundaries

## Design

This intentionally adds no unused FastAPI providers, speculative HTTP routes, reporter adapter, or legacy deletion. Promotion remains gated on `PromotableMemoryWorkspaceArtifactV1`; reporter activation separately requires the database-backed generation runner, persisted provenance, and entity resolution.

## Verification

- full-stack workspace suite: 310 passed, 70 PostgreSQL-only skips
- memory PostgreSQL read/mutation suite on disposable PostgreSQL 17: 22 passed
- independent architecture and adapter-boundary reviews found no remaining actionable code issues

Stack 5/5. Depends on #99.
