### PR TITLE
docs(memory): add application implementation plan

### DIFF
--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -54,9 +54,9 @@ hydrated from canonical typed versions before they are returned to the agent.
    context note has a complete, kind-specific content shape.
 2. **Stable items are identity envelopes.** Mutable content, participants, and
    links do not live on `memory_items`.
-3. **Semantic validation belongs at the application boundary.** Pydantic models
-   and the memory manager validate event shapes, roles, target kinds, competition
-   scope, and evidence policy.
+3. **Semantic validation belongs at the application boundary.** Pydantic models,
+   typed resource managers, and the mutation service validate event shapes,
+   roles, target kinds, competition scope, and evidence policy.
 4. **PostgreSQL still protects mechanical history.** Primary keys, revision
    sequence uniqueness, item-version uniqueness, current-pointer concurrency,
    and atomic revision advancement remain database responsibilities.

--- a/docs/memory/application-contracts.md
+++ b/docs/memory/application-contracts.md
@@ -6,7 +6,8 @@
 
 Callers should know the complete legal shape of a mutation without understanding
 ORM association rows. Routes, tools, services, and the reporter operate on typed
-resource objects; only the memory manager translates those objects into storage.
+resource objects. Typed resource managers translate their own objects, while
+the mutation service and revision manager coordinate an atomic bundle.
 
 The examples below are illustrative Pydantic-style contracts, not final code.
 
@@ -184,15 +185,42 @@ A patch-oriented UI may edit individual fields locally, but the manager validate
 and persists one complete replacement. This prevents a caller from accidentally
 creating a partial version whose omitted relationships have ambiguous meaning.
 
-Before opening the canonical write transaction, the service performs all model
-or external work. Inside the short transaction, the manager:
+### Generation-scoped proposal contract
 
-1. validates Pydantic content and schema version;
-2. loads every referenced item/version in one scoped batch;
-3. requires the expected kinds and same competition;
-4. validates references created in the same mutation bundle;
-5. locks and verifies the current canonical revision;
-6. writes the complete replacement and its search projection atomically.
+Reporter-facing `save_*` operations do not invoke these public mutations one at
+a time. `GenerationService` creates one `GenerationMemoryContext` after pinning
+the generation's canonical input revision. The context exposes retrieval at
+that revision and buffers complete typed proposals:
+
+```python
+context.propose_fact(content: FactContent)
+context.propose_event(content: EventContent)
+context.propose_storyline(content: StorylineContent)
+context.propose_trigger(content: TriggerContent)
+context.propose_context_note(identity: ContextNoteIdentity, content: ContextNoteContent)
+```
+
+The context is an in-memory, generation-scoped facade rather than a manager or
+database unit of work. It contains no open session. Proposal-local references
+allow a later proposal to target another item or version created in the same
+bundle.
+
+Searches through the context always use its immutable pinned canonical revision.
+They do not hydrate buffered proposals or treat them as established memory. On
+successful article submission, `GenerationService` hands the completed bundle
+to `MemoryMutationService` once. On failure or abandonment, it discards the
+buffer without creating a canonical revision.
+
+Before opening the canonical write transaction, the service performs all model
+or external work. Inside the short transaction, the revision manager invokes
+resource-local transaction helpers to:
+
+1. validate Pydantic content and schema version;
+2. load every referenced item/version in one scoped batch;
+3. require the expected kinds and same competition;
+4. validate references created in the same mutation bundle;
+5. lock and verify the current canonical revision;
+6. write the complete replacement and its search projection atomically.
 
 Failures return typed application errors such as target-not-found,
 wrong-target-kind, cross-competition-reference, stale-item-version, or

--- a/docs/memory/canonical-schema.md
+++ b/docs/memory/canonical-schema.md
@@ -208,7 +208,8 @@ PostgreSQL retains mechanical invariants:
 - immutable revision/version history;
 - atomic retirement, introduction, and pointer advancement.
 
-Application models and the memory manager own semantic invariants:
+Application models, typed resource managers, and the mutation service own
+semantic invariants:
 
 - legal event and trigger payloads;
 - participant and evidence roles;

--- a/docs/memory/implementation-plan.md
+++ b/docs/memory/implementation-plan.md
@@ -1,0 +1,503 @@
+# Typed Memory Application Implementation Plan
+
+**Status:** Proposed implementation plan  
+**Stack position:** `memory-0`  
+**Scope:** Application contracts, resource managers, canonical mutations,
+retrieval, API integration, and reporter integration
+
+## Purpose
+
+This document turns the accepted typed-memory design into an incremental
+implementation plan. It builds on the canonical PostgreSQL schema already in
+place and preserves the boundaries established in:
+
+- [`application-contracts.md`](application-contracts.md);
+- [`canonical-schema.md`](canonical-schema.md);
+- [`retrieval.md`](retrieval.md);
+- [`lifecycle.md`](lifecycle.md);
+- [`transition.md`](transition.md); and
+- [`../platform-architecture.md`](../platform-architecture.md).
+
+The main structural refinement is that “the memory manager” is an application
+boundary, not one class that owns every memory kind. Storylines, facts, events,
+triggers, context notes, canonical revisions, and search documents are distinct
+resources with distinct objects and managers.
+
+## Goals
+
+1. Represent every canonical memory kind with a complete Pydantic content
+   contract.
+2. Give each resource a narrow manager responsible only for that resource.
+3. Preserve one atomic, linear canonical revision history across resource
+   mutations.
+4. Maintain deterministic search documents with every accepted version.
+5. Retrieve candidates through the projection and hydrate canonical typed
+   versions before returning them to callers.
+6. Switch the reporter from the legacy SQLite memory store without introducing
+   a dual-write period.
+7. Keep every pull request small, testable, and independently reviewable.
+
+## Non-Goals
+
+- Vector embeddings before lexical and entity retrieval are implemented and
+  measured.
+- Importing legacy `reporter_memory` data into the canonical PostgreSQL model.
+- A generic memory CRUD repository or a public graph abstraction.
+- Branching or merging canonical memory history.
+- Combining all memory kinds into a single manager or caller-facing object.
+
+## Target File Structure
+
+The target structure groups memory resources for discoverability while keeping
+each resource's objects and manager separate.
+
+```text
+backend/
+├── database/
+│   └── models/
+│       └── memory/
+│           ├── items.py
+│           ├── revisions.py
+│           ├── storylines.py
+│           ├── facts.py
+│           ├── events.py
+│           ├── triggers.py
+│           ├── context_notes.py
+│           └── search_documents.py
+│
+├── resources/
+│   ├── context.py
+│   └── memory/
+│       ├── common/
+│       │   ├── kinds.py
+│       │   ├── references.py
+│       │   ├── versioning.py
+│       │   └── errors.py
+│       │
+│       ├── revisions/
+│       │   ├── objects.py
+│       │   ├── manager.py
+│       │   ├── shared.py
+│       │   └── writers.py
+│       │
+│       ├── storylines/
+│       │   ├── objects.py
+│       │   ├── codec.py
+│       │   ├── validation.py
+│       │   ├── manager.py
+│       │   └── shared.py
+│       │
+│       ├── facts/
+│       │   ├── objects.py
+│       │   ├── codec.py
+│       │   ├── validation.py
+│       │   ├── manager.py
+│       │   └── shared.py
+│       │
+│       ├── events/
+│       │   ├── objects.py
+│       │   ├── payloads/
+│       │   │   ├── trade.py
+│       │   │   └── matchup.py
+│       │   ├── codec.py
+│       │   ├── validation.py
+│       │   ├── manager.py
+│       │   └── shared.py
+│       │
+│       ├── triggers/
+│       │   ├── objects.py
+│       │   ├── conditions/
+│       │   ├── codec.py
+│       │   ├── validation.py
+│       │   ├── manager.py
+│       │   └── shared.py
+│       │
+│       ├── context_notes/
+│       │   ├── objects.py
+│       │   ├── codec.py
+│       │   ├── validation.py
+│       │   ├── manager.py
+│       │   └── shared.py
+│       │
+│       └── search_documents/
+│           ├── objects.py
+│           ├── manager.py
+│           ├── query.py
+│           └── builders/
+│               ├── storyline.py
+│               ├── fact.py
+│               ├── event.py
+│               ├── trigger.py
+│               └── context_note.py
+│
+├── services/
+│   └── memory/
+│       ├── mutation_service.py
+│       ├── retrieval_service.py
+│       └── lifecycle_service.py
+│
+└── api/
+    ├── schemas/
+    │   └── memory/
+    │       ├── storylines.py
+    │       ├── facts.py
+    │       ├── events.py
+    │       ├── triggers.py
+    │       ├── context_notes.py
+    │       └── search.py
+    └── routes/
+        └── memory/
+            ├── storylines.py
+            ├── facts.py
+            ├── events.py
+            ├── triggers.py
+            ├── context_notes.py
+            └── search.py
+```
+
+Tests mirror these boundaries under `backend/tests/resources/memory/`,
+`backend/tests/services/memory/`, and `backend/tests/api/memory/`.
+
+Not every package needs every helper on its first commit. `objects.py` and
+`manager.py` define the stable resource boundary. `codec.py`, `validation.py`,
+and `shared.py` should only be introduced when they contain real logic.
+
+## Resource Objects
+
+Each resource separates its complete mutable content from its stable identity
+and immutable version metadata.
+
+### Shared objects
+
+The common package contains only concepts genuinely shared across memory kinds:
+
+- `MemoryKind`;
+- low-level entity identity primitives;
+- version and mutation provenance metadata; and
+- typed application errors.
+
+Semantic roles remain resource-local. For example, storyline subject roles do
+not become a generic role bag shared with facts or events.
+
+### Storyline
+
+The storyline resource owns:
+
+- `StorylineContent`;
+- narrowed storyline entity references;
+- exact `EvidenceRef` values targeting fact or event versions;
+- stable related-storyline references; and
+- the hydrated storyline aggregate and history entries.
+
+### Fact
+
+The fact resource owns:
+
+- `FactContent`;
+- narrowed fact subject references;
+- exact originating-event version IDs;
+- reporting and Sleeper receipt fields; and
+- the hydrated fact aggregate and history entries.
+
+### Event
+
+The event resource owns `EventContent` and its discriminated payload union.
+Initial implementation should support the fully illustrated `trade` and
+`matchup` payloads. Later event types should be additive modules under
+`events/payloads/` and must not weaken existing payload validation.
+
+### Trigger
+
+The trigger resource owns `TriggerContent`, its condition union, and stable
+storyline/event targets. Trigger condition variants must be settled before the
+trigger manager is implemented.
+
+### Context note
+
+The context-note resource is an aggregate containing both its stable scope/key
+identity and versioned content. It does not require separate managers for the
+identity and version tables.
+
+### Revision and search document
+
+Canonical revisions and search documents are independent resources:
+
+- a revision object represents one competition-wide atomic state transition;
+- a search-document object represents derived candidate-discovery data; and
+- neither object substitutes for a typed storyline, fact, event, trigger, or
+  context note.
+
+## Manager Responsibilities
+
+### Typed resource managers
+
+`StorylineManager`, `FactManager`, `EventManager`, `TriggerManager`, and
+`ContextNoteManager` each own:
+
+- competition-scoped queries for one resource;
+- exact-version hydration and item history;
+- complete create and replacement validation for that resource;
+- ORM-to-resource conversion; and
+- resource-local transaction helpers used during composed canonical writes.
+
+They do not make model calls, Sleeper requests, expose ORM rows, or implement
+queries for other memory kinds.
+
+### Revision manager
+
+`RevisionManager` owns only the canonical revision aggregate:
+
+- current-revision lookup and pinning;
+- current-pointer locking and stale-writer detection;
+- canonical sequence allocation;
+- version introduction and retirement envelopes;
+- resulting-state hashing; and
+- commit or rollback of the complete mutation bundle.
+
+It must not contain kind-specific payload parsing, fields, or SQL. During a
+composed write it invokes narrow resource-local helpers from each resource's
+`shared.py`. Those helpers receive an existing session, never open or commit a
+transaction, and are not public application APIs.
+
+### Search-document manager
+
+`SearchDocumentManager` owns:
+
+- revision-grounded candidate queries;
+- exact entity, evidence, related-item, tag, and full-text matching;
+- compact candidates with named match reasons; and
+- deterministic projection rebuilds.
+
+It returns candidate version IDs, not canonical content. Per-kind builders are
+separate modules so adding a new event payload or memory kind does not grow one
+large builder file.
+
+## Service Responsibilities
+
+### Mutation service
+
+`MemoryMutationService` parses a typed multi-resource proposal, coordinates
+resource validation, and hands one complete bundle to `RevisionManager`. It owns
+workflow policy but no SQLAlchemy sessions or ORM imports.
+
+### Retrieval service
+
+`MemoryRetrievalService` queries `SearchDocumentManager`, dispatches each
+candidate to its typed manager, expands requested exact and stable references,
+and returns hydrated aggregates with match reasons.
+
+### Lifecycle service
+
+`MemoryLifecycleService` coordinates generation-specific behavior:
+
+- pin the generation's canonical input revision;
+- expose revision-grounded retrieval;
+- accept an optional typed mutation proposal after article generation; and
+- fail a stale live generation without creating sibling state.
+
+## Atomic Mutation Flow
+
+```mermaid
+flowchart LR
+    Proposal["Typed mutation bundle"] --> Service["Mutation service"]
+    Service --> Revision["Revision manager transaction"]
+    Revision --> Storyline["Storyline helper"]
+    Revision --> Fact["Fact helper"]
+    Revision --> Event["Event helper"]
+    Revision --> Trigger["Trigger helper"]
+    Revision --> Note["Context-note helper"]
+    Revision --> Builder["Per-kind search builders"]
+    Builder --> Projection["Search documents"]
+    Revision --> Current["Advance current revision"]
+```
+
+All model calls, external requests, and expensive work finish before this
+transaction starts. A failure rolls back the revision, versions, typed rows,
+search documents, retirements, and current pointer together.
+
+## Pull Request Stack
+
+The implementation uses the repository's `gh stack` workflow. Every branch is
+based on the preceding branch and each PR shows only its incremental changes.
+
+### `memory-0` — implementation plan
+
+**Branch:** `codex/memory-0-implementation-plan`
+
+- Add this implementation plan.
+- Make no application or database changes.
+- Establish the intended resource and stack boundaries before implementation.
+
+### `memory-1` — split memory ORM modules
+
+**Branch:** `codex/memory-1-orm-modules`
+
+- Split the existing memory ORM file into per-resource modules.
+- Keep table names, columns, constraints, and metadata unchanged.
+- Update exports and prove Alembic detects no schema diff.
+
+### `memory-2` — typed resource contracts
+
+**Branch:** `codex/memory-2-contracts`
+
+- Add manager context and shared reference/version primitives.
+- Add separate Pydantic contracts for all five memory resources.
+- Settle role enums, cardinalities, initial event payloads, and initial trigger
+  conditions.
+- Test every discriminator, semantic boundary, and retained schema version.
+
+### `memory-3` — revisions and critical query proofs
+
+**Branch:** `codex/memory-3-revisions`
+
+- Add `RevisionManager` current, pin, history, and visibility reads.
+- Add the canonical transaction skeleton and typed stale-revision errors.
+- Prove active-storyline entity lookup, storyline history, exact-evidence
+  lookup, and pinned-revision exclusion using seeded canonical rows.
+
+### `memory-4` — facts
+
+**Branch:** `codex/memory-4-facts`
+
+- Add `FactManager`, codec, validation, transaction helper, and search builder.
+- Support complete create, replace, exact-version hydration, and history.
+- Cover subject, receipt, originating-event, status, and confidence policies.
+
+### `memory-5` — events
+
+**Branch:** `codex/memory-5-events`
+
+- Add `EventManager`, codecs, transaction helper, and search builder.
+- Implement trade and matchup payloads first.
+- Reject mismatched event-type and payload discriminators.
+- Prove adding another payload does not change unrelated contracts.
+
+### `memory-6` — storylines
+
+**Branch:** `codex/memory-6-storylines`
+
+- Add `StorylineManager`, codec, transaction helper, and search builder.
+- Validate exact fact/event evidence and stable storyline relationships.
+- Cover complete replacement, historical evidence stability, and history.
+
+### `memory-7` — triggers
+
+**Branch:** `codex/memory-7-triggers`
+
+- Add `TriggerManager`, condition models, codec, transaction helper, and builder.
+- Validate stable storyline/event targets and competition scope.
+- Cover trigger status, fire policy, target time/week, and condition rules.
+
+### `memory-8` — context notes
+
+**Branch:** `codex/memory-8-context-notes`
+
+- Add `ContextNoteManager`, codec, transaction helper, and builder.
+- Treat scope/key identity and versioned content as one resource aggregate.
+- Cover competition, competition-season, and franchise scopes.
+
+### `memory-9` — atomic mutation bundles
+
+**Branch:** `codex/memory-9-mutation-bundles`
+
+- Add `MemoryMutationService` and complete multi-resource bundle commits.
+- Batch-load and validate reference targets.
+- Support same-batch references without weakening type or scope validation.
+- Insert search documents atomically and verify the resulting-state hash.
+- Test stale writers and rollback at every failure point.
+
+### `memory-10` — search projection and rebuild
+
+**Branch:** `codex/memory-10-search-projection`
+
+- Complete entity, evidence, related-item, tag, status, and full-text candidate
+  queries.
+- Preserve named score components and match reasons.
+- Add deterministic projection rebuild behavior.
+- Prove rebuilds do not create or alter canonical revisions.
+
+### `memory-11` — retrieval and hydration
+
+**Branch:** `codex/memory-11-retrieval`
+
+- Add `MemoryRetrievalService`.
+- Search at a pinned revision and hydrate through typed managers.
+- Optionally expand exact evidence and visible stable references.
+- Prove search documents are never returned as authoritative memory.
+
+### `memory-12` — HTTP API
+
+**Branch:** `codex/memory-12-api`
+
+- Add resource-specific request and response schemas.
+- Add separate routes for each resource and search.
+- Translate typed application errors into stable HTTP responses.
+- Keep sessions, ORM rows, and multi-step workflow logic out of routes.
+
+### `memory-13` — reporter retrieval
+
+**Branch:** `codex/memory-13-reporter-retrieval`
+
+- Replace legacy reporter search and candidate expansion with the new retrieval
+  service.
+- Pin every generation to its canonical input revision.
+- Preserve the rule that remembered facts are research leads requiring
+  verification against the frozen Sleeper snapshot.
+
+### `memory-14` — reporter mutation lifecycle
+
+**Branch:** `codex/memory-14-reporter-mutations`
+
+- Replace legacy reporter writes with typed mutation proposals.
+- Apply accepted proposals only after article generation completes.
+- Remove the legacy canonical write path rather than dual-writing both stores.
+- Cover successful commit, no-op proposal, invalid proposal, and stale
+  generation behavior.
+
+PRs `memory-1` through `memory-11` form the core application stack. PRs
+`memory-12` through `memory-14` are the integration tail and may be published as
+a second stack based on `memory-11` if review throughput benefits from it.
+
+## Required Acceptance Coverage
+
+The complete stack must prove:
+
+1. active storylines can be found by franchise or player at pinned revision
+   `R`;
+2. every version of one item is returned in item-local order;
+3. storylines can be found and hydrated through exact fact-version evidence;
+4. evidence versions remain exact while stable thematic references resolve at
+   the pinned revision;
+5. event-specific text is searchable without losing structured payload data;
+6. a generation pinned to `R` cannot retrieve content introduced at `R + 1`;
+7. a projection rebuild does not change canonical history;
+8. a new event payload is additive and does not weaken existing contracts;
+9. stale canonical writers produce no revision or partial projection; and
+10. all retained content-schema versions remain decodable.
+
+## Settled Implementation Constraints
+
+- Public mutations accept complete content replacements, not patches.
+- Exact evidence references target immutable version IDs.
+- Thematic and operational references target stable item IDs.
+- Managers return resource objects and own short session boundaries.
+- Services orchestrate managers but do not import ORM models or open sessions.
+- Search documents are rebuildable derived data and never canonical content.
+- The initial event implementation contains trade and matchup payloads.
+- Embeddings remain a later, independently rebuildable enhancement.
+- The legacy memory store is switched off in one integration layer; it is not a
+  second canonical authority during the transition.
+
+## Decisions Required in `memory-2`
+
+The contracts PR must explicitly settle:
+
+- allowed entity roles and cardinalities for storylines and facts;
+- evidence and related-storyline duplicate policy;
+- the first supported trigger-condition discriminators and their fields;
+- whether source hints accept only mappings or a broader JSON value;
+- normalization rules for tags and display names; and
+- the exact resource aggregate returned by history and hydration operations.
+
+These decisions belong in the typed contracts before manager behavior depends
+on them.

--- a/docs/memory/implementation-plan.md
+++ b/docs/memory/implementation-plan.md
@@ -132,9 +132,10 @@ backend/
 │
 ├── services/
 │   └── memory/
+│       ├── generation_context.py
+│       ├── proposals.py
 │       ├── mutation_service.py
-│       ├── retrieval_service.py
-│       └── lifecycle_service.py
+│       └── retrieval_service.py
 │
 └── api/
     ├── schemas/
@@ -274,32 +275,68 @@ large builder file.
 
 ## Service Responsibilities
 
+### Generation memory context
+
+`GenerationMemoryContext` is a generation-scoped facade, not a long-lived
+service or resource manager. `GenerationService` creates one after it seals the
+generation's competition, generation ID, and pinned canonical revision. The
+reporter memory tools receive this context instead of independently composing
+retrieval and mutation services.
+
+The context:
+
+- exposes search methods grounded at its immutable pinned revision;
+- buffers typed fact, event, storyline, trigger, and context-note proposals;
+- returns proposal-local references for same-bundle relationships;
+- exposes the completed mutation bundle to the generation workflow; and
+- contains no SQLAlchemy session or canonical database state.
+
+Calls such as `save_fact` or `save_memory_event` therefore stage typed proposals;
+they do not immediately write canonical memory. Searches made later in the same
+generation still read the pinned canonical revision and do not see the buffered
+proposals as established memory.
+
 ### Mutation service
 
-`MemoryMutationService` parses a typed multi-resource proposal, coordinates
-resource validation, and hands one complete bundle to `RevisionManager`. It owns
-workflow policy but no SQLAlchemy sessions or ORM imports.
+`MemoryMutationService` accepts the completed typed bundle, coordinates resource
+validation, and hands the accepted changes to `RevisionManager`. It owns bundle
+semantics such as same-batch references but no SQLAlchemy sessions or ORM
+imports. It does not decide when a generation commits.
 
 ### Retrieval service
 
 `MemoryRetrievalService` queries `SearchDocumentManager`, dispatches each
 candidate to its typed manager, expands requested exact and stable references,
-and returns hydrated aggregates with match reasons.
+and returns hydrated aggregates with match reasons. It is read-only, receives an
+explicit pinned revision on every search, and knows nothing about the current
+generation's mutation buffer.
 
-### Lifecycle service
+### Generation service
 
-`MemoryLifecycleService` coordinates generation-specific behavior:
+The existing `GenerationService` owns the run lifecycle. It:
 
-- pin the generation's canonical input revision;
-- expose revision-grounded retrieval;
-- accept an optional typed mutation proposal after article generation; and
-- fail a stale live generation without creating sibling state.
+- pins the canonical input revision;
+- constructs `GenerationMemoryContext` with immutable scope, the retrieval
+  dependency, and an empty proposal buffer;
+- gives that context to the reporter tools;
+- hands the context's completed bundle to `MemoryMutationService` once after
+  successful article submission; and
+- discards the buffer when the generation fails or is abandoned.
+
+There is no separate `MemoryLifecycleService`. Introducing one would split
+ownership of the generation lifecycle without creating a distinct application
+capability.
 
 ## Atomic Mutation Flow
 
 ```mermaid
 flowchart LR
-    Proposal["Typed mutation bundle"] --> Service["Mutation service"]
+    Generation["Generation service pins revision R"] --> Context["Generation memory context"]
+    Context -->|"search at R"| Retrieval["Retrieval service"]
+    Context -->|"buffer propose calls"| Buffer["Typed mutation bundle"]
+    Generation -->|"successful submission"| Finalize["Take completed bundle once"]
+    Buffer --> Finalize
+    Finalize --> Service["Mutation service"]
     Service --> Revision["Revision manager transaction"]
     Revision --> Storyline["Storyline helper"]
     Revision --> Fact["Fact helper"]
@@ -400,7 +437,12 @@ based on the preceding branch and each PR shows only its incremental changes.
 
 **Branch:** `codex/memory-9-mutation-bundles`
 
-- Add `MemoryMutationService` and complete multi-resource bundle commits.
+- Add `GenerationMemoryContext`, its typed proposal buffer, and
+  `MemoryMutationService`.
+- Keep context searches pinned to canonical input and exclude buffered proposals
+  from retrieval.
+- Commit the completed multi-resource bundle through one explicit finalization
+  call.
 - Batch-load and validate reference targets.
 - Support same-batch references without weakening type or scope validation.
 - Insert search documents atomically and verify the resulting-state hash.
@@ -438,9 +480,10 @@ based on the preceding branch and each PR shows only its incremental changes.
 
 **Branch:** `codex/memory-13-reporter-retrieval`
 
-- Replace legacy reporter search and candidate expansion with the new retrieval
-  service.
-- Pin every generation to its canonical input revision.
+- Have `GenerationService` pin canonical input and construct one
+  `GenerationMemoryContext` per run.
+- Replace legacy reporter search and candidate expansion with context methods
+  backed by the new retrieval service.
 - Preserve the rule that remembered facts are research leads requiring
   verification against the frozen Sleeper snapshot.
 
@@ -448,8 +491,9 @@ based on the preceding branch and each PR shows only its incremental changes.
 
 **Branch:** `codex/memory-14-reporter-mutations`
 
-- Replace legacy reporter writes with typed mutation proposals.
-- Apply accepted proposals only after article generation completes.
+- Replace legacy reporter writes with context-buffered typed mutation proposals.
+- Have `GenerationService` apply the completed bundle once after successful
+  article submission or discard it on failure.
 - Remove the legacy canonical write path rather than dual-writing both stores.
 - Cover successful commit, no-op proposal, invalid proposal, and stale
   generation behavior.
@@ -472,8 +516,13 @@ The complete stack must prove:
 6. a generation pinned to `R` cannot retrieve content introduced at `R + 1`;
 7. a projection rebuild does not change canonical history;
 8. a new event payload is additive and does not weaken existing contracts;
-9. stale canonical writers produce no revision or partial projection; and
-10. all retained content-schema versions remain decodable.
+9. several `save_*` calls in one generation create at most one canonical
+   revision;
+10. failed or abandoned generations discard their buffered proposals;
+11. searches within a generation do not treat its buffered proposals as
+    canonical memory;
+12. stale canonical writers produce no revision or partial projection; and
+13. all retained content-schema versions remain decodable.
 
 ## Settled Implementation Constraints
 
@@ -482,6 +531,12 @@ The complete stack must prove:
 - Thematic and operational references target stable item IDs.
 - Managers return resource objects and own short session boundaries.
 - Services orchestrate managers but do not import ORM models or open sessions.
+- `GenerationMemoryContext` is created once per generation and owns only pinned
+  retrieval scope plus an in-memory proposal buffer.
+- `GenerationService`, not a separate memory lifecycle service, decides when to
+  commit or discard that buffer.
+- Buffered proposals are not visible to retrieval during the producing
+  generation.
 - Search documents are rebuildable derived data and never canonical content.
 - The initial event implementation contains trade and matchup payloads.
 - Embeddings remain a later, independently rebuildable enhancement.

--- a/docs/memory/lifecycle.md
+++ b/docs/memory/lifecycle.md
@@ -16,11 +16,16 @@ Before the reporter runs, the generation service resolves and seals:
 The generation stores the exact input memory revision ID. No later memory change
 can alter what this run was allowed to retrieve.
 
+The generation service then creates one `GenerationMemoryContext` containing
+the competition ID, generation ID, pinned canonical revision, retrieval
+dependency, and an empty typed mutation buffer. This context is scoped to the
+run and does not hold a database session.
+
 ### 2. Discover memory candidates
 
 The reporter extracts teams, players, transactions, matchups, and themes from the
-request and current factual snapshot. Its memory-search tool queries the existing
-search projection using:
+request and current factual snapshot. Its memory-search tool calls the
+generation-scoped context, which delegates to the retrieval service using:
 
 - pinned canonical revision visibility;
 - competition scope;
@@ -31,12 +36,17 @@ search projection using:
 The projection was previously built when each candidate version was committed;
 it is not regenerated for this article.
 
+Every search remains grounded at the pinned canonical revision. Buffered
+proposals from this generation are not included in retrieval and cannot become
+research inputs for the run that proposed them.
+
 ### 3. Hydrate canonical memory
 
-Search returns compact candidate IDs and score explanations. The memory manager
-hydrates selected candidates from `memory_versions` and the corresponding typed
-version table. It optionally expands exact evidence and stable related items at
-the same pinned revision.
+Search returns compact candidate IDs and score explanations. The retrieval
+service dispatches selected candidates to the appropriate typed resource
+manager, which hydrates `memory_versions` and the corresponding typed version
+table. The retrieval service optionally expands exact evidence and stable
+related items at the same pinned revision.
 
 The agent receives complete typed memory as research leads, not flattened search
 documents and not article-ready factual truth. It verifies remembered claims
@@ -44,13 +54,20 @@ against the generation's frozen Sleeper snapshot.
 
 ### 4. Generate article and propose memory changes
 
-The reporter completes research, brief, drafting, and verification, then produces
-an article and an optional typed memory mutation bundle. Model calls and external
-tool work finish before the canonical memory transaction begins.
+The reporter completes research, brief, drafting, and verification, then
+produces an article. Calls such as `save_fact`, `save_memory_event`, or
+`replace_storyline` append typed proposals to the generation context's in-memory
+buffer; they do not write canonical memory immediately. Proposal-local IDs allow
+later calls in the same generation to express same-bundle references.
+
+After successful article submission, the generation service takes the completed
+bundle from the context and calls the mutation service once. A failed or
+abandoned generation discards the buffer. Model calls and external tool work
+therefore finish before the canonical memory transaction begins.
 
 ### 5. Validate the mutation bundle
 
-Application code:
+The mutation service:
 
 1. parses each proposed content object into its Pydantic type;
 2. verifies expected item versions;
@@ -64,7 +81,7 @@ database constraint failures for semantic feedback.
 
 ### 6. Commit one canonical revision
 
-In one short transaction, the manager:
+In one short transaction, the revision manager:
 
 1. locks `current_revisions` for the competition;
 2. requires it to equal the generation's pinned input revision;
@@ -131,4 +148,8 @@ into canonical search documents.
 - A damaged or stale search projection is rebuilt from canonical typed versions.
 - A builder change rebuilds projections without changing memory history.
 - A stale live generation must rerun from the now-current canonical revision.
+- A failed or abandoned generation discards its uncommitted mutation buffer.
+- Multiple proposal tool calls from one generation create at most one canonical
+  revision.
+- A generation never retrieves its buffered proposals as canonical memory.
 - Exact generation search/tool logs remain in reporting for audit.


### PR DESCRIPTION
## Description

Adds the `memory-0` implementation plan for the typed-memory application stack. The plan translates the accepted schema, application-contract, retrieval, and lifecycle designs into concrete resource boundaries, a target file structure, manager/service responsibilities, atomic mutation flow, acceptance coverage, and a small dependency-ordered PR stack through reporter integration.

It also defines `GenerationMemoryContext` as the per-generation facade that owns pinned retrieval scope and buffers typed `save_*` proposals. `GenerationService` commits that completed bundle through `MemoryMutationService` once after successful article submission, or discards it when the run fails.

This PR is intentionally documentation-only so the manager boundaries and stack topology can be reviewed before implementation begins.

<details>
<summary>🧠 Reasoning trail (AI-authored) — how this change came to be</summary>

**Orientation** — Canonical typed-memory tables and search-document storage already exist, while Pydantic resources, managers, retrieval, and reporter integration remain unimplemented. The plan maps those pending layers onto the repository's model → resource object → manager → service architecture.

**How I got to this change** — I reviewed the accepted documents under `docs/memory/`, the implemented memory ORM schema, the current API/composition boundaries, and `docs/platform-architecture.md`. The resource design treats the singular “memory manager” wording as an application boundary while assigning storylines, facts, events, triggers, context notes, revisions, and search documents to separate resource managers. Follow-up discussion exposed a missing runtime boundary, so the plan now makes the generation-scoped context and its proposal buffer explicit instead of introducing a separate lifecycle service.

**Where to look hardest** — Review `docs/memory/implementation-plan.md`, especially the target structure, revision-manager transaction boundary, and the `memory-0` through `memory-14` stack ordering. Those sections determine how later PRs avoid an omnibus memory manager while preserving one atomic canonical revision.
</details>

## Design decisions

- Keep one manager and caller-facing object package per memory resource.
- Create one `GenerationMemoryContext` per run to bind pinned retrieval and buffer typed mutation proposals without holding a database session.
- Let the existing `GenerationService` decide when to commit or discard the buffer; do not add a separate `MemoryLifecycleService`.
- Let `RevisionManager` own canonical revision atomicity without absorbing kind-specific payload logic.
- Use resource-local transaction helpers for composed writes rather than a generic CRUD repository.
- Keep search documents as a separate derived resource and hydrate canonical typed objects through a retrieval service.
- Begin event payload implementation with the fully illustrated trade and matchup contracts.
- Switch reporter persistence without a dual-write period and defer embeddings until lexical/entity retrieval is measured.

## Alternative approaches

- One `MemoryManager` and one `objects.py`: rejected because unrelated resource semantics and growth would be forced through one boundary.
- A generic repository or graph abstraction: rejected because it weakens kind-specific validation and bypasses resource policy.
- Dual-writing the legacy SQLite store and PostgreSQL during migration: rejected because it creates two canonical authorities and reconciliation behavior.
- Adding embeddings in the initial stack: deferred until exact filters and lexical/entity retrieval are operational and measured.

## Design self-review

- [ ] Audited the diff with the design-review skill
- [x] N/A — documentation-only planning change

## Testing

- `git diff --check`
- No automated tests run; this PR changes documentation only.

## Risks

- [x] No runtime or database behavior changes in this PR.
- [x] Later implementation details remain subject to review in their individual stack layers.

## Observability

- N/A — documentation-only change.

## Deployment and rollback plan

- No deployment action is required.
- Roll back by reverting the documentation commit if the plan is superseded.

## Security

- [x] N/A — no code, credentials, permissions, or runtime configuration changed.
