### PR TITLE
feat(datalayer): establish service foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ sleeper_fantasy_reporter.egg-info/
 sleeper_datalayer.egg-info/
 .output/
 .data/
+.context/

--- a/docs/database/log.md
+++ b/docs/database/log.md
@@ -502,14 +502,15 @@ simulated generations and never writes alternative rows into canonical memory.
 ## Current Implementation Decisions
 
 The current baseline is defined by DB-001 through DB-006, DB-010 through DB-011,
-DB-016 through DB-026, and DB-028 through DB-031. Within that set, later entries explicitly take
+DB-016 through DB-026, and DB-028 through DB-032. Within that set, later entries explicitly take
 precedence. DB-017 supersedes the larger identity/provider designs, DB-020
 supersedes branch/commit memory, DB-021 supersedes workflow/pricing-heavy
 reporting, DB-024 narrows the former evidence design and hardens factual snapshot
 boundaries, and DB-025 replaces persistent alternative memory with a linear
 canonical revision plus one reporting workspace. DB-028 moves product-semantic
 validation out of DDL while retaining relational, concurrency, storage-shape,
-and sealed-history guarantees.
+and sealed-history guarantees. DB-032 supersedes DB-024's exact snapshot
+observation identity with the coarse daily identity used by the datalayer.
 
 ## Pending Decisions
 
@@ -686,30 +687,40 @@ article generations; rebuilding it never creates a memory revision.
 - Vector embeddings may later be keyed by exact version, builder, model, and
   content hash without changing canonical memory.
 
-### DB-032 — Align frozen snapshot identity with factual service inputs
+### DB-032 — Use daily frozen snapshot identity
 
 **Date:** 2026-08-09
+**Amended:** 2026-08-18
 **Status:** Settled; supersedes mode-based snapshot identity in DB-024
-**Source:** Datalayer service design and implementation audit
+**Source:** Datalayer service design review and simulation-precision decision
 
 A frozen data snapshot is identified by its competition season,
-`through_week`, `observed_through`, exact selected request-set hash, and one
-snapshot-projection version. Live, historical, and retrospective are generation
-intent rather than factual snapshot modes.
+`through_week`, `as_of_date`, and one snapshot-projection version. Exact
+observation timestamps and aggregate selected-request-set hashes add precision
+without useful fantasy-football simulation fidelity, so neither participates
+in identity. Live, historical, and retrospective are generation intent rather
+than factual snapshot modes.
 
 Only active `building` and `ready` rows reserve the canonical build key. Failed
 and expired attempts remain auditable but release it for a replacement build.
 Every request membership row pins the response SHA-256 in addition to the
 request ID and scope. Ready snapshot meaning and membership are sealed; the
-only allowed retention transition is `ready` to terminal `expired`.
+only allowed retention transition is `ready` to terminal `expired`. The first
+healthy ready snapshot for a season/week/date/version is reused; observations
+completed after it became ready do not replace it, and callers normally choose
+another date label when they want another identity. Recovery after failure or
+expiration may reselect within the same intentionally coarse daily identity.
 
 **Consequences:**
 
 - Snapshot `mode` is removed.
+- Snapshot identity uses one plain caller-chosen calendar date. Request
+  timestamps do not map into or filter that date in v1.
 - Materializer and SQLite-schema versions become one
   `snapshot_projection_version` owned by compatibility policy.
-- Snapshot rows gain sanitized failure metadata and exact membership hashes.
+- Snapshot rows gain sanitized failure metadata; each exact request-membership
+  row pins its individual response SHA-256.
 - Active-key partial uniqueness supplies build concurrency without making a
-  failed attempt poison semantic identity.
+  failed attempt poison the daily reuse identity.
 - Generation rows retain their own intent and knowledge policy while pinning
   the exact ready factual snapshot used for execution.

--- a/docs/database/log.md
+++ b/docs/database/log.md
@@ -685,3 +685,31 @@ article generations; rebuilding it never creates a memory revision.
   payloads become more specific.
 - Vector embeddings may later be keyed by exact version, builder, model, and
   content hash without changing canonical memory.
+
+### DB-032 — Align frozen snapshot identity with factual service inputs
+
+**Date:** 2026-08-09
+**Status:** Settled; supersedes mode-based snapshot identity in DB-024
+**Source:** Datalayer service design and implementation audit
+
+A frozen data snapshot is identified by its competition season,
+`through_week`, `observed_through`, exact selected request-set hash, and one
+snapshot-projection version. Live, historical, and retrospective are generation
+intent rather than factual snapshot modes.
+
+Only active `building` and `ready` rows reserve the canonical build key. Failed
+and expired attempts remain auditable but release it for a replacement build.
+Every request membership row pins the response SHA-256 in addition to the
+request ID and scope. Ready snapshot meaning and membership are sealed; the
+only allowed retention transition is `ready` to terminal `expired`.
+
+**Consequences:**
+
+- Snapshot `mode` is removed.
+- Materializer and SQLite-schema versions become one
+  `snapshot_projection_version` owned by compatibility policy.
+- Snapshot rows gain sanitized failure metadata and exact membership hashes.
+- Active-key partial uniqueness supplies build concurrency without making a
+  failed attempt poison semantic identity.
+- Generation rows retain their own intent and knowledge policy while pinning
+  the exact ready factual snapshot used for execution.

--- a/docs/database/sleeper.md
+++ b/docs/database/sleeper.md
@@ -266,12 +266,12 @@ to a competition season. Its natural key is
 status, provider-created timestamp, settings/metadata JSONB, and source request.
 
 `transaction_moves` uses a UUID primary key plus unique
-`(transaction_id, move_index)`. Each row has a checked kind of `player`, `pick`,
-or `budget`, from/to season-roster IDs, and exactly one matching payload:
-`player_id`, `draft_pick_id`, or non-negative budget amount. Pick moves reference
-the canonical normalized draft-pick row rather than repeating unconstrained pick
-coordinates. A corrected complete request replaces the normalized week scope;
-the old raw request remains available for historical replay.
+`(transaction_id, move_index)`. Each application record is one `player` or
+`pick` transfer with optional from/to season-roster IDs. It references exactly
+one player or canonical normalized draft pick, and may carry the transaction's
+non-negative waiver/budget amount. A corrected complete request replaces the
+normalized week scope; the old raw request remains available for historical
+replay.
 
 ### `sleeper.draft_picks`
 
@@ -321,14 +321,21 @@ One immutable factual input to one or more generations:
 
 - `id uuid` primary key;
 - competition and primary competition-season IDs;
-- mode: `live`, `retrospective`, or `historical`;
-- domain cutoff week/time and knowledge cutoff time;
+- canonical semantic `build_key`;
+- domain cutoff week/time and `observed_through` request boundary;
 - status: `building`, `ready`, `failed`, or `expired`;
-- materializer/schema/code versions;
+- one snapshot-projection version plus audit-only code version;
 - completeness warnings JSONB;
+- sanitized failure summary for failed builds;
 - selected-request-set hash;
 - exact SQLite artifact hash, byte size, and private storage key/path;
 - created/completed timestamps.
+
+Only `building` and `ready` rows participate in the partial unique build-key
+index. Failed and expired attempts remain auditable but release the key so a
+later request can build a replacement. Generation intent such as live,
+historical, or retrospective is not factual snapshot identity and remains on
+the generation workflow.
 
 ### `sleeper.data_snapshot_requests`
 
@@ -337,6 +344,7 @@ The exact successful API requests selected for the snapshot:
 - data snapshot ID;
 - API request ID;
 - scope key;
+- response SHA-256;
 - selection role.
 
 Unique `(data_snapshot_id, scope_key)`. The baseline artifact contains one
@@ -346,14 +354,14 @@ not silently mixed into the current agent SQL surface.
 
 Snapshot selection rules:
 
-- historical mode chooses the latest complete request per required scope with
-  `completed_at <= knowledge_cutoff_at`;
-- retrospective mode may use newer corrections for domain events through the
-  cutoff, and is labeled accordingly;
+- selection chooses the latest complete request per required scope with
+  `completed_at <= observed_through`;
+- an earlier `through_week` combined with a later `observed_through` may use a
+  later correction specifically scoped to that earlier week;
 - future-week matchup/transaction requests are excluded;
-- later roster/player/user/bracket payloads cannot enter a historical snapshot;
-- missing required requests fail the snapshot unless the generation is
-  explicitly diagnostic/incomplete;
+- later roster/player/user/bracket payloads cannot cross the observation
+  boundary, and the SQLite projection suppresses later current-state fields;
+- missing required requests fail the ordinary snapshot workflow;
 - the exact SQLite artifact is retained while any generation references it.
 
 The existing normalizers build the artifact from the selected raw payloads.
@@ -367,10 +375,11 @@ factual tools should be introduced deliberately after their SQL is scoped and
 tested; dynasty continuity initially comes from core identity and memory.
 
 Once a snapshot is `ready`, its cutoff fields, request membership, selected-set
-hash, artifact locator/hash/size, and materializer versions are immutable. A
+hash, artifact locator/hash/size, and projection version are immutable. A
 snapshot becomes ready only after verifying that its selected API requests are
 succeeded and complete and that the stored artifact matches its hash. Expiration
-may change retention state but never rewrites what the snapshot meant.
+may change retention state but never rewrites what the snapshot meant; expired
+is terminal.
 
 Tables that carry both `competition_id` and `competition_season_id` use a
 composite foreign key to prevent cross-competition combinations. A data snapshot
@@ -400,7 +409,8 @@ In addition to request indexes and natural uniqueness:
 - transactions by season/week/type/status and provider transaction ID;
 - transaction moves by player, pick coordinates, and involved roster;
 - draft picks by competition/draft season/current franchise;
-- snapshots by competition season, mode, cutoff, and creation time;
+- snapshots by active build key and by competition season, observation cutoff,
+  and creation time;
 - snapshot-request membership by snapshot and API request.
 
 JSONB receives no general GIN indexes until a real query requires one.

--- a/docs/database/sleeper.md
+++ b/docs/database/sleeper.md
@@ -294,9 +294,9 @@ The latest normalized winners/losers bracket nodes, keyed by
 `(competition_season_id, bracket_kind, node_key)`, retaining the current bracket
 fields and source API request. `node_key` uses Sleeper's node/matchup identifier
 when present and otherwise a deterministic provider-array position within that
-exact response scope. Historical snapshot creation uses only a bracket request
-eligible at its knowledge cutoff; it never trims today's final bracket and
-presents it as historically known.
+exact response scope. Historical snapshot construction may use a later recorded
+bracket response, but projection policy must not present nodes beyond
+`through_week` as historical results.
 
 ## Existing Derived Tables
 
@@ -321,13 +321,13 @@ One immutable factual input to one or more generations:
 
 - `id uuid` primary key;
 - competition and primary competition-season IDs;
-- canonical semantic `build_key`;
-- domain cutoff week/time and `observed_through` request boundary;
+- canonical daily reuse `build_key`;
+- populated domain cutoff week, nullable reserved cutoff-time seam, and the
+  `as_of_date` daily reuse label;
 - status: `building`, `ready`, `failed`, or `expired`;
 - one snapshot-projection version plus audit-only code version;
 - completeness warnings JSONB;
 - sanitized failure summary for failed builds;
-- selected-request-set hash;
 - exact SQLite artifact hash, byte size, and private storage key/path;
 - created/completed timestamps.
 
@@ -354,19 +354,20 @@ not silently mixed into the current agent SQL surface.
 
 Snapshot selection rules:
 
-- selection chooses the latest complete request per required scope with
-  `completed_at <= observed_through`;
-- an earlier `through_week` combined with a later `observed_through` may use a
-  later correction specifically scoped to that earlier week;
+- selection chooses the latest complete request available per required scope;
+- an earlier `through_week` may use a later recorded correction specifically
+  scoped to that earlier week;
 - future-week matchup/transaction requests are excluded;
-- later roster/player/user/bracket payloads cannot cross the observation
-  boundary, and the SQLite projection suppresses later current-state fields;
+- later roster/player/user/bracket payloads may supply current reference data,
+  while the SQLite projection suppresses later-week state fields;
 - missing required requests fail the ordinary snapshot workflow;
-- the exact SQLite artifact is retained while any generation references it.
+- v1 retains ready SQLite artifacts and does not proactively delete benign
+  unreferenced content-addressed files.
 
 The existing normalizers build the artifact from the selected raw payloads.
 This both preserves the familiar SQLite query schema and physically prevents
-the reporter's guarded SQL tool from seeing future primary-database rows.
+the reporter's guarded SQL tool from seeing post-`through_week` week-scoped and
+volatile state from primary-database rows.
 
 The SQLite tables retain the existing provider-facing `league_id`, `roster_id`,
 and season columns expected by current query/tool code. They may add internal
@@ -374,8 +375,8 @@ competition/franchise IDs as non-breaking columns for future tools. Cross-season
 factual tools should be introduced deliberately after their SQL is scoped and
 tested; dynasty continuity initially comes from core identity and memory.
 
-Once a snapshot is `ready`, its cutoff fields, request membership, selected-set
-hash, artifact locator/hash/size, and projection version are immutable. A
+Once a snapshot is `ready`, its cutoff fields, exact request membership,
+artifact locator/hash/size, and projection version are immutable. A
 snapshot becomes ready only after verifying that its selected API requests are
 succeeded and complete and that the stored artifact matches its hash. Expiration
 may change retention state but never rewrites what the snapshot meant; expired
@@ -409,7 +410,7 @@ In addition to request indexes and natural uniqueness:
 - transactions by season/week/type/status and provider transaction ID;
 - transaction moves by player, pick coordinates, and involved roster;
 - draft picks by competition/draft season/current franchise;
-- snapshots by active build key and by competition season, observation cutoff,
+- snapshots by active build key and by competition season, `as_of_date`,
   and creation time;
 - snapshot-request membership by snapshot and API request.
 

--- a/docs/database/status.md
+++ b/docs/database/status.md
@@ -15,7 +15,7 @@ database tests, and operational runbooks only
 | Platform structure and centralized ORM location | Hardened | `../platform-architecture.md` |
 | Cross-namespace contract | Hardened | `overview.md` |
 | Minimal core identity | Hardened | `core.md` |
-| Request-oriented Sleeper persistence | Hardened | `sleeper.md` |
+| Request-oriented Sleeper persistence | Hardened; datalayer alignment planned | `sleeper.md` |
 | Linear canonical memory and isolated evaluation workspace | Hardened | `memory.md` |
 | Generation-centered reporting | Hardened | `reporting.md` |
 | Supabase/PostgreSQL infrastructure | Hardened | `infrastructure.md` |
@@ -65,8 +65,9 @@ These are deployment facts rather than schema blockers:
 
 ## Next Milestone
 
-Complete, verify, and publish the approved database-only stack with `gh stack`;
-do not begin managers or services in this stack.
+The database-only stack is complete. The first datalayer implementation PR
+lands the narrow snapshot-schema alignment required by the approved service
+contract; resource managers and services follow in later datalayer layers.
 
 ## Implementation Coordination
 

--- a/docs/datalayer/README.md
+++ b/docs/datalayer/README.md
@@ -1,0 +1,187 @@
+# Datalayer Architecture Plan
+
+**Status:** Architecture contract for the foundational PR
+
+**Scope:** `backend/services/datalayer`, its resource-manager dependencies, the
+HTTP boundary, and the frozen reporter data runtime
+
+**Authoritative schema baseline:** [`docs/database/sleeper.md`](../database/sleeper.md)
+
+The service review requires focused pre-implementation snapshot refinements:
+active-build identity, one projection version, failure metadata, exact
+request-hash membership, and corrected sealed transitions. They are called out
+in
+[`application-contracts.md`](application-contracts.md#persistence-alignment-before-implementation).
+
+## Purpose
+
+The platform datalayer turns Sleeper observations into two products with
+different guarantees:
+
+1. a durable, current PostgreSQL view for the product and cross-season reads;
+2. an immutable, cutoff-safe SQLite view for reporter generations.
+
+It preserves the strongest parts of the legacy datalayer—explicit endpoint
+helpers, pure normalization, derived fantasy-football facts, curated queries,
+name resolution, and guarded SQL—without retaining the assumption that every
+run begins by downloading one league into a new in-memory database.
+
+The target is a clean platform baseline with minimal factual-logic churn and
+minimal final-system complexity. Reuse means preserving proven behavior and
+tests, not forcing old row types or module boundaries through new adapter
+layers. Code moves unchanged when it still fits; otherwise its calculation is
+extracted or rewritten behind golden tests. Old persistence APIs do not receive
+compatibility shims.
+
+## Documents
+
+| Document | Owns |
+| --- | --- |
+| [`architecture.md`](architecture.md) | Boundaries, components, dependencies, package structure, and core abstractions |
+| [`application-contracts.md`](application-contracts.md) | HTTP, service, manager, and reporter-facing interfaces |
+| [`ingestion.md`](ingestion.md) | Refresh planning, request capture, normalization, merge policy, and failure behavior |
+| [`snapshots-and-query-runtime.md`](snapshots-and-query-runtime.md) | Cutoff selection, SQLite materialization, artifact verification, and query execution |
+| [`transition.md`](transition.md) | Legacy reuse map, implementation slices, test strategy, and exit criteria |
+
+Mutable implementation status, verification logs, and the detailed PR-stack
+plan are intentionally kept in the repository-local, gitignored
+`.context/datalayer/` workspace. Only durable architecture decisions belong in
+these tracked documents.
+
+## One-Sentence Model
+
+Sleeper responses are recorded first, normalized into a convenient current
+view second, and independently selected and re-normalized into an immutable
+generation snapshot when the reporter needs data.
+
+```mermaid
+flowchart LR
+    Caller["API, worker, or generation service"] --> Refresh["DatalayerRefreshService"]
+    Refresh --> Sleeper["Sleeper source adapter"]
+    Refresh --> Data["SleeperDataManager"]
+    Data --> Current["Normalized PostgreSQL heads"]
+    Caller --> Snapshot["DatalayerSnapshotService"]
+    Snapshot --> Data
+    Snapshot --> Frozen["Frozen SQLite artifact"]
+    Frozen --> Runtime["FrozenLeagueData"]
+    Runtime --> Reporter["Reporter curated tools and guarded SQL"]
+```
+
+## Which Database Answers Which Query?
+
+There are two query surfaces, not one:
+
+| Query | Reads from | Examples |
+| --- | --- | --- |
+| Product/current-state query | PostgreSQL normalized current view | UI league overview, current rosters, refresh audit, cross-season browsing |
+| Reporter/generation query | Frozen SQLite snapshot | Curated reporter tools, name resolution, standings/games analysis, guarded SQL |
+
+PostgreSQL therefore still contains projections: its normalized tables are the
+latest convenient projection of durable raw Sleeper observations. The initial
+architecture does not persist the legacy derived `games`, `standings`,
+`team_profiles`, and `season_context` projections in PostgreSQL. Those are built
+inside the SQLite reporter read model because they are already coupled to the
+curated query contract and must be cutoff-safe.
+
+The SQLite artifact is not necessarily unique to a generation. Several
+generations may reference the same ready snapshot when their competition,
+season, factual boundaries, selected API requests, and snapshot projection
+version match.
+
+## Settled Decisions
+
+- The service package is `backend/services/datalayer/`. Sleeper-specific code
+  lives under `backend/services/datalayer/sleeper/`; the service is not a
+  generic provider framework.
+- Refresh, snapshot construction, and query execution are separate entry
+  points. There is no platform equivalent of `SleeperLeagueData.load()`.
+- PostgreSQL is the durable source of truth. SQLite is a sealed generation
+  artifact and local test format only.
+- Every external attempt is recorded, including failures and unchanged
+  responses. The filesystem response cache is removed.
+- Reuse is behavioral, not type-preserving. Existing endpoint logic,
+  normalization calculations, derivations, queries, and fixtures move forward
+  when they simplify the new design. SQLite-coupled DTOs are changed or
+  replaced when adapting around them would add more layers than rewriting them.
+- Current normalized tables are convenient heads, not historical truth.
+  Historical snapshots select raw request history and normalize it again.
+- The reporter never receives a PostgreSQL connection. Curated queries and
+  free-form SQL execute only against a verified frozen SQLite artifact.
+- V1 stores frozen SQLite artifacts on the local filesystem under a configured
+  datalayer directory. No external object-storage service is required.
+- The initial reporter snapshot contains one competition season. Durable
+  franchise identity is included, but multi-season reporter SQL is deferred.
+- Existing query return shapes and expected `{"found": false}` lookup behavior
+  are preserved where practical. Platform resource and workflow failures use
+  typed exceptions instead of tool-shaped dictionaries.
+- Routes are thin. They parse HTTP input, establish manager context, call a
+  service, and translate errors. They do not fetch, normalize, select requests,
+  or open database sessions.
+- Snapshot callers supply a required `through_week` and `observed_through`.
+  Live/backtest/retrospective labels belong to generation policy, not snapshot
+  identity. V1 deliberately has no underspecified instant-based cutoff.
+- `DatalayerSnapshotService.get_or_create()` is the only ordinary snapshot
+  operation. It owns reuse versus build and uses an atomic canonical build key.
+
+## Primary Public Capabilities
+
+The component has three caller-facing Python entry points:
+
+```python
+refresh = DatalayerRefreshService(...)
+snapshots = DatalayerSnapshotService(...)
+data = FrozenLeagueData.open(verified_artifact)
+```
+
+- `DatalayerRefreshService` records a refresh and updates eligible current
+  normalized scopes.
+- `DatalayerSnapshotService.get_or_create()` builds or reuses a ready,
+  immutable snapshot for a precise factual cutoff contract.
+- `FrozenLeagueData` exposes curated factual queries and guarded SQL to the
+  reporter without exposing persistence or source-fetch behavior.
+
+The exact contracts are specified in
+[`application-contracts.md`](application-contracts.md).
+
+## Simplicity Budget
+
+The baseline intentionally pays for only these deep boundaries:
+
+- refresh service for external fetch/retry/orchestration;
+- snapshot service for selection, atomic reuse/build, and artifact sealing;
+- `SleeperDataManager` for the complete ingestion persistence transaction;
+- `DataSnapshotManager` for canonical snapshot lifecycle;
+- SQLite projection plus `FrozenLeagueData` for cutoff-safe reporter execution;
+- local file storage for atomic, hash-verified artifacts.
+
+There is no normalization registry, adapter registry, one-implementation reporter
+protocol, cross-resource write-helper layer, public snapshot build bypass, or
+ordinary incomplete-snapshot flag. New layers require a second caller or a new
+invariant that cannot live clearly in an existing module.
+
+## Ownership Boundary
+
+The datalayer owns:
+
+- Sleeper endpoint planning and HTTP execution;
+- complete request/payload audit capture;
+- payload completeness and normalization validation;
+- current normalized Sleeper heads;
+- request selection from explicit `through_week` and `observed_through`
+  boundaries;
+- frozen SQLite schema/materialization;
+- curated factual query functions and guarded SQL runtime.
+
+It does not own:
+
+- creation or reconciliation of competition, season, franchise, or season
+  roster identities;
+- generation lifecycle and manifest persistence;
+- reporter memory;
+- reporter prompts, tool presentation, or agent-loop policy;
+- model calls;
+- article persistence;
+- a general provider plugin system.
+
+Those boundaries keep factual data semantics reusable without turning the
+datalayer into the product's workflow coordinator.

--- a/docs/datalayer/README.md
+++ b/docs/datalayer/README.md
@@ -84,9 +84,9 @@ inside the SQLite reporter read model because they are already coupled to the
 curated query contract and must be cutoff-safe.
 
 The SQLite artifact is not necessarily unique to a generation. Several
-generations may reference the same ready snapshot when their competition,
-season, factual boundaries, selected API requests, and snapshot projection
-version match.
+generations may reference the same ready snapshot when their competition
+season, `through_week`, `as_of_date`, and snapshot projection version match.
+Exact selected API requests are sealed audit membership, not reuse identity.
 
 ## Settled Decisions
 
@@ -105,6 +105,9 @@ version match.
   replaced when adapting around them would add more layers than rewriting them.
 - Current normalized tables are convenient heads, not historical truth.
   Historical snapshots select raw request history and normalize it again.
+- V1 treats structural league settings as stable for one competition season.
+  Requirement planning may read the season's current normalized settings; it
+  does not reconstruct historical settings changes within that season.
 - The reporter never receives a PostgreSQL connection. Curated queries and
   free-form SQL execute only against a verified frozen SQLite artifact.
 - V1 stores frozen SQLite artifacts on the local filesystem under a configured
@@ -117,9 +120,10 @@ version match.
 - Routes are thin. They parse HTTP input, establish manager context, call a
   service, and translate errors. They do not fetch, normalize, select requests,
   or open database sessions.
-- Snapshot callers supply a required `through_week` and `observed_through`.
+- Snapshot callers supply a required `through_week` and plain `as_of_date`.
   Live/backtest/retrospective labels belong to generation policy, not snapshot
-  identity. V1 deliberately has no underspecified instant-based cutoff.
+  identity. `as_of_date` is a coarse daily reuse label, not a timestamp or
+  request-eligibility cutoff.
 - `DatalayerSnapshotService.get_or_create()` is the only ordinary snapshot
   operation. It owns reuse versus build and uses an atomic canonical build key.
 
@@ -130,13 +134,14 @@ The component has three caller-facing Python entry points:
 ```python
 refresh = DatalayerRefreshService(...)
 snapshots = DatalayerSnapshotService(...)
-data = FrozenLeagueData.open(verified_artifact)
+data = FrozenLeagueData.open(ready_snapshot)
 ```
 
 - `DatalayerRefreshService` records a refresh and updates eligible current
   normalized scopes.
 - `DatalayerSnapshotService.get_or_create()` builds or reuses a ready,
-  immutable snapshot for a precise factual cutoff contract.
+  immutable snapshot for a week-scoped factual boundary and daily reuse
+  contract.
 - `FrozenLeagueData` exposes curated factual queries and guarded SQL to the
   reporter without exposing persistence or source-fetch behavior.
 
@@ -167,8 +172,8 @@ The datalayer owns:
 - complete request/payload audit capture;
 - payload completeness and normalization validation;
 - current normalized Sleeper heads;
-- request selection from explicit `through_week` and `observed_through`
-  boundaries;
+- request selection from available complete observations plus an explicit
+  `through_week` domain boundary;
 - frozen SQLite schema/materialization;
 - curated factual query functions and guarded SQL runtime.
 

--- a/docs/datalayer/application-contracts.md
+++ b/docs/datalayer/application-contracts.md
@@ -1,0 +1,369 @@
+# Datalayer Application Contracts
+
+## Contract Layers
+
+The datalayer exposes different contracts to different callers. They must not be
+collapsed into one universal facade.
+
+| Caller | Contract | Why |
+| --- | --- | --- |
+| Frontend/operator | HTTP data routes | Validation, authorization, polling, and stable JSON |
+| Generation/worker services | Refresh and snapshot services | Explicit workflows with typed inputs and outcomes |
+| Resource-oriented routes | Context-scoped managers | Narrow current-state and audit reads |
+| Reporter | `FrozenLeagueData` | Read-only curated facts and guarded SQL from one snapshot |
+
+The examples below define shape and responsibility. Exact import names may be
+adjusted during implementation, but the semantic fields and boundaries should
+remain stable.
+
+## Workflow Value Objects
+
+Workflow inputs are immutable Pydantic values under
+`backend/services/datalayer/contracts.py`. They are not persisted resource
+objects or HTTP schemas.
+
+### Refresh specification
+
+```python
+class RefreshTrigger(str, Enum):
+    MANUAL = "manual"
+    GENERATION = "generation"
+    SCHEDULED = "scheduled"
+    BACKFILL = "backfill"
+
+
+class RefreshRequest(BaseModel, frozen=True):
+    competition_season_id: UUID
+    through_week: int | None
+    trigger: RefreshTrigger
+```
+
+The service derives `competition_id`, the standard endpoint set, player-catalog
+staleness, and bracket relevance. Ordinary callers cannot partially configure a
+refresh into an invalid data state. A future endpoint-specific maintenance
+command is separate from the product refresh contract.
+
+### Refresh outcome
+
+```python
+class ScopeRefreshResult(BaseModel, frozen=True):
+    scope_key: ScopeKey
+    api_request_id: UUID
+    fetch_status: RequestStatus
+    normalization_status: NormalizationStatus
+    changed_current_view: bool
+    warning_codes: tuple[str, ...] = ()
+
+
+class RefreshOutcome(BaseModel, frozen=True):
+    refresh_run_id: UUID
+    status: RefreshStatus
+    requested_scope_count: int
+    succeeded_scope_count: int
+    failed_scope_count: int
+    scope_results: tuple[ScopeRefreshResult, ...]
+```
+
+A partial refresh is a successful workflow outcome with `status="partial"`, not
+an exception. Failure to create or finalize the refresh aggregate is an
+exception.
+
+### Snapshot request
+
+```python
+class SnapshotRequest(BaseModel, frozen=True):
+    competition_season_id: UUID
+    through_week: int
+    observed_through: datetime
+```
+
+This contract describes factual availability rather than generation intent.
+The generation service converts live, historical replay, or retrospective
+policy into a valid week/observation pair. Competition identity is derived from
+the season. Missing required data always fails an ordinary snapshot request;
+incomplete diagnostic builds are not part of this API.
+
+V1 intentionally does not expose an instant-based domain cutoff. Matchups,
+transactions, standings, and lineup reconstruction are week-scoped, and the
+system has no trustworthy intra-week projection contract yet. Add an instant
+variant only with explicit service-owned resolution and intra-week rules.
+
+### Ready snapshot
+
+```python
+class ReadyDataSnapshot(BaseModel, frozen=True):
+    id: UUID
+    competition_id: UUID
+    primary_competition_season_id: UUID
+    through_week: int
+    observed_through: datetime
+    build_key: str
+    selected_request_set_sha256: str
+    snapshot_projection_version: str
+    artifact: VerifiedLocalArtifact
+    completeness_warnings: tuple[CompletenessWarning, ...]
+```
+
+The artifact value carries the verified local path/hash inside the backend. API
+responses do not return filesystem paths or relative storage keys.
+
+### Persistence alignment before implementation
+
+The existing `sleeper.data_snapshots` baseline receives these focused schema
+refinements before this service is implemented:
+
+- add `build_key` plus a partial unique constraint allowing only one active
+  `building` or `ready` row per key;
+- remove snapshot `mode`; live/backtest/retrospective intent belongs to the
+  generation rather than factual identity;
+- consolidate materializer/schema versions into one
+  `snapshot_projection_version` and add sanitized failure metadata;
+- pin `response_sha256` beside every selected request ID and scope key;
+- permit only the one-way `ready` to `expired` retention transition while
+  keeping sealed meaning and membership immutable.
+
+V1 populates `domain_cutoff_week` and leaves `domain_cutoff_at` null. The latter
+remains a future schema seam, not a capability claimed by the Python contract.
+
+## Service Interfaces
+
+### Refresh service
+
+```python
+class DatalayerRefreshService:
+    def refresh(self, request: RefreshRequest) -> RefreshOutcome: ...
+```
+
+`refresh()` is used by manual synchronization, scheduled refresh, and the
+generation input workflow. Reprocessing a recorded request after a code or
+identity correction is a maintenance command, not a second public service mode.
+
+The service accepts these constructor dependencies:
+
+- `SleeperSourceClient`;
+- `SleeperDataManager`;
+- read-only core identity lookup port;
+- a clock;
+- configured `LocalDatalayerFileStore` for raw payloads too large for inline
+  PostgreSQL JSONB.
+
+Endpoint planning and endpoint-family dispatch are ordinary module functions,
+not injected registries or one-method strategy objects.
+
+### Snapshot service
+
+```python
+class DatalayerSnapshotService:
+    def get_or_create(self, request: SnapshotRequest) -> ReadyDataSnapshot: ...
+```
+
+`get_or_create()` selects the exact request set, computes the canonical build
+key, and atomically returns or builds the one matching snapshot. Callers cannot
+bypass reuse or request a weakened incomplete build.
+
+The service accepts:
+
+- `SleeperDataManager` for eligible request reads and payload resolution;
+- `DataSnapshotManager` for atomic build-key ownership, lifecycle, and
+  membership;
+- core identity lookup port;
+- the SQLite materializer;
+- configured `LocalDatalayerFileStore`;
+- a clock plus module-level projection/build metadata.
+
+The service calls pure request-selection and endpoint-family functions directly;
+they do not become injectable wrapper objects merely to make tests mock them.
+
+### Generation-service use
+
+The generation service composes the datalayer but remains the owner of
+generation policy:
+
+```python
+snapshot = datalayer_snapshot_service.get_or_create(
+    SnapshotRequest(
+        competition_season_id=request.competition_season_id,
+        through_week=request.domain_cutoff_week,
+        observed_through=request.knowledge_cutoff_at,
+    )
+)
+
+generation_manager.start(
+    generation_id=request.id,
+    data_snapshot_id=snapshot.id,
+    # memory input, cutoffs, and complete manifest are supplied here too
+)
+```
+
+The datalayer never mutates the generation row. It returns a ready snapshot
+whose identity the generation service atomically pins with the other inputs.
+
+## Resource Manager Contracts
+
+All managers are constructed with a `ManagerContext`. Competition-scoped
+operations apply that context to every read and write. Signatures below omit
+ordinary pagination values for clarity.
+
+### `SleeperDataManager`
+
+```python
+class SleeperDataManager:
+    def start_refresh(self, command: StartRefresh) -> RefreshRun: ...
+    def record_attempt(self, command: RecordApiAttempt) -> ApiRequest: ...
+    def apply_scope(
+        self,
+        request_id: UUID,
+        records: EndpointRecords,
+    ) -> ApplyResult: ...
+    def reject_normalization(self, request_id: UUID, rejection: Rejection) -> ApiRequest: ...
+    def finish_refresh(self, refresh_id: UUID) -> RefreshRun: ...
+
+    def get_refresh(self, refresh_id: UUID) -> RefreshRun: ...
+    def list_refresh_requests(self, refresh_id: UUID) -> Page[ApiRequest]: ...
+    def list_snapshot_candidates(self, query: SnapshotCandidateQuery) -> tuple[ApiRequestCandidate, ...]: ...
+    def resolve_verified_payloads(self, request_ids: Collection[UUID]) -> tuple[VerifiedPayload, ...]: ...
+
+    def get_season_overview(self, season_id: UUID) -> LeagueSeasonOverview: ...
+    def get_roster(self, season_roster_id: UUID) -> SeasonRosterState: ...
+    def list_matchups(self, season_id: UUID, week: int) -> tuple[Matchup, ...]: ...
+    def list_transactions(self, query: TransactionQuery) -> tuple[Transaction, ...]: ...
+    def search_players(self, query: PlayerSearch) -> Page[Player]: ...
+```
+
+`record_attempt()` content-addresses a successful payload and records the
+request plus its completeness finding in one transaction. Successful parsed
+responses are validated by the owning endpoint-family module before this call;
+failed source attempts carry the refresh service's standard incomplete finding.
+Large payload bytes are stored before this call; the manager verifies the
+supplied local-file receipt/hash rather than performing filesystem or network
+I/O.
+
+`apply_scope()` owns the compare-and-swap request/head/current-view transaction
+across the Sleeper persistence namespace. `finish_refresh()` derives status and
+counts from recorded request outcomes; the service does not calculate and pass
+the same summary back down.
+
+Singular `get_*` methods either return the scoped resource or raise the common
+resource-not-found error. Normal absence uses empty list/page results or a
+specifically named search operation; callers are not forced to repeatedly
+interpret `None`.
+
+### `DataSnapshotManager`
+
+```python
+class DataSnapshotManager:
+    def begin_or_get(self, command: BeginSnapshotBuild) -> SnapshotBuildState: ...
+    def seal_ready(self, snapshot_id: UUID, command: SealSnapshot) -> ReadyDataSnapshot: ...
+    def mark_failed(self, snapshot_id: UUID, failure: SnapshotFailure) -> DataSnapshot: ...
+    def fail_stale_build(self, build_key: str, stale_before: datetime) -> bool: ...
+    def expire_unusable(self, snapshot_id: UUID, reason: ArtifactFailure) -> DataSnapshot: ...
+    def get(self, snapshot_id: UUID) -> DataSnapshot: ...
+    def list_requests(self, snapshot_id: UUID) -> tuple[SnapshotRequestMembership, ...]: ...
+```
+
+`begin_or_get()` owns the uniqueness race for the canonical build key and
+returns an explicit existing-ready, existing-building, or newly-claimed state.
+Only `building` and `ready` rows participate in the partial unique constraint;
+failed and expired attempts remain as history but do not prevent a later claim.
+`fail_stale_build()` is an atomic compare-and-transition and is a no-op when the
+matching build is no longer stale. `expire_unusable()` releases a ready build
+whose artifact is missing or fails verification. These lifecycle operations
+keep retry and recovery decisions out of callers and preserve the failed or
+expired row for audit.
+`seal_ready()` owns one transaction that validates current build state, inserts
+the exact request membership, and records hashes, sizes, versions, warnings,
+artifact key, and completion time. Ready input fields are immutable thereafter.
+
+## Reporter Data Contract
+
+The reporter uses the concrete `FrozenLeagueData` runtime. It preserves the
+existing curated query categories—league/week, teams/rosters, players,
+transactions, playoffs, and guarded SQL—without duplicating the full facade as
+a one-implementation protocol.
+
+The runtime adds context-manager lifecycle:
+
+```python
+with FrozenLeagueData.open(local_verified_snapshot) as data:
+    reporter.run(data=data)
+```
+
+`DatalayerSnapshotService.get_or_create()` returns a verified local artifact.
+The runtime validates its internal projection metadata and opens SQLite in
+immutable read-only mode without exposing the connection to callers.
+
+Convenience pairs such as games/games-with-players may remain distinct public
+tool operations, while sharing one internal query implementation where doing so
+removes duplicated SQL. Snapshot-relative naming should be explicit:
+`get_roster_at_cutoff()` replaces the ambiguous `get_roster_current()`.
+
+Reporter tool definitions stay in `services/reporter/tools/`. Tool handlers
+delegate to `FrozenLeagueData`; the datalayer does not import reporter code.
+
+## HTTP API
+
+Routes use versioned JSON under `/api/v1`. The initial surface is intentionally
+small.
+
+### Refresh workflow
+
+```text
+POST /api/v1/competitions/{competition_id}/seasons/{season_id}/data-refreshes
+GET  /api/v1/competitions/{competition_id}/data-refreshes/{refresh_id}
+GET  /api/v1/competitions/{competition_id}/data-refreshes/{refresh_id}/requests
+```
+
+The POST body contains only an optional `through_week`; the service derives the
+endpoint plan. V1 executes synchronously and returns `200 OK` with the terminal
+resource. A later worker boundary may add `202 Accepted`, but the route does not
+claim asynchronous dispatch until that worker exists. The URL season and body
+are checked against manager scope.
+
+### Current data reads
+
+```text
+GET /api/v1/competitions/{competition_id}/seasons/{season_id}/data/overview
+GET /api/v1/competitions/{competition_id}/seasons/{season_id}/data/matchups?week=8
+GET /api/v1/competitions/{competition_id}/seasons/{season_id}/data/transactions?week_from=1&week_to=8
+GET /api/v1/competitions/{competition_id}/seasons/{season_id}/data/rosters/{season_roster_id}
+GET /api/v1/players?query=mahomes&limit=20&cursor=...
+```
+
+These endpoints return typed API projections from current-view resource
+objects. They are for product display, not generation inputs and not a remote
+version of the reporter's arbitrary SQL tool.
+
+### Snapshot audit
+
+```text
+GET  /api/v1/competitions/{competition_id}/data-snapshots/{snapshot_id}
+GET  /api/v1/competitions/{competition_id}/data-snapshots/{snapshot_id}/requests
+```
+
+Ordinary generation requests resolve snapshots through `GenerationService`;
+there is no separate public build/bypass route. Snapshot JSON exposes hashes,
+cutoffs, status, warnings, and selected request metadata but never raw payload
+bodies or private storage keys.
+
+## HTTP Error Translation
+
+| Application result/error | HTTP behavior |
+| --- | --- |
+| Missing scoped resource | `404` |
+| Scope or identity mismatch | `409` |
+| Invalid cutoff/specification | `422` |
+| Required snapshot inputs unavailable | `409` with structured missing scopes |
+| Sleeper refresh completed partially | Success response with `status="partial"` |
+| Sleeper unavailable during refresh | Terminal failed/partial refresh resource; the source error is not re-raised to the route |
+| Snapshot verification/internal invariant failure | `500` with sanitized correlation ID |
+
+Reporter `found=false` results are not mapped through this table because they
+are tool-domain results, not HTTP workflow failures.
+
+## Composition
+
+`backend/composition.py` constructs concrete managers, services, source clients,
+the local datalayer file store, and clocks. Routes and workers request typed
+factories/dependencies. No code resolves the datalayer from a
+mutable global registry, and tests replace dependencies at the constructor or
+FastAPI dependency boundary.

--- a/docs/datalayer/application-contracts.md
+++ b/docs/datalayer/application-contracts.md
@@ -74,19 +74,24 @@ exception.
 class SnapshotRequest(BaseModel, frozen=True):
     competition_season_id: UUID
     through_week: int
-    observed_through: datetime
+    as_of_date: date
 ```
 
-This contract describes factual availability rather than generation intent.
-The generation service converts live, historical replay, or retrospective
-policy into a valid week/observation pair. Competition identity is derived from
-the season. Missing required data always fails an ordinary snapshot request;
-incomplete diagnostic builds are not part of this API.
+This contract describes a week-scoped simulation and its daily reuse identity,
+not exact historical knowledge. The generation service converts live,
+historical replay, or retrospective policy into a valid week/date pair.
+`as_of_date` is a plain caller-chosen calendar date; the datalayer does not map
+timestamps into dates or use it to filter source requests. Competition identity
+is derived from the season. Missing required data always fails an ordinary
+snapshot request; incomplete diagnostic builds are not part of this API.
 
-V1 intentionally does not expose an instant-based domain cutoff. Matchups,
-transactions, standings, and lineup reconstruction are week-scoped, and the
-system has no trustworthy intra-week projection contract yet. Add an instant
-variant only with explicit service-owned resolution and intra-week rules.
+V1 intentionally exposes neither an instant-based domain cutoff nor an
+observation-time cutoff. Matchups, transactions, standings, and lineup
+reconstruction are week-scoped. A historical week may be rebuilt later from the
+latest complete requests visible during the post-claim candidate read. Request
+start time may order candidates within one scope, but no request timestamp maps
+into `as_of_date` or creates a knowledge boundary. Add exact knowledge-time
+simulation only if a concrete product need justifies that additional contract.
 
 ### Ready snapshot
 
@@ -96,9 +101,8 @@ class ReadyDataSnapshot(BaseModel, frozen=True):
     competition_id: UUID
     primary_competition_season_id: UUID
     through_week: int
-    observed_through: datetime
+    as_of_date: date
     build_key: str
-    selected_request_set_sha256: str
     snapshot_projection_version: str
     artifact: VerifiedLocalArtifact
     completeness_warnings: tuple[CompletenessWarning, ...]
@@ -116,6 +120,7 @@ refinements before this service is implemented:
   `building` or `ready` row per key;
 - remove snapshot `mode`; live/backtest/retrospective intent belongs to the
   generation rather than factual identity;
+- store the `as_of_date` used by the daily build identity;
 - consolidate materializer/schema versions into one
   `snapshot_projection_version` and add sanitized failure metadata;
 - pin `response_sha256` beside every selected request ID and scope key;
@@ -157,9 +162,24 @@ class DatalayerSnapshotService:
     def get_or_create(self, request: SnapshotRequest) -> ReadyDataSnapshot: ...
 ```
 
-`get_or_create()` selects the exact request set, computes the canonical build
-key, and atomically returns or builds the one matching snapshot. Callers cannot
-bypass reuse or request a weakened incomplete build.
+`get_or_create()` validates the request, computes the daily canonical build key,
+and asks the snapshot manager to atomically reuse or claim that identity before
+selecting source requests. If a ready row exists, the service verifies its
+artifact hash and size before returning it; an unusable artifact is atomically
+expired before another claim. A newly claimed build selects exact request
+membership into an immutable in-memory manifest, performs payload/file/SQLite
+work outside database transactions, and atomically persists that membership
+with the ready result. Callers cannot bypass reuse or request a weakened
+incomplete build.
+
+The first healthy ready snapshot for one season/week/date/projection-version
+key is reused. During normal reuse, observations completed after that snapshot
+became ready do not replace it; callers normally choose another date label when
+they want another identity. A failed or expired row releases the key so recovery
+can reselect from the same coarse daily reuse bucket; the replacement may
+therefore contain different exact membership under the same intentional daily
+identity. Every attempt preserves its own audit row and a ready attempt seals
+its exact membership.
 
 The service accepts:
 
@@ -184,7 +204,7 @@ snapshot = datalayer_snapshot_service.get_or_create(
     SnapshotRequest(
         competition_season_id=request.competition_season_id,
         through_week=request.domain_cutoff_week,
-        observed_through=request.knowledge_cutoff_at,
+        as_of_date=request.snapshot_date,
     )
 )
 
@@ -220,6 +240,10 @@ class SleeperDataManager:
 
     def get_refresh(self, refresh_id: UUID) -> RefreshRun: ...
     def list_refresh_requests(self, refresh_id: UUID) -> Page[ApiRequest]: ...
+    def get_snapshot_planning_context(
+        self,
+        competition_season_id: UUID,
+    ) -> SnapshotPlanningContext: ...
     def list_snapshot_candidates(self, query: SnapshotCandidateQuery) -> tuple[ApiRequestCandidate, ...]: ...
     def resolve_verified_payloads(self, request_ids: Collection[UUID]) -> tuple[VerifiedPayload, ...]: ...
 
@@ -242,6 +266,11 @@ I/O.
 across the Sleeper persistence namespace. `finish_refresh()` derives status and
 counts from recorded request outcomes; the service does not calculate and pass
 the same summary back down.
+
+`get_snapshot_planning_context()` returns the current normalized structural
+settings for the requested season under v1's season-stability assumption.
+`SnapshotCandidateQuery` is limited by season, required endpoint scopes, and
+`through_week`; it never contains or applies `as_of_date`.
 
 Singular `get_*` methods either return the scoped resource or raise the common
 resource-not-found error. Normal absence uses empty list/page results or a
@@ -272,7 +301,8 @@ keep retry and recovery decisions out of callers and preserve the failed or
 expired row for audit.
 `seal_ready()` owns one transaction that validates current build state, inserts
 the exact request membership, and records hashes, sizes, versions, warnings,
-artifact key, and completion time. Ready input fields are immutable thereafter.
+artifact key, and completion time. It succeeds only while that snapshot is
+currently `building`. Ready input fields are immutable thereafter.
 
 ## Reporter Data Contract
 
@@ -284,13 +314,15 @@ a one-implementation protocol.
 The runtime adds context-manager lifecycle:
 
 ```python
-with FrozenLeagueData.open(local_verified_snapshot) as data:
+with FrozenLeagueData.open(snapshot) as data:
     reporter.run(data=data)
 ```
 
-`DatalayerSnapshotService.get_or_create()` returns a verified local artifact.
-The runtime validates its internal projection metadata and opens SQLite in
-immutable read-only mode without exposing the connection to callers.
+`DatalayerSnapshotService.get_or_create()` returns the complete
+`ReadyDataSnapshot`. The runtime opens its nested verified artifact, compares
+the file's internal build key and projection version with the expected values on
+that snapshot, and opens SQLite in immutable read-only mode without exposing the
+connection to callers.
 
 Convenience pairs such as games/games-with-players may remain distinct public
 tool operations, while sharing one internal query implementation where doing so

--- a/docs/datalayer/architecture.md
+++ b/docs/datalayer/architecture.md
@@ -1,0 +1,487 @@
+# Datalayer Component Architecture
+
+## Goals
+
+The new component must:
+
+1. preserve every source observation needed to explain current facts and build
+   historical inputs;
+2. maintain a convenient, competition-scoped current view in PostgreSQL;
+3. produce physically cutoff-safe reporter inputs;
+4. preserve proven legacy behavior without preserving types or wrappers that
+   make the target design harder to understand;
+5. support partial refreshes, retries, empty endpoint results, and concurrent
+   request completion without rolling current state backward;
+6. keep ORM rows and SQLAlchemy sessions out of services, routes, workers, and
+   reporter tools;
+7. make cutoff semantics explicit rather than overloading a football week.
+
+## Architectural Shape
+
+```mermaid
+flowchart TB
+    subgraph External["External callers"]
+        API["FastAPI data routes"]
+        Generation["Generation service"]
+        Worker["Worker"]
+        Reporter["Reporter tools"]
+    end
+
+    subgraph Service["backend/services/datalayer"]
+        Refresh["DatalayerRefreshService"]
+        Source["Sleeper source adapter"]
+        Endpoints["Endpoint-family modules"]
+        Snapshot["DatalayerSnapshotService"]
+        Selector["Snapshot request selector"]
+        Projection["SQLite cutoff projection"]
+        Query["FrozenLeagueData"]
+    end
+
+    subgraph Resources["backend/resources"]
+        DataManager["SleeperDataManager"]
+        SnapshotManager["DataSnapshotManager"]
+        CoreManagers["Competition and identity managers"]
+    end
+
+    subgraph Infrastructure["Infrastructure"]
+        PG["PostgreSQL"]
+        Files["Local datalayer file store"]
+        SQLite["Frozen SQLite"]
+        SleeperAPI["Sleeper API"]
+    end
+
+    API --> Refresh
+    Generation --> Refresh
+    Generation --> Snapshot
+    Worker --> Refresh
+    Refresh --> Source
+    Source --> SleeperAPI
+    Refresh --> Endpoints
+    Refresh --> DataManager
+    DataManager --> PG
+    Snapshot --> Selector
+    Snapshot --> DataManager
+    Snapshot --> SnapshotManager
+    Snapshot --> Endpoints
+    Snapshot --> Projection
+    Snapshot --> Files
+    SnapshotManager --> PG
+    Projection --> SQLite
+    Reporter --> Query
+    Query --> SQLite
+    Refresh -. "resolved IDs" .-> CoreManagers
+```
+
+`SleeperDataManager` owns the whole ingestion write aggregate, including the
+atomic “apply request and advance scope head” transaction. No manager reaches
+through another resource with session-bound write helpers.
+
+## Projection and Query Boundaries
+
+“Projection” refers to two related but separate things:
+
+| Projection | Lifetime | Consumers | Contents |
+| --- | --- | --- | --- |
+| PostgreSQL normalized current view | Durable and updated by refresh | Product UI, current-state APIs, cross-season application reads | Latest normalized league, user, player, roster, matchup, transaction, pick, and bracket heads |
+| SQLite reporter read model | Immutable and reusable | One or more reporter generations | One cutoff-safe season plus legacy derived/query tables and snapshot metadata |
+
+The PostgreSQL view is not bypassed by the application. Resource managers query
+it for current product behavior. The reporter intentionally does not query it,
+because guarded SQL against a database containing later observations would
+defeat the snapshot boundary.
+
+The initial baseline keeps `games`, `standings`, `team_profiles`, and
+`season_context` as SQLite-only derivations. A future UI feature may justify a
+durable PostgreSQL read model, but that is independent of the reporter snapshot
+and should be added for a demonstrated product query rather than preemptively.
+
+## Proposed Package Layout
+
+```text
+backend/
+├── services/
+│   └── datalayer/
+│       ├── __init__.py
+│       ├── contracts.py
+│       ├── errors.py
+│       ├── local_files.py
+│       ├── refresh_service.py
+│       ├── snapshot_service.py
+│       ├── sleeper/
+│       │   ├── client.py
+│       │   ├── responses.py
+│       │   ├── scope.py
+│       │   └── endpoints/
+│       │       ├── league.py
+│       │       ├── rosters.py
+│       │       ├── weekly.py
+│       │       ├── players.py
+│       │       └── brackets.py
+│       ├── snapshots/
+│       │   ├── selection.py
+│       │   ├── projection.py
+│       │   ├── schema.py
+│       └── query/
+│           ├── runtime.py
+│           ├── guarded_sql.py
+│           └── curated/
+├── resources/
+│   ├── sleeper_data/
+│   │   ├── objects.py
+│   │   └── manager.py
+│   └── data_snapshots/
+│       ├── objects.py
+│       └── manager.py
+└── api/
+    ├── schemas/data.py
+    └── routes/data.py
+```
+
+This refines the `services/sleeper/` placeholder in the platform document into
+one datalayer capability. Sleeper remains explicit below the source boundary;
+no provider registry or provider-neutral persisted model is introduced. It also
+refines the proposed split `sleeper_observations` / `player_catalog` /
+`league_state` manager layout into one `sleeper_data` write aggregate. The
+centralized PostgreSQL model namespaces remain unchanged.
+
+Files stay together until their contents justify another boundary. In
+particular, refresh planning and result assembly begin in `refresh_service.py`;
+projection derivations and verification begin in `snapshots/projection.py`.
+They should be extracted only after they become independently substantial or
+gain another caller.
+
+## High-Level Components
+
+### `DatalayerRefreshService`
+
+Owns one refresh workflow from request planning through refresh completion. It:
+
+- accepts a competition season and optional through-week target;
+- resolves the standard endpoint plan itself from season state and trigger;
+- executes requests through the Sleeper source adapter;
+- delegates completeness validation of parsed successes to the owning
+  endpoint-family module;
+- records every attempt with its completeness finding before applying any
+  normalized facts;
+- delegates normalization of complete payloads to that same endpoint-family
+  module;
+- asks `SleeperDataManager` to atomically apply eligible endpoint records;
+- asks the manager to derive and persist the final succeeded, partial, failed,
+  or cancelled status from its recorded child requests.
+
+It does not open sessions or hold a transaction during HTTP work.
+
+### Sleeper Source Adapter
+
+The source adapter contains the provider-specific HTTP boundary. Its client
+returns a discriminated successful-or-failed attempt value containing request
+and completion timestamps, sanitized path and parameters, status, HTTP status,
+latency, and either a parsed payload with its hash or a sanitized source error.
+Callers never interpret a mostly optional payload-or-error object.
+
+It has no filesystem cache. PostgreSQL request history and content-addressed
+payload storage provide the durable observation record. An unchanged response
+still creates a request row.
+
+### Endpoint-Family Modules
+
+Provider knowledge is grouped by endpoint family rather than split across an
+endpoint registry, completeness registry, normalizer registry, and adapter
+registry. Each family module owns:
+
+- request path and parameter construction;
+- deterministic scope-key construction;
+- response shape/completeness validation;
+- raw payload normalization into endpoint records.
+
+`weekly.py`, for example, owns matchup and transaction request/validation logic.
+The existing normalizers and derivations are reused inside these modules when
+their interfaces remain natural. If an old SQLite DTO would require adapters on
+both sides, the calculation is preserved but the DTO is replaced.
+
+Endpoint records contain normalized domain values only. Request ID, observation
+timestamps, scope key, and version already belong to `ApiRequest` and are passed
+separately when records are applied or materialized.
+
+A small explicit `match EndpointKind` dispatch is sufficient. A new registry or
+base class requires a demonstrated second behavior, not merely multiple
+endpoint kinds.
+
+### Resource Managers
+
+Two managers own deep persistence aggregates:
+
+| Manager | Aggregate and responsibilities |
+| --- | --- |
+| `SleeperDataManager` | Refresh runs, API attempts/payloads, normalized scope heads, current normalized Sleeper tables, current product reads, snapshot candidates, and the atomic request/head/current-view transaction |
+| `DataSnapshotManager` | Canonical build-key claim/reuse, snapshot lifecycle, exact request membership, immutable sealing, and failure state |
+
+There are no cross-resource `shared.py` write helpers. The Sleeper request,
+scope head, player catalog, and league current view form one ingestion write
+aggregate, so one manager owns that transaction. Its public read methods still
+apply explicit competition or global scope and return resource objects rather
+than ORM rows.
+
+### `DatalayerSnapshotService`
+
+Exposes one ordinary operation, `get_or_create(request)`, and owns the complete
+long-running snapshot workflow:
+
+- asks `SleeperDataManager` for eligible request candidates;
+- selects exactly one request for every required scope;
+- computes a canonical build key from the factual inputs;
+- asks `DataSnapshotManager.begin_or_get()` to atomically return the existing
+  snapshot or claim the build;
+- bounds waiting on an existing build, atomically fails an abandoned build,
+  and retries the claim without exposing recovery policy to its caller;
+- resolves and hash-verifies raw payloads;
+- runs the same normalizers used by ingestion;
+- projects endpoint records into cutoff-safe snapshot tables;
+- writes and verifies a temporary SQLite file;
+- stores the artifact through the local datalayer file store;
+- atomically seals request membership and artifact metadata as ready.
+
+There is no public `build()` bypass and no ordinary incomplete-build flag.
+Missing required inputs fail the request. A future diagnostic workflow, if
+needed, is a separate command and cannot weaken generation snapshot guarantees.
+
+No database transaction remains open while payload files are read, SQLite is
+built, or the artifact is written to its final local path.
+
+### SQLite Snapshot Materializer
+
+The materializer projects selected endpoint records plus core identity mappings
+into the versioned reporter SQLite schema. It is the sole owner of field-level
+cutoff policy for current-state payloads and owns snapshot-only derivations such
+as games, standings, team profiles, season context, and pick ownership.
+
+For a post-domain roster response, this module may retain allowed reference
+fields, must derive lineup/standings state from week-scoped records, and omits
+unreconstructable volatile fields with a warning. The selector chooses eligible
+requests; it does not duplicate this field policy. Projection tests, rather than
+a second verifier implementation, prove which fields are copied, derived, or
+omitted.
+
+It never reads PostgreSQL directly. All inputs are explicit, making it usable in
+unit tests and preventing an accidental query outside the selected request set.
+
+### `FrozenLeagueData`
+
+This is the read-only replacement for the query half of
+`SleeperLeagueData`. It opens a previously verified artifact, validates its
+schema/manifest metadata, holds the SQLite query connection, and exposes the
+curated query methods plus guarded SQL.
+
+It cannot fetch, refresh, save, mutate, or connect to PostgreSQL. The reporter
+uses this concrete runtime directly. Tests open real fixture snapshots, which
+are already fast. A protocol should be introduced only if a second runtime
+actually exists.
+
+## Core Abstractions
+
+### Deterministic endpoint scope
+
+`EndpointKind` is a closed application enum and `ScopeKey` is a validated value
+defined in `scope.py` and constructed by the owning endpoint-family module.
+Examples include:
+
+```text
+league:<competition-season-id>
+users:<competition-season-id>
+rosters:<competition-season-id>
+matchups:<competition-season-id>:8
+transactions:<competition-season-id>:8
+players:nfl
+bracket:<competition-season-id>:winners
+```
+
+Callers never hand-build scope strings. Stable scope keys connect request audit,
+current-head concurrency, refresh results, and snapshot membership.
+
+### Canonical snapshot build key
+
+Snapshot reuse is manager-owned and concurrency safe. After selecting the exact
+request set, the service computes a build key from content-affecting inputs:
+
+- primary competition season;
+- validated `through_week` and `observed_through` boundaries;
+- ordered selected-request-set hash;
+- snapshot projection version.
+
+`DataSnapshotManager.begin_or_get(build_key)` relies on a partial unique
+constraint over active (`building` or `ready`) rows, so concurrent callers
+cannot create duplicate canonical builds. Failed and expired rows remain
+auditable but release the key for a later attempt. The snapshot service uses a
+bounded wait for another active builder and asks the manager to atomically fail
+an abandoned build before retrying. A ready row with a missing or invalid
+artifact is atomically expired before replacement. No lease or heartbeat
+abstraction is needed for v1.
+
+The deployed code revision is recorded for audit but does not invalidate reuse
+unless the snapshot projection version changes.
+
+The SQLite artifact omits snapshot-row UUID and creation time so equivalent
+builds can produce equivalent bytes. Those instance/audit fields remain in
+PostgreSQL.
+
+### Identity mapping port
+
+Normalization cannot invent durable competition, franchise, or season-roster
+IDs. The refresh service receives a narrow identity lookup dependency that can
+resolve a Sleeper league/roster to existing core identities. New-season setup
+and ambiguous franchise mapping remain owned by `services/league`.
+
+If a roster response introduces an unmapped Sleeper roster, the request remains
+audited but normalization for that scope is blocked with a structured mapping
+error. The setup workflow can establish the mapping and retry normalization
+without refetching the raw payload.
+
+### V1 local file storage
+
+V1 uses one concrete `LocalDatalayerFileStore` rooted at a configured local
+directory. It stores content-addressed files such as:
+
+```text
+<data-root>/payloads/sha256/ab/<full-hash>.json
+<data-root>/snapshots/sha256/ab/<full-hash>.sqlite
+```
+
+Writes use a temporary file in the same filesystem, verify byte length and
+SHA-256, and atomically rename into place. PostgreSQL stores the relative key,
+not an environment-specific absolute path. Tests construct the same class with
+a temporary root. Storing content whose verified hash already exists is a
+successful no-op; callers do not handle file-exists races. Opening content
+re-verifies root containment, size, and hash.
+
+This is intentionally not a general object-store framework. The two operations
+the services need—store verified content and open verified content—form a small
+seam that can be extracted into a protocol later if the application moves to
+shared/cloud storage. No external storage service is required for v1.
+
+### Versioned schema and algorithms
+
+V1 has three version concepts:
+
+- ingestion normalizer version on an API request records the logic that produced
+  its current-view outcome;
+- snapshot projection version covers selected-payload normalization,
+  derivations, field cutoff policy, and SQLite schema compatibility;
+- deployed code revision is audit-only.
+
+These are module/build constants, not a version-provider abstraction. Split the
+snapshot projection version only after two parts need independent compatibility.
+
+## Dependency Rules
+
+Allowed:
+
+```text
+api/worker/generation service -> datalayer services
+datalayer services -> resource managers and external protocols
+refresh service -> source adapter and endpoint-family modules
+snapshot service -> selector, endpoint-family modules, materializer, local file store
+FrozenLeagueData -> SQLite query functions only
+resource managers -> centralized ORM models and database infrastructure
+```
+
+Forbidden:
+
+- datalayer services importing `backend.database.models` or opening sessions;
+- source clients writing database rows;
+- normalizers returning ORM objects or executing SQL;
+- provenance duplicated into normalized endpoint records;
+- routes calling the Sleeper client or materializer;
+- current-view managers performing HTTP requests;
+- snapshot materialization reading arbitrary PostgreSQL tables;
+- reporter tools connecting to PostgreSQL or resolving artifact storage keys;
+- query functions depending on refresh or source code;
+- one generic repository exposing unscoped CRUD for Sleeper tables.
+
+## Extension Paths
+
+The architecture uses explicit endpoint-family modules so common
+changes have a short, comprehensible path.
+
+### Add a tool over existing snapshot data
+
+1. Add or extend one curated query function.
+2. Add its reporter tool schema and handler.
+3. Add query-contract tests against a fixture SQLite snapshot.
+
+No ingestion, PostgreSQL, or snapshot-schema change is required.
+
+### Add a derived reporter table
+
+1. Add the SQLite table and row dataclass beside the existing snapshot schema.
+2. Add one pure derivation/materializer step.
+3. Add curated queries/tools that use it.
+4. Bump the SQLite schema/materializer version and add leakage tests.
+
+No PostgreSQL table is required unless the product UI also needs that derived
+view outside a generation.
+
+### Add a Sleeper endpoint or source field
+
+1. Add or extend one endpoint-family module and fixture.
+2. Reuse or add focused normalization calculations with an output that is
+   natural for the new consumers.
+3. Add the PostgreSQL model/migration and manager projection if the current
+   product view needs it.
+4. Add snapshot selection/materialization only if reporter tools need it.
+5. Add refresh, manager, and cutoff tests appropriate to the new data.
+
+### Add a PostgreSQL-only product feature
+
+Add a resource-manager read model and API projection over the normalized current
+tables. It does not need to enter SQLite unless a reporter generation must use
+it reproducibly.
+
+These paths deliberately avoid a generic projection engine, provider plugin
+system, reflection-based mapper, or stack of registries. New features are
+discoverable by following one endpoint-family module into the persistence and
+snapshot projections that consume its records.
+
+## Cross-Cutting Behavior
+
+### Scope and provenance
+
+Every manager is constructed with an explicit `ManagerContext` containing the
+actor, competition scope, and correlation/generation identifiers. Global player
+catalog access requires explicit global scope and a reason. Competition season,
+request, roster, snapshot, and generation IDs remain explicit method arguments
+where they affect semantics.
+
+### Transactions
+
+- Request recording is a short transaction after each HTTP attempt.
+- Applying one normalized scope is one short transaction.
+- Refresh finalization is a short transaction after all attempts settle.
+- Atomic build-key claim, request selection reads, artifact work, and snapshot
+  sealing are separate operations.
+- Sealing a snapshot inserts exact request membership and ready artifact
+  metadata atomically.
+
+### Errors
+
+Only boundary failures escape services:
+
+- scoped resource-not-found/invalid-request errors;
+- `SnapshotUnavailable`, carrying missing-scope context when factual inputs do
+  not exist;
+- one sanitized internal datalayer failure with a correlation ID.
+
+Source failures, invalid payloads, normalization rejection, and identity mapping
+gaps are recorded as refresh request outcomes and contribute to the manager-
+derived refresh status. Local file collisions with matching content are no-ops.
+Artifact/schema verification failures are handled inside the snapshot service,
+which marks the build failed before returning a sanitized boundary failure.
+
+Expected reporter lookup misses remain ordinary query results with
+`found = false`; they are not service exceptions.
+
+### Observability
+
+Refresh audit belongs to the Sleeper resource tables. Generation-time reads are
+also recorded by reporting tool-call instrumentation. Service logs add refresh,
+request, snapshot, competition, season, and generation correlation IDs, but do
+not duplicate full payloads or expose private object keys.

--- a/docs/datalayer/architecture.md
+++ b/docs/datalayer/architecture.md
@@ -227,13 +227,16 @@ than ORM rows.
 Exposes one ordinary operation, `get_or_create(request)`, and owns the complete
 long-running snapshot workflow:
 
-- asks `SleeperDataManager` for eligible request candidates;
-- selects exactly one request for every required scope;
-- computes a canonical build key from the factual inputs;
+- computes the daily canonical build key from the validated factual inputs;
 - asks `DataSnapshotManager.begin_or_get()` to atomically return the existing
-  snapshot or claim the build;
+  snapshot or claim the build before request selection;
+- hash/size-verifies an existing ready artifact and expires it before retrying
+  when verification fails;
 - bounds waiting on an existing build, atomically fails an abandoned build,
   and retries the claim without exposing recovery policy to its caller;
+- reads season-stable planning settings, derives explicit required scopes, asks
+  `SleeperDataManager` for eligible request candidates, and selects exactly one
+  request for every requirement;
 - resolves and hash-verifies raw payloads;
 - runs the same normalizers used by ingestion;
 - projects endpoint records into cutoff-safe snapshot tables;
@@ -246,7 +249,12 @@ Missing required inputs fail the request. A future diagnostic workflow, if
 needed, is a separate command and cannot weaken generation snapshot guarantees.
 
 No database transaction remains open while payload files are read, SQLite is
-built, or the artifact is written to its final local path.
+built, or the artifact is written to its final local path. Claim/reuse and
+ready sealing are separate atomic manager operations around that external work.
+If content-addressed storage succeeds but sealing fails, the unreferenced bytes
+are a benign orphan rather than a reason to span a database transaction across
+the file write. V1 retains benign orphans; reference-aware cleanup is a future,
+separate operator workflow.
 
 ### SQLite Snapshot Materializer
 
@@ -298,15 +306,37 @@ bracket:<competition-season-id>:winners
 Callers never hand-build scope strings. Stable scope keys connect request audit,
 current-head concurrency, refresh results, and snapshot membership.
 
-### Canonical snapshot build key
+### Canonical daily snapshot identity
 
-Snapshot reuse is manager-owned and concurrency safe. After selecting the exact
-request set, the service computes a build key from content-affecting inputs:
+Snapshot reuse is manager-owned and concurrency safe. Before reading candidates
+or selecting exact request membership, the service computes a daily reuse key
+from:
 
 - primary competition season;
-- validated `through_week` and `observed_through` boundaries;
-- ordered selected-request-set hash;
+- validated `through_week`;
+- `as_of_date`;
 - snapshot projection version.
+
+The key intentionally does not contain an exact observation timestamp or an
+aggregate selected-request-set hash. Exact request IDs, roles, scope keys, and
+individual response hashes remain sealed membership for audit and replay, but
+they do not create multiple identities within one daily reuse key. The first
+healthy ready snapshot for a key is reused; observations completed after it
+became ready do not replace it, and callers normally choose another date label
+when they want another identity.
+
+The daily key is an intentionally coarse product identity. Exact request
+membership and artifact SHA-256 audit the concrete build attempt without
+refining that identity. While a ready artifact remains healthy, later
+observations do not replace it. If a failed or expired row releases the key, a
+recovery attempt may select different eligible membership under the same daily
+identity; preserving availability with that coarsening is an explicit v1
+tradeoff.
+
+One versioned module function canonicalizes these four fields; callers never
+construct or supply a raw build key. The date is encoded as ISO `YYYY-MM-DD`,
+UUIDs use canonical lowercase text, and the projection-version string is
+included verbatim after validation.
 
 `DataSnapshotManager.begin_or_get(build_key)` relies on a partial unique
 constraint over active (`building` or `ready`) rows, so concurrent callers
@@ -364,8 +394,9 @@ V1 has three version concepts:
 
 - ingestion normalizer version on an API request records the logic that produced
   its current-view outcome;
-- snapshot projection version covers selected-payload normalization,
-  derivations, field cutoff policy, and SQLite schema compatibility;
+- snapshot projection version covers requirement planning, request-selection
+  policy, selected-payload normalization, derivations, field cutoff policy, and
+  SQLite schema compatibility;
 - deployed code revision is audit-only.
 
 These are module/build constants, not a version-provider abstraction. Split the
@@ -473,8 +504,10 @@ Only boundary failures escape services:
 Source failures, invalid payloads, normalization rejection, and identity mapping
 gaps are recorded as refresh request outcomes and contribute to the manager-
 derived refresh status. Local file collisions with matching content are no-ops.
-Artifact/schema verification failures are handled inside the snapshot service,
-which marks the build failed before returning a sanitized boundary failure.
+Artifact/schema verification failures during construction mark the `building`
+attempt failed before returning a sanitized boundary failure. Missing, corrupt,
+or incompatible bytes discovered while reusing a `ready` snapshot atomically
+expire that ready row before a replay claim.
 
 Expected reporter lookup misses remain ordinary query results with
 `found = false`; they are not service exceptions.

--- a/docs/datalayer/ingestion.md
+++ b/docs/datalayer/ingestion.md
@@ -1,0 +1,324 @@
+# Datalayer Ingestion and Normalization
+
+## Invariants
+
+The ingestion design is governed by these rules:
+
+1. Record the source attempt before attempting to change normalized facts.
+2. A failed or incomplete response never erases the current normalized scope.
+3. A successful complete empty response is authoritative and can erase the
+   prior rows for that scope.
+4. Request start time, with request ID as a tiebreaker, orders competing heads.
+5. Normalization of one endpoint scope and advancement of its head are atomic.
+6. Every normalized current row points to the request that supplied it.
+7. Normalizers are deterministic, side-effect free, and reusable for snapshot
+   replay.
+8. Exact fantasy values enter the application as `Decimal`, never binary float.
+
+## Refresh Sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Service as DatalayerRefreshService
+    participant Data as SleeperDataManager
+    participant Source as SleeperSourceClient
+    participant Endpoint as Endpoint-family module
+    participant DB as PostgreSQL
+
+    Caller->>Service: refresh(RefreshRequest)
+    Service->>Data: start_refresh(...)
+    Data->>DB: insert running refresh
+    Service->>Service: build explicit endpoint plan
+    loop each endpoint request
+        Service->>Source: execute(request)
+        Source-->>Service: SourceAttempt result
+        alt failed source attempt
+            Service->>Data: record_attempt(failure, incomplete finding)
+            Data->>DB: insert failed request
+        else parsed successful response
+            Service->>Endpoint: validate completeness(payload, request)
+            Endpoint-->>Service: CompletenessFinding
+            Service->>Data: record_attempt(response, payload receipt, finding)
+            Data->>DB: insert request and deduplicate payload
+            alt incomplete response
+                Note over Service,Data: retained for audit; current scope is unchanged
+            else complete response
+                Service->>Endpoint: normalize(payload, domain context)
+                alt normalization rejected
+                    Service->>Data: reject_normalization(request ID, reason)
+                else normalized
+                    Endpoint-->>Service: EndpointRecords
+                    Service->>Data: apply_scope(request ID, records)
+                    Data->>DB: compare head, replace scope, advance head
+                end
+            end
+        end
+    end
+    Service->>Data: finish_refresh(refresh ID)
+    Data->>DB: derive and persist counts/status
+    Service-->>Caller: RefreshOutcome
+```
+
+Endpoint requests may execute concurrently with bounded concurrency, but each
+attempt is recorded and each normalized scope commits independently. A partial
+failure does not roll back unrelated successful scopes.
+
+Fetch concurrency does not imply arbitrary apply order. The refresh service
+applies complete records in an explicit dependency order required by the
+relational model:
+
+1. league metadata, league users, and the global player catalog;
+2. rosters, managers, current roster players, and seeded draft-pick coordinates;
+3. weekly matchups/player performances, transactions/moves, traded-pick
+   ownership, and bracket nodes.
+
+An unmet dependency produces a structured normalization rejection for that
+scope; it is never retried by accidentally holding a database transaction open
+across another endpoint. Independent scopes at the same level may still apply
+concurrently when manager transactions remain short.
+
+## Endpoint-Family Ownership
+
+Provider-facing knowledge lives in one explicit module per endpoint family.
+Each module owns request construction, deterministic scope construction,
+response completeness validation, and raw normalization. There is no separate
+endpoint, completeness, or normalizer registry.
+
+Initial endpoint kinds:
+
+| Endpoint kind | Scope | Current target | Snapshot use |
+| --- | --- | --- | --- |
+| `league` | competition season | league state | Required metadata |
+| `league_users` | competition season | users + league users | Required names/managers |
+| `league_rosters` | competition season | rosters/managers/current players | Required roster state and profiles |
+| `nfl_state` | global sport | observation only | Season/week provenance |
+| `player_catalog` | global sport | player catalog | Required player resolution |
+| `matchups` | season + week | matchups + player performances | Required for every included week |
+| `transactions` | season + week | transactions + moves | Required even when empty |
+| `traded_picks` | competition season | draft-pick current view | Required when draft rounds exist |
+| `winners_bracket` | season + bracket kind | playoff bracket | Conditional |
+| `losers_bracket` | season + bracket kind | playoff bracket | Conditional |
+
+Refresh planning owns what to fetch. Snapshot selection owns which scopes a
+snapshot requires. Persistence projection owns where endpoint records are
+stored. They share `EndpointKind` and `ScopeKey` values but do not duplicate
+provider parsing rules. An ordinary explicit dispatch by endpoint kind keeps
+the path discoverable.
+
+## Source Response Capture
+
+The source client returns a discriminated result rather than raising away audit
+information or forcing callers to interpret a mostly-optional response object:
+
+```python
+class SuccessfulSourceAttempt(BaseModel, frozen=True):
+    outcome: Literal["succeeded"] = "succeeded"
+    endpoint: EndpointRequest
+    requested_at: datetime
+    completed_at: datetime
+    http_status: int
+    latency_ms: int
+    payload: JsonValue
+    raw_sha256: str
+    byte_length: int
+    media_type: str
+
+
+class FailedSourceAttempt(BaseModel, frozen=True):
+    outcome: Literal["failed"] = "failed"
+    endpoint: EndpointRequest
+    requested_at: datetime
+    completed_at: datetime
+    status: Literal["http_error", "transport_error", "invalid_payload"]
+    http_status: int | None
+    latency_ms: int
+    error: SanitizedSourceError
+
+
+SourceAttempt = Annotated[
+    SuccessfulSourceAttempt | FailedSourceAttempt,
+    Field(discriminator="outcome"),
+]
+```
+
+Transport exceptions are converted into `transport_error` envelopes. HTTP error
+bodies are sanitized and recorded in the request error shape; they are not
+eligible payloads. Invalid JSON becomes `invalid_payload`. Secrets, headers,
+environment values, and arbitrary exception representations are never stored.
+
+After successful JSON parsing, payload hashing uses the canonical JSON encoding
+defined by the datalayer (UTF-8, stable object-key order, compact separators),
+not a pretty-printed or provider-whitespace-dependent representation. Inline
+JSONB and locally file-stored canonical bytes therefore verify against the same
+hash. The local file store verifies large payload writes before
+`record_attempt()` references them.
+
+The source parser constructs fractional JSON numbers as `Decimal`; binary float
+never precedes fantasy-value normalization. Canonical encoding renders those
+decimals as JSON numbers with insignificant zeros removed. Inline JSONB writes
+use the canonical JSON text at the PostgreSQL boundary, and reads used for
+replay return canonical text for Decimal-first parsing and hash verification.
+
+## Completeness
+
+Completeness answers “is this response authoritative for its requested scope?”
+It is deliberately distinct from success and from non-emptiness.
+
+Examples:
+
+- `[]` for Week 8 transactions is successful and complete;
+- an HTML 200 response is invalid, not a complete empty response;
+- a roster list whose league identity cannot be reconciled is complete source
+  data but blocked from normalization by identity mapping;
+- a truncated or malformed player catalog is retained but incomplete;
+- a bracket request made before Sleeper has created a bracket may be complete
+  and empty when the endpoint contract says so.
+
+Completeness findings are persisted as `is_complete` and a safe reason. The
+request remains available for audit even when it cannot be normalized or
+selected into a snapshot.
+
+For a parsed successful response, the endpoint-family module determines
+completeness before `record_attempt()` so the finding is stored with the source
+observation. A failed source attempt is recorded with a standard incomplete
+finding owned by the refresh service. If a completeness validator itself fails
+unexpectedly, the service still records the attempt as incomplete with a
+sanitized internal validation code, then reports that scope as failed. It never
+guesses that an unvalidated response is authoritative.
+
+## Endpoint Records
+
+Normalization returns endpoint-specific domain records without workflow
+metadata. Request ID, scope key, observation timestamps, hashes, and version
+remain on the recorded `ApiRequest` and selected-request manifest.
+
+Legacy row dataclasses are reused only when they are already a natural record
+for the new consumers. Otherwise, the existing calculation is extracted into a
+new endpoint record rather than surrounded by provenance and sink adapters.
+Pydantic validation is added at new or changed application boundaries where
+PostgreSQL intentionally does not own semantic validation.
+
+Normalizers may use small pure parsing/derivation helpers shared within endpoint
+families. They may not:
+
+- query current PostgreSQL state;
+- open SQLite;
+- construct ORM rows;
+- resolve names through a database connection;
+- drop malformed records without a structured rejection/warning;
+- infer durable core identities from display names.
+
+## Identity Inputs
+
+The service resolves these values before normalizing competition-scoped data:
+
+```python
+class SeasonIdentityMap(BaseModel, frozen=True):
+    competition_id: UUID
+    competition_season_id: UUID
+    sleeper_league_id: str
+    season_year: int
+    roster_by_sleeper_id: Mapping[str, SeasonRosterIdentity]
+```
+
+The map comes from the core identity boundary. It maps provider IDs to stable
+season-roster/franchise IDs but does not expose ORM objects.
+
+The first league/users/rosters observations may be captured during competition
+setup before all roster mappings exist. Those requests remain valid source
+history. `services/league/mapping_service.py` establishes mappings, after which a
+maintenance command can reapply the already captured roster request. The
+datalayer never silently creates a franchise based only on array position or
+manager name.
+
+## Atomic Scope Application
+
+`SleeperDataManager.apply_scope()` follows this transaction:
+
+1. load the recorded request and lock its `normalized_scopes` row;
+2. verify the source request is successful, complete, payload-hash verified,
+   and consistent with the endpoint records;
+3. compare request start time and request ID against the current head;
+4. return `stale_ignored` if the incoming request is older;
+5. return `already_applied` for the same request;
+6. if the response hash matches the head, advance only observation/head
+   provenance and return `identical_head_advanced`;
+7. otherwise replace/upsert exactly that complete scope inside the manager;
+8. update request normalization status/version/time and advance the scope head;
+9. commit once.
+
+An identical newer response does not rewrite current rows. Those rows may retain
+the earlier request ID that supplied identical content, while the head proves a
+newer observation occurred.
+
+### Scope replacement examples
+
+- Matchups and player performances replace one season/week scope.
+- Transactions and moves replace one season/week scope, including deletion to
+  zero rows for an authoritative empty response.
+- League users replace one competition-season users scope, while global user
+  profiles upsert by Sleeper user ID.
+- The player catalog upserts observed players and does not delete players that
+  disappear from a later catalog.
+- Roster managers and current roster players replace one season's roster scope.
+- Bracket nodes replace one season/bracket-kind scope.
+
+The internal projection for each endpoint kind is explicit and tested; there is
+no cross-resource write helper, generic JSON diff, or generic CRUD repository.
+
+`sleeper.users` is global even though user observations arrive through
+competition-season scopes. Its upsert compares the incoming request's
+`(requested_at, request_id)` with the request that supplied the existing global
+row; an older observation from another league cannot roll a newer global user
+profile backward. Any future normalized table written by more than one scope
+must define the same cross-scope ordering invariant rather than relying only on
+the per-scope head.
+
+## Refresh Status
+
+Refresh finalization derives status from recorded request results:
+
+- `succeeded`: every required planned request succeeded and normalized or was
+  safely recognized as an identical/stale observation;
+- `partial`: at least one scope succeeded and at least one required scope
+  failed, was incomplete, or needs identity mapping;
+- `failed`: no required scope completed successfully or a refresh-level
+  invariant prevented useful work;
+- `cancelled`: caller cancellation stopped remaining requests;
+- `running`: non-terminal only.
+
+Optional failures are retained and summarized but do not necessarily make the
+refresh partial. `finish_refresh()` derives counts and status from the child
+request outcomes inside the manager transaction rather than trusting a caller-
+supplied summary.
+
+`RefreshRun.endpoint_scope` stores the ordered plan as scope key, endpoint kind,
+requiredness, and dependency keys. Finalization groups retry attempts by planned
+scope and uses its latest terminal attempt. A required planned scope with no
+attempt is failed unless the run was cancelled, in which case it is counted as
+not attempted and the aggregate remains `cancelled`. Public outcome counts are
+scope counts; raw request-attempt counts remain audit metadata.
+
+## Retries
+
+Each HTTP attempt is an `api_requests` row. A bounded retry therefore creates a
+new request with the same scope key and its own timing, status, error, and
+payload reference. The source client executes exactly one attempt; retry policy
+lives in the refresh executor, which records an outcome before deciding whether
+to try again.
+
+Maintenance reprocessing does not create an API request. It updates
+normalization status for the existing request and may advance the scope head
+only through the same eligibility transaction.
+
+## Current-View Read Models
+
+`SleeperDataManager` returns resource objects designed for product display and
+cross-season application workflows. They may join normalized Sleeper tables to
+core competition/franchise identities, but they do not expose source ORM rows.
+
+These reads clearly describe themselves as current observations. They must not
+accept a historical week and then filter latest rows as if doing so recreated
+historical knowledge. Historically bounded facts always go through a data
+snapshot.

--- a/docs/datalayer/snapshots-and-query-runtime.md
+++ b/docs/datalayer/snapshots-and-query-runtime.md
@@ -12,7 +12,7 @@ consists of:
   SQLite compatibility;
 - a content-addressed, read-only SQLite artifact;
 - completeness/reconstruction warnings;
-- immutable hashes tying those pieces together.
+- immutable per-request response hashes plus the final artifact hash.
 
 PostgreSQL remains the source of truth. The SQLite file is a reproducibility and
 future-data safety artifact. It also preserves the existing reporter query
@@ -21,31 +21,37 @@ PostgreSQL projection.
 
 ## Boundary Semantics
 
-The datalayer accepts factual boundaries, not a mode label:
+The datalayer accepts a week boundary and a daily reuse label, not a mode label:
 
 - `through_week` is the last fantasy week whose week-scoped facts may appear;
-- `observed_through` is the latest time at which an API request could have
-  completed and remained eligible.
+- `as_of_date` groups compatible builds under one caller-chosen calendar date.
 
 Generation policy translates user intent into those values:
 
-| Generation intent | `through_week` | `observed_through` |
+| Generation intent | `through_week` | `as_of_date` |
 | --- | --- | --- |
-| Live/current | Current effective week | Current time |
-| Historical replay | Requested historical week | Historical instant being simulated |
-| Retrospective correction | Requested earlier week | Present or another later correction time |
+| Live/current | Current effective week | Current date |
+| Historical replay | Requested historical week | Generation-selected reuse date |
+| Retrospective correction | Requested earlier week | Present or another later date |
 
-Two generation intents with identical factual boundaries can and should reuse
+Two generation intents with identical week/date inputs can and should reuse
 the same snapshot. Intent remains on the generation rather than creating
 duplicate factual artifacts.
 
-Every snapshot excludes requests completed after `observed_through` and
-endpoint scopes after `through_week`. A Week 9 matchup request cannot
-enter a Week 8 snapshot. A Week 8 roster, user, player, or bracket response
-observed after the observation boundary is also unavailable even if its rows
-appear innocuous.
+`as_of_date` is not a source-request eligibility boundary. After claiming a
+build, the service selects the latest complete requests visible when each
+candidate read executes, including later backfills for an earlier football
+week. `through_week` remains the factual domain cutoff: a Week 9 matchup request
+cannot enter a Week 8 snapshot.
 
-A week alone never implies an observation timestamp.
+The date is deliberately a coarse reuse bucket, not a claim about what the
+system knew by the end of that date. During healthy reuse, the first ready
+snapshot wins and observations completed after it became ready do not replace
+it; callers normally choose another date label when they want another identity.
+Recovery after failure or expiration may reselect within the same daily bucket;
+that coarsening is an explicit tradeoff. Request start time may rank complete
+candidates within one scope, but no request timestamp maps into `as_of_date` or
+affects identity or eligibility.
 
 Selection is endpoint-aware:
 
@@ -58,11 +64,10 @@ Selection is endpoint-aware:
   comes from the selected Week 8 matchup payload, not from a Week 10 rosters
   response.
 
-V1 does not accept an instant-based domain cutoff. The source data needed to
-reconstruct matchups, transactions, lineups, and standings is week-scoped, and
-the datalayer does not yet have trustworthy intra-week rules. An instant
-variant should be added only when the service can own those rules without
-making callers choose projection details.
+V1 does not accept an instant-based domain or observation cutoff. The source
+data needed to reconstruct matchups, transactions, lineups, and standings is
+week-scoped, and the datalayer does not need timestamp-level simulation
+precision. Exact knowledge-time replay is deliberately outside this contract.
 
 ## Build Flow
 
@@ -72,23 +77,35 @@ sequenceDiagram
     participant Service as DatalayerSnapshotService
     participant Snap as DataSnapshotManager
     participant Obs as SleeperDataManager
+    participant Require as Pure requirement planning
     participant Select as Pure request selection
     participant Norm as Endpoint-family modules
     participant Mat as SQLiteMaterializer
     participant Files as LocalDatalayerFileStore
 
     Caller->>Service: get_or_create(SnapshotRequest)
-    Service->>Obs: list_snapshot_candidates(...)
-    Obs-->>Service: candidate metadata
-    Service->>Select: select(spec, required scopes, candidates)
-    Select-->>Service: SelectedRequestManifest
-    Service->>Snap: begin_or_get(canonical build key)
+    Service->>Snap: begin_or_get(daily build key)
     alt ready snapshot exists
-        Snap-->>Service: ReadyDataSnapshot
+        Snap-->>Service: ready metadata
+        Service->>Files: resolve and verify hash/size
+        alt artifact valid
+            Files-->>Service: VerifiedLocalArtifact
+        else artifact missing or invalid
+            Service->>Snap: atomically expire unusable ready row
+            Service->>Snap: retry begin_or_get(...)
+        end
     else another caller is building
         Service->>Snap: wait bounded time for ready/failed state
         Service->>Snap: atomically fail build if stale, then retry claim
     else this caller claimed the build
+        Service->>Obs: get season-stable planning settings
+        Obs-->>Service: SnapshotPlanningContext
+        Service->>Require: plan(spec, season settings)
+        Require-->>Service: SnapshotRequirements
+        Service->>Obs: list candidate metadata for required season/scopes
+        Obs-->>Service: candidate metadata
+        Service->>Select: select(requirements, candidates)
+        Select-->>Service: SelectedRequestManifest
         Service->>Obs: resolve_verified_payloads(ids)
         Obs-->>Service: verified raw payloads
         Service->>Norm: endpoint modules normalize selected payloads
@@ -116,24 +133,42 @@ to failed and the service retries the claim. A non-stale build that does not
 finish within the request's wait budget produces `SnapshotUnavailable`; the
 caller is never asked whether to steal, wait, or retry the build.
 
+The manager operations that claim/reuse identity and seal readiness are atomic;
+the overall build is intentionally not one database transaction. Candidate
+reads, payload verification, normalization, SQLite work, and local-file writes
+happen between those operations. If the content-addressed file write succeeds
+but sealing fails, the file is a harmless unreferenced orphan. V1 retains it
+rather than adding a reference-aware cleanup workflow.
+
 ## Required Request Set
 
-The selector expands a `SnapshotRequest` into explicit required scopes using
-the shared `EndpointKind` and `ScopeKey` vocabulary.
+V1 assumes structural league settings remain stable within one competition
+season. `SleeperDataManager` returns a season-scoped `SnapshotPlanningContext`
+from the current normalized league configuration; a pure planner expands that
+context and the `SnapshotRequest` into explicit `SnapshotRequirements` using
+the shared `EndpointKind` and `ScopeKey` vocabulary. These planning settings
+decide obligations such as draft-pick and bracket scopes but are not represented
+as historical cutoff facts. The selected league response still supplies the
+artifact's league content and provenance.
+
+The selector never infers that a conditional scope was optional merely because
+no request candidate exists. Historical midseason settings changes are
+deliberately unsupported in v1; supporting them later requires versioned
+settings observations and a snapshot-projection-version change.
 
 For the initial single-season artifact:
 
 - one league response;
 - one league-users response;
-- one league-rosters response eligible for the cutoff;
+- one latest complete league-rosters response;
 - one NFL-state response when required for provenance;
 - one player-catalog response;
 - one matchup response for every included week;
 - one transaction response for every included week, including authoritative
   empty lists;
 - the traded-picks response when the league has draft rounds;
-- winners/losers bracket responses only when the bracket is relevant and could
-  have been known by the cutoff.
+- winners/losers bracket responses only when relevant under `through_week` and
+  season-stable settings.
 
 The request manifest assigns each selected request a stable selection role.
 Requiredness comes from the snapshot request and league settings—not from
@@ -155,20 +190,19 @@ Eligibility requires:
 - `is_complete == true`;
 - verified payload ID and matching response hash;
 - exact scope/season agreement;
-- completion at or before `observed_through`;
 - endpoint week at or before `through_week`;
-- bracket timing compatible with `through_week` and `observed_through`;
+- bracket relevance compatible with `through_week` and season settings;
 - global scope only for explicitly global endpoint kinds.
 
-For current-state payloads selected after `through_week` but before
-`observed_through`, eligibility does not mean every field can be copied into
-the artifact. The materializer has an explicit cutoff policy per target table:
+For current-state payloads fetched after `through_week`, eligibility does not
+mean every field can be copied into the artifact. The materializer has an
+explicit cutoff policy per target table:
 
 - weekly membership and starter/bench roles come from matchup payloads;
 - standings and scores are derived only through `through_week`;
 - later roster membership and later record totals are not copied as cutoff
   truth;
-- reference/display fields known by the observation boundary may be retained;
+- reference/display fields may be retained;
 - unreconstructable volatile fields are null/absent and produce a structured
   warning rather than silently leaking later state.
 
@@ -178,18 +212,19 @@ not maintain a second field list. Projection unit tests and its emitted warnings
 are the evidence for field-level safety.
 
 Within a scope, the latest eligible observation is selected by request start
-time, then request ID. Completion time remains the observation gate,
-while start time prevents out-of-order completions from reversing source order.
+time, then request ID. Start time prevents out-of-order completions from
+reversing source order.
 
-The manifest is canonicalized and hashed from ordered entries containing at
-least request ID, scope key, selection role, response hash, and endpoint kind.
-This `selected_request_set_sha256` is not a hash of query results; it identifies
-the exact source membership.
+The manifest contains a deterministic ordered entry for every selected request,
+including request ID, scope key, selection role, response hash, and endpoint
+kind. Those exact entries are sealed for audit/replay and embedded as
+provenance. No aggregate selected-request-set hash is computed or used in
+snapshot identity.
 
 ## Worked Week 8 Cases
 
-A “Week 8 snapshot” is incomplete terminology. The caller must also provide an
-observation boundary.
+A “Week 8 snapshot” is incomplete terminology. The caller must also provide a
+daily reuse label.
 
 ### Week 8 data observed during Week 8
 
@@ -200,50 +235,50 @@ For:
 
 ```text
 through_week = 8
-observed_through = end of Week 8
+as_of_date = caller-chosen Week 8 reuse label
 ```
 
 the selector chooses the latest complete request for every required scope that
-finished by that timestamp. The materializer builds games and standings through
-Week 8, uses Week 8 matchup data for cutoff roster/lineup membership, and omits
-all Week 9+ endpoint scopes.
+is visible when the post-claim candidate read executes. The materializer builds
+games and standings through Week 8, uses Week 8 matchup data for cutoff
+roster/lineup membership, and omits all Week 9+ endpoint scopes.
 
 ### Week 8 endpoint fetched for the first time during Week 10
 
 Suppose the only Week 8 matchup request is a Week 10 call to
 `/league/.../matchups/8`.
 
-- A snapshot observed only through the end of Week 8 cannot use
-  it. The required `matchups:<season>:8` scope is missing, so an ordinary build
-  fails rather than guessing from the PostgreSQL current view.
-- A Week 8 snapshot observed through Week 10 may use
-  it because the response is specifically scoped to the Week 8 domain.
+- A new or recovery Week 8 build may use it because the response is explicitly
+  scoped to the Week 8 domain; `as_of_date` does not pretend the request was
+  observed earlier.
+- A healthy ready snapshot with the same daily key is still reused rather than
+  silently upgraded with the backfill.
 - A request to `/matchups/10` can never substitute for `/matchups/8`, regardless
-  of generation intent or observation boundary.
+  of generation intent or calendar label.
 
 ### Only current-state roster data was captured during Week 10
 
-A Week 10 `/rosters` response is unavailable to a snapshot observed only through
-Week 8. If the observation boundary is Week 10, the request may
-provide identities and display/reference metadata that AIdam knew by then, but
-the snapshot must not copy Week 10 membership or record totals as Week 8 truth.
+A Week 10 `/rosters` response may provide current identities and
+display/reference metadata to a Week 8 rebuild, but the snapshot must not copy
+Week 10 membership or record totals as Week 8 truth.
 Week 8 lineup membership comes from `matchups:8`; standings are derived through
 Week 8.
 
 If no eligible request supplies a required identity/reference scope, the
 snapshot fails. There is no ordinary incomplete-build flag.
 
-This is why raw request history is essential: the latest PostgreSQL normalized
-row alone cannot answer when AIdam observed a value or whether it was safe for a
-particular cutoff.
+This is why raw request history is still useful: the build seals exact replay
+provenance and can choose corrected week-scoped responses without treating the
+latest PostgreSQL normalized row as historical truth.
 
 ## Snapshot Reuse
 
-`get_or_create()` computes one canonical build key from:
+Before request selection, `get_or_create()` computes one canonical build key
+from:
 
 - primary competition season;
-- validated `through_week` and `observed_through`;
-- exact selected request-set hash;
+- validated `through_week`;
+- `as_of_date`;
 - snapshot projection version.
 
 The database partially constrains that build key across active `building` and
@@ -254,7 +289,17 @@ the service retries the claim. Code revision is stored for audit but is not part
 of the key; code changes that affect output must bump the snapshot projection
 version.
 
-Artifact SHA-256 verifies bytes but is not the semantic build identity. The
+The key deliberately omits exact request membership. While a ready artifact is
+healthy, later observations do not replace it; callers normally choose another
+date label to request another identity. Failed or expired recovery may reselect
+newer eligible membership under the same intentionally coarse daily identity.
+Exact membership and individual response hashes remain immutable audit/replay
+data on each ready row.
+Changes to requirement planning or request-selection policy must bump the
+snapshot projection version just like normalization, derivation, cutoff-policy,
+or SQLite-schema changes.
+
+Artifact SHA-256 verifies bytes but does not define the daily reuse identity. The
 active-key constraint prevents concurrent duplicate rows/work instead of
 declaring them harmless.
 
@@ -312,15 +357,15 @@ The file contains exactly one `snapshot_metadata` row with:
 
 - canonical build key, competition ID, and primary season ID;
 - Sleeper league ID and season year;
-- `through_week` and `observed_through`;
-- selected-request-set hash;
+- `through_week` and `as_of_date`;
+- ordered selected-request provenance with individual response hashes;
 - snapshot projection version;
 - structured completeness warning JSON.
 
 Snapshot-row UUID, creation time, and deployed code revision remain in
 PostgreSQL and are deliberately omitted from the file. This lets equivalent
 builds produce equivalent bytes while allowing the runtime to reject a valid
-SQLite file with the wrong semantic build key.
+SQLite file with the wrong expected build key.
 
 ## Deterministic Materialization
 
@@ -336,6 +381,11 @@ The materializer:
 
 It accepts no PostgreSQL manager or connection. Determinism excludes volatile
 instance values such as snapshot UUID and creation time from the file.
+The materializer's temporary-file hash and size prove its output; the local file
+store independently verifies and moves those bytes, and its stored receipt is
+the authoritative artifact metadata passed to `seal_ready()`. The manager owns
+database membership/sealing, while the materializer only embeds the selector's
+manifest as SQLite provenance.
 
 ### Snapshot-only derivations
 
@@ -345,8 +395,7 @@ The following legacy logic is retained and extracted into pure functions:
   two members;
 - compute standings through `through_week`;
 - interpret league-average-match record strings;
-- derive current-as-of-cutoff team/manager profiles from selected users and
-  rosters;
+- derive cutoff-safe team/manager profiles from selected users and rosters;
 - seed draft-pick coordinates and apply selected traded-pick ownership;
 - derive starter/bench roster snapshots from weekly matchup payloads;
 - record `effective_week` from the snapshot request rather than the machine's
@@ -363,7 +412,6 @@ A snapshot is not ready until automated checks prove:
 - no matchup, transaction, performance, game, standing, or bracket row exceeds
   `through_week`;
 - every source-backed row traces to a selected request scope;
-- no request completed after the snapshot's observation boundary;
 - the artifact contains only the primary competition season plus declared
   global resources;
 - roster/franchise mappings belong to the same competition;
@@ -392,11 +440,12 @@ with shared storage without changing snapshot identity or query runtime.
 
 ## `FrozenLeagueData`
 
-`FrozenLeagueData.open()`:
+`FrozenLeagueData.open(ready_snapshot)`:
 
 - uses SQLite read-only immutable mode;
 - validates snapshot projection version against supported versions;
-- compares the internal build key with `VerifiedLocalArtifact`;
+- compares the internal build key and projection version with the expected
+  values on `ReadyDataSnapshot`;
 - opens one query connection for the context lifetime;
 - exposes only curated methods and guarded SQL;
 - closes deterministically at context exit.
@@ -445,10 +494,12 @@ statements, oversized results, and attempts to inspect attached databases.
 
 ## Retention
 
-Ready snapshot membership and meaning are immutable. An artifact remains
-available while referenced by a generation. Retention may mark an unreferenced
-snapshot expired and remove its artifact bytes, but request membership, hashes,
-versions, and the visible loss of artifact availability remain auditable. The
-expired row no longer participates in active build-key uniqueness, so a later
-`get_or_create()` can produce a replacement artifact with the same semantic
-key.
+Ready snapshot membership and meaning are immutable. V1 performs no proactive
+snapshot or orphan deletion: healthy ready artifacts and benign unreferenced
+content-addressed files are retained. If a ready artifact is missing or corrupt,
+the service marks its snapshot expired while preserving request membership,
+hashes, versions, and the visible loss of availability for audit. The expired
+row no longer participates in active build-key uniqueness, so a later
+`get_or_create()` can reselect and produce a replacement artifact with the same
+coarse daily key. Reference-aware retention can be added later as a separate
+operator workflow.

--- a/docs/datalayer/snapshots-and-query-runtime.md
+++ b/docs/datalayer/snapshots-and-query-runtime.md
@@ -1,0 +1,454 @@
+# Frozen Snapshots and Reporter Query Runtime
+
+## Purpose
+
+A data snapshot is the exact factual world available to one or more compatible
+generations. It is not merely a SQL filter over the latest PostgreSQL tables. It
+consists of:
+
+- an explicit cutoff contract;
+- one selected complete API request per required endpoint scope;
+- one snapshot projection version covering normalization, derivation, and
+  SQLite compatibility;
+- a content-addressed, read-only SQLite artifact;
+- completeness/reconstruction warnings;
+- immutable hashes tying those pieces together.
+
+PostgreSQL remains the source of truth. The SQLite file is a reproducibility and
+future-data safety artifact. It also preserves the existing reporter query
+schema without requiring every legacy derived table to become a persistent
+PostgreSQL projection.
+
+## Boundary Semantics
+
+The datalayer accepts factual boundaries, not a mode label:
+
+- `through_week` is the last fantasy week whose week-scoped facts may appear;
+- `observed_through` is the latest time at which an API request could have
+  completed and remained eligible.
+
+Generation policy translates user intent into those values:
+
+| Generation intent | `through_week` | `observed_through` |
+| --- | --- | --- |
+| Live/current | Current effective week | Current time |
+| Historical replay | Requested historical week | Historical instant being simulated |
+| Retrospective correction | Requested earlier week | Present or another later correction time |
+
+Two generation intents with identical factual boundaries can and should reuse
+the same snapshot. Intent remains on the generation rather than creating
+duplicate factual artifacts.
+
+Every snapshot excludes requests completed after `observed_through` and
+endpoint scopes after `through_week`. A Week 9 matchup request cannot
+enter a Week 8 snapshot. A Week 8 roster, user, player, or bracket response
+observed after the observation boundary is also unavailable even if its rows
+appear innocuous.
+
+A week alone never implies an observation timestamp.
+
+Selection is endpoint-aware:
+
+- week-scoped endpoints such as `matchups:8` and `transactions:8` describe a
+  bounded domain week;
+- current-state endpoints such as rosters, users, players, and league metadata
+  describe what Sleeper returned when AIdam made that request;
+- the materializer derives or suppresses current-state fields that would claim
+  state after `through_week`. For example, Week 8 lineup membership
+  comes from the selected Week 8 matchup payload, not from a Week 10 rosters
+  response.
+
+V1 does not accept an instant-based domain cutoff. The source data needed to
+reconstruct matchups, transactions, lineups, and standings is week-scoped, and
+the datalayer does not yet have trustworthy intra-week rules. An instant
+variant should be added only when the service can own those rules without
+making callers choose projection details.
+
+## Build Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Service as DatalayerSnapshotService
+    participant Snap as DataSnapshotManager
+    participant Obs as SleeperDataManager
+    participant Select as Pure request selection
+    participant Norm as Endpoint-family modules
+    participant Mat as SQLiteMaterializer
+    participant Files as LocalDatalayerFileStore
+
+    Caller->>Service: get_or_create(SnapshotRequest)
+    Service->>Obs: list_snapshot_candidates(...)
+    Obs-->>Service: candidate metadata
+    Service->>Select: select(spec, required scopes, candidates)
+    Select-->>Service: SelectedRequestManifest
+    Service->>Snap: begin_or_get(canonical build key)
+    alt ready snapshot exists
+        Snap-->>Service: ReadyDataSnapshot
+    else another caller is building
+        Service->>Snap: wait bounded time for ready/failed state
+        Service->>Snap: atomically fail build if stale, then retry claim
+    else this caller claimed the build
+        Service->>Obs: resolve_verified_payloads(ids)
+        Obs-->>Service: verified raw payloads
+        Service->>Norm: endpoint modules normalize selected payloads
+        Service->>Mat: materialize(temp path, endpoint records, identities, manifest)
+        Mat-->>Service: verified local artifact metadata
+        Service->>Files: put_verified(...)
+        Files-->>Service: relative key and verified receipt
+        Service->>Snap: seal_ready(requests, hashes, receipt, warnings)
+        Snap-->>Service: ReadyDataSnapshot
+    end
+    Service-->>Caller: ReadyDataSnapshot
+```
+
+If any step after claiming a build fails, the service marks the
+snapshot failed with a sanitized category/summary. A failed build is never
+reused. Temporary SQLite files are created in a task-specific temporary
+directory and atomically moved into the configured local snapshot directory
+after verification.
+
+`begin_or_get()` is backed by a partial unique constraint for active `building`
+and `ready` rows. If another local caller owns the same build, the service waits
+for a bounded interval rather than starting duplicate work. When the row is
+older than the service-owned stale threshold, the manager atomically changes it
+to failed and the service retries the claim. A non-stale build that does not
+finish within the request's wait budget produces `SnapshotUnavailable`; the
+caller is never asked whether to steal, wait, or retry the build.
+
+## Required Request Set
+
+The selector expands a `SnapshotRequest` into explicit required scopes using
+the shared `EndpointKind` and `ScopeKey` vocabulary.
+
+For the initial single-season artifact:
+
+- one league response;
+- one league-users response;
+- one league-rosters response eligible for the cutoff;
+- one NFL-state response when required for provenance;
+- one player-catalog response;
+- one matchup response for every included week;
+- one transaction response for every included week, including authoritative
+  empty lists;
+- the traded-picks response when the league has draft rounds;
+- winners/losers bracket responses only when the bracket is relevant and could
+  have been known by the cutoff.
+
+The request manifest assigns each selected request a stable selection role.
+Requiredness comes from the snapshot request and league settings—not from
+whichever scopes happen to exist.
+
+If required scopes are missing, ordinary builds fail with
+`SnapshotUnavailable` listing safe scope metadata. Missing required input is not
+a configurable warning. Completeness warnings are reserved for known
+reconstruction limits in otherwise valid snapshots.
+
+## Request Selection
+
+The selector is a pure function over candidate metadata. It never loads payload
+bodies or queries current normalized tables.
+
+Eligibility requires:
+
+- request `status == succeeded`;
+- `is_complete == true`;
+- verified payload ID and matching response hash;
+- exact scope/season agreement;
+- completion at or before `observed_through`;
+- endpoint week at or before `through_week`;
+- bracket timing compatible with `through_week` and `observed_through`;
+- global scope only for explicitly global endpoint kinds.
+
+For current-state payloads selected after `through_week` but before
+`observed_through`, eligibility does not mean every field can be copied into
+the artifact. The materializer has an explicit cutoff policy per target table:
+
+- weekly membership and starter/bench roles come from matchup payloads;
+- standings and scores are derived only through `through_week`;
+- later roster membership and later record totals are not copied as cutoff
+  truth;
+- reference/display fields known by the observation boundary may be retained;
+- unreconstructable volatile fields are null/absent and produce a structured
+  warning rather than silently leaking later state.
+
+This copy/derive/omit classification is defined only in the endpoint's snapshot
+projection. Selection does not know field policy, and generic leakage checks do
+not maintain a second field list. Projection unit tests and its emitted warnings
+are the evidence for field-level safety.
+
+Within a scope, the latest eligible observation is selected by request start
+time, then request ID. Completion time remains the observation gate,
+while start time prevents out-of-order completions from reversing source order.
+
+The manifest is canonicalized and hashed from ordered entries containing at
+least request ID, scope key, selection role, response hash, and endpoint kind.
+This `selected_request_set_sha256` is not a hash of query results; it identifies
+the exact source membership.
+
+## Worked Week 8 Cases
+
+A “Week 8 snapshot” is incomplete terminology. The caller must also provide an
+observation boundary.
+
+### Week 8 data observed during Week 8
+
+Assume AIdam captured league/users/rosters/player data and the Week 1–8 matchup
+and transaction endpoints by Sunday night of Week 8.
+
+For:
+
+```text
+through_week = 8
+observed_through = end of Week 8
+```
+
+the selector chooses the latest complete request for every required scope that
+finished by that timestamp. The materializer builds games and standings through
+Week 8, uses Week 8 matchup data for cutoff roster/lineup membership, and omits
+all Week 9+ endpoint scopes.
+
+### Week 8 endpoint fetched for the first time during Week 10
+
+Suppose the only Week 8 matchup request is a Week 10 call to
+`/league/.../matchups/8`.
+
+- A snapshot observed only through the end of Week 8 cannot use
+  it. The required `matchups:<season>:8` scope is missing, so an ordinary build
+  fails rather than guessing from the PostgreSQL current view.
+- A Week 8 snapshot observed through Week 10 may use
+  it because the response is specifically scoped to the Week 8 domain.
+- A request to `/matchups/10` can never substitute for `/matchups/8`, regardless
+  of generation intent or observation boundary.
+
+### Only current-state roster data was captured during Week 10
+
+A Week 10 `/rosters` response is unavailable to a snapshot observed only through
+Week 8. If the observation boundary is Week 10, the request may
+provide identities and display/reference metadata that AIdam knew by then, but
+the snapshot must not copy Week 10 membership or record totals as Week 8 truth.
+Week 8 lineup membership comes from `matchups:8`; standings are derived through
+Week 8.
+
+If no eligible request supplies a required identity/reference scope, the
+snapshot fails. There is no ordinary incomplete-build flag.
+
+This is why raw request history is essential: the latest PostgreSQL normalized
+row alone cannot answer when AIdam observed a value or whether it was safe for a
+particular cutoff.
+
+## Snapshot Reuse
+
+`get_or_create()` computes one canonical build key from:
+
+- primary competition season;
+- validated `through_week` and `observed_through`;
+- exact selected request-set hash;
+- snapshot projection version.
+
+The database partially constrains that build key across active `building` and
+`ready` rows. Failed and expired attempts remain auditable while allowing a
+replacement build. A ready snapshot is reusable only while its artifact remains
+available and hash-verifiable; otherwise the manager atomically expires it and
+the service retries the claim. Code revision is stored for audit but is not part
+of the key; code changes that affect output must bump the snapshot projection
+version.
+
+Artifact SHA-256 verifies bytes but is not the semantic build identity. The
+active-key constraint prevents concurrent duplicate rows/work instead of
+declaring them harmless.
+
+## Payload Replay
+
+The service resolves only payloads listed in the selected manifest. Each payload
+is verified against its recorded SHA-256 and byte length before parsing. Inline
+JSON and locally file-stored payloads become the same `VerifiedPayload`
+abstraction.
+
+Snapshot replay uses the endpoint normalization and projection logic pinned by
+the snapshot projection version; it does not reuse the version that happened to
+populate the PostgreSQL current view. This
+lets old raw payloads benefit from a corrected normalizer without pretending to
+reproduce a prior buggy interpretation. Exact code/version inputs in the
+generation manifest make that distinction auditable.
+
+## SQLite Schema
+
+The artifact intentionally retains legacy reporter table names and provider IDs
+so existing curated SQL can be moved with minimal change:
+
+- `leagues`;
+- `season_context`;
+- `users`;
+- `rosters`;
+- `roster_players`;
+- `team_profiles`;
+- `draft_picks`;
+- `players`;
+- `matchups`;
+- `player_performances`;
+- `games`;
+- `standings`;
+- `transactions`;
+- `transaction_moves`;
+- `playoff_matchups`;
+- `snapshot_metadata` (new).
+
+Internal UUID columns may be added alongside the existing `league_id`,
+`roster_id`, and `player_id` columns:
+
+- `competition_id`;
+- `competition_season_id`;
+- `franchise_id`;
+- `season_roster_id`.
+
+The initial curated queries continue to scope to one Sleeper league/season.
+Internal IDs support unambiguous tool results and future queries without
+silently combining multiple seasons now.
+
+### Snapshot metadata table
+
+The file contains exactly one `snapshot_metadata` row with:
+
+- canonical build key, competition ID, and primary season ID;
+- Sleeper league ID and season year;
+- `through_week` and `observed_through`;
+- selected-request-set hash;
+- snapshot projection version;
+- structured completeness warning JSON.
+
+Snapshot-row UUID, creation time, and deployed code revision remain in
+PostgreSQL and are deliberately omitted from the file. This lets equivalent
+builds produce equivalent bytes while allowing the runtime to reject a valid
+SQLite file with the wrong semantic build key.
+
+## Deterministic Materialization
+
+The materializer:
+
+1. creates a new file using the declared snapshot projection version;
+2. inserts endpoint records in stable key order;
+3. derives snapshot-only facts from explicit selected endpoint records;
+4. inserts snapshot metadata;
+5. runs integrity and leakage checks;
+6. closes the connection and computes file hash/size;
+7. reopens read-only for verification before returning.
+
+It accepts no PostgreSQL manager or connection. Determinism excludes volatile
+instance values such as snapshot UUID and creation time from the file.
+
+### Snapshot-only derivations
+
+The following legacy logic is retained and extracted into pure functions:
+
+- pair matchup rows into `games` without assuming malformed groups have exactly
+  two members;
+- compute standings through `through_week`;
+- interpret league-average-match record strings;
+- derive current-as-of-cutoff team/manager profiles from selected users and
+  rosters;
+- seed draft-pick coordinates and apply selected traded-pick ownership;
+- derive starter/bench roster snapshots from weekly matchup payloads;
+- record `effective_week` from the snapshot request rather than the machine's
+  current Sleeper state.
+
+Weekly matchup payloads support historically faithful starter/bench membership.
+They do not establish exact taxi/IR or intra-week ownership. Such limitations
+are explicit reconstruction warnings rather than invented precision.
+
+## Leakage Verification
+
+A snapshot is not ready until automated checks prove:
+
+- no matchup, transaction, performance, game, standing, or bracket row exceeds
+  `through_week`;
+- every source-backed row traces to a selected request scope;
+- no request completed after the snapshot's observation boundary;
+- the artifact contains only the primary competition season plus declared
+  global resources;
+- roster/franchise mappings belong to the same competition;
+- required tables and the one metadata row exist;
+- `PRAGMA integrity_check` succeeds before the file is sealed;
+- the final content hash matches the atomically stored local-file receipt.
+
+These are build-time checks. They complement, rather than replace, the
+PostgreSQL constraints on ready snapshot metadata and membership.
+
+## Artifact Resolution Inside the Snapshot Service
+
+The reporter does not receive a database storage key. Before
+`get_or_create()` returns, the snapshot service:
+
+1. loads the ready snapshot resource in the generation's competition scope;
+2. resolves the artifact's relative key under the configured local data root;
+3. verifies byte length and SHA-256;
+4. makes the verified immutable file available for the duration of the run;
+5. returns `ReadyDataSnapshot` with a `VerifiedLocalArtifact`.
+
+In v1 the content-addressed file is already local, so resolution does not copy or
+download it. If API and worker processes are separated, they must share the
+configured data directory. A future hosted deployment can replace this seam
+with shared storage without changing snapshot identity or query runtime.
+
+## `FrozenLeagueData`
+
+`FrozenLeagueData.open()`:
+
+- uses SQLite read-only immutable mode;
+- validates snapshot projection version against supported versions;
+- compares the internal build key with `VerifiedLocalArtifact`;
+- opens one query connection for the context lifetime;
+- exposes only curated methods and guarded SQL;
+- closes deterministically at context exit.
+
+It has no `load()`, `save_to_file()`, source client, or week override. The
+effective week and all identity come from sealed metadata.
+
+The existing `get_roster_current()` name should become
+`get_roster_at_cutoff()` because “current” inside this runtime always means the
+snapshot boundary, not current PostgreSQL state.
+
+## Curated Query Compatibility
+
+The current query modules are moved under `services/datalayer/query/curated/`
+with focused changes:
+
+- preserve familiar result shapes and `found` semantics;
+- use snapshot metadata rather than facade configuration for league/week;
+- include stable competition/franchise IDs where helpful and non-breaking;
+- normalize `Decimal` values at the JSON/tool boundary;
+- make every SQL statement explicitly single-season scoped;
+- add query-contract tests against legacy fixture expectations.
+
+Tool schemas and descriptions belong to the reporter. This prevents factual
+query code from depending on the agent framework while still preserving the
+tool behavior.
+
+## Guarded SQL
+
+The SQL escape hatch remains because it is a core reporter strength, but the
+runtime boundary is hardened:
+
+- connection is SQLite read-only/immutable;
+- only one SQL statement is accepted;
+- statement must be a read query (`SELECT` or approved `WITH ... SELECT`);
+- attach/detach, pragma, DDL, DML, extension loading, and filesystem features are
+  rejected;
+- row limit and execution deadline are enforced by the runtime, not trusted to
+  prompt instructions;
+- returned rows are JSON-safe and the full tool result is recorded by reporting
+  instrumentation.
+
+The legacy keyword check is a useful starting point but is not by itself the
+complete platform guard. Tests include comments, quoted strings, CTEs, multiple
+statements, oversized results, and attempts to inspect attached databases.
+
+## Retention
+
+Ready snapshot membership and meaning are immutable. An artifact remains
+available while referenced by a generation. Retention may mark an unreferenced
+snapshot expired and remove its artifact bytes, but request membership, hashes,
+versions, and the visible loss of artifact availability remain auditable. The
+expired row no longer participates in active build-key uniqueness, so a later
+`get_or_create()` can produce a replacement artifact with the same semantic
+key.

--- a/docs/datalayer/transition.md
+++ b/docs/datalayer/transition.md
@@ -1,0 +1,324 @@
+# Legacy Datalayer Transition Plan
+
+## Policy
+
+This is behavioral reuse inside a clean architecture, not storage or API
+compatibility work. Existing in-memory SQLite data, exports, cache files, CLI
+commands, and persisted identifiers can be discarded and regenerated. No dual
+reads, dual writes, import migrations, or wrapper maintained solely for the old
+application should be introduced.
+
+The implementation should preserve proven factual behavior through extracted
+code and golden tests while replacing lifecycle and persistence assumptions.
+
+## Behavior-First Reuse Rule
+
+The default is to preserve proven behavior, not necessarily the old file, type,
+or function boundary. For each legacy area, choose the implementation with the
+fewest concepts in the final architecture:
+
+1. move the code unchanged when its inputs, outputs, and ownership still fit;
+2. extract a pure calculation when the surrounding SQLite DTO/lifecycle does
+   not fit;
+3. rewrite behind golden tests when keeping the old shape would require wrappers
+   or adapters on both sides.
+
+In particular:
+
+- reuse endpoint paths, fixtures, fantasy calculations, derivations, and curated
+  SQL aggressively;
+- do not mandate legacy row dataclasses as the new canonical representation;
+- do not add a provenance wrapper plus PostgreSQL adapter plus SQLite adapter
+  merely to avoid changing one old DTO;
+- establish golden output parity before and after every moved or rewritten
+  module;
+- require a concrete simplification or new correctness need for a rewrite, but
+  count removal of adapter layers as a valid simplification.
+
+This is still a clean replacement of storage/lifecycle APIs. Behavioral reuse
+must make the final system smaller or safer, not preserve historical structure
+for its own sake.
+
+## Reuse Map
+
+| Legacy area | Reuse | Target/change |
+| --- | --- | --- |
+| `datalayer/sleeper_data/sleeper_api/endpoints.py` | High | Keep endpoint paths and payload expectations inside explicit endpoint-family modules and validated scope-key builders |
+| `sleeper_api/client.py` | Low | Keep error lessons and timeout defaults; replace filesystem cache and payload-only return with an auditable response envelope and injectable transport |
+| `normalize/*.py` parsing and football calculations | High | Preserve pure logic and outputs through golden tests; extract it from SQLite-coupled functions when that produces a simpler shared record |
+| `normalize/*.py` row dataclasses | Case by case | Keep a row type only when it naturally feeds the new consumer; replace it when preserving it would require two sink adapters or retain float/SQLite-specific semantics |
+| Game, standings, profile, pick derivations | High | Move to snapshot derivations; add cutoff/reconstruction tests |
+| `schema/` SQLite tables | High for snapshots | Version as the frozen reporter schema, add `snapshot_metadata` and optional internal identity columns; do not use as PostgreSQL models |
+| `store/sqlite_store.py` | Medium | Reuse deterministic table creation/bulk insert ideas inside the materializer; add verification and read-only artifact lifecycle |
+| `load.py` | Low as code, high as behavioral checklist | Split into refresh planning/execution, normalization commit, request selection, and snapshot materialization |
+| `queries/*.py` | Very high | Move into the frozen query runtime, preserve contracts, add explicit snapshot identity/single-season scoping |
+| `queries/_resolvers.py` | High | Preserve name/ID ambiguity behavior; optionally surface stable franchise/season-roster IDs |
+| `queries/sql_tool.py` | Medium | Preserve result shape and auto-limit intent; strengthen statement parsing, readonly mode, deadlines, and JSON conversion |
+| `SleeperLeagueData.from_file()` | High conceptually | Becomes `FrozenLeagueData.open()` with verified metadata and context-managed lifecycle |
+| `SleeperLeagueData.load()` / `save_to_file()` | None as public API | Replaced by refresh and snapshot services |
+| `datalayer/tools.py` | High contract reuse | Tool schemas/handlers move under reporter and call `FrozenLeagueData` |
+| `sleeperdl` CLI | Selective | Rebuild only useful operator diagnostics on service APIs; do not preserve ephemeral load semantics |
+| JSON fixture corpus | Very high | Becomes normalization, ingestion, snapshot, cutoff, and query-contract fixtures |
+
+## Important Refactors
+
+### 1. Split the legacy facade
+
+The old facade owns four concerns: source configuration, load orchestration,
+SQLite lifecycle, and curated queries. The new design has no direct replacement
+class with all four responsibilities.
+
+```text
+SleeperLeagueData.load()       -> DatalayerRefreshService + DatalayerSnapshotService
+SleeperLeagueData.from_file()  -> FrozenLeagueData.open()
+SleeperLeagueData query calls  -> FrozenLeagueData / curated query modules
+SleeperLeagueData.save_to_file -> LocalDatalayerFileStore owned by snapshot service
+```
+
+This split should land early so later code cannot continue depending on the
+ephemeral-load lifecycle.
+
+### 2. Normalize once without mandating the old DTO
+
+Today many normalizers return dataclasses coupled to SQLite table vocabulary.
+The target keeps a normalizer unchanged only when its result is already a
+natural endpoint record for both current persistence and snapshot projection.
+Otherwise, preserve its parsing/calculation logic and return a simpler new
+endpoint record.
+
+```text
+raw Sleeper payload
+  -> endpoint-family validation/normalization
+  -> EndpointRecords
+      -> SleeperDataManager current-view projection
+      -> SQLite cutoff projection
+```
+
+Request provenance remains on `ApiRequest` and the selected-request manifest;
+it is passed beside endpoint records instead of copied into a bundle hierarchy.
+Snapshot-only derivations remain in the snapshot projection.
+
+### 3. Separate observations from facts
+
+The legacy cache can make a request disappear from runtime behavior. The new
+client always performs the planned call, and `SleeperDataManager` records
+the attempt. Payload hashes deduplicate bytes without deduplicating observations.
+
+### 4. Make historical reconstruction physical
+
+The legacy `week_override` prevents some obvious future loads but still begins
+from current responses. It becomes a required `through_week` plus an
+`observed_through` boundary, selected raw requests, and cutoff-safe projection.
+
+## Implementation Slices
+
+Each slice should be independently testable and leave the reporter behavior
+working through fixtures before production wiring advances.
+
+### Slice 1: Contracts and fixture characterization
+
+- Add datalayer workflow value objects, endpoint kinds, scope-key builders, and
+  typed errors.
+- Convert current query outputs into golden contract tests using existing
+  Sleeper fixtures.
+- Add characterization tests for every legacy normalizer and derivation before
+  moving code.
+- Define ingestion-normalizer and snapshot-projection version constants.
+- Align snapshot persistence with the factual service contract: active build
+  key, one projection version, failure metadata, request-response hashes, and
+  terminal expiration.
+
+**Exit:** fixture payloads have explicit expected endpoint records and query
+results; migration `0007` upgrades/downgrades and its concurrency/immutability
+constraints are proven before manager code depends on them.
+
+### Slice 2: Deep persistence aggregates
+
+- Implement `SleeperDataManager` against the completed PostgreSQL models.
+- Implement content-addressed payload receipts and request recording.
+- Implement scope-head compare-and-swap and atomic apply behavior.
+- Make refresh finalization derive counts/status from child requests.
+
+**Exit:** manager tests prove competition scope, empty replacement, stale
+request rejection, identical-head advancement, payload deduplication, and short
+transactions.
+
+### Slice 3: Source adapter and refresh service
+
+- Replace the legacy client with the typed response envelope and injectable
+  transport.
+- Implement the standard refresh plan in the service and provider behavior in
+  endpoint-family modules.
+- Reuse or extract legacy normalization calculations per endpoint based on the
+  simplest resulting representation.
+- Wire the one refresh workflow.
+- Add manual refresh/status HTTP routes.
+
+**Exit:** fixture-backed source responses populate the latest PostgreSQL view;
+partial refreshes remain auditable and do not erase good heads.
+
+### Slice 4: Snapshot selection and atomic identity
+
+- Implement `DataSnapshotManager` against the snapshot contract completed in
+  Slice 1.
+- Implement request candidate reads and pure selection from `through_week` and
+  `observed_through`.
+- Implement concrete `LocalDatalayerFileStore`, payload verification, and canonical
+  request-set hashing.
+- Implement `begin_or_get(build_key)` and snapshot lifecycle methods.
+- Add bounded waiting plus atomic stale-build failure and unusable-artifact
+  expiration; failed/expired history must not block a replacement claim.
+- Make missing required scopes fail without a configurable incomplete mode.
+
+**Exit:** a snapshot build can deterministically select and persist exact source
+membership without yet generating SQLite.
+
+### Slice 5: SQLite materializer
+
+- Move/version the legacy schema as a snapshot-only schema.
+- Add deterministic `snapshot_metadata` without snapshot UUID or creation time.
+- Project endpoint records into rows.
+- Extract games, standings, profiles, pick ownership, and season-context
+  derivations.
+- Centralize late current-state field policy in the projection and add integrity,
+  provenance, cutoff, and artifact hash verification.
+
+**Exit:** selected fixture request sets produce deterministic, verified SQLite
+artifacts with no future rows.
+
+### Slice 6: Frozen query runtime and reporter integration
+
+- Move curated queries and resolvers behind concrete `FrozenLeagueData`.
+- Implement `FrozenLeagueData` context-managed read-only runtime.
+- Harden guarded SQL.
+- Move tool definitions/handlers into reporter and call the runtime directly.
+- Rename snapshot-relative “current roster” behavior to “roster at cutoff.”
+- Update generation service to call `get_or_create()`, pin the snapshot ID in
+  the manifest, and run the reporter.
+
+**Exit:** reporter contract tests pass against the new frozen artifact without
+any source or PostgreSQL access during the agent loop.
+
+### Slice 7: Current-data and audit API
+
+- Add product read projections for overview, roster, matchup, transaction,
+  refresh, request, and snapshot audit views.
+- Add pagination and safe error translation.
+- Add polling support for refresh/snapshot status where builds run in a worker.
+
+**Exit:** the frontend can inspect current data and provenance without using the
+reporter SQLite or raw SQL.
+
+### Slice 8: Remove legacy runtime paths
+
+- Remove the old ephemeral load entry point, filesystem cache, obsolete export
+  path, and direct reporter dependency on `datalayer.tools`.
+- Keep only fixtures or temporarily imported query/normalization modules still
+  needed by the new package.
+- Update packaging and docs to point to `backend/services/datalayer`.
+
+**Exit:** production code has one refresh path, one snapshot path, and one
+reporter query runtime. No dual behavior remains.
+
+## Testing Strategy
+
+### Pure unit tests
+
+- endpoint request planning and stable scope keys;
+- completeness validators, especially authoritative empty lists;
+- every reused/extracted endpoint normalizer with existing JSON fixtures;
+- `Decimal` preservation and JSON boundary conversion;
+- request selection across `through_week`/`observed_through` combinations;
+- canonical request-set hashing;
+- standings, games, profiles, picks, and reconstruction warnings;
+- guarded SQL parser/limits/deadlines.
+
+### PostgreSQL manager tests
+
+Use real disposable PostgreSQL sessions and manager contexts to prove:
+
+- competition isolation and explicit global catalog scope;
+- payload hash deduplication with distinct request observations;
+- old request finishing late cannot replace a newer head;
+- identical newer payload advances observation head without rewriting rows;
+- failed/incomplete response preserves current rows;
+- complete empty response removes the old scope;
+- normalized rows and head advance commit or roll back together;
+- refresh final status/counts are derived transactionally;
+- concurrent identical snapshot requests share one canonical build key;
+- a crashed build becomes failed after the stale threshold and can be rebuilt;
+- failed, expired, missing-artifact, and corrupt-artifact rows do not poison a
+  semantic build key;
+- snapshot membership and ready metadata seal atomically;
+- ready snapshot fields are immutable.
+
+### Snapshot integration tests
+
+Build real SQLite files from fixture request histories and assert:
+
+- a Week 8 snapshot observed through Week 8 contains no Week 9 facts;
+- a roster, user, player, or bracket response observed after the observation
+  boundary is absent even if its domain fields appear earlier;
+- changing the observation boundary changes eligibility while changing only
+  generation intent does not duplicate a factual snapshot;
+- weekly lineup membership comes from the selected matchup payload;
+- exact request IDs and hashes appear in snapshot provenance;
+- missing required scopes fail ordinary builds;
+- post-domain roster fields are copied, derived, or omitted only by the snapshot
+  projection's explicit policy;
+- the artifact hash changes when selected input or snapshot projection version
+  changes;
+- repeated identical builds have one build key and byte-equivalent artifacts;
+- SQLite integrity and metadata validation fail closed.
+
+### Query contract tests
+
+Run the existing curated query suite against artifacts produced by the new
+materializer. Compare canonicalized outputs to the legacy fixture baseline,
+allowing only approved additions such as stable IDs or exact decimal formatting.
+
+### Service tests
+
+Inject fake transports/managers and use a temporary local file root, fake
+clocks, and identity maps. Test workflow ordering and failure behavior without
+patching private helpers. In
+particular, assert that no manager transaction spans an HTTP request, artifact
+file write, or SQLite build.
+
+### API tests
+
+Use dependency overrides and verify request validation, scope enforcement,
+status polling, pagination, safe error translation, and absence of private
+payload/storage details.
+
+## Acceptance Criteria
+
+The component is ready for platform use when:
+
+- refreshes durably record every attempt and safely maintain current heads;
+- current product reads are competition-scoped and do not return ORM rows;
+- every snapshot selects exact request history under its `through_week` and
+  `observed_through` boundaries;
+- every ready snapshot is immutable, hash-verified, and physically excludes
+  future facts;
+- reporter tools and guarded SQL operate only through `FrozenLeagueData`;
+- core curated query behavior passes migrated legacy tests;
+- no service, route, worker, or reporter tool imports ORM models or opens a
+  database session;
+- no transaction remains open during Sleeper, local-file, SQLite, or model work;
+- there is no legacy cache, ephemeral production load path, or PostgreSQL SQL
+  escape hatch;
+- generation manifests pin the data snapshot ID and all relevant build/cutoff
+  versions.
+
+## Deliberately Deferred
+
+- provider registries and generic provider-normalized facts;
+- multi-season reporter SQL in one snapshot;
+- persistent games/standings projection builds in PostgreSQL;
+- exact taxi/IR and intra-week roster ownership history;
+- a generalized scheduler, leases, resumable snapshot builds, or event stream;
+- a public arbitrary-SQL endpoint;
+- broad JSONB indexing or a generic normalization-diff engine;
+- preserving the old SQLite schema as an indefinite external compatibility
+  contract.

--- a/docs/datalayer/transition.md
+++ b/docs/datalayer/transition.md
@@ -106,9 +106,11 @@ the attempt. Payload hashes deduplicate bytes without deduplicating observations
 
 ### 4. Make historical reconstruction physical
 
-The legacy `week_override` prevents some obvious future loads but still begins
-from current responses. It becomes a required `through_week` plus an
-`observed_through` boundary, selected raw requests, and cutoff-safe projection.
+The legacy `week_override` becomes a required `through_week` plus an
+`as_of_date` daily reuse label, selected raw requests, and cutoff-safe
+projection. The date does not filter source observations. The first healthy
+daily snapshot is reused, while recovery after failure or expiration may
+reselect within the same daily key.
 
 ## Implementation Slices
 
@@ -152,7 +154,6 @@ transactions.
 - Reuse or extract legacy normalization calculations per endpoint based on the
   simplest resulting representation.
 - Wire the one refresh workflow.
-- Add manual refresh/status HTTP routes.
 
 **Exit:** fixture-backed source responses populate the latest PostgreSQL view;
 partial refreshes remain auditable and do not erase good heads.
@@ -161,17 +162,22 @@ partial refreshes remain auditable and do not erase good heads.
 
 - Implement `DataSnapshotManager` against the snapshot contract completed in
   Slice 1.
-- Implement request candidate reads and pure selection from `through_week` and
-  `observed_through`.
-- Implement concrete `LocalDatalayerFileStore`, payload verification, and canonical
-  request-set hashing.
+- Implement the daily build key and claim/reuse it before candidate selection.
+- Implement explicit season-stable requirement planning, request candidate
+  reads, and pure selection of the latest complete observations compatible with
+  `through_week`.
+- Reuse the concrete `LocalDatalayerFileStore` from the source-I/O layer and
+  verify selected payloads; each membership row retains its individual response
+  SHA-256 rather than one aggregate identity hash.
 - Implement `begin_or_get(build_key)` and snapshot lifecycle methods.
 - Add bounded waiting plus atomic stale-build failure and unusable-artifact
   expiration; failed/expired history must not block a replacement claim.
 - Make missing required scopes fail without a configurable incomplete mode.
 
-**Exit:** a snapshot build can deterministically select and persist exact source
-membership without yet generating SQLite.
+**Exit:** the service can deterministically select an immutable in-memory source
+manifest, and manager tests can atomically seal that membership with a synthetic
+verified artifact receipt. Production membership is not persisted before the
+artifact is ready.
 
 ### Slice 5: SQLite materializer
 
@@ -182,9 +188,14 @@ membership without yet generating SQLite.
   derivations.
 - Centralize late current-state field policy in the projection and add integrity,
   provenance, cutoff, and artifact hash verification.
+- Wire the real materializer and file store into the snapshot service and prove
+  selection, payload replay, materialization, storage, and atomic sealing in one
+  end-to-end integration test.
 
 **Exit:** selected fixture request sets produce deterministic, verified SQLite
-artifacts with no future rows.
+artifacts with no post-`through_week` week-scoped or volatile state, and the real
+snapshot workflow returns a ready, hash-verified artifact with exact sealed
+membership.
 
 ### Slice 6: Frozen query runtime and reporter integration
 
@@ -201,10 +212,11 @@ any source or PostgreSQL access during the agent loop.
 
 ### Slice 7: Current-data and audit API
 
+- Add synchronous manual refresh/status HTTP routes.
 - Add product read projections for overview, roster, matchup, transaction,
   refresh, request, and snapshot audit views.
 - Add pagination and safe error translation.
-- Add polling support for refresh/snapshot status where builds run in a worker.
+- Leave worker polling as a future seam until an asynchronous worker exists.
 
 **Exit:** the frontend can inspect current data and provenance without using the
 reporter SQLite or raw SQL.
@@ -228,8 +240,9 @@ reporter query runtime. No dual behavior remains.
 - completeness validators, especially authoritative empty lists;
 - every reused/extracted endpoint normalizer with existing JSON fixtures;
 - `Decimal` preservation and JSON boundary conversion;
-- request selection across `through_week`/`observed_through` combinations;
-- canonical request-set hashing;
+- request selection across `through_week` and available request-history
+  combinations;
+- daily build-key canonicalization and deterministic membership ordering;
 - standings, games, profiles, picks, and reconstruction warnings;
 - guarded SQL parser/limits/deadlines.
 
@@ -247,8 +260,10 @@ Use real disposable PostgreSQL sessions and manager contexts to prove:
 - refresh final status/counts are derived transactionally;
 - concurrent identical snapshot requests share one canonical build key;
 - a crashed build becomes failed after the stale threshold and can be rebuilt;
+- a late original builder cannot seal after its row is failed and a replacement
+  claims the same daily key;
 - failed, expired, missing-artifact, and corrupt-artifact rows do not poison a
-  semantic build key;
+  daily build key;
 - snapshot membership and ready metadata seal atomically;
 - ready snapshot fields are immutable.
 
@@ -256,11 +271,18 @@ Use real disposable PostgreSQL sessions and manager contexts to prove:
 
 Build real SQLite files from fixture request histories and assert:
 
-- a Week 8 snapshot observed through Week 8 contains no Week 9 facts;
-- a roster, user, player, or bracket response observed after the observation
-  boundary is absent even if its domain fields appear earlier;
-- changing the observation boundary changes eligibility while changing only
-  generation intent does not duplicate a factual snapshot;
+- a Week 8 snapshot with any caller-chosen date label contains no Week 9 facts;
+- `as_of_date` and request timestamps do not filter candidate selection;
+- a fresh Week 8 build may select a later complete correction scoped to Week 8;
+- current season-stable settings, rather than historical league-payload
+  settings, determine conditional request requirements;
+- a later roster, user, player, or bracket response may supply reference data,
+  while projection policy prevents later-week state from becoming cutoff truth;
+- the first ready snapshot is reused for the same season/week/date/version,
+  while a caller-chosen different date label may select later observations;
+- recovery after failure/expiration may reselect newer eligible membership
+  under the same coarse daily key and preserves both attempts for audit;
+- changing only generation intent does not duplicate a factual snapshot;
 - weekly lineup membership comes from the selected matchup payload;
 - exact request IDs and hashes appear in snapshot provenance;
 - missing required scopes fail ordinary builds;
@@ -268,7 +290,8 @@ Build real SQLite files from fixture request histories and assert:
   projection's explicit policy;
 - the artifact hash changes when selected input or snapshot projection version
   changes;
-- repeated identical builds have one build key and byte-equivalent artifacts;
+- identical selected membership and projection version produce byte-equivalent
+  artifacts, while one active daily build key prevents duplicate work;
 - SQLite integrity and metadata validation fail closed.
 
 ### Query contract tests
@@ -288,8 +311,8 @@ file write, or SQLite build.
 ### API tests
 
 Use dependency overrides and verify request validation, scope enforcement,
-status polling, pagination, safe error translation, and absence of private
-payload/storage details.
+synchronous status reads, pagination, safe error translation, and absence of
+private payload/storage details.
 
 ## Acceptance Criteria
 
@@ -297,10 +320,10 @@ The component is ready for platform use when:
 
 - refreshes durably record every attempt and safely maintain current heads;
 - current product reads are competition-scoped and do not return ORM rows;
-- every snapshot selects exact request history under its `through_week` and
-  `observed_through` boundaries;
+- every snapshot seals exact selected request history and enforces its
+  `through_week` domain boundary;
 - every ready snapshot is immutable, hash-verified, and physically excludes
-  future facts;
+  post-`through_week` week-scoped and volatile state;
 - reporter tools and guarded SQL operate only through `FrozenLeagueData`;
 - core curated query behavior passes migrated legacy tests;
 - no service, route, worker, or reporter tool imports ORM models or opens a

--- a/docs/platform-architecture.md
+++ b/docs/platform-architecture.md
@@ -679,8 +679,8 @@ Tests should follow the designed boundary:
 - API tests use dependency overrides and focus on authentication, validation,
   and response translation.
 - Worker tests inject fake services and verify generation status/progress behavior.
-- Snapshot tests use real SQLite fixtures and verify that future facts are
-  physically absent.
+- Snapshot tests use real SQLite fixtures and verify that post-`through_week`
+  week-scoped and volatile state is physically absent.
 - Scope tests prove competition isolation and deliberate global access.
 - Transaction tests verify that composed finalization writes commit or roll
   back together.


### PR DESCRIPTION
## Description

Stack 1 of 3. Establishes the durable datalayer foundation: architecture and transition contracts, the refined snapshot schema/migration, exact JSON handling, a content-addressed local file store, typed Sleeper source responses, canonical endpoint scopes, and deterministic endpoint-family normalization.

This PR intentionally stops before PostgreSQL ingestion orchestration. The next PR in the stack is `codex/datalayer-ingestion`.

<details>
<summary>🧠 Reasoning trail (AI-authored) — how this change came to be</summary>

**Orientation** — The platform keeps PostgreSQL as the durable source/audit store, then derives immutable SQLite artifacts for cutoff-safe reporter queries. This layer defines those boundaries and the source records needed by both ingestion and replay.

**How I got to this change** — The legacy datalayer contains valuable normalization behavior but couples fetch, in-memory SQLite loading, and queries. The design audit separated stable provider parsing from persistence and artifact lifecycle, refined the existing snapshot schema, and chose a local filesystem content store for V1 to avoid introducing an object-store deployment dependency.

**Where to look hardest** — Review `backend/migrations/versions/0007_datalayer_snapshot_contract.py` for snapshot identity/sealing semantics, `backend/services/datalayer/local_files.py` for content verification and containment, and `backend/services/datalayer/sleeper/endpoints/` for preserved normalization rules.
</details>

## Design decisions

- PostgreSQL stores durable request history and current normalized heads; SQLite remains an immutable per-snapshot query projection.
- Snapshot identity is factual cutoff plus exact selected request membership and projection version—not generation identity.
- JSON enters through a Decimal-first parser and canonical encoder so hashes and fantasy values never depend on binary float.
- V1 stores large payloads and snapshots in a concrete local content-addressed filesystem store.
- Endpoint modules own request construction, completeness, and pure normalization without registries or database access.

## Alternative approaches

- Querying PostgreSQL directly from reporter tools was rejected because it cannot preserve a sealed historical knowledge boundary.
- A remote object store was deferred; local storage satisfies V1 durability and verification needs with less operational surface.
- Copying the legacy loader wholesale was rejected where it would preserve coupling or float-based behavior; fixture-backed business rules were retained instead.

## Design self-review

- [ ] Audited with the design-review skill
- [x] N/A

## Testing

- `.venv/bin/python -m pytest -q` — 347 passed, 51 PostgreSQL-only tests skipped.
- Offline Alembic upgrade and downgrade SQL compiled through migration `0007`.
- Python compilation and `git diff --check` passed.

## Risks

- Live PostgreSQL constraint tests require `AIDAM_TEST_DATABASE_URL` and remain a CI gate.
- The snapshot runtime itself is intentionally implemented in a later stack layer.

## Observability

- Request/snapshot audit fields and sanitized failure metadata are defined; no production alerts are added in this layer.

## Deployment and rollback plan

- Apply migration `0007` before deploying dependent ingestion code.
- Roll back by reverting this PR and downgrading `0007` before any dependent PR is deployed.

## Security

- Local storage keys are contained under the configured root and content is verified by SHA-256 and byte length.
