### PR TITLE
feat(memory): add typed resource contracts

### DIFF
--- a/backend/resources/__init__.py
+++ b/backend/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Caller-facing application resources."""

--- a/backend/resources/_contracts.py
+++ b/backend/resources/_contracts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, StringConstraints
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+NonBlankStr = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+]
+
+
+def _optional_display_name(value: Any) -> Any:
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return value
+
+
+DisplayName = Annotated[str | None, BeforeValidator(_optional_display_name)]
+
+
+def _normalize_tags(value: Any) -> Any:
+    if not isinstance(value, list):
+        raise ValueError("tags must be provided as a list")
+
+    normalized: list[Any] = []
+    seen: set[str] = set()
+    for tag in value:
+        if not isinstance(tag, str):
+            normalized.append(tag)
+            continue
+        tag = tag.strip().casefold()
+        if tag and tag not in seen:
+            normalized.append(tag)
+            seen.add(tag)
+    return normalized
+
+
+Tags = Annotated[list[NonBlankStr], BeforeValidator(_normalize_tags)]

--- a/backend/resources/context.py
+++ b/backend/resources/context.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Annotated, Generic, Literal, TypeVar
+from uuid import UUID
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+class LocalUserActor(ContractModel):
+    kind: Literal["local_user"] = "local_user"
+
+
+class SystemProcessActor(ContractModel):
+    kind: Literal["system_process"] = "system_process"
+    process_name: NonBlankStr
+
+
+class GenerationActor(ContractModel):
+    kind: Literal["generation"] = "generation"
+    generation_id: UUID
+
+
+Actor = Annotated[
+    LocalUserActor | SystemProcessActor | GenerationActor,
+    Field(discriminator="kind"),
+]
+
+
+class CompetitionScope(ContractModel):
+    kind: Literal["competition"] = "competition"
+    competition_id: UUID
+
+
+class GlobalScope(ContractModel):
+    kind: Literal["global"] = "global"
+    reason: NonBlankStr
+
+
+ScopeT = TypeVar("ScopeT", CompetitionScope, GlobalScope)
+
+
+class ManagerContext(ContractModel, Generic[ScopeT]):
+    actor: Actor
+    scope: ScopeT
+    correlation_id: UUID

--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Typed memory resources, grouped by canonical resource kind."""

--- a/backend/resources/memory/common/__init__.py
+++ b/backend/resources/memory/common/__init__.py
@@ -1,0 +1,47 @@
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    MemoryApplicationError,
+    StaleCanonicalRevisionError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.references import (
+    FranchiseRef,
+    PlayerRef,
+    SeasonRef,
+    SeasonRosterRef,
+    SleeperUserRef,
+)
+from backend.resources.memory.common.receipts import (
+    ReceiptConfidence,
+    ReceiptedMemoryContent,
+)
+from backend.resources.memory.common.versioning import (
+    MemoryContent,
+    MemoryItemIdentity,
+    MemoryVersionMetadata,
+    VersionedMemory,
+)
+
+__all__ = [
+    "CrossCompetitionReferenceError",
+    "FranchiseRef",
+    "MemoryApplicationError",
+    "MemoryContent",
+    "MemoryItemIdentity",
+    "MemoryKind",
+    "MemoryVersionMetadata",
+    "PlayerRef",
+    "ReceiptConfidence",
+    "ReceiptedMemoryContent",
+    "SeasonRef",
+    "SeasonRosterRef",
+    "SleeperUserRef",
+    "StaleCanonicalRevisionError",
+    "StaleItemVersionError",
+    "TargetNotFoundError",
+    "VersionedMemory",
+    "WrongTargetKindError",
+]

--- a/backend/resources/memory/common/errors.py
+++ b/backend/resources/memory/common/errors.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.resources.memory.common.kinds import MemoryKind
+
+
+class MemoryApplicationError(Exception):
+    """Base class for stable memory application failures."""
+
+
+class TargetNotFoundError(MemoryApplicationError):
+    def __init__(
+        self,
+        reference_id: UUID,
+        expected_kinds: tuple[MemoryKind, ...],
+    ) -> None:
+        self.reference_id = reference_id
+        self.expected_kinds = expected_kinds
+        expected = ", ".join(kind.value for kind in expected_kinds)
+        super().__init__(f"target {reference_id} was not found; expected {expected}")
+
+
+class WrongTargetKindError(MemoryApplicationError):
+    def __init__(
+        self,
+        reference_id: UUID,
+        expected_kinds: tuple[MemoryKind, ...],
+        actual_kind: MemoryKind,
+    ) -> None:
+        self.reference_id = reference_id
+        self.expected_kinds = expected_kinds
+        self.actual_kind = actual_kind
+        expected = ", ".join(kind.value for kind in expected_kinds)
+        super().__init__(
+            f"target {reference_id} has kind {actual_kind.value}; expected {expected}"
+        )
+
+
+class CrossCompetitionReferenceError(MemoryApplicationError):
+    def __init__(
+        self,
+        reference_id: UUID,
+        expected_competition_id: UUID,
+        actual_competition_id: UUID,
+    ) -> None:
+        self.reference_id = reference_id
+        self.expected_competition_id = expected_competition_id
+        self.actual_competition_id = actual_competition_id
+        super().__init__(
+            f"target {reference_id} belongs to competition {actual_competition_id}, "
+            f"not {expected_competition_id}"
+        )
+
+
+class StaleItemVersionError(MemoryApplicationError):
+    def __init__(
+        self,
+        item_id: UUID,
+        expected_revision_number: int,
+        actual_revision_number: int,
+    ) -> None:
+        self.item_id = item_id
+        self.expected_revision_number = expected_revision_number
+        self.actual_revision_number = actual_revision_number
+        super().__init__(
+            f"item {item_id} is at revision {actual_revision_number}, "
+            f"not {expected_revision_number}"
+        )
+
+
+class StaleCanonicalRevisionError(MemoryApplicationError):
+    def __init__(
+        self,
+        competition_id: UUID,
+        expected_revision_id: UUID,
+        actual_revision_id: UUID,
+    ) -> None:
+        self.competition_id = competition_id
+        self.expected_revision_id = expected_revision_id
+        self.actual_revision_id = actual_revision_id
+        super().__init__(
+            f"competition {competition_id} is at canonical revision "
+            f"{actual_revision_id}, not {expected_revision_id}"
+        )

--- a/backend/resources/memory/common/kinds.py
+++ b/backend/resources/memory/common/kinds.py
@@ -1,0 +1,9 @@
+from enum import StrEnum
+
+
+class MemoryKind(StrEnum):
+    STORYLINE = "storyline"
+    FACT = "fact"
+    EVENT = "event"
+    TRIGGER = "trigger"
+    CONTEXT_NOTE = "context_note"

--- a/backend/resources/memory/common/receipts.py
+++ b/backend/resources/memory/common/receipts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import JsonValue, model_validator
+
+from backend.resources.memory.common.versioning import MemoryContent
+
+
+class ReceiptConfidence(StrEnum):
+    UNVERIFIED = "unverified"
+    INFERRED = "inferred"
+    SOURCE_BACKED = "source_backed"
+
+
+class ReceiptedMemoryContent(MemoryContent):
+    confidence: ReceiptConfidence
+    primary_tool_call_id: UUID | None = None
+    primary_api_request_id: UUID | None = None
+    source_hints: dict[str, JsonValue] | None = None
+
+    @model_validator(mode="after")
+    def validate_primary_receipt(self) -> ReceiptedMemoryContent:
+        if (
+            self.confidence == ReceiptConfidence.SOURCE_BACKED
+            and self.primary_tool_call_id is None
+            and self.primary_api_request_id is None
+        ):
+            raise ValueError("source-backed content requires a typed primary receipt")
+        return self

--- a/backend/resources/memory/common/references.py
+++ b/backend/resources/memory/common/references.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Generic, Literal, TypeVar
+from uuid import UUID
+
+from backend.resources._contracts import (
+    ContractModel,
+    DisplayName,
+    NonBlankStr,
+)
+
+
+RoleT = TypeVar("RoleT", bound=str)
+
+
+class EntityReference(ContractModel, Generic[RoleT]):
+    role: RoleT
+    display_name: DisplayName = None
+
+
+class FranchiseRef(EntityReference[RoleT], Generic[RoleT]):
+    kind: Literal["franchise"] = "franchise"
+    id: UUID
+
+
+class PlayerRef(EntityReference[RoleT], Generic[RoleT]):
+    kind: Literal["player"] = "player"
+    id: NonBlankStr
+
+
+class SeasonRosterRef(EntityReference[RoleT], Generic[RoleT]):
+    kind: Literal["season_roster"] = "season_roster"
+    id: UUID
+
+
+class SeasonRef(EntityReference[RoleT], Generic[RoleT]):
+    kind: Literal["season"] = "season"
+    id: UUID
+
+
+class SleeperUserRef(EntityReference[RoleT], Generic[RoleT]):
+    kind: Literal["sleeper_user"] = "sleeper_user"
+    id: NonBlankStr

--- a/backend/resources/memory/common/versioning.py
+++ b/backend/resources/memory/common/versioning.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import ClassVar, Generic, TypeVar
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+from backend.resources.memory.common.kinds import MemoryKind
+
+
+class MemoryContent(ContractModel):
+    memory_kind: ClassVar[MemoryKind]
+    schema_version: int
+
+
+class MemoryItemIdentity(ContractModel):
+    item_id: UUID
+    competition_id: UUID
+    kind: MemoryKind
+    agent_key: NonBlankStr | None = None
+    created_at: AwareDatetime
+
+
+class MemoryVersionMetadata(ContractModel):
+    version_id: UUID
+    revision_number: int = Field(gt=0, strict=True)
+    content_schema_version: int = Field(gt=0, strict=True)
+    introduced_revision_id: UUID
+    retired_revision_id: UUID | None = None
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    occurred_at: AwareDatetime | None = None
+    creating_generation_id: UUID
+    creating_tool_call_id: UUID | None = None
+    change_reason: NonBlankStr | None = None
+    recorded_at: AwareDatetime
+
+
+ContentT = TypeVar("ContentT", bound=MemoryContent)
+
+
+class VersionedMemory(ContractModel, Generic[ContentT]):
+    item: MemoryItemIdentity
+    version: MemoryVersionMetadata
+    content: ContentT
+
+    @model_validator(mode="after")
+    def validate_envelope(self) -> VersionedMemory[ContentT]:
+        if self.item.kind != self.content.memory_kind:
+            raise ValueError("item kind does not match content kind")
+        if self.version.content_schema_version != self.content.schema_version:
+            raise ValueError("version metadata does not match content schema version")
+        return self

--- a/backend/resources/memory/context_notes/__init__.py
+++ b/backend/resources/memory/context_notes/__init__.py
@@ -1,0 +1,19 @@
+from backend.resources.memory.context_notes.objects import (
+    CompetitionContextNoteIdentity,
+    CompetitionSeasonContextNoteIdentity,
+    ContextNote,
+    ContextNoteContent,
+    ContextNoteIdentity,
+    ContextNoteStatus,
+    FranchiseContextNoteIdentity,
+)
+
+__all__ = [
+    "CompetitionContextNoteIdentity",
+    "CompetitionSeasonContextNoteIdentity",
+    "ContextNote",
+    "ContextNoteContent",
+    "ContextNoteIdentity",
+    "ContextNoteStatus",
+    "FranchiseContextNoteIdentity",
+]

--- a/backend/resources/memory/context_notes/objects.py
+++ b/backend/resources/memory/context_notes/objects.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel, NonBlankStr, Tags
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.versioning import MemoryContent, VersionedMemory
+
+
+class ContextNoteStatus(StrEnum):
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+
+
+class CompetitionContextNoteIdentity(ContractModel):
+    scope: Literal["competition"] = "competition"
+    note_key: NonBlankStr
+
+
+class CompetitionSeasonContextNoteIdentity(ContractModel):
+    scope: Literal["competition_season"] = "competition_season"
+    competition_season_id: UUID
+    note_key: NonBlankStr
+
+
+class FranchiseContextNoteIdentity(ContractModel):
+    scope: Literal["franchise"] = "franchise"
+    franchise_id: UUID
+    note_key: NonBlankStr
+
+
+ContextNoteIdentity = Annotated[
+    CompetitionContextNoteIdentity
+    | CompetitionSeasonContextNoteIdentity
+    | FranchiseContextNoteIdentity,
+    Field(discriminator="scope"),
+]
+
+
+class ContextNoteContent(MemoryContent):
+    memory_kind: ClassVar[MemoryKind] = MemoryKind.CONTEXT_NOTE
+    schema_version: Literal[1] = 1
+    narrative: NonBlankStr
+    outlook: NonBlankStr | None = None
+    status: ContextNoteStatus
+    tags: Tags
+
+
+class ContextNote(VersionedMemory[ContextNoteContent]):
+    note_identity: ContextNoteIdentity

--- a/backend/resources/memory/events/__init__.py
+++ b/backend/resources/memory/events/__init__.py
@@ -1,0 +1,33 @@
+from backend.resources.memory.events.objects import (
+    Event,
+    EventConfidence,
+    EventContent,
+    EventPayload,
+    EventStatus,
+    EventType,
+)
+from backend.resources.memory.events.payloads.matchup import MatchupEventPayload
+from backend.resources.memory.events.payloads.trade import (
+    BudgetTradeAsset,
+    DraftPickTradeAsset,
+    PlayerTradeAsset,
+    TradeAsset,
+    TradeAssetDirection,
+    TradeEventPayload,
+)
+
+__all__ = [
+    "BudgetTradeAsset",
+    "DraftPickTradeAsset",
+    "Event",
+    "EventConfidence",
+    "EventContent",
+    "EventPayload",
+    "EventStatus",
+    "EventType",
+    "MatchupEventPayload",
+    "PlayerTradeAsset",
+    "TradeAsset",
+    "TradeAssetDirection",
+    "TradeEventPayload",
+]

--- a/backend/resources/memory/events/objects.py
+++ b/backend/resources/memory/events/objects.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, ClassVar, Literal
+
+from pydantic import Field, model_validator
+
+from backend.resources._contracts import NonBlankStr
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.receipts import (
+    ReceiptConfidence,
+    ReceiptedMemoryContent,
+)
+from backend.resources.memory.common.versioning import VersionedMemory
+from backend.resources.memory.events.payloads.matchup import MatchupEventPayload
+from backend.resources.memory.events.payloads.trade import TradeEventPayload
+
+
+class EventType(StrEnum):
+    TRADE = "trade"
+    MATCHUP = "matchup"
+
+
+EventConfidence = ReceiptConfidence
+
+
+class EventStatus(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+EventPayload = Annotated[
+    TradeEventPayload | MatchupEventPayload,
+    Field(discriminator="kind"),
+]
+
+
+class EventContent(ReceiptedMemoryContent):
+    memory_kind: ClassVar[MemoryKind] = MemoryKind.EVENT
+    schema_version: Literal[1] = 1
+    event_type: EventType
+    headline: NonBlankStr
+    summary: NonBlankStr
+    salience: int = Field(ge=1, le=5, strict=True)
+    status: EventStatus
+    details: EventPayload
+
+    @model_validator(mode="after")
+    def validate_event(self) -> EventContent:
+        if self.event_type != self.details.kind:
+            raise ValueError("event type does not match payload kind")
+        return self
+
+
+Event = VersionedMemory[EventContent]

--- a/backend/resources/memory/events/payloads/__init__.py
+++ b/backend/resources/memory/events/payloads/__init__.py
@@ -1,0 +1,19 @@
+from backend.resources.memory.events.payloads.matchup import MatchupEventPayload
+from backend.resources.memory.events.payloads.trade import (
+    BudgetTradeAsset,
+    DraftPickTradeAsset,
+    PlayerTradeAsset,
+    TradeAsset,
+    TradeAssetDirection,
+    TradeEventPayload,
+)
+
+__all__ = [
+    "BudgetTradeAsset",
+    "DraftPickTradeAsset",
+    "MatchupEventPayload",
+    "PlayerTradeAsset",
+    "TradeAsset",
+    "TradeAssetDirection",
+    "TradeEventPayload",
+]

--- a/backend/resources/memory/events/payloads/matchup.py
+++ b/backend/resources/memory/events/payloads/matchup.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+class MatchupEventPayload(ContractModel):
+    kind: Literal["matchup"] = "matchup"
+    winner_franchise_id: UUID
+    loser_franchise_id: UUID
+    sleeper_matchup_id: NonBlankStr
+
+    @model_validator(mode="after")
+    def validate_matchup(self) -> MatchupEventPayload:
+        if self.winner_franchise_id == self.loser_franchise_id:
+            raise ValueError("matchup winner and loser must differ")
+        return self

--- a/backend/resources/memory/events/payloads/trade.py
+++ b/backend/resources/memory/events/payloads/trade.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+class TradeAssetDirection(StrEnum):
+    SENDER_TO_RECEIVER = "sender_to_receiver"
+    RECEIVER_TO_SENDER = "receiver_to_sender"
+
+
+class PlayerTradeAsset(ContractModel):
+    kind: Literal["player"] = "player"
+    direction: TradeAssetDirection
+    player_id: NonBlankStr
+
+
+class DraftPickTradeAsset(ContractModel):
+    kind: Literal["draft_pick"] = "draft_pick"
+    direction: TradeAssetDirection
+    draft_pick_id: UUID
+
+
+class BudgetTradeAsset(ContractModel):
+    kind: Literal["budget"] = "budget"
+    direction: TradeAssetDirection
+    amount: int = Field(ge=0, strict=True)
+
+
+TradeAsset = Annotated[
+    PlayerTradeAsset | DraftPickTradeAsset | BudgetTradeAsset,
+    Field(discriminator="kind"),
+]
+
+
+class TradeEventPayload(ContractModel):
+    kind: Literal["trade"] = "trade"
+    sender_franchise_id: UUID
+    receiver_franchise_id: UUID
+    assets: list[TradeAsset] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_trade(self) -> TradeEventPayload:
+        if self.sender_franchise_id == self.receiver_franchise_id:
+            raise ValueError("trade sender and receiver must differ")
+
+        asset_keys: list[tuple[object, ...]] = []
+        for asset in self.assets:
+            if isinstance(asset, PlayerTradeAsset):
+                asset_keys.append((asset.kind, asset.player_id))
+            elif isinstance(asset, DraftPickTradeAsset):
+                asset_keys.append((asset.kind, asset.draft_pick_id))
+            else:
+                asset_keys.append((asset.kind, asset.direction))
+        if len(asset_keys) != len(set(asset_keys)):
+            raise ValueError("trade assets must be distinct")
+        return self

--- a/backend/resources/memory/facts/__init__.py
+++ b/backend/resources/memory/facts/__init__.py
@@ -1,0 +1,17 @@
+from backend.resources.memory.facts.objects import (
+    Fact,
+    FactConfidence,
+    FactContent,
+    FactEntityRef,
+    FactStatus,
+    FactSubjectRole,
+)
+
+__all__ = [
+    "Fact",
+    "FactConfidence",
+    "FactContent",
+    "FactEntityRef",
+    "FactStatus",
+    "FactSubjectRole",
+]

--- a/backend/resources/memory/facts/objects.py
+++ b/backend/resources/memory/facts/objects.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import Field, JsonValue, model_validator
+
+from backend.resources._contracts import NonBlankStr
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.receipts import (
+    ReceiptConfidence,
+    ReceiptedMemoryContent,
+)
+from backend.resources.memory.common.references import (
+    FranchiseRef,
+    PlayerRef,
+    SeasonRef,
+    SeasonRosterRef,
+    SleeperUserRef,
+)
+from backend.resources.memory.common.versioning import VersionedMemory
+
+
+FactConfidence = ReceiptConfidence
+
+
+class FactStatus(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    REJECTED = "rejected"
+    ARCHIVED = "archived"
+
+
+class FactSubjectRole(StrEnum):
+    SUBJECT = "subject"
+
+
+FactEntityRef = Annotated[
+    FranchiseRef[FactSubjectRole]
+    | PlayerRef[FactSubjectRole]
+    | SeasonRosterRef[FactSubjectRole]
+    | SeasonRef[FactSubjectRole]
+    | SleeperUserRef[FactSubjectRole],
+    Field(discriminator="kind"),
+]
+
+
+class FactContent(ReceiptedMemoryContent):
+    memory_kind: ClassVar[MemoryKind] = MemoryKind.FACT
+    schema_version: Literal[1] = 1
+    claim: NonBlankStr
+    category: NonBlankStr
+    numbers: dict[str, JsonValue]
+    status: FactStatus
+    subjects: list[FactEntityRef]
+    originating_event_version_ids: list[UUID]
+
+    @model_validator(mode="after")
+    def validate_evidence(self) -> FactContent:
+        subject_ids = [(subject.kind, subject.id) for subject in self.subjects]
+        if len(subject_ids) != len(set(subject_ids)):
+            raise ValueError("fact subjects must target distinct entities")
+
+        if len(self.originating_event_version_ids) != len(
+            set(self.originating_event_version_ids)
+        ):
+            raise ValueError("originating event versions must be distinct")
+
+        return self
+
+
+Fact = VersionedMemory[FactContent]

--- a/backend/resources/memory/storylines/__init__.py
+++ b/backend/resources/memory/storylines/__init__.py
@@ -1,0 +1,23 @@
+from backend.resources.memory.storylines.objects import (
+    EvidenceRef,
+    EvidenceRole,
+    RelatedStorylineRef,
+    RelatedStorylineRole,
+    Storyline,
+    StorylineContent,
+    StorylineEntityRef,
+    StorylineStatus,
+    StorylineSubjectRole,
+)
+
+__all__ = [
+    "EvidenceRef",
+    "EvidenceRole",
+    "RelatedStorylineRef",
+    "RelatedStorylineRole",
+    "Storyline",
+    "StorylineContent",
+    "StorylineEntityRef",
+    "StorylineStatus",
+    "StorylineSubjectRole",
+]

--- a/backend/resources/memory/storylines/objects.py
+++ b/backend/resources/memory/storylines/objects.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr, Tags
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.references import (
+    FranchiseRef,
+    PlayerRef,
+    SeasonRef,
+    SeasonRosterRef,
+    SleeperUserRef,
+)
+from backend.resources.memory.common.versioning import MemoryContent, VersionedMemory
+
+
+class StorylineStatus(StrEnum):
+    ACTIVE = "active"
+    DORMANT = "dormant"
+    RESOLVED = "resolved"
+    ARCHIVED = "archived"
+
+
+class StorylineSubjectRole(StrEnum):
+    FOCUS = "focus"
+    COUNTERPARTY = "counterparty"
+
+
+StorylineEntityRef = Annotated[
+    FranchiseRef[StorylineSubjectRole]
+    | PlayerRef[StorylineSubjectRole]
+    | SeasonRosterRef[StorylineSubjectRole]
+    | SeasonRef[StorylineSubjectRole]
+    | SleeperUserRef[StorylineSubjectRole],
+    Field(discriminator="kind"),
+]
+
+
+class EvidenceRole(StrEnum):
+    ORIGIN = "origin"
+    SUPPORT = "support"
+    UPDATE = "update"
+    PAYOFF = "payoff"
+
+
+class EvidenceReference(ContractModel):
+    version_id: UUID
+    role: EvidenceRole
+
+
+class FactEvidenceRef(EvidenceReference):
+    kind: Literal["fact"] = "fact"
+
+
+class EventEvidenceRef(EvidenceReference):
+    kind: Literal["event"] = "event"
+
+
+EvidenceRef = Annotated[
+    FactEvidenceRef | EventEvidenceRef,
+    Field(discriminator="kind"),
+]
+
+
+class RelatedStorylineRole(StrEnum):
+    RELATED_ARC = "related_arc"
+    CONTINUATION = "continuation"
+    COUNTERPOINT = "counterpoint"
+
+
+class RelatedStorylineRef(ContractModel):
+    item_id: UUID
+    role: RelatedStorylineRole
+
+
+class StorylineContent(MemoryContent):
+    memory_kind: ClassVar[MemoryKind] = MemoryKind.STORYLINE
+    schema_version: Literal[1] = 1
+    headline: NonBlankStr
+    summary: NonBlankStr
+    status: StorylineStatus
+    arc_type: NonBlankStr | None = None
+    salience: int = Field(ge=1, le=5, strict=True)
+    tags: Tags
+    subjects: list[StorylineEntityRef]
+    evidence: list[EvidenceRef]
+    related_storylines: list[RelatedStorylineRef]
+    callback_condition: NonBlankStr | None = None
+    resolution_summary: NonBlankStr | None = None
+
+    @model_validator(mode="after")
+    def validate_relationships(self) -> StorylineContent:
+        subject_ids = [(subject.kind, subject.id) for subject in self.subjects]
+        if len(subject_ids) != len(set(subject_ids)):
+            raise ValueError("storyline subjects must target distinct entities")
+        if self.subjects and not any(
+            subject.role == StorylineSubjectRole.FOCUS for subject in self.subjects
+        ):
+            raise ValueError("a storyline with subjects requires a focus")
+
+        evidence_ids = [reference.version_id for reference in self.evidence]
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise ValueError("storyline evidence versions must be distinct")
+
+        related_ids = [reference.item_id for reference in self.related_storylines]
+        if len(related_ids) != len(set(related_ids)):
+            raise ValueError("related storyline items must be distinct")
+
+        return self
+
+
+Storyline = VersionedMemory[StorylineContent]

--- a/backend/resources/memory/triggers/__init__.py
+++ b/backend/resources/memory/triggers/__init__.py
@@ -1,0 +1,23 @@
+from backend.resources.memory.triggers.conditions.rematch import RematchCondition
+from backend.resources.memory.triggers.conditions.trade_evaluation import (
+    TradeEvaluationCondition,
+)
+from backend.resources.memory.triggers.objects import (
+    FirePolicy,
+    Trigger,
+    TriggerCondition,
+    TriggerContent,
+    TriggerStatus,
+    TriggerType,
+)
+
+__all__ = [
+    "FirePolicy",
+    "RematchCondition",
+    "TradeEvaluationCondition",
+    "Trigger",
+    "TriggerCondition",
+    "TriggerContent",
+    "TriggerStatus",
+    "TriggerType",
+]

--- a/backend/resources/memory/triggers/conditions/__init__.py
+++ b/backend/resources/memory/triggers/conditions/__init__.py
@@ -1,0 +1,6 @@
+from backend.resources.memory.triggers.conditions.rematch import RematchCondition
+from backend.resources.memory.triggers.conditions.trade_evaluation import (
+    TradeEvaluationCondition,
+)
+
+__all__ = ["RematchCondition", "TradeEvaluationCondition"]

--- a/backend/resources/memory/triggers/conditions/rematch.py
+++ b/backend/resources/memory/triggers/conditions/rematch.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import model_validator
+
+from backend.resources._contracts import ContractModel
+
+
+class RematchCondition(ContractModel):
+    kind: Literal["rematch"] = "rematch"
+    franchise_ids: tuple[UUID, UUID]
+
+    @model_validator(mode="after")
+    def validate_franchises(self) -> RematchCondition:
+        if self.franchise_ids[0] == self.franchise_ids[1]:
+            raise ValueError("rematch franchises must differ")
+        return self

--- a/backend/resources/memory/triggers/conditions/trade_evaluation.py
+++ b/backend/resources/memory/triggers/conditions/trade_evaluation.py
@@ -1,0 +1,7 @@
+from typing import Literal
+
+from backend.resources._contracts import ContractModel
+
+
+class TradeEvaluationCondition(ContractModel):
+    kind: Literal["trade_evaluation"] = "trade_evaluation"

--- a/backend/resources/memory/triggers/objects.py
+++ b/backend/resources/memory/triggers/objects.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, ClassVar, Literal
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from backend.resources._contracts import NonBlankStr
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.versioning import MemoryContent, VersionedMemory
+from backend.resources.memory.triggers.conditions.rematch import RematchCondition
+from backend.resources.memory.triggers.conditions.trade_evaluation import (
+    TradeEvaluationCondition,
+)
+
+
+class TriggerType(StrEnum):
+    REMATCH = "rematch"
+    TRADE_EVALUATION = "trade_evaluation"
+
+
+class TriggerStatus(StrEnum):
+    OPEN = "open"
+    FIRED = "fired"
+    SATISFIED = "satisfied"
+    EXPIRED = "expired"
+    ARCHIVED = "archived"
+
+
+class FirePolicy(StrEnum):
+    ONE_SHOT = "one_shot"
+    RECURRING = "recurring"
+    UNTIL_RESOLVED = "until_resolved"
+
+
+TriggerCondition = Annotated[
+    RematchCondition | TradeEvaluationCondition,
+    Field(discriminator="kind"),
+]
+
+
+class TriggerContent(MemoryContent):
+    memory_kind: ClassVar[MemoryKind] = MemoryKind.TRIGGER
+    schema_version: Literal[1] = 1
+    trigger_type: TriggerType
+    status: TriggerStatus
+    fire_policy: FirePolicy
+    target_competition_season_id: UUID | None = None
+    target_storyline_item_id: UUID | None = None
+    origin_event_item_id: UUID | None = None
+    target_week: int | None = Field(default=None, ge=0, strict=True)
+    target_at: AwareDatetime | None = None
+    condition: TriggerCondition
+    resolution_reason: NonBlankStr | None = None
+
+    @model_validator(mode="after")
+    def validate_trigger(self) -> TriggerContent:
+        if self.trigger_type != self.condition.kind:
+            raise ValueError("trigger type does not match condition kind")
+
+        if isinstance(self.condition, RematchCondition):
+            if self.target_competition_season_id is None or self.target_week is None:
+                raise ValueError("rematch triggers require a target season and week")
+        elif self.origin_event_item_id is None:
+            raise ValueError("trade-evaluation triggers require an origin event")
+
+        if (
+            isinstance(self.condition, TradeEvaluationCondition)
+            and self.target_week is None
+            and self.target_at is None
+        ):
+            raise ValueError("trade-evaluation triggers require a target week or time")
+        return self
+
+
+Trigger = VersionedMemory[TriggerContent]

--- a/backend/tests/resources/memory/test_common_contracts.py
+++ b/backend/tests/resources/memory/test_common_contracts.py
@@ -1,0 +1,147 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from backend.resources.context import CompetitionScope, GlobalScope, ManagerContext
+from backend.resources.memory.common import (
+    MemoryItemIdentity,
+    MemoryVersionMetadata,
+    VersionedMemory,
+)
+from backend.resources.memory.storylines import StorylineContent, StorylineEntityRef
+
+
+@pytest.mark.parametrize(
+    ("actor", "expected_kind"),
+    [
+        ({"kind": "local_user"}, "local_user"),
+        ({"kind": "system_process", "process_name": "worker"}, "system_process"),
+        ({"kind": "generation", "generation_id": uuid4()}, "generation"),
+    ],
+)
+def test_manager_context_discriminates_every_actor(
+    actor: dict[str, object],
+    expected_kind: str,
+) -> None:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": actor,
+            "scope": {"kind": "competition", "competition_id": uuid4()},
+            "correlation_id": uuid4(),
+        }
+    )
+
+    assert context.actor.kind == expected_kind
+    assert context.scope.kind == "competition"
+
+
+def test_manager_context_discriminates_both_scopes() -> None:
+    global_context = ManagerContext[GlobalScope].model_validate(
+        {
+            "actor": {"kind": "system_process", "process_name": "catalog-refresh"},
+            "scope": {"kind": "global", "reason": "player catalog refresh"},
+            "correlation_id": uuid4(),
+        }
+    )
+    assert global_context.scope.kind == "global"
+
+    with pytest.raises(ValidationError):
+        ManagerContext[CompetitionScope].model_validate(
+            {
+                "actor": {"kind": "system_process", "process_name": "worker"},
+                "scope": {"kind": "global", "reason": "player catalog refresh"},
+                "correlation_id": uuid4(),
+            }
+        )
+
+
+def test_contract_models_are_frozen_and_reject_unknown_fields() -> None:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "competition", "competition_id": uuid4()},
+            "correlation_id": uuid4(),
+        }
+    )
+
+    with pytest.raises(ValidationError, match="frozen"):
+        context.correlation_id = uuid4()
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ManagerContext[CompetitionScope].model_validate(
+            {
+                **context.model_dump(),
+                "pinned_revision_id": uuid4(),
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("kind", "reference_id"),
+    [
+        ("franchise", uuid4()),
+        ("player", "player-1"),
+        ("season_roster", uuid4()),
+        ("season", uuid4()),
+        ("sleeper_user", "user-1"),
+    ],
+)
+def test_storyline_entity_reference_discriminator(
+    kind: str,
+    reference_id: object,
+) -> None:
+    reference = TypeAdapter(StorylineEntityRef).validate_python(
+        {"kind": kind, "id": reference_id, "role": "focus"}
+    )
+
+    assert reference.kind == kind
+
+
+def test_versioned_memory_enforces_kind_and_schema_version() -> None:
+    content = StorylineContent(
+        headline="A rivalry resumes",
+        summary="The league's longest-running rivalry has another chapter.",
+        status="active",
+        salience=4,
+        tags=[],
+        subjects=[],
+        evidence=[],
+        related_storylines=[],
+    )
+    item = MemoryItemIdentity(
+        item_id=uuid4(),
+        competition_id=uuid4(),
+        kind="storyline",
+        created_at=datetime.now(UTC),
+    )
+    version = MemoryVersionMetadata(
+        version_id=uuid4(),
+        revision_number=1,
+        content_schema_version=1,
+        introduced_revision_id=uuid4(),
+        creating_generation_id=uuid4(),
+        recorded_at=datetime.now(UTC),
+    )
+
+    resource = VersionedMemory[StorylineContent](
+        item=item,
+        version=version,
+        content=content,
+    )
+    assert resource.content.schema_version == 1
+
+    with pytest.raises(ValidationError, match="item kind"):
+        VersionedMemory[StorylineContent](
+            item=item.model_copy(update={"kind": "fact"}),
+            version=version,
+            content=content,
+        )
+
+    with pytest.raises(ValidationError, match="content schema version"):
+        VersionedMemory[StorylineContent](
+            item=item,
+            version=version.model_copy(update={"content_schema_version": 2}),
+            content=content,
+        )

--- a/backend/tests/resources/memory/test_content_contracts.py
+++ b/backend/tests/resources/memory/test_content_contracts.py
@@ -1,0 +1,224 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from backend.resources.memory.context_notes import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.events import EventContent
+from backend.resources.memory.facts import FactContent, FactEntityRef
+from backend.resources.memory.storylines import EvidenceRef, StorylineContent
+from backend.resources.memory.triggers import TriggerContent
+
+
+def test_storyline_contract_normalizes_tags_and_validates_relationships() -> None:
+    evidence_id = uuid4()
+    storyline = StorylineContent.model_validate(
+        {
+            "headline": "  Deadline fallout  ",
+            "summary": "A contender paid up to complete its roster.",
+            "status": "active",
+            "salience": 4,
+            "tags": [" Trade ", "trade", "  "],
+            "subjects": [
+                {"kind": "franchise", "id": uuid4(), "role": "focus"},
+                {"kind": "player", "id": "player-1", "role": "counterparty"},
+            ],
+            "evidence": [
+                {"kind": "fact", "version_id": evidence_id, "role": "support"}
+            ],
+            "related_storylines": [
+                {"item_id": uuid4(), "role": "continuation"}
+            ],
+        }
+    )
+
+    assert storyline.headline == "Deadline fallout"
+    assert storyline.tags == ["trade"]
+    assert storyline.evidence[0].kind == "fact"
+
+    with pytest.raises(ValidationError, match="evidence versions must be distinct"):
+        StorylineContent.model_validate(
+            {
+                **storyline.model_dump(),
+                "evidence": [
+                    {"kind": "fact", "version_id": evidence_id, "role": "support"},
+                    {"kind": "fact", "version_id": evidence_id, "role": "update"},
+                ],
+            }
+        )
+
+    with pytest.raises(ValidationError, match="requires a focus"):
+        StorylineContent.model_validate(
+            {
+                **storyline.model_dump(),
+                "subjects": [
+                    {
+                        "kind": "player",
+                        "id": "player-1",
+                        "role": "counterparty",
+                    }
+                ],
+            }
+        )
+
+
+def test_fact_entity_reference_has_a_resource_local_role() -> None:
+    reference = TypeAdapter(FactEntityRef).validate_python(
+        {"kind": "player", "id": "player-1", "role": "subject"}
+    )
+    assert reference.role == "subject"
+
+    with pytest.raises(ValidationError):
+        TypeAdapter(FactEntityRef).validate_python(
+            {"kind": "player", "id": "player-1", "role": "focus"}
+        )
+
+
+@pytest.mark.parametrize("kind", ["fact", "event"])
+def test_storyline_evidence_discriminator_covers_exact_reference_kinds(
+    kind: str,
+) -> None:
+    reference = TypeAdapter(EvidenceRef).validate_python(
+        {"kind": kind, "version_id": uuid4(), "role": "support"}
+    )
+    assert reference.kind == kind
+
+
+def test_fact_contract_requires_typed_receipt_for_source_backed_claim() -> None:
+    fact = FactContent(
+        claim="The franchise won six straight games.",
+        category="streak",
+        numbers={"wins": 6},
+        confidence="source_backed",
+        status="active",
+        subjects=[],
+        originating_event_version_ids=[],
+        primary_api_request_id=uuid4(),
+    )
+    assert fact.numbers == {"wins": 6}
+
+    with pytest.raises(ValidationError, match="typed primary receipt"):
+        FactContent.model_validate(
+            {
+                **fact.model_dump(),
+                "primary_api_request_id": None,
+                "source_hints": {"note": "remembered from last week"},
+            }
+        )
+
+    with pytest.raises(ValidationError, match="finite number"):
+        FactContent.model_validate(
+            {
+                **fact.model_dump(),
+                "confidence": "unverified",
+                "numbers": {"invalid": float("nan")},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"scope": "competition", "note_key": "league_voice"},
+        {
+            "scope": "competition_season",
+            "competition_season_id": uuid4(),
+            "note_key": "playoff_race",
+        },
+        {"scope": "franchise", "franchise_id": uuid4(), "note_key": "outlook"},
+    ],
+)
+def test_context_note_identity_discriminator(identity: dict[str, object]) -> None:
+    parsed = TypeAdapter(ContextNoteIdentity).validate_python(identity)
+    assert parsed.scope == identity["scope"]
+
+
+def test_context_note_identity_rejects_mixed_scope_shape() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(ContextNoteIdentity).validate_python(
+            {
+                "scope": "competition",
+                "franchise_id": uuid4(),
+                "note_key": "outlook",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("contract", "payload"),
+    [
+        (
+            StorylineContent,
+            {
+                "headline": "h",
+                "summary": "s",
+                "status": "active",
+                "salience": 1,
+                "tags": [],
+                "subjects": [],
+                "evidence": [],
+                "related_storylines": [],
+            },
+        ),
+        (
+            FactContent,
+            {
+                "claim": "c",
+                "category": "cat",
+                "numbers": {},
+                "confidence": "unverified",
+                "status": "active",
+                "subjects": [],
+                "originating_event_version_ids": [],
+            },
+        ),
+        (
+            EventContent,
+            {
+                "event_type": "matchup",
+                "headline": "h",
+                "summary": "s",
+                "salience": 1,
+                "confidence": "unverified",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": uuid4(),
+                    "loser_franchise_id": uuid4(),
+                    "sleeper_matchup_id": "1",
+                },
+            },
+        ),
+        (
+            TriggerContent,
+            {
+                "trigger_type": "rematch",
+                "status": "open",
+                "fire_policy": "one_shot",
+                "target_competition_season_id": uuid4(),
+                "target_week": 1,
+                "condition": {
+                    "kind": "rematch",
+                    "franchise_ids": [uuid4(), uuid4()],
+                },
+            },
+        ),
+        (
+            ContextNoteContent,
+            {"narrative": "n", "status": "active", "tags": []},
+        ),
+    ],
+)
+def test_current_resource_schema_decodes_and_unknown_versions_are_rejected(
+    contract: type[BaseModel],
+    payload: dict[str, object],
+) -> None:
+    current = contract.model_validate(payload)
+    assert current.schema_version == 1
+    assert contract.model_validate_json(current.model_dump_json()) == current
+
+    with pytest.raises(ValidationError):
+        contract.model_validate({**payload, "schema_version": 2})

--- a/backend/tests/resources/memory/test_event_trigger_contracts.py
+++ b/backend/tests/resources/memory/test_event_trigger_contracts.py
@@ -1,0 +1,164 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.memory.events import EventContent, TradeEventPayload
+from backend.resources.memory.triggers import TriggerContent
+
+
+def _event(details: dict[str, object], event_type: str) -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": event_type,
+            "headline": "A consequential result",
+            "summary": "The event changed the season's narrative.",
+            "salience": 4,
+            "confidence": "source_backed",
+            "status": "active",
+            "details": details,
+            "primary_tool_call_id": uuid4(),
+        }
+    )
+
+
+def test_trade_payload_discriminates_all_initial_asset_types() -> None:
+    trade = _event(
+        {
+            "kind": "trade",
+            "sender_franchise_id": uuid4(),
+            "receiver_franchise_id": uuid4(),
+            "assets": [
+                {
+                    "kind": "player",
+                    "direction": "sender_to_receiver",
+                    "player_id": "player-1",
+                },
+                {
+                    "kind": "draft_pick",
+                    "direction": "receiver_to_sender",
+                    "draft_pick_id": uuid4(),
+                },
+                {
+                    "kind": "budget",
+                    "direction": "sender_to_receiver",
+                    "amount": 10,
+                },
+            ],
+        },
+        "trade",
+    )
+
+    assert isinstance(trade.details, TradeEventPayload)
+    assert [asset.kind for asset in trade.details.assets] == [
+        "player",
+        "draft_pick",
+        "budget",
+    ]
+
+    duplicate_assets = trade.details.model_dump()
+    duplicate_assets["assets"] = [
+        {
+            "kind": "player",
+            "direction": "sender_to_receiver",
+            "player_id": "player-1",
+        },
+        {
+            "kind": "player",
+            "direction": "receiver_to_sender",
+            "player_id": "player-1",
+        },
+    ]
+    with pytest.raises(ValidationError, match="assets must be distinct"):
+        _event(duplicate_assets, "trade")
+
+
+def test_event_contract_rejects_payload_mismatch_and_invalid_participants() -> None:
+    winner_id = uuid4()
+    matchup = {
+        "kind": "matchup",
+        "winner_franchise_id": winner_id,
+        "loser_franchise_id": winner_id,
+        "sleeper_matchup_id": "3",
+    }
+    with pytest.raises(ValidationError, match="winner and loser"):
+        _event(matchup, "matchup")
+
+    matchup["loser_franchise_id"] = uuid4()
+    with pytest.raises(ValidationError, match="does not match payload kind"):
+        _event(matchup, "trade")
+
+    franchise_id = uuid4()
+    with pytest.raises(ValidationError, match="sender and receiver"):
+        _event(
+            {
+                "kind": "trade",
+                "sender_franchise_id": franchise_id,
+                "receiver_franchise_id": franchise_id,
+                "assets": [
+                    {
+                        "kind": "player",
+                        "direction": "sender_to_receiver",
+                        "player_id": "player-1",
+                    }
+                ],
+            },
+            "trade",
+        )
+
+
+def test_trigger_contract_discriminates_initial_conditions() -> None:
+    rematch = TriggerContent.model_validate(
+        {
+            "trigger_type": "rematch",
+            "status": "open",
+            "fire_policy": "one_shot",
+            "target_competition_season_id": uuid4(),
+            "target_week": 7,
+            "condition": {
+                "kind": "rematch",
+                "franchise_ids": [uuid4(), uuid4()],
+            },
+        }
+    )
+    trade_evaluation = TriggerContent.model_validate(
+        {
+            "trigger_type": "trade_evaluation",
+            "status": "open",
+            "fire_policy": "until_resolved",
+            "origin_event_item_id": uuid4(),
+            "target_at": datetime.now(UTC),
+            "condition": {"kind": "trade_evaluation"},
+        }
+    )
+
+    assert rematch.condition.kind == "rematch"
+    assert trade_evaluation.condition.kind == "trade_evaluation"
+
+
+def test_trigger_contract_owns_condition_specific_requirements() -> None:
+    with pytest.raises(ValidationError, match="target season and week"):
+        TriggerContent.model_validate(
+            {
+                "trigger_type": "rematch",
+                "status": "open",
+                "fire_policy": "one_shot",
+                "condition": {
+                    "kind": "rematch",
+                    "franchise_ids": [uuid4(), uuid4()],
+                },
+            }
+        )
+
+    with pytest.raises(ValidationError, match="does not match condition kind"):
+        TriggerContent.model_validate(
+            {
+                "trigger_type": "rematch",
+                "status": "open",
+                "fire_policy": "one_shot",
+                "origin_event_item_id": uuid4(),
+                "target_week": 8,
+                "condition": {"kind": "trade_evaluation"},
+            }
+        )

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -92,6 +92,8 @@ storylines involving this franchise.”
 
 ## Documents
 
+- [`status.md`](status.md) — implementation ownership, verification, stack, and
+  open-decision ledger.
 - [`canonical-schema.md`](canonical-schema.md) — canonical PostgreSQL model,
   version boundaries, and reference rules.
 - [`application-contracts.md`](application-contracts.md) — Pydantic content

--- a/docs/memory/application-contracts.md
+++ b/docs/memory/application-contracts.md
@@ -1,6 +1,6 @@
 # Application Memory Contracts
 
-**Status:** Application design; database storage implemented, application code pending
+**Status:** Typed v1 contracts implemented; resource managers pending
 
 ## Goal
 
@@ -9,7 +9,8 @@ ORM association rows. Routes, tools, services, and the reporter operate on typed
 resource objects. Typed resource managers translate their own objects, while
 the mutation service and revision manager coordinate an atomic bundle.
 
-The examples below are illustrative Pydantic-style contracts, not final code.
+The shapes below describe the implemented v1 Pydantic contracts. Contract model
+fields cannot be reassigned after validation, and unknown fields are rejected.
 
 ## Shared Reference Primitives
 
@@ -36,10 +37,20 @@ EntityRef = Annotated[
 ]
 ```
 
-Each owning content type narrows the roles it accepts. A trade event may accept
-`sender`, `receiver`, and `asset`; a fact may accept `subject`; a storyline may
-accept `focus` and `counterparty`. Sharing the low-level reference primitive does
-not imply sharing one generic semantic role bag.
+Each owning content type narrows the roles it accepts. A fact accepts `subject`,
+while a storyline accepts `focus` and `counterparty`. Event-specific participant
+meaning lives in its typed payload instead of a generic role bag. Sharing the
+low-level reference primitive does not imply sharing generic semantic roles.
+
+The initial storyline roles are `focus` and `counterparty`; the initial fact role
+is `subject`. Franchise, player, season-roster, season, and Sleeper-user references
+are legal for both resources. Empty subject lists remain legal for
+competition-wide memory, but a non-empty storyline subject list must contain a
+focus. Repeated targets are invalid even when their roles differ.
+
+Human-readable strings are trimmed and must be nonblank. Tags are normalized to
+case-folded, first-seen order; blank and repeated tags are removed. Complete
+collection fields remain required even when their legal value is an empty list.
 
 Evidence references identify exact immutable content:
 
@@ -85,18 +96,23 @@ class FactContent(BaseModel):
     schema_version: Literal[1]
     claim: str
     category: str
-    numbers: dict[str, object]
+    numbers: dict[str, JsonValue]
     confidence: FactConfidence
     status: FactStatus
     subjects: list[FactEntityRef]
     originating_event_version_ids: list[UUID]
     primary_tool_call_id: UUID | None = None
     primary_api_request_id: UUID | None = None
-    source_hints: dict[str, object] | None = None
+    source_hints: dict[str, JsonValue] | None = None
 ```
 
 An originating event is optional context; the fact remains a claim with its own
 receipts. It does not contain another event payload.
+
+Fact confidence is `unverified`, `inferred`, or `source_backed`; status is
+`active`, `superseded`, `rejected`, or `archived`. A source-backed fact requires
+at least one typed primary tool-call or API-request receipt. Source hints are
+JSON-valued mappings and cannot independently establish source-backed confidence.
 
 ### Event
 
@@ -116,7 +132,7 @@ class MatchupEventPayload(BaseModel):
 
 
 EventPayload = Annotated[
-    TradeEventPayload | MatchupEventPayload | WaiverEventPayload,
+    TradeEventPayload | MatchupEventPayload,
     Field(discriminator="kind"),
 ]
 
@@ -132,10 +148,19 @@ class EventContent(BaseModel):
     details: EventPayload
     primary_tool_call_id: UUID | None = None
     primary_api_request_id: UUID | None = None
+    source_hints: dict[str, JsonValue] | None = None
 ```
 
 `details` describes this event. It is not a collection of related events. The
 declared event type and discriminated payload must agree.
+
+The initial event union contains only `trade` and `matchup`. Event confidence and
+status use the same values and typed-receipt rule as facts. Trade assets form a
+second discriminated union over players, normalized draft picks, and budget.
+Every asset states `sender_to_receiver` or `receiver_to_sender`, making bilateral
+trades unambiguous. A trade requires distinct franchises and at least one unique
+asset; a matchup requires distinct winner and loser franchises and a nonblank
+Sleeper matchup ID.
 
 ### Trigger
 
@@ -145,6 +170,7 @@ class TriggerContent(BaseModel):
     trigger_type: TriggerType
     status: TriggerStatus
     fire_policy: FirePolicy
+    target_competition_season_id: UUID | None = None
     target_storyline_item_id: UUID | None = None
     origin_event_item_id: UUID | None = None
     target_week: int | None = None
@@ -152,6 +178,17 @@ class TriggerContent(BaseModel):
     condition: TriggerCondition
     resolution_reason: str | None = None
 ```
+
+Initial trigger types and conditions are:
+
+- `rematch`, with exactly two distinct franchise IDs; it requires a target
+  competition season and week;
+- `trade_evaluation`, whose stable origin event supplies the trade details; it
+  requires that origin event plus either a target week or target time.
+
+The condition discriminator must agree with `trigger_type`. Trigger status is
+`open`, `fired`, `satisfied`, `expired`, or `archived`; fire policy is `one_shot`,
+`recurring`, or `until_resolved`. Target times must be timezone-aware.
 
 ### Context note
 
@@ -165,6 +202,26 @@ class ContextNoteContent(BaseModel):
 ```
 
 The note's scope and key are loaded from its stable typed identity.
+
+Context-note status is initially `active` or `archived`. Its identity is a
+discriminated union for competition, competition-season, and franchise scopes,
+so impossible mixed scope/target shapes cannot be constructed.
+
+## Manager Context and Hydrated Resources
+
+Every manager receives an immutable, already-resolved `ManagerContext` with a
+discriminated local-user, system-process, or generation actor; an explicit
+competition or global resource scope; and a required correlation ID. Memory
+managers accept only competition scope. Global scope requires a nonblank reason.
+Generation cutoffs and pinned memory revisions remain explicit workflow inputs,
+not authorization context.
+
+Hydration returns one generic `VersionedMemory[Content]` envelope containing the
+stable memory-item identity, immutable version metadata, and the resource's typed
+content. The envelope validates item kind and stored content-schema version.
+History is a sequence of the same complete envelopes rather than a second shallow
+history DTO. Context notes add their stable typed scope/key identity to this
+aggregate.
 
 ## Mutation Contract
 

--- a/docs/memory/implementation-plan.md
+++ b/docs/memory/implementation-plan.md
@@ -381,7 +381,9 @@ based on the preceding branch and each PR shows only its incremental changes.
 - Add separate Pydantic contracts for all five memory resources.
 - Settle role enums, cardinalities, initial event payloads, and initial trigger
   conditions.
-- Test every discriminator, semantic boundary, and retained schema version.
+- Use lean contract tests for public discriminator branches, meaningful semantic
+  boundaries, and every retained schema version; do not mirror implementation
+  details or enumerate low-value permutations.
 
 ### `memory-3` — revisions and critical query proofs
 

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -1,0 +1,75 @@
+# Typed Memory Implementation Status
+
+## Current Phase
+
+**Active layer:** `memory-2` complete; `memory-3` queued  
+**Current branch:** `codex/memory-2-contracts`  
+**Stack:** `main` ← `memory-0` ← `memory-1` ← `memory-2`  
+**Publication:** Remote branches exist through `memory-2`; PR state is unverified
+because GitHub CLI is not authenticated in the implementation environment.
+
+This file is the coordination ledger for the typed-memory application stack.
+The completed database stack remains tracked separately in
+[`docs/database/status.md`](../database/status.md).
+
+## Layer Ledger
+
+| Layer | Branch | State | Owner | Verification | Commit / PR |
+| --- | --- | --- | --- | --- | --- |
+| `memory-0` implementation plan | `codex/memory-0-implementation-plan` | Complete | `root` | Documentation review | `45477b0`; PR unverified |
+| `memory-1` ORM modules | `codex/memory-1-orm-modules` | Complete | `root` | Schema-preserving split already committed | `b7f758c`; PR unverified |
+| `memory-2` contracts | `codex/memory-2-contracts` | Complete | `root` + `contracts_audit` | 29 focused contract tests; backend: 52 passed, 49 PostgreSQL tests skipped | Branch head; PR unverified |
+| `memory-3` revisions | `codex/memory-3-revisions` | Queued | Unassigned | Not started | — |
+| `memory-4` facts | `codex/memory-4-facts` | Pending | Unassigned | Not started | — |
+| `memory-5` events | `codex/memory-5-events` | Pending | Unassigned | Not started | — |
+| `memory-6` storylines | `codex/memory-6-storylines` | Pending | Unassigned | Not started | — |
+| `memory-7` triggers | `codex/memory-7-triggers` | Pending | Unassigned | Not started | — |
+| `memory-8` context notes | `codex/memory-8-context-notes` | Pending | Unassigned | Not started | — |
+| `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Pending | Unassigned | Not started | — |
+| `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
+| `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
+| `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |
+| `memory-13` reporter retrieval | `codex/memory-13-reporter-retrieval` | Pending | Unassigned | Not started | — |
+| `memory-14` reporter mutations | `codex/memory-14-reporter-mutations` | Pending | Unassigned | Not started | — |
+
+## Coordination Rules
+
+- Work on one stack layer at a time and keep each layer independently testable.
+- Keep tests lean and contract-based: cover behavior that materially increases
+  confidence, not implementation details or exhaustive edge-case permutations.
+- Record an active owner and assigned paths before delegated edits begin.
+- Do not edit paths owned by another active implementer.
+- Update verification, commit, and PR state before advancing to the next layer.
+- Record uncovered design decisions here rather than resolving them implicitly.
+- Keep the integration tail on the same stack unless the optional split after
+  `memory-11` is explicitly approved.
+
+## Open Design Decisions
+
+1. **`memory-3` query-proof boundary.** The layer requires storyline entity and
+   exact-evidence query proofs, but `RevisionManager` cannot contain kind-specific
+   SQL and `StorylineManager` is scheduled for `memory-6`. Recommended default:
+   prove the PostgreSQL query shapes with seeded acceptance tests in `memory-3`
+   while keeping public storyline reads in `memory-6`.
+2. **Canonical state hashing.** The deterministic serialization and algorithm
+   for `MemoryRevision.state_content_hash` are not specified. Recommended
+   default: keep `memory-3` limited to transaction locking and stale-writer
+   scaffolding, then settle state hashing with the complete mutation bundle in
+   `memory-9`; do not accept an opaque caller-computed hash.
+3. **Search-document builder contract.** Per-kind builders begin in `memory-4`,
+   while the search-document application resource is otherwise scheduled with
+   `memory-10`. Its smallest stable result contract must be chosen before the
+   first builder lands.
+4. **Projection rebuild ownership.** The transition design leaves command/API
+   ownership open. Resolve before `memory-10` without moving canonical mutation
+   ownership into the projection manager.
+5. **Integration-tail stack split.** Layers `memory-12` through `memory-14` may
+   become a second stack based on `memory-11`, but only with explicit approval.
+
+## Environment Notes
+
+- A workspace `.venv` contains the locked development dependencies.
+- Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
+  pytest temp-directory permission issue.
+- PostgreSQL-backed tests require `AIDAM_TEST_DATABASE_URL`; no local test
+  database is currently configured.

--- a/docs/memory/transition.md
+++ b/docs/memory/transition.md
@@ -110,7 +110,9 @@ historically safe:
 
 ## Remaining Application Decisions
 
-- final role enums and reference cardinalities;
-- which event payload types are required in the first implementation;
-- projection rebuild command/API ownership;
-- embedding provider, model, and retention policy;
+The typed v1 contracts settled the role enums, reference cardinalities, and
+initial trade/matchup event payloads. Remaining decisions are tracked in
+[`status.md`](status.md), including:
+
+- projection rebuild command/API ownership; and
+- embedding provider, model, and retention policy.


### PR DESCRIPTION
## Description

Implements the `memory-2` stack layer with strict Pydantic v1 contracts for storylines, facts, events, triggers, and context notes. It also introduces the resolved manager context, role-parameterized entity references, canonical item/version envelopes, shared receipt semantics, and typed application errors that later managers and services will use.

The application contract documentation now records the choices this layer settles: resource-local roles, collection cardinality and normalization, trade/matchup payloads, rematch/trade-evaluation conditions, context-note identity shapes, and hydrated resource envelopes. No ORM model, migration, manager, service, or database behavior changes in this PR.

<details>
<summary>🧠 Implementation rationale (AI-authored)</summary>

**Orientation** — Canonical memory already has per-kind PostgreSQL tables, but callers still lacked legal application-level shapes. These contracts become the boundary that later managers translate to and from those storage rows.

**How this change was derived** — The accepted memory and platform documents were compared with the current ORM schema and retained reporter behavior. Explicitly unsettled v1 choices were resolved at the narrowest owning resource, then tested at discriminators and semantic boundaries. A design review pulled the identical fact/event receipt rule into one shared invariant and caught non-finite JSON, iterable-tag, and boolean-as-integer coercions before commit.

**Where to look hardest** — `backend/resources/memory/common/receipts.py` owns receipt confidence and evidence requirements; `backend/resources/memory/events/payloads/trade.py` defines the initial asset union; `backend/resources/memory/triggers/objects.py` owns condition-specific trigger requirements; and `docs/memory/application-contracts.md` records the settled public semantics.
</details>

## Design decisions

- Keep one contract module per memory resource; there is no omnibus memory object or manager.
- Parameterize shared entity identity references by resource-local roles instead of creating a generic semantic role bag.
- Allow empty subject lists for competition-wide memory; when storyline subjects exist, require one focus and reject repeated targets.
- Share receipt confidence, receipt fields, and the source-backed invariant between facts and events while keeping their lifecycle status enums resource-local.
- Model trades as player, normalized draft-pick, or budget assets with explicit bilateral direction; initially support only trade and matchup events.
- Start triggers with rematch and trade-evaluation conditions, keeping their target requirements inside `TriggerContent`.
- Reuse one invariant-owning `VersionedMemory[Content]` envelope for current hydration and history instead of duplicating shallow aggregate wrappers.

## Alternative approaches

- One generic content model with optional per-kind fields: rejected because it would weaken payload validation and combine unrelated resources.
- Duplicate fact/event receipt rules locally: replaced during design review because the policy is genuinely shared and would otherwise drift.
- Defer semantic validation to managers: rejected for shape-local invariants; managers remain responsible for database-backed existence, kind, competition, and concurrency checks.
- Carry forward legacy SQLite status and payload shapes: rejected under the accepted rip-and-replace policy.

## Design self-review

- [ ] Audited with the design-review skill
- [ ] N/A

The committed design was independently reviewed against the strategic-programming principles. All findings were addressed before publication; no must-fix findings remain.

## Testing

- `.venv/bin/pytest backend/tests/resources/memory -q` — 22 passed
- `.venv/bin/python -m compileall -q backend/resources`
- `git diff --cached --check`
- Generated JSON Schema for manager context and all five resource contracts

## Risks

- [x] No ORM schema or migration changes.
- [x] Unknown fields, unknown discriminators, and retained schema versions are rejected at the contract boundary.
- [x] Non-finite JSON and boolean coercion at semantic integer fields are rejected before canonical persistence.
- [x] Database-backed reference and concurrency validation remains intentionally deferred to the relevant managers.

## Observability

- N/A — this PR adds application contracts but no runtime workflow.

## Deployment and rollback plan

- No deployment action beyond the normal application release is required.
- Revert this commit to remove the unused contract layer before manager integration.

## Security

- [x] N/A — no authentication, permissions, credentials, external calls, or runtime configuration changed.
