### PR TITLE
feat(memory): add event resource operations

### DIFF
--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -1,5 +1,13 @@
 """Typed memory resources, grouped by canonical resource kind."""
 
+from backend.resources.memory.events import (
+    Event,
+    EventConfidence,
+    EventContent,
+    EventManager,
+    EventStatus,
+    EventType,
+)
 from backend.resources.memory.facts import (
     Fact,
     FactConfidence,
@@ -11,6 +19,12 @@ from backend.resources.memory.facts import (
 )
 
 __all__ = [
+    "Event",
+    "EventConfidence",
+    "EventContent",
+    "EventManager",
+    "EventStatus",
+    "EventType",
     "Fact",
     "FactConfidence",
     "FactContent",

--- a/backend/resources/memory/common/receipt_validation.py
+++ b/backend/resources/memory/common/receipt_validation.py
@@ -1,0 +1,66 @@
+"""Competition-scoped validation for typed reporting and Sleeper receipts."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason
+from backend.database.models.reporting import Generation, ToolCall
+from backend.database.models.sleeper import ApiRequest
+from backend.resources.memory.common.errors import (
+    CrossCompetitionEntityReferenceError,
+    EntityReferenceNotFoundError,
+)
+
+
+def validate_tool_receipt(
+    session: Session,
+    competition_id: UUID,
+    tool_call_id: UUID | None,
+) -> UUID | None:
+    """Validate a tool-call receipt and return its owning generation ID."""
+
+    if tool_call_id is None:
+        return None
+    row = session.execute(
+        sa.select(ToolCall.generation_id, Generation.competition_id)
+        .join(Generation, Generation.id == ToolCall.generation_id)
+        .where(ToolCall.id == tool_call_id)
+    ).one_or_none()
+    if row is None:
+        raise EntityReferenceNotFoundError("tool_call", tool_call_id)
+    generation_id, actual_scope = row
+    if actual_scope != competition_id:
+        raise CrossCompetitionEntityReferenceError(
+            "tool_call", tool_call_id, competition_id
+        )
+    return generation_id
+
+
+def validate_api_receipt(
+    session: Session,
+    competition_id: UUID,
+    api_request_id: UUID | None,
+) -> None:
+    """Validate an API-request receipt when its request has competition scope."""
+
+    if api_request_id is None:
+        return
+    row = session.execute(
+        sa.select(ApiRequest.id, CompetitionSeason.competition_id)
+        .outerjoin(
+            CompetitionSeason,
+            CompetitionSeason.id == ApiRequest.competition_season_id,
+        )
+        .where(ApiRequest.id == api_request_id)
+    ).one_or_none()
+    if row is None:
+        raise EntityReferenceNotFoundError("api_request", api_request_id)
+    _, actual_scope = row
+    if actual_scope is not None and actual_scope != competition_id:
+        raise CrossCompetitionEntityReferenceError(
+            "api_request", api_request_id, competition_id
+        )

--- a/backend/resources/memory/events/__init__.py
+++ b/backend/resources/memory/events/__init__.py
@@ -1,3 +1,4 @@
+from backend.resources.memory.events.manager import EventManager
 from backend.resources.memory.events.objects import (
     Event,
     EventConfidence,
@@ -22,6 +23,7 @@ __all__ = [
     "Event",
     "EventConfidence",
     "EventContent",
+    "EventManager",
     "EventPayload",
     "EventStatus",
     "EventType",

--- a/backend/resources/memory/events/codec.py
+++ b/backend/resources/memory/events/codec.py
@@ -1,0 +1,126 @@
+"""Stored-schema codecs for event versions."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.sql import Select
+
+from backend.database.models.memory import EventVersion, MemoryItem, MemoryVersion
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.events.objects import Event, EventContent
+from backend.resources.memory.revisions.hashing import StoredSchemaContent
+
+
+def event_rows_statement() -> Select[tuple[MemoryItem, MemoryVersion, EventVersion]]:
+    """Select complete event aggregates without exposing their storage joins."""
+
+    return (
+        sa.select(MemoryItem, MemoryVersion, EventVersion)
+        .join(MemoryVersion, MemoryVersion.item_id == MemoryItem.id)
+        .join(EventVersion, EventVersion.version_id == MemoryVersion.id)
+        .where(MemoryItem.kind == MemoryKind.EVENT.value)
+    )
+
+
+def decode_event(
+    item: MemoryItem,
+    version: MemoryVersion,
+    stored: EventVersion,
+) -> Event:
+    content = _decode_content(version.content_schema_version, stored)
+    return Event.model_validate(
+        {
+            "item": {
+                "item_id": item.id,
+                "competition_id": item.competition_id,
+                "kind": item.kind,
+                "agent_key": item.agent_key,
+                "created_at": item.created_at,
+            },
+            "version": {
+                "version_id": version.id,
+                "revision_number": version.revision_number,
+                "content_schema_version": version.content_schema_version,
+                "introduced_revision_id": version.introduced_revision_id,
+                "retired_revision_id": version.retired_revision_id,
+                "competition_season_id": version.competition_season_id,
+                "week": version.week,
+                "occurred_at": version.occurred_at,
+                "creating_generation_id": version.creating_generation_id,
+                "creating_tool_call_id": version.creating_tool_call_id,
+                "change_reason": version.change_reason,
+                "recorded_at": version.recorded_at,
+            },
+            "content": content,
+        }
+    )
+
+
+def encode_event(
+    content: EventContent,
+    receipt_generation_id: UUID | None,
+) -> dict[str, Any]:
+    """Translate complete typed content into the current stored v1 row."""
+
+    return {
+        "event_type": content.event_type.value,
+        "headline": content.headline,
+        "summary": content.summary,
+        "salience": content.salience,
+        "confidence": content.confidence.value,
+        "status": content.status.value,
+        "details": content.details.model_dump(mode="json"),
+        "additional_source_hints": content.source_hints,
+        "primary_tool_call_id": content.primary_tool_call_id,
+        "primary_tool_call_generation_id": receipt_generation_id,
+        "primary_api_request_id": content.primary_api_request_id,
+    }
+
+
+def stored_event_content(content: EventContent) -> StoredSchemaContent:
+    """Encode exact retained v1 logical content for canonical state hashing."""
+
+    if content.schema_version != 1:
+        raise ValueError(
+            f"unsupported event content schema version {content.schema_version}"
+        )
+    return StoredSchemaContent(
+        memory_kind=MemoryKind.EVENT,
+        schema_version=1,
+        payload={
+            "schema_version": 1,
+            "event_type": content.event_type.value,
+            "headline": content.headline,
+            "summary": content.summary,
+            "salience": content.salience,
+            "confidence": content.confidence.value,
+            "status": content.status.value,
+            "details": content.details.model_dump(mode="python"),
+            "primary_tool_call_id": content.primary_tool_call_id,
+            "primary_api_request_id": content.primary_api_request_id,
+            "source_hints": content.source_hints,
+        },
+    )
+
+
+def _decode_content(schema_version: int, stored: EventVersion) -> EventContent:
+    if schema_version != 1:
+        raise ValueError(f"unsupported event content schema version {schema_version}")
+    return EventContent.model_validate(
+        {
+            "schema_version": 1,
+            "event_type": stored.event_type,
+            "headline": stored.headline,
+            "summary": stored.summary,
+            "salience": stored.salience,
+            "confidence": stored.confidence,
+            "status": stored.status,
+            "details": stored.details,
+            "primary_tool_call_id": stored.primary_tool_call_id,
+            "primary_api_request_id": stored.primary_api_request_id,
+            "source_hints": stored.additional_source_hints,
+        }
+    )

--- a/backend/resources/memory/events/manager.py
+++ b/backend/resources/memory/events/manager.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common.errors import TargetNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.events.codec import decode_event, event_rows_statement
+from backend.resources.memory.events.objects import Event
+
+
+class EventManager:
+    """Competition-scoped hydration of immutable event versions."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def exact(self, version_id: UUID) -> Event:
+        """Hydrate one exact event version, including retired history."""
+
+        statement = event_rows_statement().where(
+            MemoryVersion.id == version_id,
+            MemoryVersion.competition_id == self._competition_id,
+        )
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(statement).one_or_none()
+        if row is None:
+            raise TargetNotFoundError(version_id, (MemoryKind.EVENT,))
+        return decode_event(row[0], row[1], row[2])
+
+    def history(self, item_id: UUID) -> tuple[Event, ...]:
+        """Return every immutable version of one event item, newest first."""
+
+        statement = (
+            event_rows_statement()
+            .where(
+                MemoryItem.id == item_id,
+                MemoryItem.competition_id == self._competition_id,
+            )
+            .order_by(sa.desc(MemoryVersion.revision_number))
+        )
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(statement).all()
+        if not rows:
+            raise TargetNotFoundError(item_id, (MemoryKind.EVENT,))
+        return tuple(decode_event(row[0], row[1], row[2]) for row in rows)

--- a/backend/resources/memory/events/shared.py
+++ b/backend/resources/memory/events/shared.py
@@ -1,0 +1,125 @@
+"""Package-internal event validation and persistence for canonical writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import EventVersion, MemoryItem, MemoryVersion
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.events.codec import encode_event
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.events.validation import (
+    ValidatedEventContent,
+    validate_event_content,
+)
+from backend.resources.memory.search_documents.builders.event import (
+    build_event_document,
+)
+from backend.resources.memory.search_documents.shared import insert_search_document
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedEventReplacement:
+    validated: ValidatedEventContent
+    previous_version: MemoryVersion
+    next_revision_number: int
+
+
+def prepare_event_write(
+    session: Session,
+    competition_id: UUID,
+    content: EventContent,
+) -> ValidatedEventContent:
+    """Validate a complete create/replacement payload in the active transaction."""
+
+    return validate_event_content(session, competition_id, content)
+
+
+def prepare_event_replacement(
+    session: Session,
+    competition_id: UUID,
+    item_id: UUID,
+    expected_item_revision: int,
+    content: EventContent,
+) -> PreparedEventReplacement:
+    """Validate one complete replacement and resolve its current envelope."""
+
+    item = session.get(MemoryItem, item_id)
+    if item is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.EVENT,))
+    if item.competition_id != competition_id:
+        raise CrossCompetitionReferenceError(
+            item_id,
+            competition_id,
+            item.competition_id,
+        )
+    if item.kind != MemoryKind.EVENT.value:
+        raise WrongTargetKindError(
+            item_id,
+            (MemoryKind.EVENT,),
+            MemoryKind(item.kind),
+        )
+    previous = session.scalar(
+        sa.select(MemoryVersion)
+        .join(EventVersion, EventVersion.version_id == MemoryVersion.id)
+        .where(
+            MemoryVersion.item_id == item_id,
+            MemoryVersion.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    )
+    if previous is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.EVENT,))
+    if previous.revision_number != expected_item_revision:
+        raise StaleItemVersionError(
+            item_id,
+            expected_item_revision,
+            previous.revision_number,
+        )
+    return PreparedEventReplacement(
+        validated=validate_event_content(session, competition_id, content),
+        previous_version=previous,
+        next_revision_number=previous.revision_number + 1,
+    )
+
+
+def insert_event_version(
+    session: Session,
+    version: MemoryVersion,
+    prepared: ValidatedEventContent,
+) -> None:
+    """Insert typed content and its derived projection beside a new envelope."""
+
+    content = prepared.content
+    if version.competition_id != prepared.competition_id:
+        raise CrossCompetitionReferenceError(
+            version.id,
+            prepared.competition_id,
+            version.competition_id,
+        )
+    if version.content_schema_version != content.schema_version:
+        raise ValueError("event schema version does not match version envelope")
+    if not inspect(version).persistent:
+        raise ValueError("event version envelope must be persisted before content")
+    session.add(
+        EventVersion(
+            version_id=version.id,
+            competition_id=version.competition_id,
+            **encode_event(
+                content,
+                prepared.primary_tool_call_generation_id,
+            ),
+        )
+    )
+    insert_search_document(session, version, build_event_document(content))

--- a/backend/resources/memory/events/validation.py
+++ b/backend/resources/memory/events/validation.py
@@ -1,0 +1,138 @@
+"""Competition-scoped reference validation for complete event content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+
+from backend.database.models.core import Franchise
+from backend.database.models.sleeper import DraftPick, Player
+from backend.resources.memory.common.errors import (
+    CrossCompetitionEntityReferenceError,
+    EntityReferenceNotFoundError,
+)
+from backend.resources.memory.common.receipt_validation import (
+    validate_api_receipt,
+    validate_tool_receipt,
+)
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.events.payloads.matchup import MatchupEventPayload
+from backend.resources.memory.events.payloads.trade import (
+    DraftPickTradeAsset,
+    PlayerTradeAsset,
+    TradeEventPayload,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedEventContent:
+    competition_id: UUID
+    content: EventContent
+    primary_tool_call_generation_id: UUID | None
+
+
+def validate_event_content(
+    session: Session,
+    competition_id: UUID,
+    content: EventContent,
+) -> ValidatedEventContent:
+    """Validate all database-backed event references in the active transaction."""
+
+    _validate_details(session, competition_id, content)
+    receipt_generation_id = validate_tool_receipt(
+        session, competition_id, content.primary_tool_call_id
+    )
+    validate_api_receipt(session, competition_id, content.primary_api_request_id)
+    return ValidatedEventContent(
+        competition_id=competition_id,
+        content=content,
+        primary_tool_call_generation_id=receipt_generation_id,
+    )
+
+
+def _validate_details(
+    session: Session,
+    competition_id: UUID,
+    content: EventContent,
+) -> None:
+    details = content.details
+    if isinstance(details, TradeEventPayload):
+        _validate_scoped_entities(
+            session,
+            competition_id,
+            "franchise",
+            Franchise.id,
+            Franchise.competition_id,
+            [details.sender_franchise_id, details.receiver_franchise_id],
+        )
+        player_ids = [
+            asset.player_id
+            for asset in details.assets
+            if isinstance(asset, PlayerTradeAsset)
+        ]
+        if player_ids:
+            found_players = set(
+                session.scalars(
+                    sa.select(Player.sleeper_player_id).where(
+                        Player.sleeper_player_id.in_(set(player_ids))
+                    )
+                )
+            )
+            for player_id in player_ids:
+                if player_id not in found_players:
+                    raise EntityReferenceNotFoundError("player", player_id)
+        draft_pick_ids = [
+            asset.draft_pick_id
+            for asset in details.assets
+            if isinstance(asset, DraftPickTradeAsset)
+        ]
+        _validate_scoped_entities(
+            session,
+            competition_id,
+            "draft_pick",
+            DraftPick.id,
+            DraftPick.competition_id,
+            draft_pick_ids,
+        )
+        return
+
+    if isinstance(details, MatchupEventPayload):
+        _validate_scoped_entities(
+            session,
+            competition_id,
+            "franchise",
+            Franchise.id,
+            Franchise.competition_id,
+            [details.winner_franchise_id, details.loser_franchise_id],
+        )
+        return
+
+    raise TypeError(f"unsupported event payload: {type(details).__name__}")
+
+
+def _validate_scoped_entities(
+    session: Session,
+    competition_id: UUID,
+    entity_kind: str,
+    id_column: InstrumentedAttribute[UUID],
+    competition_column: InstrumentedAttribute[UUID],
+    ids: list[UUID],
+) -> None:
+    if not ids:
+        return
+    rows = session.execute(
+        sa.select(id_column, competition_column).where(id_column.in_(set(ids)))
+    )
+    found: dict[UUID, UUID] = {entity_id: scope for entity_id, scope in rows}
+    for entity_id in ids:
+        actual_scope = found.get(entity_id)
+        if actual_scope is None:
+            raise EntityReferenceNotFoundError(entity_kind, entity_id)
+        if actual_scope != competition_id:
+            raise CrossCompetitionEntityReferenceError(
+                entity_kind, entity_id, competition_id
+            )

--- a/backend/resources/memory/facts/validation.py
+++ b/backend/resources/memory/facts/validation.py
@@ -11,8 +11,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from backend.database.models.core import CompetitionSeason, Franchise, SeasonRoster
 from backend.database.models.memory import EventVersion, MemoryItem, MemoryVersion
-from backend.database.models.reporting import Generation, ToolCall
-from backend.database.models.sleeper import ApiRequest, LeagueUser, Player, User
+from backend.database.models.sleeper import LeagueUser, Player, User
 from backend.resources.memory.common.errors import (
     CrossCompetitionEntityReferenceError,
     CrossCompetitionReferenceError,
@@ -21,6 +20,10 @@ from backend.resources.memory.common.errors import (
     WrongTargetKindError,
 )
 from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.common.receipt_validation import (
+    validate_api_receipt,
+    validate_tool_receipt,
+)
 from backend.resources.memory.facts.objects import FactContent
 
 
@@ -40,10 +43,10 @@ def validate_fact_content(
 
     _validate_subjects(session, competition_id, content)
     _validate_originating_events(session, competition_id, content)
-    receipt_generation_id = _validate_tool_receipt(
+    receipt_generation_id = validate_tool_receipt(
         session, competition_id, content.primary_tool_call_id
     )
-    _validate_api_receipt(session, competition_id, content.primary_api_request_id)
+    validate_api_receipt(session, competition_id, content.primary_api_request_id)
     return ValidatedFactContent(
         competition_id=competition_id,
         content=content,
@@ -203,49 +206,3 @@ def _validate_originating_events(
             )
         if typed_event_id is None:
             raise TargetNotFoundError(version_id, (MemoryKind.EVENT,))
-
-
-def _validate_tool_receipt(
-    session: Session,
-    competition_id: UUID,
-    tool_call_id: UUID | None,
-) -> UUID | None:
-    if tool_call_id is None:
-        return None
-    row = session.execute(
-        sa.select(ToolCall.generation_id, Generation.competition_id)
-        .join(Generation, Generation.id == ToolCall.generation_id)
-        .where(ToolCall.id == tool_call_id)
-    ).one_or_none()
-    if row is None:
-        raise EntityReferenceNotFoundError("tool_call", tool_call_id)
-    generation_id, actual_scope = row
-    if actual_scope != competition_id:
-        raise CrossCompetitionEntityReferenceError(
-            "tool_call", tool_call_id, competition_id
-        )
-    return generation_id
-
-
-def _validate_api_receipt(
-    session: Session,
-    competition_id: UUID,
-    api_request_id: UUID | None,
-) -> None:
-    if api_request_id is None:
-        return
-    row = session.execute(
-        sa.select(ApiRequest.id, CompetitionSeason.competition_id)
-        .outerjoin(
-            CompetitionSeason,
-            CompetitionSeason.id == ApiRequest.competition_season_id,
-        )
-        .where(ApiRequest.id == api_request_id)
-    ).one_or_none()
-    if row is None:
-        raise EntityReferenceNotFoundError("api_request", api_request_id)
-    _, actual_scope = row
-    if actual_scope is not None and actual_scope != competition_id:
-        raise CrossCompetitionEntityReferenceError(
-            "api_request", api_request_id, competition_id
-        )

--- a/backend/resources/memory/search_documents/__init__.py
+++ b/backend/resources/memory/search_documents/__init__.py
@@ -1,5 +1,9 @@
 """Derived search-document contracts shared by per-kind builders."""
 
+from backend.resources.memory.search_documents.builders.event import (
+    EVENT_DOCUMENT_BUILDER_VERSION,
+    build_event_document,
+)
 from backend.resources.memory.search_documents.builders.fact import (
     FACT_DOCUMENT_BUILDER_VERSION,
     build_fact_document,
@@ -7,7 +11,9 @@ from backend.resources.memory.search_documents.builders.fact import (
 from backend.resources.memory.search_documents.objects import SearchDocumentProjection
 
 __all__ = [
+    "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
     "SearchDocumentProjection",
+    "build_event_document",
     "build_fact_document",
 ]

--- a/backend/resources/memory/search_documents/builders/__init__.py
+++ b/backend/resources/memory/search_documents/builders/__init__.py
@@ -1,6 +1,15 @@
+from backend.resources.memory.search_documents.builders.event import (
+    EVENT_DOCUMENT_BUILDER_VERSION,
+    build_event_document,
+)
 from backend.resources.memory.search_documents.builders.fact import (
     FACT_DOCUMENT_BUILDER_VERSION,
     build_fact_document,
 )
 
-__all__ = ["FACT_DOCUMENT_BUILDER_VERSION", "build_fact_document"]
+__all__ = [
+    "EVENT_DOCUMENT_BUILDER_VERSION",
+    "FACT_DOCUMENT_BUILDER_VERSION",
+    "build_event_document",
+    "build_fact_document",
+]

--- a/backend/resources/memory/search_documents/builders/event.py
+++ b/backend/resources/memory/search_documents/builders/event.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final, cast
+
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.events.payloads.matchup import MatchupEventPayload
+from backend.resources.memory.events.payloads.trade import (
+    BudgetTradeAsset,
+    DraftPickTradeAsset,
+    PlayerTradeAsset,
+    TradeEventPayload,
+)
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentProjection,
+)
+
+
+EVENT_DOCUMENT_BUILDER_VERSION: Final = 1
+
+
+def build_event_document(content: EventContent) -> SearchDocumentProjection:
+    """Deterministically flatten complete event content for candidate discovery."""
+
+    entity_keys = tuple(sorted(_event_entity_keys(content)))
+    text_parts = [
+        content.headline,
+        content.summary,
+        f"event type: {content.event_type.value}",
+        f"status: {content.status.value}",
+        f"confidence: {content.confidence.value}",
+        *_event_detail_text(content),
+    ]
+    if entity_keys:
+        text_parts.append(f"entities: {' '.join(entity_keys)}")
+
+    return SearchDocumentProjection(
+        kind=MemoryKind.EVENT,
+        status=content.status.value,
+        salience=content.salience,
+        entity_keys=entity_keys,
+        document_text="\n".join(text_parts),
+        builder_version=EVENT_DOCUMENT_BUILDER_VERSION,
+        content_hash=_event_content_hash(content),
+    )
+
+
+def _event_entity_keys(content: EventContent) -> set[str]:
+    details = content.details
+    if isinstance(details, TradeEventPayload):
+        keys = {
+            f"franchise:{details.sender_franchise_id}",
+            f"franchise:{details.receiver_franchise_id}",
+        }
+        for asset in details.assets:
+            if isinstance(asset, PlayerTradeAsset):
+                keys.add(f"player:{asset.player_id}")
+            elif isinstance(asset, DraftPickTradeAsset):
+                keys.add(f"draft_pick:{asset.draft_pick_id}")
+        return keys
+    if isinstance(details, MatchupEventPayload):
+        return {
+            f"franchise:{details.winner_franchise_id}",
+            f"franchise:{details.loser_franchise_id}",
+        }
+    raise TypeError(f"unsupported event payload: {type(details).__name__}")
+
+
+def _event_detail_text(content: EventContent) -> list[str]:
+    details = content.details
+    if isinstance(details, TradeEventPayload):
+        parts = [
+            f"sender: franchise:{details.sender_franchise_id}",
+            f"receiver: franchise:{details.receiver_franchise_id}",
+        ]
+        assets = sorted(_trade_asset_text(asset) for asset in details.assets)
+        parts.append(f"assets: {'; '.join(assets)}")
+        return parts
+    if isinstance(details, MatchupEventPayload):
+        return [
+            f"winner: franchise:{details.winner_franchise_id}",
+            f"loser: franchise:{details.loser_franchise_id}",
+            f"matchup: {details.sleeper_matchup_id}",
+        ]
+    raise TypeError(f"unsupported event payload: {type(details).__name__}")
+
+
+def _trade_asset_text(
+    asset: PlayerTradeAsset | DraftPickTradeAsset | BudgetTradeAsset,
+) -> str:
+    if isinstance(asset, PlayerTradeAsset):
+        value = f"player:{asset.player_id}"
+    elif isinstance(asset, DraftPickTradeAsset):
+        value = f"draft_pick:{asset.draft_pick_id}"
+    else:
+        value = f"budget:{asset.amount}"
+    return f"{asset.direction.value} {value}"
+
+
+def _event_content_hash(content: EventContent) -> str:
+    serialized = _canonical_json(_canonical_event_content(content)).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _canonical_event_content(content: EventContent) -> dict[str, Any]:
+    dumped = cast(dict[str, Any], content.model_dump(mode="json"))
+    details = cast(dict[str, Any], dumped["details"])
+    if details["kind"] == "trade":
+        assets = cast(list[dict[str, Any]], details["assets"])
+        details["assets"] = sorted(assets, key=_canonical_json)
+    return {
+        "memory_kind": content.memory_kind.value,
+        "content": dumped,
+    }
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )

--- a/backend/tests/resources/memory/test_event_codec.py
+++ b/backend/tests/resources/memory/test_event_codec.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from backend.database.models.memory import EventVersion
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.events import EventContent, MatchupEventPayload
+from backend.resources.memory.events.codec import (
+    _decode_content,
+    encode_event,
+    stored_event_content,
+)
+
+
+def _matchup() -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "matchup",
+            "headline": "A rivalry result",
+            "summary": "The favorite survived a close matchup.",
+            "salience": 3,
+            "confidence": "inferred",
+            "status": "active",
+            "details": {
+                "kind": "matchup",
+                "winner_franchise_id": uuid4(),
+                "loser_franchise_id": uuid4(),
+                "sleeper_matchup_id": "opaque-matchup-key",
+            },
+            "source_hints": {"week": 8},
+        }
+    )
+
+
+def test_event_v1_codec_round_trips_discriminated_payload() -> None:
+    content = _matchup()
+    encoded = encode_event(content, receipt_generation_id=None)
+    stored = EventVersion(
+        version_id=uuid4(),
+        competition_id=uuid4(),
+        **encoded,
+    )
+
+    decoded = _decode_content(1, stored)
+    retained = stored_event_content(content)
+
+    assert decoded == content
+    assert isinstance(decoded.details, MatchupEventPayload)
+    assert retained.memory_kind is MemoryKind.EVENT
+    assert retained.schema_version == 1
+    assert retained.payload["details"] == content.details.model_dump(mode="python")
+
+
+def test_event_codec_rejects_unknown_retained_schema_version() -> None:
+    content = _matchup()
+    stored = EventVersion(
+        version_id=uuid4(),
+        competition_id=uuid4(),
+        **encode_event(content, receipt_generation_id=None),
+    )
+
+    with pytest.raises(ValueError, match="unsupported event content schema version 2"):
+        _decode_content(2, stored)

--- a/backend/tests/resources/memory/test_event_manager.py
+++ b/backend/tests/resources/memory/test_event_manager.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    CurrentRevision,
+    EventVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+)
+from backend.database.models.reporting import AICall, Generation, ToolCall
+from backend.database.models.sleeper import ApiRequest, DraftPick, Player, RefreshRun
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import (
+    CrossCompetitionEntityReferenceError,
+    CrossCompetitionReferenceError,
+    EntityReferenceNotFoundError,
+    StaleItemVersionError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.events import (
+    EventContent,
+    EventManager,
+    MatchupEventPayload,
+    TradeEventPayload,
+)
+from backend.resources.memory.events.shared import (
+    insert_event_version,
+    prepare_event_replacement,
+    prepare_event_write,
+)
+from backend.resources.memory.revisions.writers import persist_version_envelopes
+from backend.resources.memory.search_documents import (
+    EVENT_DOCUMENT_BUILDER_VERSION,
+    build_event_document,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@dataclass(frozen=True)
+class EventDomain:
+    competition_id: UUID
+    season_id: UUID
+    sender_id: UUID
+    receiver_id: UUID
+    player_id: str
+    draft_pick_id: UUID
+    generation_id: UUID
+    tool_call_id: UUID
+    api_request_id: UUID
+    root_revision_id: UUID
+    other_competition_id: UUID
+    other_franchise_id: UUID
+    other_draft_pick_id: UUID
+
+
+def _seed_domain(database_engine: Engine) -> EventDomain:
+    competition_id = uuid4()
+    season_id = uuid4()
+    sender_id = uuid4()
+    receiver_id = uuid4()
+    player_id = f"player-{uuid4()}"
+    draft_pick_id = uuid4()
+    generation_id = uuid4()
+    ai_call_id = uuid4()
+    tool_call_id = uuid4()
+    refresh_run_id = uuid4()
+    api_request_id = uuid4()
+    root_revision_id = uuid4()
+    other_competition_id = uuid4()
+    other_franchise_id = uuid4()
+    other_draft_pick_id = uuid4()
+    now = datetime.now(UTC)
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": competition_id, "display_name": "Event Manager League"},
+                {
+                    "id": other_competition_id,
+                    "display_name": "Other Event League",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": sender_id,
+                    "competition_id": competition_id,
+                    "display_name": "Sender Franchise",
+                },
+                {
+                    "id": receiver_id,
+                    "competition_id": competition_id,
+                    "display_name": "Receiver Franchise",
+                },
+                {
+                    "id": other_franchise_id,
+                    "competition_id": other_competition_id,
+                    "display_name": "Other Franchise",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "kind": "test",
+                "status": "pending",
+                "request_text": "seed event manager",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+        connection.execute(
+            sa.insert(RefreshRun),
+            {
+                "id": refresh_run_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "endpoint_scope": {},
+                "trigger_source": "test",
+                "status": "succeeded",
+                "code_version": "test",
+                "normalizer_version": "test",
+            },
+        )
+        connection.execute(
+            sa.insert(AICall),
+            {
+                "id": ai_call_id,
+                "generation_id": generation_id,
+                "turn_number": 1,
+                "attempt_number": 1,
+                "requested_model": "test-model",
+                "input_messages": [],
+                "tool_definitions": [],
+                "request_parameters": {},
+                "status": "succeeded",
+            },
+        )
+        connection.execute(
+            sa.insert(ToolCall),
+            {
+                "id": tool_call_id,
+                "generation_id": generation_id,
+                "ai_call_id": ai_call_id,
+                "tool_ordinal": 0,
+                "tool_name": "get_transactions",
+                "implementation_version": "test",
+                "arguments_jsonb": {},
+                "status": "succeeded",
+            },
+        )
+        connection.execute(
+            sa.insert(ApiRequest),
+            {
+                "id": api_request_id,
+                "refresh_run_id": refresh_run_id,
+                "competition_season_id": season_id,
+                "endpoint_kind": "transactions",
+                "scope_key": f"transactions:{uuid4()}",
+                "request_path": "/test",
+                "request_parameters": {},
+                "requested_at": now,
+                "completed_at": now,
+                "status": "succeeded",
+                "normalization_status": "succeeded",
+            },
+        )
+        connection.execute(
+            sa.insert(cast(sa.Table, Player.__table__)),
+            {
+                "sleeper_player_id": player_id,
+                "full_name": "Event Player",
+                "metadata": {},
+                "source_api_request_id": api_request_id,
+            },
+        )
+        connection.execute(
+            sa.insert(DraftPick),
+            [
+                {
+                    "id": draft_pick_id,
+                    "competition_id": competition_id,
+                    "draft_season_year": 2027,
+                    "round": 1,
+                    "original_franchise_id": sender_id,
+                    "current_franchise_id": sender_id,
+                    "source": "seed",
+                },
+                {
+                    "id": other_draft_pick_id,
+                    "competition_id": other_competition_id,
+                    "draft_season_year": 2027,
+                    "round": 1,
+                    "original_franchise_id": other_franchise_id,
+                    "current_franchise_id": other_franchise_id,
+                    "source": "seed",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": root_revision_id,
+                "competition_id": competition_id,
+                "sequence_number": 0,
+                "competition_season_id": season_id,
+                "week": 0,
+                "state_content_hash": "seed-root",
+            },
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": competition_id,
+                "current_revision_id": root_revision_id,
+                "lock_version": 0,
+            },
+        )
+
+    return EventDomain(
+        competition_id=competition_id,
+        season_id=season_id,
+        sender_id=sender_id,
+        receiver_id=receiver_id,
+        player_id=player_id,
+        draft_pick_id=draft_pick_id,
+        generation_id=generation_id,
+        tool_call_id=tool_call_id,
+        api_request_id=api_request_id,
+        root_revision_id=root_revision_id,
+        other_competition_id=other_competition_id,
+        other_franchise_id=other_franchise_id,
+        other_draft_pick_id=other_draft_pick_id,
+    )
+
+
+def _trade(domain: EventDomain) -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "trade",
+            "headline": "A blockbuster trade changed the league.",
+            "summary": "The sender moved a star for a future pick and budget.",
+            "salience": 5,
+            "confidence": "source_backed",
+            "status": "active",
+            "details": {
+                "kind": "trade",
+                "sender_franchise_id": domain.sender_id,
+                "receiver_franchise_id": domain.receiver_id,
+                "assets": [
+                    {
+                        "kind": "player",
+                        "direction": "sender_to_receiver",
+                        "player_id": domain.player_id,
+                    },
+                    {
+                        "kind": "draft_pick",
+                        "direction": "receiver_to_sender",
+                        "draft_pick_id": domain.draft_pick_id,
+                    },
+                    {
+                        "kind": "budget",
+                        "direction": "sender_to_receiver",
+                        "amount": 15,
+                    },
+                ],
+            },
+            "primary_api_request_id": domain.api_request_id,
+            "primary_tool_call_id": domain.tool_call_id,
+            "source_hints": {"week": 6},
+        }
+    )
+
+
+def _matchup(domain: EventDomain) -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "matchup",
+            "headline": "The receiver won the rematch.",
+            "summary": "The trade partners met without settling the argument.",
+            "salience": 4,
+            "confidence": "inferred",
+            "status": "archived",
+            "details": {
+                "kind": "matchup",
+                "winner_franchise_id": domain.receiver_id,
+                "loser_franchise_id": domain.sender_id,
+                "sleeper_matchup_id": "opaque-rematch-id",
+            },
+        }
+    )
+
+
+def _manager(database_engine: Engine, competition_id: UUID) -> EventManager:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "competition", "competition_id": competition_id},
+            "correlation_id": uuid4(),
+        }
+    )
+    return EventManager(create_session_factory(database_engine), context)
+
+
+def test_complete_event_create_replace_exact_history_and_projection(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    first_version_id = uuid4()
+    first_revision_id = uuid4()
+    second_version_id = uuid4()
+    second_revision_id = uuid4()
+
+    with session_factory.begin() as session:
+        first_revision = MemoryRevision(
+            id=first_revision_id,
+            competition_id=domain.competition_id,
+            sequence_number=1,
+            previous_revision_id=domain.root_revision_id,
+            competition_season_id=domain.season_id,
+            week=6,
+            state_content_hash="test-event-state-one",
+        )
+        item = MemoryItem(
+            id=item_id,
+            competition_id=domain.competition_id,
+            kind="event",
+            agent_key="event:blockbuster",
+        )
+        version = MemoryVersion(
+            id=first_version_id,
+            item_id=item_id,
+            competition_id=domain.competition_id,
+            revision_number=1,
+            content_schema_version=1,
+            introduced_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=6,
+            creating_generation_id=domain.generation_id,
+            change_reason="record the trade",
+        )
+        persist_version_envelopes(
+            session,
+            first_revision,
+            new_items=(item,),
+            new_versions=(version,),
+        )
+        prepared = prepare_event_write(session, domain.competition_id, _trade(domain))
+        insert_event_version(session, version, prepared)
+        session.flush()
+        session.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain.competition_id)
+            .values(current_revision_id=first_revision_id, lock_version=1)
+        )
+
+    with session_factory.begin() as session:
+        replacement_content = _matchup(domain)
+        with pytest.raises(StaleItemVersionError):
+            prepare_event_replacement(
+                session,
+                domain.competition_id,
+                item_id,
+                0,
+                replacement_content,
+            )
+        replacement = prepare_event_replacement(
+            session,
+            domain.competition_id,
+            item_id,
+            1,
+            replacement_content,
+        )
+        second_revision = MemoryRevision(
+            id=second_revision_id,
+            competition_id=domain.competition_id,
+            sequence_number=2,
+            previous_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=7,
+            state_content_hash="test-event-state-two",
+        )
+        version = MemoryVersion(
+            id=second_version_id,
+            item_id=item_id,
+            competition_id=domain.competition_id,
+            revision_number=replacement.next_revision_number,
+            content_schema_version=1,
+            introduced_revision_id=second_revision_id,
+            competition_season_id=domain.season_id,
+            week=7,
+            creating_generation_id=domain.generation_id,
+            change_reason="record the rematch",
+        )
+        persist_version_envelopes(
+            session,
+            second_revision,
+            new_items=(),
+            new_versions=(version,),
+            retired_versions=(replacement.previous_version,),
+        )
+        insert_event_version(session, version, replacement.validated)
+        session.flush()
+        session.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain.competition_id)
+            .values(current_revision_id=second_revision_id, lock_version=2)
+        )
+
+    manager = _manager(database_engine, domain.competition_id)
+    exact = manager.exact(first_version_id)
+    history = manager.history(item_id)
+
+    assert isinstance(exact.content.details, TradeEventPayload)
+    assert exact.version.retired_revision_id == second_revision_id
+    assert [event.version.version_id for event in history] == [
+        second_version_id,
+        first_version_id,
+    ]
+    assert isinstance(history[0].content.details, MatchupEventPayload)
+    assert history[0].content.details.sleeper_matchup_id == "opaque-rematch-id"
+
+    expected_projection = build_event_document(_trade(domain))
+    with session_factory() as session:
+        search_row = session.get_one(MemorySearchDocument, first_version_id)
+        assert search_row.item_id == item_id
+        assert search_row.competition_id == domain.competition_id
+        assert search_row.kind == "event"
+        assert search_row.status == "active"
+        assert search_row.salience == 5
+        assert search_row.builder_version == EVENT_DOCUMENT_BUILDER_VERSION
+        assert search_row.content_hash == expected_projection.content_hash
+        assert f"player:{domain.player_id}" in search_row.entity_keys
+        assert search_row.evidence_version_ids == []
+        assert search_row.related_item_ids == []
+        assert search_row.tags == []
+        event_row = session.get_one(EventVersion, first_version_id)
+        assert event_row.primary_tool_call_generation_id == domain.generation_id
+        assert session.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemorySearchDocument)
+            .where(MemorySearchDocument.item_id == item_id)
+        ) == 2
+
+
+def test_event_write_validates_payload_scope_receipts_and_item_boundary(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    content = _trade(domain)
+    details = content.details
+    assert isinstance(details, TradeEventPayload)
+
+    missing_player = content.model_copy(
+        update={
+            "details": details.model_copy(
+                update={
+                    "assets": [
+                        details.assets[0].model_copy(update={"player_id": "missing"}),
+                        *details.assets[1:],
+                    ]
+                }
+            )
+        }
+    )
+    missing_pick = content.model_copy(
+        update={
+            "details": details.model_copy(
+                update={
+                    "assets": [
+                        details.assets[0],
+                        details.assets[1].model_copy(update={"draft_pick_id": uuid4()}),
+                        details.assets[2],
+                    ]
+                }
+            )
+        }
+    )
+    cross_pick = content.model_copy(
+        update={
+            "details": details.model_copy(
+                update={
+                    "assets": [
+                        details.assets[0],
+                        details.assets[1].model_copy(
+                            update={"draft_pick_id": domain.other_draft_pick_id}
+                        ),
+                        details.assets[2],
+                    ]
+                }
+            )
+        }
+    )
+    cross_franchise = content.model_copy(
+        update={
+            "details": details.model_copy(
+                update={"sender_franchise_id": domain.other_franchise_id}
+            )
+        }
+    )
+    invalid_receipt = content.model_copy(
+        update={"primary_api_request_id": uuid4()}
+    )
+    invalid_tool_receipt = content.model_copy(
+        update={"primary_tool_call_id": uuid4(), "primary_api_request_id": None}
+    )
+
+    wrong_kind_item_id = uuid4()
+    cross_scope_item_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                {
+                    "id": wrong_kind_item_id,
+                    "competition_id": domain.competition_id,
+                    "kind": "fact",
+                },
+                {
+                    "id": cross_scope_item_id,
+                    "competition_id": domain.other_competition_id,
+                    "kind": "event",
+                },
+            ],
+        )
+
+    with session_factory() as session:
+        with pytest.raises(EntityReferenceNotFoundError):
+            prepare_event_write(session, domain.competition_id, missing_player)
+        with pytest.raises(EntityReferenceNotFoundError):
+            prepare_event_write(session, domain.competition_id, missing_pick)
+        with pytest.raises(CrossCompetitionEntityReferenceError):
+            prepare_event_write(session, domain.competition_id, cross_pick)
+        with pytest.raises(CrossCompetitionEntityReferenceError):
+            prepare_event_write(session, domain.competition_id, cross_franchise)
+        with pytest.raises(EntityReferenceNotFoundError):
+            prepare_event_write(session, domain.competition_id, invalid_receipt)
+        with pytest.raises(EntityReferenceNotFoundError):
+            prepare_event_write(
+                session, domain.competition_id, invalid_tool_receipt
+            )
+        with pytest.raises(WrongTargetKindError):
+            prepare_event_replacement(
+                session,
+                domain.competition_id,
+                wrong_kind_item_id,
+                1,
+                content,
+            )
+        with pytest.raises(CrossCompetitionReferenceError):
+            prepare_event_replacement(
+                session,
+                domain.competition_id,
+                cross_scope_item_id,
+                1,
+                content,
+            )
+
+        prepared = prepare_event_write(session, domain.competition_id, content)
+        mismatched_version = MemoryVersion(
+            id=uuid4(),
+            item_id=uuid4(),
+            competition_id=uuid4(),
+            revision_number=1,
+            introduced_revision_id=uuid4(),
+        )
+        with pytest.raises(CrossCompetitionReferenceError):
+            insert_event_version(session, mismatched_version, prepared)
+
+
+def test_event_content_and_projection_roll_back_with_canonical_envelope(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    version_id = uuid4()
+    revision_id = uuid4()
+
+    with pytest.raises(RuntimeError, match="abort canonical write"):
+        with session_factory.begin() as session:
+            revision = MemoryRevision(
+                id=revision_id,
+                competition_id=domain.competition_id,
+                sequence_number=1,
+                previous_revision_id=domain.root_revision_id,
+                competition_season_id=domain.season_id,
+                week=6,
+                state_content_hash="must-roll-back",
+            )
+            item = MemoryItem(
+                id=item_id,
+                competition_id=domain.competition_id,
+                kind="event",
+            )
+            version = MemoryVersion(
+                id=version_id,
+                item_id=item_id,
+                competition_id=domain.competition_id,
+                revision_number=1,
+                content_schema_version=1,
+                introduced_revision_id=revision_id,
+                competition_season_id=domain.season_id,
+                week=6,
+                creating_generation_id=domain.generation_id,
+            )
+            persist_version_envelopes(
+                session,
+                revision,
+                new_items=(item,),
+                new_versions=(version,),
+            )
+            prepared = prepare_event_write(
+                session,
+                domain.competition_id,
+                _trade(domain),
+            )
+            insert_event_version(session, version, prepared)
+            session.flush()
+            assert session.get(EventVersion, version_id) is not None
+            assert session.get(MemorySearchDocument, version_id) is not None
+            raise RuntimeError("abort canonical write")
+
+    with database_engine.connect() as connection:
+        for model, id_column in (
+            (MemoryRevision, MemoryRevision.id),
+            (MemoryItem, MemoryItem.id),
+            (MemoryVersion, MemoryVersion.id),
+            (EventVersion, EventVersion.version_id),
+            (MemorySearchDocument, MemorySearchDocument.version_id),
+        ):
+            expected_id = (
+                revision_id
+                if model is MemoryRevision
+                else item_id if model is MemoryItem else version_id
+            )
+            assert connection.scalar(
+                sa.select(sa.func.count())
+                .select_from(model)
+                .where(id_column == expected_id)
+            ) == 0

--- a/backend/tests/resources/memory/test_event_search_builder.py
+++ b/backend/tests/resources/memory/test_event_search_builder.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.events import EventContent
+from backend.resources.memory.search_documents import (
+    EVENT_DOCUMENT_BUILDER_VERSION,
+    build_event_document,
+)
+
+
+SENDER_ID = UUID("11111111-1111-1111-1111-111111111111")
+RECEIVER_ID = UUID("22222222-2222-2222-2222-222222222222")
+PICK_ID = UUID("33333333-3333-3333-3333-333333333333")
+RECEIPT_ID = UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _trade(*, reversed_assets: bool = False) -> EventContent:
+    assets = [
+        {
+            "kind": "player",
+            "direction": "sender_to_receiver",
+            "player_id": "player-7",
+        },
+        {
+            "kind": "draft_pick",
+            "direction": "receiver_to_sender",
+            "draft_pick_id": PICK_ID,
+        },
+        {
+            "kind": "budget",
+            "direction": "sender_to_receiver",
+            "amount": 25,
+        },
+    ]
+    if reversed_assets:
+        assets.reverse()
+    return EventContent.model_validate(
+        {
+            "event_type": "trade",
+            "headline": "The Sharks and Owls completed a blockbuster.",
+            "summary": "A star and future pick changed sides.",
+            "salience": 5,
+            "confidence": "source_backed",
+            "status": "active",
+            "details": {
+                "kind": "trade",
+                "sender_franchise_id": SENDER_ID,
+                "receiver_franchise_id": RECEIVER_ID,
+                "assets": assets,
+            },
+            "primary_api_request_id": RECEIPT_ID,
+            "source_hints": {"provider": "Sleeper"},
+        }
+    )
+
+
+def _matchup() -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "matchup",
+            "headline": "The Sharks defeated the Owls.",
+            "summary": "The rematch settled the week's top rivalry.",
+            "salience": 4,
+            "confidence": "inferred",
+            "status": "active",
+            "details": {
+                "kind": "matchup",
+                "winner_franchise_id": SENDER_ID,
+                "loser_franchise_id": RECEIVER_ID,
+                "sleeper_matchup_id": "week-9-table-2",
+            },
+        }
+    )
+
+
+def test_trade_projection_is_identity_free_and_normalizes_asset_order() -> None:
+    projection = build_event_document(_trade())
+    reordered = build_event_document(_trade(reversed_assets=True))
+
+    assert projection == reordered
+    assert projection.kind is MemoryKind.EVENT
+    assert projection.status == "active"
+    assert projection.salience == 5
+    assert projection.entity_keys == (
+        f"draft_pick:{PICK_ID}",
+        f"franchise:{SENDER_ID}",
+        f"franchise:{RECEIVER_ID}",
+        "player:player-7",
+    )
+    assert projection.evidence_version_ids == ()
+    assert projection.related_item_ids == ()
+    assert projection.tags == ()
+    assert projection.builder_version == EVENT_DOCUMENT_BUILDER_VERSION
+    assert "event type: trade" in projection.document_text
+    assert "sender_to_receiver player:player-7" in projection.document_text
+    assert "receiver_to_sender draft_pick:" in projection.document_text
+    assert str(RECEIPT_ID) not in projection.document_text
+
+
+def test_matchup_projection_preserves_searchable_payload_details() -> None:
+    projection = build_event_document(_matchup())
+
+    assert projection.entity_keys == (
+        f"franchise:{SENDER_ID}",
+        f"franchise:{RECEIVER_ID}",
+    )
+    assert "winner: franchise:" in projection.document_text
+    assert "loser: franchise:" in projection.document_text
+    assert "matchup: week-9-table-2" in projection.document_text
+
+
+def test_event_projection_hash_covers_complete_content_not_search_text() -> None:
+    content = _trade()
+    original = build_event_document(content)
+    changed_receipt = build_event_document(
+        content.model_copy(update={"primary_api_request_id": SENDER_ID})
+    )
+
+    assert original.document_text == changed_receipt.document_text
+    assert original.content_hash != changed_receipt.content_hash

--- a/backend/tests/resources/memory/test_event_trigger_contracts.py
+++ b/backend/tests/resources/memory/test_event_trigger_contracts.py
@@ -4,7 +4,11 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from backend.resources.memory.events import EventContent, TradeEventPayload
+from backend.resources.memory.events import (
+    EventContent,
+    MatchupEventPayload,
+    TradeEventPayload,
+)
 from backend.resources.memory.triggers import TriggerContent
 
 
@@ -76,7 +80,7 @@ def test_trade_payload_discriminates_all_initial_asset_types() -> None:
 
 def test_event_contract_rejects_payload_mismatch_and_invalid_participants() -> None:
     winner_id = uuid4()
-    matchup = {
+    matchup: dict[str, object] = {
         "kind": "matchup",
         "winner_franchise_id": winner_id,
         "loser_franchise_id": winner_id,
@@ -106,6 +110,32 @@ def test_event_contract_rejects_payload_mismatch_and_invalid_participants() -> N
             },
             "trade",
         )
+
+
+def test_payload_contracts_remain_independently_validatable() -> None:
+    matchup = MatchupEventPayload.model_validate(
+        {
+            "winner_franchise_id": uuid4(),
+            "loser_franchise_id": uuid4(),
+            "sleeper_matchup_id": "standalone-matchup",
+        }
+    )
+    trade = TradeEventPayload.model_validate(
+        {
+            "sender_franchise_id": uuid4(),
+            "receiver_franchise_id": uuid4(),
+            "assets": [
+                {
+                    "kind": "budget",
+                    "direction": "sender_to_receiver",
+                    "amount": 5,
+                }
+            ],
+        }
+    )
+
+    assert matchup.kind == "matchup"
+    assert trade.kind == "trade"
 
 
 def test_trigger_contract_discriminates_initial_conditions() -> None:

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,11 +2,10 @@
 
 ## Current Phase
 
-**Active layer:** `memory-4` complete; publication pending
-**Current branch:** `codex/memory-4-facts`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4`
-**Publication:** Stack #108 is published through draft PR #110 (`memory-3`).
-`memory-4` is complete locally and ready to commit and submit.
+**Active layer:** `memory-5` complete; publication pending
+**Current branch:** `codex/memory-5-events`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5`
+**Publication:** Stack #108 is published through draft PR #112 (`memory-5`).
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -20,8 +19,8 @@ The completed database stack remains tracked separately in
 | `memory-1` ORM modules | `codex/memory-1-orm-modules` | Complete | `root` | Schema-preserving split already committed | `b7f758c`; draft PR #107 |
 | `memory-2` contracts | `codex/memory-2-contracts` | Complete | `root` + `contracts_audit` | 29 focused contract tests; backend: 52 passed, 49 PostgreSQL tests skipped | `e16e5ce`; draft PR #109 |
 | `memory-3` revisions | `codex/memory-3-revisions` | Complete | `root` + `contracts_audit` + reviewers | 3 focused PostgreSQL tests; backend: 104 passed; basedpyright: clean | `d70cb4c`; draft PR #110 |
-| `memory-4` facts | `codex/memory-4-facts` | Complete | `root` + `plan_mapper` + `stack_audit` + `contracts_audit` | 8 focused tests; memory: 40 passed; backend: 112 passed; basedpyright: clean | Active branch head; PR pending |
-| `memory-5` events | `codex/memory-5-events` | Pending | Unassigned | Not started | — |
+| `memory-4` facts | `codex/memory-4-facts` | Complete | `root` + `plan_mapper` + `stack_audit` + `contracts_audit` | 8 focused tests; memory: 40 passed; backend: 112 passed; basedpyright: clean | `5b71628`; draft PR #111 |
+| `memory-5` events | `codex/memory-5-events` | Complete | `root` | 9 focused event tests; memory: 49 passed; backend: 121 passed; basedpyright 1.39.10 found no new errors and 16 pre-existing backend errors | Active branch head; draft PR #112 |
 | `memory-6` storylines | `codex/memory-6-storylines` | Pending | Unassigned | Not started | — |
 | `memory-7` triggers | `codex/memory-7-triggers` | Pending | Unassigned | Not started | — |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Pending | Unassigned | Not started | — |
@@ -43,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-5` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/resources/memory/events/`, event projection builder/exports, shared receipt validation, event tests, `docs/memory/status.md` | Event manager reads, v1 codec, validation, canonical-write helpers, deterministic projection, verification, and coordination ownership |
 
 ## `memory-4` Assignments
 
@@ -134,6 +139,28 @@ design and correctness pass.
   resource-local validation and SQL helpers are composed by
   `MemoryMutationService` in `memory-9`, including the one-proposal case.
 
+## `memory-5` Boundary Notes
+
+- `EventManager` exposes competition-scoped exact-version hydration and
+  newest-first item history. Exact reads include retired immutable versions.
+- Event v1 codecs preserve the complete `trade` or `matchup` discriminator and
+  payload. Retained canonical state content preserves exact asset order, while
+  the derived projection normalizes the order-insensitive asset collection.
+- Trade validation requires both franchises in scope, globally known players,
+  competition-scoped normalized draft picks, and valid typed receipts. Matchup
+  validation requires both franchises in scope; `sleeper_matchup_id` remains an
+  opaque nonblank external identifier and does not require a normalized row.
+- Reporting tool-call and Sleeper API-request validation now live in one shared
+  package helper used unchanged by both facts and events.
+- Event projections contain status, salience, deterministic franchise/player/
+  draft-pick keys, and payload-specific lexical text. Receipt IDs and canonical
+  persistence identity do not enter searchable text, but complete content still
+  contributes to the projection content hash.
+- Resource-local create/replacement preparation validates item kind, scope,
+  expected revision, envelope persistence, and schema agreement. Typed content
+  and its search projection remain part of the caller-owned canonical
+  transaction. Public mutation operations remain deferred to `memory-9`.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -162,5 +189,10 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The test container and
-  its tmpfs data were removed after the 104-test backend run passed.
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-5` run
+  passed all 49 memory tests and all 121 backend tests; the test container and
+  its tmpfs data were removed afterward.
+- `uvx basedpyright backend` with basedpyright 1.39.10 reports 16 diagnostics
+  already present at the `memory-4` parent, including the existing Pydantic
+  `schema_version` narrowing pattern. No new diagnostic originates in the
+  `memory-5` implementation or tests.


### PR DESCRIPTION
## Summary

- add competition-scoped event exact/history hydration and retained v1 codecs
- validate trade/matchup references and persist event content plus deterministic search projections atomically
- share typed receipt validation between facts and events

## Testing

- 49 memory resource tests passed against PostgreSQL
- 121 backend tests passed against PostgreSQL
- git diff --check passed
- basedpyright 1.39.10 reports 16 diagnostics already present on the memory-4 parent and no new memory-5 diagnostics

## Stack

- base: #111 (memory-4 facts)
- stack: #108