### PR TITLE
feat(memory): add trigger resource operations

### DIFF
--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -23,6 +23,13 @@ from backend.resources.memory.storylines import (
     StorylineManager,
     StorylineStatus,
 )
+from backend.resources.memory.triggers import (
+    Trigger,
+    TriggerContent,
+    TriggerManager,
+    TriggerStatus,
+    TriggerType,
+)
 
 __all__ = [
     "Event",
@@ -42,4 +49,9 @@ __all__ = [
     "StorylineContent",
     "StorylineManager",
     "StorylineStatus",
+    "Trigger",
+    "TriggerContent",
+    "TriggerManager",
+    "TriggerStatus",
+    "TriggerType",
 ]

--- a/backend/resources/memory/search_documents/__init__.py
+++ b/backend/resources/memory/search_documents/__init__.py
@@ -12,6 +12,10 @@ from backend.resources.memory.search_documents.builders.storyline import (
     STORYLINE_DOCUMENT_BUILDER_VERSION,
     build_storyline_document,
 )
+from backend.resources.memory.search_documents.builders.trigger import (
+    TRIGGER_DOCUMENT_BUILDER_VERSION,
+    build_trigger_document,
+)
 from backend.resources.memory.search_documents.objects import SearchDocumentProjection
 
 __all__ = [
@@ -19,7 +23,9 @@ __all__ = [
     "FACT_DOCUMENT_BUILDER_VERSION",
     "SearchDocumentProjection",
     "STORYLINE_DOCUMENT_BUILDER_VERSION",
+    "TRIGGER_DOCUMENT_BUILDER_VERSION",
     "build_event_document",
     "build_fact_document",
     "build_storyline_document",
+    "build_trigger_document",
 ]

--- a/backend/resources/memory/search_documents/builders/__init__.py
+++ b/backend/resources/memory/search_documents/builders/__init__.py
@@ -10,12 +10,18 @@ from backend.resources.memory.search_documents.builders.storyline import (
     STORYLINE_DOCUMENT_BUILDER_VERSION,
     build_storyline_document,
 )
+from backend.resources.memory.search_documents.builders.trigger import (
+    TRIGGER_DOCUMENT_BUILDER_VERSION,
+    build_trigger_document,
+)
 
 __all__ = [
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
     "STORYLINE_DOCUMENT_BUILDER_VERSION",
+    "TRIGGER_DOCUMENT_BUILDER_VERSION",
     "build_event_document",
     "build_fact_document",
     "build_storyline_document",
+    "build_trigger_document",
 ]

--- a/backend/resources/memory/search_documents/builders/trigger.py
+++ b/backend/resources/memory/search_documents/builders/trigger.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final, cast
+from uuid import UUID
+
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentProjection,
+)
+from backend.resources.memory.triggers.conditions.rematch import RematchCondition
+from backend.resources.memory.triggers.objects import TriggerContent
+
+
+TRIGGER_DOCUMENT_BUILDER_VERSION: Final = 1
+
+
+def build_trigger_document(content: TriggerContent) -> SearchDocumentProjection:
+    """Deterministically flatten complete trigger content for discovery."""
+
+    entity_keys = tuple(sorted(_entity_keys(content)))
+    related_item_ids = tuple(sorted(_related_item_ids(content), key=str))
+    text_parts = [
+        f"trigger type: {content.trigger_type.value}",
+        f"status: {content.status.value}",
+        f"fire policy: {content.fire_policy.value}",
+        *_target_text(content),
+        *_condition_text(content),
+    ]
+    if content.resolution_reason is not None:
+        text_parts.append(f"resolution: {content.resolution_reason}")
+
+    return SearchDocumentProjection(
+        kind=MemoryKind.TRIGGER,
+        status=content.status.value,
+        entity_keys=entity_keys,
+        related_item_ids=related_item_ids,
+        document_text="\n".join(text_parts),
+        builder_version=TRIGGER_DOCUMENT_BUILDER_VERSION,
+        content_hash=_trigger_content_hash(content),
+    )
+
+
+def _entity_keys(content: TriggerContent) -> set[str]:
+    keys: set[str] = set()
+    if content.target_competition_season_id is not None:
+        keys.add(f"season:{content.target_competition_season_id}")
+    if isinstance(content.condition, RematchCondition):
+        keys.update(
+            f"franchise:{franchise_id}"
+            for franchise_id in content.condition.franchise_ids
+        )
+    return keys
+
+
+def _related_item_ids(content: TriggerContent) -> set[UUID]:
+    return {
+        item_id
+        for item_id in (
+            content.target_storyline_item_id,
+            content.origin_event_item_id,
+        )
+        if item_id is not None
+    }
+
+
+def _target_text(content: TriggerContent) -> list[str]:
+    parts: list[str] = []
+    if content.target_competition_season_id is not None:
+        parts.append(f"target season: {content.target_competition_season_id}")
+    if content.target_storyline_item_id is not None:
+        parts.append(f"target storyline: {content.target_storyline_item_id}")
+    if content.origin_event_item_id is not None:
+        parts.append(f"origin event: {content.origin_event_item_id}")
+    if content.target_week is not None:
+        parts.append(f"target week: {content.target_week}")
+    if content.target_at is not None:
+        parts.append(f"target time: {content.target_at.isoformat()}")
+    return parts
+
+
+def _condition_text(content: TriggerContent) -> list[str]:
+    if isinstance(content.condition, RematchCondition):
+        franchises = sorted(str(value) for value in content.condition.franchise_ids)
+        return [f"rematch franchises: {' '.join(franchises)}"]
+    return ["condition: trade evaluation"]
+
+
+def _trigger_content_hash(content: TriggerContent) -> str:
+    serialized = _canonical_json(_canonical_trigger_content(content)).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _canonical_trigger_content(content: TriggerContent) -> dict[str, Any]:
+    dumped = cast(dict[str, Any], content.model_dump(mode="json"))
+    condition = cast(dict[str, Any], dumped["condition"])
+    if condition["kind"] == "rematch":
+        franchise_ids = cast(list[str], condition["franchise_ids"])
+        condition["franchise_ids"] = sorted(franchise_ids)
+    return {
+        "memory_kind": content.memory_kind.value,
+        "content": dumped,
+    }
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )

--- a/backend/resources/memory/triggers/__init__.py
+++ b/backend/resources/memory/triggers/__init__.py
@@ -2,6 +2,7 @@ from backend.resources.memory.triggers.conditions.rematch import RematchConditio
 from backend.resources.memory.triggers.conditions.trade_evaluation import (
     TradeEvaluationCondition,
 )
+from backend.resources.memory.triggers.manager import TriggerManager
 from backend.resources.memory.triggers.objects import (
     FirePolicy,
     Trigger,
@@ -18,6 +19,7 @@ __all__ = [
     "Trigger",
     "TriggerCondition",
     "TriggerContent",
+    "TriggerManager",
     "TriggerStatus",
     "TriggerType",
 ]

--- a/backend/resources/memory/triggers/codec.py
+++ b/backend/resources/memory/triggers/codec.py
@@ -1,0 +1,124 @@
+"""Stored-schema codecs for trigger versions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.sql import Select
+
+from backend.database.models.memory import MemoryItem, MemoryVersion, TriggerVersion
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.revisions.hashing import StoredSchemaContent
+from backend.resources.memory.triggers.objects import Trigger, TriggerContent
+
+
+def trigger_rows_statement(
+) -> Select[tuple[MemoryItem, MemoryVersion, TriggerVersion]]:
+    """Select complete trigger aggregates without exposing storage joins."""
+
+    return (
+        sa.select(MemoryItem, MemoryVersion, TriggerVersion)
+        .join(MemoryVersion, MemoryVersion.item_id == MemoryItem.id)
+        .join(TriggerVersion, TriggerVersion.version_id == MemoryVersion.id)
+        .where(MemoryItem.kind == MemoryKind.TRIGGER.value)
+    )
+
+
+def decode_trigger(
+    item: MemoryItem,
+    version: MemoryVersion,
+    stored: TriggerVersion,
+) -> Trigger:
+    content = _decode_content(version.content_schema_version, stored)
+    return Trigger.model_validate(
+        {
+            "item": {
+                "item_id": item.id,
+                "competition_id": item.competition_id,
+                "kind": item.kind,
+                "agent_key": item.agent_key,
+                "created_at": item.created_at,
+            },
+            "version": {
+                "version_id": version.id,
+                "revision_number": version.revision_number,
+                "content_schema_version": version.content_schema_version,
+                "introduced_revision_id": version.introduced_revision_id,
+                "retired_revision_id": version.retired_revision_id,
+                "competition_season_id": version.competition_season_id,
+                "week": version.week,
+                "occurred_at": version.occurred_at,
+                "creating_generation_id": version.creating_generation_id,
+                "creating_tool_call_id": version.creating_tool_call_id,
+                "change_reason": version.change_reason,
+                "recorded_at": version.recorded_at,
+            },
+            "content": content,
+        }
+    )
+
+
+def encode_trigger(content: TriggerContent) -> dict[str, Any]:
+    """Translate complete typed content into the current stored v1 row."""
+
+    return {
+        "trigger_type": content.trigger_type.value,
+        "status": content.status.value,
+        "fire_policy": content.fire_policy.value,
+        "target_competition_season_id": content.target_competition_season_id,
+        "target_storyline_item_id": content.target_storyline_item_id,
+        "origin_event_item_id": content.origin_event_item_id,
+        "target_week": content.target_week,
+        "target_at": content.target_at,
+        "condition": content.condition.model_dump(mode="json"),
+        "resolution_reason": content.resolution_reason,
+    }
+
+
+def stored_trigger_content(content: TriggerContent) -> StoredSchemaContent:
+    """Encode exact retained v1 logical content for canonical state hashing."""
+
+    if content.schema_version != 1:
+        raise ValueError(
+            f"unsupported trigger content schema version {content.schema_version}"
+        )
+    return StoredSchemaContent(
+        memory_kind=MemoryKind.TRIGGER,
+        schema_version=1,
+        payload={
+            "schema_version": 1,
+            "trigger_type": content.trigger_type.value,
+            "status": content.status.value,
+            "fire_policy": content.fire_policy.value,
+            "target_competition_season_id": content.target_competition_season_id,
+            "target_storyline_item_id": content.target_storyline_item_id,
+            "origin_event_item_id": content.origin_event_item_id,
+            "target_week": content.target_week,
+            "target_at": content.target_at,
+            "condition": content.condition.model_dump(mode="python"),
+            "resolution_reason": content.resolution_reason,
+        },
+    )
+
+
+def _decode_content(schema_version: int, stored: TriggerVersion) -> TriggerContent:
+    if schema_version != 1:
+        raise ValueError(
+            f"unsupported trigger content schema version {schema_version}"
+        )
+    return TriggerContent.model_validate(
+        {
+            "schema_version": 1,
+            "trigger_type": stored.trigger_type,
+            "status": stored.status,
+            "fire_policy": stored.fire_policy,
+            "target_competition_season_id": stored.target_competition_season_id,
+            "target_storyline_item_id": stored.target_storyline_item_id,
+            "origin_event_item_id": stored.origin_event_item_id,
+            "target_week": stored.target_week,
+            "target_at": stored.target_at,
+            "condition": stored.condition,
+            "resolution_reason": stored.resolution_reason,
+        }
+    )

--- a/backend/resources/memory/triggers/manager.py
+++ b/backend/resources/memory/triggers/manager.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common.errors import TargetNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.triggers.codec import (
+    decode_trigger,
+    trigger_rows_statement,
+)
+from backend.resources.memory.triggers.objects import Trigger
+
+
+class TriggerManager:
+    """Competition-scoped hydration of immutable trigger versions."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def exact(self, version_id: UUID) -> Trigger:
+        """Hydrate one exact trigger version, including retired history."""
+
+        statement = trigger_rows_statement().where(
+            MemoryVersion.id == version_id,
+            MemoryVersion.competition_id == self._competition_id,
+        )
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(statement).one_or_none()
+        if row is None:
+            raise TargetNotFoundError(version_id, (MemoryKind.TRIGGER,))
+        return decode_trigger(row[0], row[1], row[2])
+
+    def history(self, item_id: UUID) -> tuple[Trigger, ...]:
+        """Return every immutable version of one trigger item, newest first."""
+
+        statement = (
+            trigger_rows_statement()
+            .where(
+                MemoryItem.id == item_id,
+                MemoryItem.competition_id == self._competition_id,
+            )
+            .order_by(sa.desc(MemoryVersion.revision_number))
+        )
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(statement).all()
+        if not rows:
+            raise TargetNotFoundError(item_id, (MemoryKind.TRIGGER,))
+        return tuple(decode_trigger(row[0], row[1], row[2]) for row in rows)

--- a/backend/resources/memory/triggers/shared.py
+++ b/backend/resources/memory/triggers/shared.py
@@ -1,0 +1,122 @@
+"""Package-internal trigger validation and persistence for canonical writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import MemoryItem, MemoryVersion, TriggerVersion
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.search_documents.builders.trigger import (
+    build_trigger_document,
+)
+from backend.resources.memory.search_documents.shared import insert_search_document
+from backend.resources.memory.triggers.codec import encode_trigger
+from backend.resources.memory.triggers.objects import TriggerContent
+from backend.resources.memory.triggers.validation import (
+    ValidatedTriggerContent,
+    validate_trigger_content,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedTriggerReplacement:
+    validated: ValidatedTriggerContent
+    previous_version: MemoryVersion
+    next_revision_number: int
+
+
+def prepare_trigger_write(
+    session: Session,
+    competition_id: UUID,
+    content: TriggerContent,
+) -> ValidatedTriggerContent:
+    """Validate a complete create/replacement payload in the active transaction."""
+
+    return validate_trigger_content(session, competition_id, content)
+
+
+def prepare_trigger_replacement(
+    session: Session,
+    competition_id: UUID,
+    item_id: UUID,
+    expected_item_revision: int,
+    content: TriggerContent,
+) -> PreparedTriggerReplacement:
+    """Validate one complete replacement and resolve its current envelope."""
+
+    item = session.get(MemoryItem, item_id)
+    if item is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.TRIGGER,))
+    if item.competition_id != competition_id:
+        raise CrossCompetitionReferenceError(
+            item_id,
+            competition_id,
+            item.competition_id,
+        )
+    if item.kind != MemoryKind.TRIGGER.value:
+        raise WrongTargetKindError(
+            item_id,
+            (MemoryKind.TRIGGER,),
+            MemoryKind(item.kind),
+        )
+    previous = session.scalar(
+        sa.select(MemoryVersion)
+        .join(TriggerVersion, TriggerVersion.version_id == MemoryVersion.id)
+        .where(
+            MemoryVersion.item_id == item_id,
+            MemoryVersion.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    )
+    if previous is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.TRIGGER,))
+    if previous.revision_number != expected_item_revision:
+        raise StaleItemVersionError(
+            item_id,
+            expected_item_revision,
+            previous.revision_number,
+        )
+    return PreparedTriggerReplacement(
+        validated=validate_trigger_content(session, competition_id, content),
+        previous_version=previous,
+        next_revision_number=previous.revision_number + 1,
+    )
+
+
+def insert_trigger_version(
+    session: Session,
+    version: MemoryVersion,
+    prepared: ValidatedTriggerContent,
+) -> None:
+    """Insert typed content and its derived projection beside a new envelope."""
+
+    content = prepared.content
+    if version.competition_id != prepared.competition_id:
+        raise CrossCompetitionReferenceError(
+            version.id,
+            prepared.competition_id,
+            version.competition_id,
+        )
+    if version.content_schema_version != content.schema_version:
+        raise ValueError("trigger schema version does not match version envelope")
+    if not inspect(version).persistent:
+        raise ValueError("trigger version envelope must be persisted before content")
+    session.add(
+        TriggerVersion(
+            version_id=version.id,
+            competition_id=version.competition_id,
+            **encode_trigger(content),
+        )
+    )
+    insert_search_document(session, version, build_trigger_document(content))

--- a/backend/resources/memory/triggers/validation.py
+++ b/backend/resources/memory/triggers/validation.py
@@ -1,0 +1,128 @@
+"""Competition-scoped reference validation for complete trigger content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason, Franchise
+from backend.database.models.memory import MemoryItem
+from backend.resources.memory.common.errors import (
+    CrossCompetitionEntityReferenceError,
+    CrossCompetitionReferenceError,
+    EntityReferenceNotFoundError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.triggers.conditions.rematch import RematchCondition
+from backend.resources.memory.triggers.objects import TriggerContent
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedTriggerContent:
+    competition_id: UUID
+    content: TriggerContent
+
+
+def validate_trigger_content(
+    session: Session,
+    competition_id: UUID,
+    content: TriggerContent,
+) -> ValidatedTriggerContent:
+    """Validate all database-backed trigger references in the transaction."""
+
+    _validate_target_season(session, competition_id, content)
+    _validate_condition(session, competition_id, content)
+    _validate_stable_target(
+        session,
+        competition_id,
+        content.target_storyline_item_id,
+        MemoryKind.STORYLINE,
+    )
+    _validate_stable_target(
+        session,
+        competition_id,
+        content.origin_event_item_id,
+        MemoryKind.EVENT,
+    )
+    return ValidatedTriggerContent(
+        competition_id=competition_id,
+        content=content,
+    )
+
+
+def _validate_target_season(
+    session: Session,
+    competition_id: UUID,
+    content: TriggerContent,
+) -> None:
+    season_id = content.target_competition_season_id
+    if season_id is None:
+        return
+    actual_scope = session.scalar(
+        sa.select(CompetitionSeason.competition_id).where(
+            CompetitionSeason.id == season_id
+        )
+    )
+    if actual_scope is None:
+        raise EntityReferenceNotFoundError("season", season_id)
+    if actual_scope != competition_id:
+        raise CrossCompetitionEntityReferenceError(
+            "season",
+            season_id,
+            competition_id,
+        )
+
+
+def _validate_condition(
+    session: Session,
+    competition_id: UUID,
+    content: TriggerContent,
+) -> None:
+    if not isinstance(content.condition, RematchCondition):
+        return
+    rows = session.execute(
+        sa.select(Franchise.id, Franchise.competition_id).where(
+            Franchise.id.in_(set(content.condition.franchise_ids))
+        )
+    )
+    found = {franchise_id: scope for franchise_id, scope in rows}
+    for franchise_id in content.condition.franchise_ids:
+        actual_scope = found.get(franchise_id)
+        if actual_scope is None:
+            raise EntityReferenceNotFoundError("franchise", franchise_id)
+        if actual_scope != competition_id:
+            raise CrossCompetitionEntityReferenceError(
+                "franchise",
+                franchise_id,
+                competition_id,
+            )
+
+
+def _validate_stable_target(
+    session: Session,
+    competition_id: UUID,
+    item_id: UUID | None,
+    expected_kind: MemoryKind,
+) -> None:
+    if item_id is None:
+        return
+    item = session.get(MemoryItem, item_id)
+    if item is None:
+        raise TargetNotFoundError(item_id, (expected_kind,))
+    if item.competition_id != competition_id:
+        raise CrossCompetitionReferenceError(
+            item_id,
+            competition_id,
+            item.competition_id,
+        )
+    if item.kind != expected_kind.value:
+        raise WrongTargetKindError(
+            item_id,
+            (expected_kind,),
+            MemoryKind(item.kind),
+        )

--- a/backend/tests/resources/memory/test_trigger_codec.py
+++ b/backend/tests/resources/memory/test_trigger_codec.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.database.models.memory import TriggerVersion
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.triggers import TriggerContent
+from backend.resources.memory.triggers.codec import (
+    _decode_content,
+    encode_trigger,
+    stored_trigger_content,
+)
+
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+STORYLINE_ID = UUID("22222222-2222-2222-2222-222222222222")
+EVENT_ID = UUID("33333333-3333-3333-3333-333333333333")
+
+
+def _rematch() -> TriggerContent:
+    return TriggerContent.model_validate(
+        {
+            "trigger_type": "rematch",
+            "status": "open",
+            "fire_policy": "one_shot",
+            "target_competition_season_id": SEASON_ID,
+            "target_storyline_item_id": STORYLINE_ID,
+            "target_week": 8,
+            "condition": {
+                "kind": "rematch",
+                "franchise_ids": [uuid4(), uuid4()],
+            },
+        }
+    )
+
+
+def _trade_evaluation() -> TriggerContent:
+    return TriggerContent.model_validate(
+        {
+            "trigger_type": "trade_evaluation",
+            "status": "satisfied",
+            "fire_policy": "until_resolved",
+            "target_storyline_item_id": STORYLINE_ID,
+            "origin_event_item_id": EVENT_ID,
+            "target_at": datetime(2026, 11, 3, 18, 30, tzinfo=UTC),
+            "condition": {"kind": "trade_evaluation"},
+            "resolution_reason": "The evaluation window closed.",
+        }
+    )
+
+
+@pytest.mark.parametrize("content", [_rematch(), _trade_evaluation()])
+def test_trigger_v1_codec_round_trips_each_condition(
+    content: TriggerContent,
+) -> None:
+    stored = TriggerVersion(
+        version_id=uuid4(),
+        competition_id=uuid4(),
+        **encode_trigger(content),
+    )
+
+    decoded = _decode_content(1, stored)
+    retained = stored_trigger_content(content)
+
+    assert decoded == content
+    assert retained.memory_kind is MemoryKind.TRIGGER
+    assert retained.schema_version == 1
+    assert retained.payload["condition"] == content.condition.model_dump(mode="python")
+
+
+def test_trigger_codec_rejects_unknown_retained_schema_version() -> None:
+    content = _rematch()
+    stored = TriggerVersion(
+        version_id=uuid4(),
+        competition_id=uuid4(),
+        **encode_trigger(content),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported trigger content schema version 2",
+    ):
+        _decode_content(2, stored)

--- a/backend/tests/resources/memory/test_trigger_manager.py
+++ b/backend/tests/resources/memory/test_trigger_manager.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    CurrentRevision,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    TriggerVersion,
+)
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import (
+    CrossCompetitionEntityReferenceError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.revisions.writers import persist_version_envelopes
+from backend.resources.memory.search_documents import TRIGGER_DOCUMENT_BUILDER_VERSION
+from backend.resources.memory.triggers import TriggerContent, TriggerManager
+from backend.resources.memory.triggers.shared import (
+    insert_trigger_version,
+    prepare_trigger_replacement,
+    prepare_trigger_write,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@dataclass(frozen=True)
+class TriggerDomain:
+    competition_id: UUID
+    other_competition_id: UUID
+    season_id: UUID
+    generation_id: UUID
+    current_revision_id: UUID
+    franchise_ids: tuple[UUID, UUID]
+    cross_franchise_id: UUID
+    storyline_item_id: UUID
+    event_item_id: UUID
+    cross_trigger_version_id: UUID
+
+
+def _seed_domain(database_engine: Engine) -> TriggerDomain:
+    competition_id = uuid4()
+    other_competition_id = uuid4()
+    season_id = uuid4()
+    other_season_id = uuid4()
+    generation_id = uuid4()
+    other_generation_id = uuid4()
+    root_revision_id = uuid4()
+    current_revision_id = uuid4()
+    other_revision_id = uuid4()
+    franchise_ids = (uuid4(), uuid4())
+    cross_franchise_id = uuid4()
+    storyline_item_id = uuid4()
+    event_item_id = uuid4()
+    cross_event_item_id = uuid4()
+    cross_trigger_item_id = uuid4()
+    cross_trigger_version_id = uuid4()
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": competition_id, "display_name": "Trigger League"},
+                {"id": other_competition_id, "display_name": "Other League"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                _season(season_id, competition_id),
+                _season(other_season_id, other_competition_id),
+            ],
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                _franchise(franchise_ids[0], competition_id, "Owls"),
+                _franchise(franchise_ids[1], competition_id, "Sharks"),
+                _franchise(cross_franchise_id, other_competition_id, "Foxes"),
+            ],
+        )
+        connection.execute(
+            sa.insert(Generation),
+            [
+                _generation(generation_id, competition_id, season_id),
+                _generation(
+                    other_generation_id,
+                    other_competition_id,
+                    other_season_id,
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            [
+                _revision(root_revision_id, competition_id, 0, season_id),
+                _revision(
+                    current_revision_id,
+                    competition_id,
+                    1,
+                    season_id,
+                    previous_revision_id=root_revision_id,
+                ),
+                _revision(
+                    other_revision_id,
+                    other_competition_id,
+                    0,
+                    other_season_id,
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            [
+                {
+                    "competition_id": competition_id,
+                    "current_revision_id": current_revision_id,
+                    "lock_version": 1,
+                },
+                {
+                    "competition_id": other_competition_id,
+                    "current_revision_id": other_revision_id,
+                    "lock_version": 0,
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                _item(storyline_item_id, competition_id, "storyline"),
+                _item(event_item_id, competition_id, "event"),
+                _item(cross_event_item_id, other_competition_id, "event"),
+                _item(cross_trigger_item_id, other_competition_id, "trigger"),
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryVersion),
+            _version(
+                cross_trigger_version_id,
+                cross_trigger_item_id,
+                other_competition_id,
+                other_revision_id,
+                other_season_id,
+                other_generation_id,
+            ),
+        )
+        connection.execute(
+            sa.insert(TriggerVersion),
+            {
+                "version_id": cross_trigger_version_id,
+                "competition_id": other_competition_id,
+                "trigger_type": "trade_evaluation",
+                "status": "open",
+                "fire_policy": "one_shot",
+                "origin_event_item_id": cross_event_item_id,
+                "target_week": 4,
+                "condition": {"kind": "trade_evaluation"},
+            },
+        )
+
+    return TriggerDomain(
+        competition_id=competition_id,
+        other_competition_id=other_competition_id,
+        season_id=season_id,
+        generation_id=generation_id,
+        current_revision_id=current_revision_id,
+        franchise_ids=franchise_ids,
+        cross_franchise_id=cross_franchise_id,
+        storyline_item_id=storyline_item_id,
+        event_item_id=event_item_id,
+        cross_trigger_version_id=cross_trigger_version_id,
+    )
+
+
+def _season(season_id: UUID, competition_id: UUID) -> dict[str, object]:
+    return {
+        "id": season_id,
+        "competition_id": competition_id,
+        "season_year": 2026,
+        "sequence_number": 1,
+        "sleeper_league_id": f"league-{season_id}",
+    }
+
+
+def _franchise(
+    franchise_id: UUID,
+    competition_id: UUID,
+    display_name: str,
+) -> dict[str, object]:
+    return {
+        "id": franchise_id,
+        "competition_id": competition_id,
+        "display_name": display_name,
+    }
+
+
+def _generation(
+    generation_id: UUID,
+    competition_id: UUID,
+    season_id: UUID,
+) -> dict[str, object]:
+    return {
+        "id": generation_id,
+        "competition_id": competition_id,
+        "competition_season_id": season_id,
+        "kind": "test",
+        "status": "pending",
+        "request_text": "seed trigger manager",
+        "requested_primary_model": "test-model",
+        "settings_jsonb": {},
+        "current_turn": 0,
+    }
+
+
+def _revision(
+    revision_id: UUID,
+    competition_id: UUID,
+    sequence_number: int,
+    season_id: UUID,
+    *,
+    previous_revision_id: UUID | None = None,
+) -> dict[str, object]:
+    return {
+        "id": revision_id,
+        "competition_id": competition_id,
+        "sequence_number": sequence_number,
+        "previous_revision_id": previous_revision_id,
+        "competition_season_id": season_id,
+        "week": sequence_number,
+        "state_content_hash": f"seed-{revision_id}",
+    }
+
+
+def _item(item_id: UUID, competition_id: UUID, kind: str) -> dict[str, object]:
+    return {"id": item_id, "competition_id": competition_id, "kind": kind}
+
+
+def _version(
+    version_id: UUID,
+    item_id: UUID,
+    competition_id: UUID,
+    revision_id: UUID,
+    season_id: UUID,
+    generation_id: UUID,
+) -> dict[str, object]:
+    return {
+        "id": version_id,
+        "item_id": item_id,
+        "competition_id": competition_id,
+        "revision_number": 1,
+        "content_schema_version": 1,
+        "introduced_revision_id": revision_id,
+        "competition_season_id": season_id,
+        "week": 1,
+        "creating_generation_id": generation_id,
+    }
+
+
+def _trade_trigger(
+    domain: TriggerDomain,
+    *,
+    resolved: bool = False,
+) -> TriggerContent:
+    return TriggerContent.model_validate(
+        {
+            "trigger_type": "trade_evaluation",
+            "status": "satisfied" if resolved else "open",
+            "fire_policy": "until_resolved",
+            "target_storyline_item_id": domain.storyline_item_id,
+            "origin_event_item_id": domain.event_item_id,
+            "target_week": None if resolved else 5,
+            "target_at": (
+                datetime(2026, 11, 3, 18, 30, tzinfo=UTC) if resolved else None
+            ),
+            "condition": {"kind": "trade_evaluation"},
+            "resolution_reason": (
+                "Trade reviewed after the deadline." if resolved else None
+            ),
+        }
+    )
+
+
+def _manager(database_engine: Engine, competition_id: UUID) -> TriggerManager:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "competition", "competition_id": competition_id},
+            "correlation_id": uuid4(),
+        }
+    )
+    return TriggerManager(create_session_factory(database_engine), context)
+
+
+def test_trigger_lifecycle_hydrates_history_and_projects_replacements(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    first_version_id = uuid4()
+    first_revision_id = uuid4()
+    second_version_id = uuid4()
+    second_revision_id = uuid4()
+
+    with session_factory.begin() as session:
+        revision = MemoryRevision(
+            **_revision(
+                first_revision_id,
+                domain.competition_id,
+                2,
+                domain.season_id,
+                previous_revision_id=domain.current_revision_id,
+            )
+        )
+        item = MemoryItem(
+            id=item_id,
+            competition_id=domain.competition_id,
+            kind="trigger",
+        )
+        version = MemoryVersion(
+            **_version(
+                first_version_id,
+                item_id,
+                domain.competition_id,
+                first_revision_id,
+                domain.season_id,
+                domain.generation_id,
+            )
+        )
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=(item,),
+            new_versions=(version,),
+        )
+        insert_trigger_version(
+            session,
+            version,
+            prepare_trigger_write(
+                session,
+                domain.competition_id,
+                _trade_trigger(domain),
+            ),
+        )
+        session.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain.competition_id)
+            .values(current_revision_id=first_revision_id, lock_version=2)
+        )
+
+    with session_factory.begin() as session:
+        replacement = prepare_trigger_replacement(
+            session,
+            domain.competition_id,
+            item_id,
+            1,
+            _trade_trigger(domain, resolved=True),
+        )
+        revision = MemoryRevision(
+            **_revision(
+                second_revision_id,
+                domain.competition_id,
+                3,
+                domain.season_id,
+                previous_revision_id=first_revision_id,
+            )
+        )
+        version_data = _version(
+            second_version_id,
+            item_id,
+            domain.competition_id,
+            second_revision_id,
+            domain.season_id,
+            domain.generation_id,
+        )
+        version_data["revision_number"] = replacement.next_revision_number
+        version = MemoryVersion(**version_data)
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=(),
+            new_versions=(version,),
+            retired_versions=(replacement.previous_version,),
+        )
+        insert_trigger_version(session, version, replacement.validated)
+
+    manager = _manager(database_engine, domain.competition_id)
+    historical = manager.exact(first_version_id)
+    current, previous = manager.history(item_id)
+
+    assert historical.version.retired_revision_id == second_revision_id
+    assert current.version.version_id == second_version_id
+    assert previous.version.version_id == first_version_id
+    assert current.content.status == "satisfied"
+    assert current.content.target_week is None
+
+    with session_factory() as session:
+        projections = session.scalars(
+            sa.select(MemorySearchDocument).where(
+                MemorySearchDocument.item_id == item_id
+            )
+        ).all()
+    assert len(projections) == 2
+    assert {projection.builder_version for projection in projections} == {
+        TRIGGER_DOCUMENT_BUILDER_VERSION
+    }
+
+    with pytest.raises(TargetNotFoundError):
+        manager.exact(domain.cross_trigger_version_id)
+
+
+def test_trigger_reference_validation_enforces_kind_and_scope(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    rematch = TriggerContent.model_validate(
+        {
+            "trigger_type": "rematch",
+            "status": "open",
+            "fire_policy": "one_shot",
+            "target_competition_season_id": domain.season_id,
+            "target_week": 8,
+            "condition": {
+                "kind": "rematch",
+                "franchise_ids": domain.franchise_ids,
+            },
+        }
+    )
+
+    with session_factory() as session:
+        prepare_trigger_write(session, domain.competition_id, rematch)
+        with pytest.raises(WrongTargetKindError):
+            prepare_trigger_write(
+                session,
+                domain.competition_id,
+                _trade_trigger(domain).model_copy(
+                    update={"target_storyline_item_id": domain.event_item_id}
+                ),
+            )
+        with pytest.raises(CrossCompetitionEntityReferenceError):
+            prepare_trigger_write(
+                session,
+                domain.competition_id,
+                rematch.model_copy(
+                    update={
+                        "condition": rematch.condition.model_copy(
+                            update={
+                                "franchise_ids": (
+                                    domain.franchise_ids[0],
+                                    domain.cross_franchise_id,
+                                )
+                            }
+                        )
+                    }
+                ),
+            )
+
+
+def test_trigger_write_rolls_back_typed_content_and_projection(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    version_id = uuid4()
+    revision_id = uuid4()
+
+    with pytest.raises(RuntimeError, match="abort canonical write"):
+        with session_factory.begin() as session:
+            revision = MemoryRevision(
+                **_revision(
+                    revision_id,
+                    domain.competition_id,
+                    2,
+                    domain.season_id,
+                    previous_revision_id=domain.current_revision_id,
+                )
+            )
+            item = MemoryItem(
+                id=item_id,
+                competition_id=domain.competition_id,
+                kind="trigger",
+            )
+            version = MemoryVersion(
+                **_version(
+                    version_id,
+                    item_id,
+                    domain.competition_id,
+                    revision_id,
+                    domain.season_id,
+                    domain.generation_id,
+                )
+            )
+            persist_version_envelopes(
+                session,
+                revision,
+                new_items=(item,),
+                new_versions=(version,),
+            )
+            insert_trigger_version(
+                session,
+                version,
+                prepare_trigger_write(
+                    session,
+                    domain.competition_id,
+                    _trade_trigger(domain),
+                ),
+            )
+            session.flush()
+            raise RuntimeError("abort canonical write")
+
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(TriggerVersion)
+            .where(TriggerVersion.version_id == version_id)
+        ) == 0
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemorySearchDocument)
+            .where(MemorySearchDocument.version_id == version_id)
+        ) == 0

--- a/backend/tests/resources/memory/test_trigger_search_builder.py
+++ b/backend/tests/resources/memory/test_trigger_search_builder.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.search_documents import (
+    TRIGGER_DOCUMENT_BUILDER_VERSION,
+    build_trigger_document,
+)
+from backend.resources.memory.triggers import TriggerContent, TriggerStatus
+
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+STORYLINE_ID = UUID("22222222-2222-2222-2222-222222222222")
+FRANCHISE_A = UUID("33333333-3333-3333-3333-333333333333")
+FRANCHISE_B = UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _rematch(*, reversed_franchises: bool = False) -> TriggerContent:
+    franchises = [FRANCHISE_A, FRANCHISE_B]
+    if reversed_franchises:
+        franchises.reverse()
+    return TriggerContent.model_validate(
+        {
+            "trigger_type": "rematch",
+            "status": "open",
+            "fire_policy": "recurring",
+            "target_competition_season_id": SEASON_ID,
+            "target_storyline_item_id": STORYLINE_ID,
+            "target_week": 9,
+            "condition": {
+                "kind": "rematch",
+                "franchise_ids": franchises,
+            },
+        }
+    )
+
+
+def test_trigger_projection_normalizes_rematch_participants() -> None:
+    projection = build_trigger_document(_rematch())
+    reordered = build_trigger_document(_rematch(reversed_franchises=True))
+
+    assert projection == reordered
+    assert projection.kind is MemoryKind.TRIGGER
+    assert projection.status == "open"
+    assert projection.entity_keys == (
+        f"franchise:{FRANCHISE_A}",
+        f"franchise:{FRANCHISE_B}",
+        f"season:{SEASON_ID}",
+    )
+    assert projection.related_item_ids == (STORYLINE_ID,)
+    assert projection.builder_version == TRIGGER_DOCUMENT_BUILDER_VERSION
+    assert "target week: 9" in projection.document_text
+
+
+def test_trigger_projection_hash_covers_complete_content() -> None:
+    content = _rematch()
+    original = build_trigger_document(content)
+    resolved = build_trigger_document(
+        content.model_copy(
+            update={
+                "status": TriggerStatus.SATISFIED,
+                "resolution_reason": "The rematch was played.",
+            }
+        )
+    )
+
+    assert original.content_hash != resolved.content_hash

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,10 +2,10 @@
 
 ## Current Phase
 
-**Active layer:** `memory-6` complete; publication pending
-**Current branch:** `codex/memory-6-storylines`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6`
-**Publication:** Stack #108 is published through draft PR #112 (`memory-5`); `memory-6` remains local.
+**Active layer:** `memory-7` complete; `memory-8` is next
+**Current branch:** `codex/memory-7-triggers`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7`
+**Publication:** Stack #108 is published through draft PR #112 (`memory-5`); `memory-6` and `memory-7` remain local.
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -22,7 +22,7 @@ The completed database stack remains tracked separately in
 | `memory-4` facts | `codex/memory-4-facts` | Complete | `root` + `plan_mapper` + `stack_audit` + `contracts_audit` | 8 focused tests; memory: 40 passed; backend: 112 passed; basedpyright: clean | `5b71628`; draft PR #111 |
 | `memory-5` events | `codex/memory-5-events` | Complete | `root` | 9 focused event tests; memory: 49 passed; backend: 121 passed; basedpyright 1.39.10 found no new errors and 16 pre-existing backend errors | Active branch head; draft PR #112 |
 | `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | Active branch head; not published |
-| `memory-7` triggers | `codex/memory-7-triggers` | Pending | Unassigned | Not started | — |
+| `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | Active branch head; not published |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Pending | Unassigned | Not started | — |
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Pending | Unassigned | Not started | — |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
@@ -42,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-7` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/resources/memory/triggers/`, trigger projection builder/exports, trigger tests, `docs/memory/status.md` | Trigger manager reads, v1 codec, stable-target and rematch-entity validation, canonical-write helpers, deterministic projection, lean verification, and coordination ownership |
 
 ## `memory-6` Assignments
 
@@ -191,6 +197,29 @@ design and correctness pass.
   atomic typed-row plus projection insertion. Public mutations remain deferred
   to `memory-9`.
 
+## `memory-7` Boundary Notes
+
+- `TriggerManager` exposes competition-scoped exact-version hydration and
+  newest-first item history. Exact reads include retired immutable versions and
+  do not disclose cross-competition targets.
+- Trigger v1 codecs retain the complete status, fire policy, scheduling,
+  stable targets, discriminated condition, and resolution payload. Canonical
+  state hashing preserves exact stored rematch-franchise order.
+- Database-backed validation requires target seasons and rematch franchises to
+  exist in the competition. Optional storyline and origin-event references
+  target stable same-scope items of their declared kinds; current visibility is
+  irrelevant. Existing typed-contract rules remain the sole source of pure
+  trigger-condition validation.
+- Trigger projections include status, rematch franchise and season entity keys,
+  stable storyline/event item IDs, and deterministic type, policy, schedule,
+  condition, and resolution text. The unordered rematch pair is normalized for
+  projection equality and hashing without changing canonical stored ordering.
+- Resource-local create/replacement helpers enforce complete replacement,
+  expected item revision, persisted envelope ordering, schema agreement, and
+  atomic typed-row plus projection insertion. Public mutations remain deferred
+  to `memory-9`; migrations, retrieval behavior, and reporter integration remain
+  outside this layer.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -219,10 +248,10 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-6` run
-  passed all 56 memory tests and all 128 backend tests; the test container and
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-7` run
+  passed all 64 memory tests and all 136 backend tests; the test container and
   its tmpfs data were removed afterward.
 - `uvx basedpyright backend` reports the same 16 diagnostics already present at
   the `memory-5` parent, including the existing Pydantic `schema_version`
-  narrowing pattern. No new diagnostic originates in the `memory-6`
+  narrowing pattern. No new error originates in the `memory-7`
   implementation or tests.


### PR DESCRIPTION
## Summary

- add competition-scoped exact and history reads for immutable trigger versions
- add trigger v1 codecs, retained-schema hashing payloads, database-backed reference validation, and canonical-write helpers
- add deterministic trigger search projection with normalized rematch ordering
- export trigger resource interfaces and mark memory-7 complete in the status ledger
- keep coverage lean and contract-focused

## Verification

- 8 focused trigger tests passed
- 64 memory-resource tests passed
- 136 backend tests passed
- basedpyright reported no new errors; the same 16 pre-existing backend errors remain

## Stack

- Base: codex/memory-6-storylines
- Head: codex/memory-7-triggers