### PR TITLE
feat(memory): add storyline resource operations

### DIFF
--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -17,6 +17,12 @@ from backend.resources.memory.facts import (
     FactStatus,
     FactSubjectRole,
 )
+from backend.resources.memory.storylines import (
+    Storyline,
+    StorylineContent,
+    StorylineManager,
+    StorylineStatus,
+)
 
 __all__ = [
     "Event",
@@ -32,4 +38,8 @@ __all__ = [
     "FactManager",
     "FactStatus",
     "FactSubjectRole",
+    "Storyline",
+    "StorylineContent",
+    "StorylineManager",
+    "StorylineStatus",
 ]

--- a/backend/resources/memory/common/entity_validation.py
+++ b/backend/resources/memory/common/entity_validation.py
@@ -1,0 +1,149 @@
+"""Competition-scoped validation for shared memory entity references."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TypeVar
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+
+from backend.database.models.core import CompetitionSeason, Franchise, SeasonRoster
+from backend.database.models.sleeper import LeagueUser, Player, User
+from backend.resources.memory.common.errors import (
+    CrossCompetitionEntityReferenceError,
+    EntityReferenceNotFoundError,
+)
+from backend.resources.memory.common.references import (
+    FranchiseRef,
+    PlayerRef,
+    SeasonRef,
+    SeasonRosterRef,
+    SleeperUserRef,
+)
+
+
+RoleT = TypeVar("RoleT", bound=str)
+SharedEntityRef = (
+    FranchiseRef[RoleT]
+    | PlayerRef[RoleT]
+    | SeasonRosterRef[RoleT]
+    | SeasonRef[RoleT]
+    | SleeperUserRef[RoleT]
+)
+
+
+def validate_entity_references(
+    session: Session,
+    competition_id: UUID,
+    references: Iterable[SharedEntityRef[RoleT]],
+) -> None:
+    """Validate shared entity existence and competition membership."""
+
+    franchise_ids: list[UUID] = []
+    roster_ids: list[UUID] = []
+    season_ids: list[UUID] = []
+    player_ids: list[str] = []
+    user_ids: list[str] = []
+    for reference in references:
+        match reference.kind:
+            case "franchise":
+                franchise_ids.append(reference.id)
+            case "season_roster":
+                roster_ids.append(reference.id)
+            case "season":
+                season_ids.append(reference.id)
+            case "player":
+                player_ids.append(reference.id)
+            case "sleeper_user":
+                user_ids.append(reference.id)
+
+    _validate_scoped_uuid_entities(
+        session,
+        competition_id,
+        "franchise",
+        Franchise.id,
+        Franchise.competition_id,
+        franchise_ids,
+    )
+    _validate_scoped_uuid_entities(
+        session,
+        competition_id,
+        "season_roster",
+        SeasonRoster.id,
+        SeasonRoster.competition_id,
+        roster_ids,
+    )
+    _validate_scoped_uuid_entities(
+        session,
+        competition_id,
+        "season",
+        CompetitionSeason.id,
+        CompetitionSeason.competition_id,
+        season_ids,
+    )
+
+    if player_ids:
+        found_players = set(
+            session.scalars(
+                sa.select(Player.sleeper_player_id).where(
+                    Player.sleeper_player_id.in_(set(player_ids))
+                )
+            )
+        )
+        for player_id in player_ids:
+            if player_id not in found_players:
+                raise EntityReferenceNotFoundError("player", player_id)
+
+    if user_ids:
+        rows = session.execute(
+            sa.select(User.sleeper_user_id, CompetitionSeason.competition_id)
+            .outerjoin(
+                LeagueUser,
+                LeagueUser.sleeper_user_id == User.sleeper_user_id,
+            )
+            .outerjoin(
+                CompetitionSeason,
+                CompetitionSeason.id == LeagueUser.competition_season_id,
+            )
+            .where(User.sleeper_user_id.in_(set(user_ids)))
+        )
+        memberships: dict[str, set[UUID]] = {}
+        found_users: set[str] = set()
+        for user_id, scoped_competition_id in rows:
+            found_users.add(user_id)
+            if scoped_competition_id is not None:
+                memberships.setdefault(user_id, set()).add(scoped_competition_id)
+        for user_id in user_ids:
+            if user_id not in found_users:
+                raise EntityReferenceNotFoundError("sleeper_user", user_id)
+            if competition_id not in memberships.get(user_id, set()):
+                raise CrossCompetitionEntityReferenceError(
+                    "sleeper_user", user_id, competition_id
+                )
+
+
+def _validate_scoped_uuid_entities(
+    session: Session,
+    competition_id: UUID,
+    entity_kind: str,
+    id_column: InstrumentedAttribute[UUID],
+    competition_column: InstrumentedAttribute[UUID],
+    ids: list[UUID],
+) -> None:
+    if not ids:
+        return
+    rows = session.execute(
+        sa.select(id_column, competition_column).where(id_column.in_(set(ids)))
+    )
+    found: dict[UUID, UUID] = {entity_id: scope for entity_id, scope in rows}
+    for entity_id in ids:
+        actual_scope = found.get(entity_id)
+        if actual_scope is None:
+            raise EntityReferenceNotFoundError(entity_kind, entity_id)
+        if actual_scope != competition_id:
+            raise CrossCompetitionEntityReferenceError(
+                entity_kind, entity_id, competition_id
+            )

--- a/backend/resources/memory/facts/validation.py
+++ b/backend/resources/memory/facts/validation.py
@@ -7,17 +7,15 @@ from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.attributes import InstrumentedAttribute
 
-from backend.database.models.core import CompetitionSeason, Franchise, SeasonRoster
 from backend.database.models.memory import EventVersion, MemoryItem, MemoryVersion
-from backend.database.models.sleeper import LeagueUser, Player, User
 from backend.resources.memory.common.errors import (
-    CrossCompetitionEntityReferenceError,
     CrossCompetitionReferenceError,
-    EntityReferenceNotFoundError,
     TargetNotFoundError,
     WrongTargetKindError,
+)
+from backend.resources.memory.common.entity_validation import (
+    validate_entity_references,
 )
 from backend.resources.memory.common.kinds import MemoryKind
 from backend.resources.memory.common.receipt_validation import (
@@ -41,7 +39,7 @@ def validate_fact_content(
 ) -> ValidatedFactContent:
     """Validate all database-backed fact references in the caller's transaction."""
 
-    _validate_subjects(session, competition_id, content)
+    validate_entity_references(session, competition_id, content.subjects)
     _validate_originating_events(session, competition_id, content)
     receipt_generation_id = validate_tool_receipt(
         session, competition_id, content.primary_tool_call_id
@@ -52,119 +50,6 @@ def validate_fact_content(
         content=content,
         primary_tool_call_generation_id=receipt_generation_id,
     )
-
-
-def _validate_subjects(
-    session: Session,
-    competition_id: UUID,
-    content: FactContent,
-) -> None:
-    franchise_ids: list[UUID] = []
-    roster_ids: list[UUID] = []
-    season_ids: list[UUID] = []
-    player_ids: list[str] = []
-    user_ids: list[str] = []
-    for subject in content.subjects:
-        match subject.kind:
-            case "franchise":
-                franchise_ids.append(subject.id)
-            case "season_roster":
-                roster_ids.append(subject.id)
-            case "season":
-                season_ids.append(subject.id)
-            case "player":
-                player_ids.append(subject.id)
-            case "sleeper_user":
-                user_ids.append(subject.id)
-
-    _validate_scoped_uuid_entities(
-        session,
-        competition_id,
-        "franchise",
-        Franchise.id,
-        Franchise.competition_id,
-        franchise_ids,
-    )
-    _validate_scoped_uuid_entities(
-        session,
-        competition_id,
-        "season_roster",
-        SeasonRoster.id,
-        SeasonRoster.competition_id,
-        roster_ids,
-    )
-    _validate_scoped_uuid_entities(
-        session,
-        competition_id,
-        "season",
-        CompetitionSeason.id,
-        CompetitionSeason.competition_id,
-        season_ids,
-    )
-
-    if player_ids:
-        found_players = set(
-            session.scalars(
-                sa.select(Player.sleeper_player_id).where(
-                    Player.sleeper_player_id.in_(set(player_ids))
-                )
-            )
-        )
-        for player_id in player_ids:
-            if player_id not in found_players:
-                raise EntityReferenceNotFoundError("player", player_id)
-
-    if user_ids:
-        rows = session.execute(
-            sa.select(User.sleeper_user_id, CompetitionSeason.competition_id)
-            .outerjoin(
-                LeagueUser,
-                LeagueUser.sleeper_user_id == User.sleeper_user_id,
-            )
-            .outerjoin(
-                CompetitionSeason,
-                CompetitionSeason.id == LeagueUser.competition_season_id,
-            )
-            .where(User.sleeper_user_id.in_(set(user_ids)))
-        )
-        memberships: dict[str, set[UUID]] = {}
-        found_users: set[str] = set()
-        for user_id, scoped_competition_id in rows:
-            found_users.add(user_id)
-            if scoped_competition_id is not None:
-                memberships.setdefault(user_id, set()).add(scoped_competition_id)
-        for user_id in user_ids:
-            if user_id not in found_users:
-                raise EntityReferenceNotFoundError("sleeper_user", user_id)
-            if competition_id not in memberships.get(user_id, set()):
-                raise CrossCompetitionEntityReferenceError(
-                    "sleeper_user", user_id, competition_id
-                )
-
-
-def _validate_scoped_uuid_entities(
-    session: Session,
-    competition_id: UUID,
-    entity_kind: str,
-    id_column: InstrumentedAttribute[UUID],
-    competition_column: InstrumentedAttribute[UUID],
-    ids: list[UUID],
-) -> None:
-    if not ids:
-        return
-    rows = session.execute(
-        sa.select(id_column, competition_column).where(id_column.in_(set(ids)))
-    )
-    found: dict[UUID, UUID] = {entity_id: scope for entity_id, scope in rows}
-    for entity_id in ids:
-        actual_scope = found.get(entity_id)
-        if actual_scope is None:
-            raise EntityReferenceNotFoundError(entity_kind, entity_id)
-        if actual_scope != competition_id:
-            raise CrossCompetitionEntityReferenceError(
-                entity_kind, entity_id, competition_id
-            )
-
 
 def _validate_originating_events(
     session: Session,

--- a/backend/resources/memory/search_documents/__init__.py
+++ b/backend/resources/memory/search_documents/__init__.py
@@ -8,12 +8,18 @@ from backend.resources.memory.search_documents.builders.fact import (
     FACT_DOCUMENT_BUILDER_VERSION,
     build_fact_document,
 )
+from backend.resources.memory.search_documents.builders.storyline import (
+    STORYLINE_DOCUMENT_BUILDER_VERSION,
+    build_storyline_document,
+)
 from backend.resources.memory.search_documents.objects import SearchDocumentProjection
 
 __all__ = [
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
     "SearchDocumentProjection",
+    "STORYLINE_DOCUMENT_BUILDER_VERSION",
     "build_event_document",
     "build_fact_document",
+    "build_storyline_document",
 ]

--- a/backend/resources/memory/search_documents/builders/__init__.py
+++ b/backend/resources/memory/search_documents/builders/__init__.py
@@ -6,10 +6,16 @@ from backend.resources.memory.search_documents.builders.fact import (
     FACT_DOCUMENT_BUILDER_VERSION,
     build_fact_document,
 )
+from backend.resources.memory.search_documents.builders.storyline import (
+    STORYLINE_DOCUMENT_BUILDER_VERSION,
+    build_storyline_document,
+)
 
 __all__ = [
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
+    "STORYLINE_DOCUMENT_BUILDER_VERSION",
     "build_event_document",
     "build_fact_document",
+    "build_storyline_document",
 ]

--- a/backend/resources/memory/search_documents/builders/storyline.py
+++ b/backend/resources/memory/search_documents/builders/storyline.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final, cast
+
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentProjection,
+)
+from backend.resources.memory.storylines.objects import (
+    EvidenceRef,
+    RelatedStorylineRef,
+    StorylineContent,
+    StorylineEntityRef,
+)
+
+
+STORYLINE_DOCUMENT_BUILDER_VERSION: Final = 1
+
+
+def build_storyline_document(
+    content: StorylineContent,
+) -> SearchDocumentProjection:
+    """Deterministically flatten complete storyline content for discovery."""
+
+    entity_keys = tuple(sorted({_entity_key(subject) for subject in content.subjects}))
+    evidence_version_ids = tuple(
+        sorted({reference.version_id for reference in content.evidence}, key=str)
+    )
+    related_item_ids = tuple(
+        sorted(
+            {reference.item_id for reference in content.related_storylines},
+            key=str,
+        )
+    )
+    tags = tuple(sorted(set(content.tags)))
+
+    text_parts = [
+        content.headline,
+        content.summary,
+        f"status: {content.status.value}",
+    ]
+    if content.arc_type is not None:
+        text_parts.append(f"arc type: {content.arc_type}")
+    if tags:
+        text_parts.append(f"tags: {' '.join(tags)}")
+
+    participants = sorted(_participant_text(subject) for subject in content.subjects)
+    if participants:
+        text_parts.append(f"participants: {'; '.join(participants)}")
+    if content.evidence:
+        labels = sorted(_evidence_text(reference) for reference in content.evidence)
+        text_parts.append(f"evidence: {'; '.join(labels)}")
+    if content.related_storylines:
+        labels = sorted(
+            _relationship_text(reference)
+            for reference in content.related_storylines
+        )
+        text_parts.append(f"related storylines: {'; '.join(labels)}")
+    if content.callback_condition is not None:
+        text_parts.append(f"callback: {content.callback_condition}")
+    if content.resolution_summary is not None:
+        text_parts.append(f"resolution: {content.resolution_summary}")
+    if entity_keys:
+        text_parts.append(f"entities: {' '.join(entity_keys)}")
+
+    return SearchDocumentProjection(
+        kind=MemoryKind.STORYLINE,
+        status=content.status.value,
+        salience=content.salience,
+        entity_keys=entity_keys,
+        evidence_version_ids=evidence_version_ids,
+        related_item_ids=related_item_ids,
+        tags=tags,
+        document_text="\n".join(text_parts),
+        builder_version=STORYLINE_DOCUMENT_BUILDER_VERSION,
+        content_hash=_storyline_content_hash(content),
+    )
+
+
+def _entity_key(subject: StorylineEntityRef) -> str:
+    prefix = "roster" if subject.kind == "season_roster" else subject.kind
+    return f"{prefix}:{subject.id}"
+
+
+def _participant_text(subject: StorylineEntityRef) -> str:
+    label = subject.display_name or _entity_key(subject)
+    return f"{subject.role.value} {label}"
+
+
+def _evidence_text(reference: EvidenceRef) -> str:
+    return f"{reference.role.value} {reference.kind}:{reference.version_id}"
+
+
+def _relationship_text(reference: RelatedStorylineRef) -> str:
+    return f"{reference.role.value} storyline:{reference.item_id}"
+
+
+def _storyline_content_hash(content: StorylineContent) -> str:
+    serialized = _canonical_json(_canonical_storyline_content(content)).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _canonical_storyline_content(content: StorylineContent) -> dict[str, Any]:
+    dumped = cast(dict[str, Any], content.model_dump(mode="json"))
+    subjects = cast(list[dict[str, Any]], dumped["subjects"])
+    dumped["subjects"] = sorted(subjects, key=_canonical_json)
+    evidence = cast(list[dict[str, Any]], dumped["evidence"])
+    dumped["evidence"] = sorted(evidence, key=_canonical_json)
+    related = cast(list[dict[str, Any]], dumped["related_storylines"])
+    dumped["related_storylines"] = sorted(related, key=_canonical_json)
+    tags = cast(list[str], dumped["tags"])
+    dumped["tags"] = sorted(set(tags))
+    return {
+        "memory_kind": content.memory_kind.value,
+        "content": dumped,
+    }
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )

--- a/backend/resources/memory/storylines/__init__.py
+++ b/backend/resources/memory/storylines/__init__.py
@@ -1,3 +1,4 @@
+from backend.resources.memory.storylines.manager import StorylineManager
 from backend.resources.memory.storylines.objects import (
     EvidenceRef,
     EvidenceRole,
@@ -18,6 +19,7 @@ __all__ = [
     "Storyline",
     "StorylineContent",
     "StorylineEntityRef",
+    "StorylineManager",
     "StorylineStatus",
     "StorylineSubjectRole",
 ]

--- a/backend/resources/memory/storylines/codec.py
+++ b/backend/resources/memory/storylines/codec.py
@@ -1,0 +1,154 @@
+"""Stored-schema codecs for storyline versions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.sql import Select
+
+from backend.database.models.memory import MemoryItem, MemoryVersion, StorylineVersion
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.revisions.hashing import StoredSchemaContent
+from backend.resources.memory.storylines.objects import Storyline, StorylineContent
+
+
+def storyline_rows_statement(
+) -> Select[tuple[MemoryItem, MemoryVersion, StorylineVersion]]:
+    """Select complete storyline aggregates without exposing storage joins."""
+
+    return (
+        sa.select(MemoryItem, MemoryVersion, StorylineVersion)
+        .join(MemoryVersion, MemoryVersion.item_id == MemoryItem.id)
+        .join(StorylineVersion, StorylineVersion.version_id == MemoryVersion.id)
+        .where(MemoryItem.kind == MemoryKind.STORYLINE.value)
+    )
+
+
+def decode_storyline(
+    item: MemoryItem,
+    version: MemoryVersion,
+    stored: StorylineVersion,
+) -> Storyline:
+    content = _decode_content(version.content_schema_version, stored)
+    return Storyline.model_validate(
+        {
+            "item": {
+                "item_id": item.id,
+                "competition_id": item.competition_id,
+                "kind": item.kind,
+                "agent_key": item.agent_key,
+                "created_at": item.created_at,
+            },
+            "version": {
+                "version_id": version.id,
+                "revision_number": version.revision_number,
+                "content_schema_version": version.content_schema_version,
+                "introduced_revision_id": version.introduced_revision_id,
+                "retired_revision_id": version.retired_revision_id,
+                "competition_season_id": version.competition_season_id,
+                "week": version.week,
+                "occurred_at": version.occurred_at,
+                "creating_generation_id": version.creating_generation_id,
+                "creating_tool_call_id": version.creating_tool_call_id,
+                "change_reason": version.change_reason,
+                "recorded_at": version.recorded_at,
+            },
+            "content": content,
+        }
+    )
+
+
+def encode_storyline(content: StorylineContent) -> dict[str, Any]:
+    """Translate complete typed content into the current stored v1 row."""
+
+    return {
+        "headline": content.headline,
+        "summary": content.summary,
+        "status": content.status.value,
+        "arc_type": content.arc_type,
+        "salience": content.salience,
+        "tags": list(content.tags),
+        "subjects": [subject.model_dump(mode="json") for subject in content.subjects],
+        "evidence": [reference.model_dump(mode="json") for reference in content.evidence],
+        "related_storylines": [
+            reference.model_dump(mode="json")
+            for reference in content.related_storylines
+        ],
+        "callback_condition": content.callback_condition,
+        "resolution_summary": content.resolution_summary,
+    }
+
+
+def stored_storyline_content(content: StorylineContent) -> StoredSchemaContent:
+    """Encode exact retained v1 logical content for canonical state hashing."""
+
+    if content.schema_version != 1:
+        raise ValueError(
+            f"unsupported storyline content schema version {content.schema_version}"
+        )
+    return StoredSchemaContent(
+        memory_kind=MemoryKind.STORYLINE,
+        schema_version=1,
+        payload={
+            "schema_version": 1,
+            "headline": content.headline,
+            "summary": content.summary,
+            "status": content.status.value,
+            "arc_type": content.arc_type,
+            "salience": content.salience,
+            "tags": list(content.tags),
+            "subjects": [
+                {
+                    "kind": subject.kind,
+                    "id": subject.id,
+                    "role": subject.role.value,
+                    "display_name": subject.display_name,
+                }
+                for subject in content.subjects
+            ],
+            "evidence": [
+                {
+                    "kind": reference.kind,
+                    "version_id": reference.version_id,
+                    "role": reference.role.value,
+                }
+                for reference in content.evidence
+            ],
+            "related_storylines": [
+                {
+                    "item_id": reference.item_id,
+                    "role": reference.role.value,
+                }
+                for reference in content.related_storylines
+            ],
+            "callback_condition": content.callback_condition,
+            "resolution_summary": content.resolution_summary,
+        },
+    )
+
+
+def _decode_content(
+    schema_version: int,
+    stored: StorylineVersion,
+) -> StorylineContent:
+    if schema_version != 1:
+        raise ValueError(
+            f"unsupported storyline content schema version {schema_version}"
+        )
+    return StorylineContent.model_validate(
+        {
+            "schema_version": 1,
+            "headline": stored.headline,
+            "summary": stored.summary,
+            "status": stored.status,
+            "arc_type": stored.arc_type,
+            "salience": stored.salience,
+            "tags": stored.tags,
+            "subjects": stored.subjects,
+            "evidence": stored.evidence,
+            "related_storylines": stored.related_storylines,
+            "callback_condition": stored.callback_condition,
+            "resolution_summary": stored.resolution_summary,
+        }
+    )

--- a/backend/resources/memory/storylines/manager.py
+++ b/backend/resources/memory/storylines/manager.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common.errors import TargetNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.storylines.codec import (
+    decode_storyline,
+    storyline_rows_statement,
+)
+from backend.resources.memory.storylines.objects import Storyline
+
+
+class StorylineManager:
+    """Competition-scoped hydration of immutable storyline versions."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def exact(self, version_id: UUID) -> Storyline:
+        """Hydrate one exact storyline version, including retired history."""
+
+        statement = storyline_rows_statement().where(
+            MemoryVersion.id == version_id,
+            MemoryVersion.competition_id == self._competition_id,
+        )
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(statement).one_or_none()
+        if row is None:
+            raise TargetNotFoundError(version_id, (MemoryKind.STORYLINE,))
+        return decode_storyline(row[0], row[1], row[2])
+
+    def history(self, item_id: UUID) -> tuple[Storyline, ...]:
+        """Return every immutable version of one storyline item, newest first."""
+
+        statement = (
+            storyline_rows_statement()
+            .where(
+                MemoryItem.id == item_id,
+                MemoryItem.competition_id == self._competition_id,
+            )
+            .order_by(sa.desc(MemoryVersion.revision_number))
+        )
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(statement).all()
+        if not rows:
+            raise TargetNotFoundError(item_id, (MemoryKind.STORYLINE,))
+        return tuple(decode_storyline(row[0], row[1], row[2]) for row in rows)

--- a/backend/resources/memory/storylines/shared.py
+++ b/backend/resources/memory/storylines/shared.py
@@ -1,0 +1,121 @@
+"""Package-internal storyline validation and persistence for canonical writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import MemoryItem, MemoryVersion, StorylineVersion
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.search_documents.builders.storyline import (
+    build_storyline_document,
+)
+from backend.resources.memory.search_documents.shared import insert_search_document
+from backend.resources.memory.storylines.codec import encode_storyline
+from backend.resources.memory.storylines.objects import StorylineContent
+from backend.resources.memory.storylines.validation import (
+    ValidatedStorylineContent,
+    validate_storyline_content,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedStorylineReplacement:
+    validated: ValidatedStorylineContent
+    previous_version: MemoryVersion
+    next_revision_number: int
+
+
+def prepare_storyline_write(
+    session: Session,
+    competition_id: UUID,
+    content: StorylineContent,
+) -> ValidatedStorylineContent:
+    """Validate a complete create/replacement payload in the active transaction."""
+
+    return validate_storyline_content(session, competition_id, content)
+
+
+def prepare_storyline_replacement(
+    session: Session,
+    competition_id: UUID,
+    item_id: UUID,
+    expected_item_revision: int,
+    content: StorylineContent,
+) -> PreparedStorylineReplacement:
+    """Validate one complete replacement and resolve its current envelope."""
+
+    item = session.get(MemoryItem, item_id)
+    if item is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.STORYLINE,))
+    if item.competition_id != competition_id:
+        raise CrossCompetitionReferenceError(
+            item_id,
+            competition_id,
+            item.competition_id,
+        )
+    if item.kind != MemoryKind.STORYLINE.value:
+        raise WrongTargetKindError(
+            item_id,
+            (MemoryKind.STORYLINE,),
+            MemoryKind(item.kind),
+        )
+    previous = session.scalar(
+        sa.select(MemoryVersion)
+        .join(StorylineVersion, StorylineVersion.version_id == MemoryVersion.id)
+        .where(
+            MemoryVersion.item_id == item_id,
+            MemoryVersion.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    )
+    if previous is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.STORYLINE,))
+    if previous.revision_number != expected_item_revision:
+        raise StaleItemVersionError(
+            item_id,
+            expected_item_revision,
+            previous.revision_number,
+        )
+    return PreparedStorylineReplacement(
+        validated=validate_storyline_content(session, competition_id, content),
+        previous_version=previous,
+        next_revision_number=previous.revision_number + 1,
+    )
+
+
+def insert_storyline_version(
+    session: Session,
+    version: MemoryVersion,
+    prepared: ValidatedStorylineContent,
+) -> None:
+    """Insert typed content and its derived projection beside a new envelope."""
+
+    content = prepared.content
+    if version.competition_id != prepared.competition_id:
+        raise CrossCompetitionReferenceError(
+            version.id,
+            prepared.competition_id,
+            version.competition_id,
+        )
+    if version.content_schema_version != content.schema_version:
+        raise ValueError("storyline schema version does not match version envelope")
+    if not inspect(version).persistent:
+        raise ValueError("storyline version envelope must be persisted before content")
+    session.add(
+        StorylineVersion(
+            version_id=version.id,
+            **encode_storyline(content),
+        )
+    )
+    insert_search_document(session, version, build_storyline_document(content))

--- a/backend/resources/memory/storylines/validation.py
+++ b/backend/resources/memory/storylines/validation.py
@@ -1,0 +1,132 @@
+"""Competition-scoped reference validation for complete storyline content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import (
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemoryVersion,
+)
+from backend.resources.memory.common.entity_validation import (
+    validate_entity_references,
+)
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.storylines.objects import StorylineContent
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedStorylineContent:
+    competition_id: UUID
+    content: StorylineContent
+
+
+def validate_storyline_content(
+    session: Session,
+    competition_id: UUID,
+    content: StorylineContent,
+) -> ValidatedStorylineContent:
+    """Validate all database-backed storyline references in the transaction."""
+
+    validate_entity_references(session, competition_id, content.subjects)
+    _validate_evidence(session, competition_id, content)
+    _validate_related_storylines(session, competition_id, content)
+    return ValidatedStorylineContent(
+        competition_id=competition_id,
+        content=content,
+    )
+
+
+def _validate_evidence(
+    session: Session,
+    competition_id: UUID,
+    content: StorylineContent,
+) -> None:
+    if not content.evidence:
+        return
+    expected_ids = {reference.version_id for reference in content.evidence}
+    rows = session.execute(
+        sa.select(
+            MemoryVersion.id,
+            MemoryVersion.competition_id,
+            MemoryItem.kind,
+            FactVersion.version_id.label("typed_fact_version_id"),
+            EventVersion.version_id.label("typed_event_version_id"),
+        )
+        .join(MemoryItem, MemoryItem.id == MemoryVersion.item_id)
+        .outerjoin(FactVersion, FactVersion.version_id == MemoryVersion.id)
+        .outerjoin(EventVersion, EventVersion.version_id == MemoryVersion.id)
+        .where(MemoryVersion.id.in_(expected_ids))
+    )
+    found = {
+        version_id: (scope, kind, typed_fact_id, typed_event_id)
+        for version_id, scope, kind, typed_fact_id, typed_event_id in rows
+    }
+    for reference in content.evidence:
+        expected_kind = MemoryKind(reference.kind)
+        target = found.get(reference.version_id)
+        if target is None:
+            raise TargetNotFoundError(reference.version_id, (expected_kind,))
+        target_scope, target_kind, typed_fact_id, typed_event_id = target
+        if target_scope != competition_id:
+            raise CrossCompetitionReferenceError(
+                reference.version_id,
+                competition_id,
+                target_scope,
+            )
+        if target_kind != expected_kind.value:
+            raise WrongTargetKindError(
+                reference.version_id,
+                (expected_kind,),
+                MemoryKind(target_kind),
+            )
+        typed_id = typed_fact_id if expected_kind is MemoryKind.FACT else typed_event_id
+        if typed_id is None:
+            raise TargetNotFoundError(reference.version_id, (expected_kind,))
+
+
+def _validate_related_storylines(
+    session: Session,
+    competition_id: UUID,
+    content: StorylineContent,
+) -> None:
+    if not content.related_storylines:
+        return
+    expected_ids = {reference.item_id for reference in content.related_storylines}
+    rows = session.execute(
+        sa.select(MemoryItem.id, MemoryItem.competition_id, MemoryItem.kind).where(
+            MemoryItem.id.in_(expected_ids)
+        )
+    )
+    found = {
+        item_id: (scope, kind)
+        for item_id, scope, kind in rows
+    }
+    for reference in content.related_storylines:
+        target = found.get(reference.item_id)
+        if target is None:
+            raise TargetNotFoundError(reference.item_id, (MemoryKind.STORYLINE,))
+        target_scope, target_kind = target
+        if target_scope != competition_id:
+            raise CrossCompetitionReferenceError(
+                reference.item_id,
+                competition_id,
+                target_scope,
+            )
+        if target_kind != MemoryKind.STORYLINE.value:
+            raise WrongTargetKindError(
+                reference.item_id,
+                (MemoryKind.STORYLINE,),
+                MemoryKind(target_kind),
+            )

--- a/backend/tests/resources/memory/test_storyline_codec.py
+++ b/backend/tests/resources/memory/test_storyline_codec.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.database.models.memory import StorylineVersion
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.storylines import StorylineContent
+from backend.resources.memory.storylines.codec import (
+    _decode_content,
+    encode_storyline,
+    stored_storyline_content,
+)
+
+
+FACT_VERSION_ID = UUID("11111111-1111-1111-1111-111111111111")
+RELATED_ITEM_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _storyline() -> StorylineContent:
+    return StorylineContent.model_validate(
+        {
+            "headline": "A rivalry reaches the playoffs",
+            "summary": "The Sharks and Owls meet with a season at stake.",
+            "status": "active",
+            "arc_type": "rivalry",
+            "salience": 5,
+            "tags": ["Playoffs", "Rivalry"],
+            "subjects": [
+                {
+                    "kind": "player",
+                    "id": "player-7",
+                    "role": "counterparty",
+                    "display_name": "The Captain",
+                },
+                {
+                    "kind": "franchise",
+                    "id": uuid4(),
+                    "role": "focus",
+                    "display_name": "Sharks",
+                },
+            ],
+            "evidence": [
+                {
+                    "kind": "fact",
+                    "version_id": FACT_VERSION_ID,
+                    "role": "support",
+                }
+            ],
+            "related_storylines": [
+                {
+                    "item_id": RELATED_ITEM_ID,
+                    "role": "continuation",
+                }
+            ],
+            "callback_condition": "Revisit after the semifinal.",
+            "resolution_summary": None,
+        }
+    )
+
+
+def test_storyline_v1_codec_round_trips_complete_content() -> None:
+    content = _storyline()
+    stored = StorylineVersion(version_id=uuid4(), **encode_storyline(content))
+
+    decoded = _decode_content(1, stored)
+    retained = stored_storyline_content(content)
+
+    assert decoded == content
+    assert retained.memory_kind is MemoryKind.STORYLINE
+    assert retained.schema_version == 1
+    evidence = cast(list[dict[str, object]], retained.payload["evidence"])
+    assert evidence[0]["version_id"] == FACT_VERSION_ID
+
+
+def test_storyline_codec_rejects_unknown_retained_schema_version() -> None:
+    content = _storyline()
+    stored = StorylineVersion(version_id=uuid4(), **encode_storyline(content))
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported storyline content schema version 2",
+    ):
+        _decode_content(2, stored)

--- a/backend/tests/resources/memory/test_storyline_manager.py
+++ b/backend/tests/resources/memory/test_storyline_manager.py
@@ -1,0 +1,679 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    CurrentRevision,
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+)
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import (
+    CrossCompetitionReferenceError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.revisions.writers import persist_version_envelopes
+from backend.resources.memory.search_documents import (
+    STORYLINE_DOCUMENT_BUILDER_VERSION,
+)
+from backend.resources.memory.storylines import StorylineContent, StorylineManager
+from backend.resources.memory.storylines.shared import (
+    insert_storyline_version,
+    prepare_storyline_replacement,
+    prepare_storyline_write,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@dataclass(frozen=True)
+class StorylineDomain:
+    competition_id: UUID
+    other_competition_id: UUID
+    season_id: UUID
+    generation_id: UUID
+    franchise_id: UUID
+    root_revision_id: UUID
+    current_revision_id: UUID
+    historical_fact_version_id: UUID
+    current_fact_version_id: UUID
+    event_item_id: UUID
+    event_version_id: UUID
+    related_storyline_item_id: UUID
+    related_storyline_version_id: UUID
+    cross_storyline_item_id: UUID
+    cross_storyline_version_id: UUID
+
+
+def _seed_domain(database_engine: Engine) -> StorylineDomain:
+    competition_id = uuid4()
+    other_competition_id = uuid4()
+    season_id = uuid4()
+    other_season_id = uuid4()
+    generation_id = uuid4()
+    other_generation_id = uuid4()
+    franchise_id = uuid4()
+    root_revision_id = uuid4()
+    current_revision_id = uuid4()
+    other_revision_id = uuid4()
+    fact_item_id = uuid4()
+    historical_fact_version_id = uuid4()
+    current_fact_version_id = uuid4()
+    event_item_id = uuid4()
+    event_version_id = uuid4()
+    related_storyline_item_id = uuid4()
+    related_storyline_version_id = uuid4()
+    cross_storyline_item_id = uuid4()
+    cross_storyline_version_id = uuid4()
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": competition_id, "display_name": "Storyline League"},
+                {"id": other_competition_id, "display_name": "Other League"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                {
+                    "id": season_id,
+                    "competition_id": competition_id,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+                {
+                    "id": other_season_id,
+                    "competition_id": other_competition_id,
+                    "season_year": 2026,
+                    "sequence_number": 1,
+                    "sleeper_league_id": f"league-{uuid4()}",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            {
+                "id": franchise_id,
+                "competition_id": competition_id,
+                "display_name": "Sharks",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            [
+                _generation(generation_id, competition_id, season_id),
+                _generation(
+                    other_generation_id,
+                    other_competition_id,
+                    other_season_id,
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            [
+                _revision(root_revision_id, competition_id, 0, season_id),
+                _revision(
+                    current_revision_id,
+                    competition_id,
+                    1,
+                    season_id,
+                    previous_revision_id=root_revision_id,
+                ),
+                _revision(
+                    other_revision_id,
+                    other_competition_id,
+                    0,
+                    other_season_id,
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            [
+                {
+                    "competition_id": competition_id,
+                    "current_revision_id": current_revision_id,
+                    "lock_version": 1,
+                },
+                {
+                    "competition_id": other_competition_id,
+                    "current_revision_id": other_revision_id,
+                    "lock_version": 0,
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryItem),
+            [
+                _item(fact_item_id, competition_id, "fact"),
+                _item(event_item_id, competition_id, "event"),
+                _item(related_storyline_item_id, competition_id, "storyline"),
+                _item(
+                    cross_storyline_item_id,
+                    other_competition_id,
+                    "storyline",
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(MemoryVersion),
+            [
+                _version(
+                    historical_fact_version_id,
+                    fact_item_id,
+                    competition_id,
+                    1,
+                    root_revision_id,
+                    season_id,
+                    generation_id,
+                    retired_revision_id=current_revision_id,
+                ),
+                _version(
+                    current_fact_version_id,
+                    fact_item_id,
+                    competition_id,
+                    2,
+                    current_revision_id,
+                    season_id,
+                    generation_id,
+                ),
+                _version(
+                    event_version_id,
+                    event_item_id,
+                    competition_id,
+                    1,
+                    root_revision_id,
+                    season_id,
+                    generation_id,
+                ),
+                _version(
+                    related_storyline_version_id,
+                    related_storyline_item_id,
+                    competition_id,
+                    1,
+                    root_revision_id,
+                    season_id,
+                    generation_id,
+                ),
+                _version(
+                    cross_storyline_version_id,
+                    cross_storyline_item_id,
+                    other_competition_id,
+                    1,
+                    other_revision_id,
+                    other_season_id,
+                    other_generation_id,
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(FactVersion),
+            [
+                _fact(historical_fact_version_id, competition_id, "superseded"),
+                _fact(current_fact_version_id, competition_id, "active"),
+            ],
+        )
+        connection.execute(
+            sa.insert(EventVersion),
+            {
+                "version_id": event_version_id,
+                "competition_id": competition_id,
+                "event_type": "matchup",
+                "headline": "The Owls beat the Sharks.",
+                "summary": "The first rivalry meeting set the stakes.",
+                "salience": 3,
+                "confidence": "unverified",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": str(uuid4()),
+                    "loser_franchise_id": str(uuid4()),
+                    "sleeper_matchup_id": "seed-matchup",
+                },
+            },
+        )
+        connection.execute(
+            sa.insert(StorylineVersion),
+            [
+                _storyline_row(related_storyline_version_id),
+                _storyline_row(cross_storyline_version_id),
+            ],
+        )
+
+    return StorylineDomain(
+        competition_id=competition_id,
+        other_competition_id=other_competition_id,
+        season_id=season_id,
+        generation_id=generation_id,
+        franchise_id=franchise_id,
+        root_revision_id=root_revision_id,
+        current_revision_id=current_revision_id,
+        historical_fact_version_id=historical_fact_version_id,
+        current_fact_version_id=current_fact_version_id,
+        event_item_id=event_item_id,
+        event_version_id=event_version_id,
+        related_storyline_item_id=related_storyline_item_id,
+        related_storyline_version_id=related_storyline_version_id,
+        cross_storyline_item_id=cross_storyline_item_id,
+        cross_storyline_version_id=cross_storyline_version_id,
+    )
+
+
+def _generation(
+    generation_id: UUID,
+    competition_id: UUID,
+    season_id: UUID,
+) -> dict[str, object]:
+    return {
+        "id": generation_id,
+        "competition_id": competition_id,
+        "competition_season_id": season_id,
+        "kind": "test",
+        "status": "pending",
+        "request_text": "seed storyline manager",
+        "requested_primary_model": "test-model",
+        "settings_jsonb": {},
+        "current_turn": 0,
+    }
+
+
+def _revision(
+    revision_id: UUID,
+    competition_id: UUID,
+    sequence_number: int,
+    season_id: UUID,
+    *,
+    previous_revision_id: UUID | None = None,
+) -> dict[str, object]:
+    return {
+        "id": revision_id,
+        "competition_id": competition_id,
+        "sequence_number": sequence_number,
+        "previous_revision_id": previous_revision_id,
+        "competition_season_id": season_id,
+        "week": sequence_number,
+        "state_content_hash": f"seed-{revision_id}",
+    }
+
+
+def _item(item_id: UUID, competition_id: UUID, kind: str) -> dict[str, object]:
+    return {"id": item_id, "competition_id": competition_id, "kind": kind}
+
+
+def _version(
+    version_id: UUID,
+    item_id: UUID,
+    competition_id: UUID,
+    revision_number: int,
+    introduced_revision_id: UUID,
+    season_id: UUID,
+    generation_id: UUID,
+    *,
+    retired_revision_id: UUID | None = None,
+) -> dict[str, object]:
+    return {
+        "id": version_id,
+        "item_id": item_id,
+        "competition_id": competition_id,
+        "revision_number": revision_number,
+        "content_schema_version": 1,
+        "introduced_revision_id": introduced_revision_id,
+        "retired_revision_id": retired_revision_id,
+        "competition_season_id": season_id,
+        "week": revision_number,
+        "creating_generation_id": generation_id,
+    }
+
+
+def _fact(
+    version_id: UUID,
+    competition_id: UUID,
+    status: str,
+) -> dict[str, object]:
+    return {
+        "version_id": version_id,
+        "competition_id": competition_id,
+        "claim": "The Sharks lost a rivalry meeting.",
+        "category": "result",
+        "structured_numbers": {"losses": 1},
+        "confidence": "unverified",
+        "subjects": [],
+        "originating_event_version_ids": [],
+        "status": status,
+    }
+
+
+def _storyline_row(version_id: UUID) -> dict[str, object]:
+    return {
+        "version_id": version_id,
+        "headline": "A related arc",
+        "summary": "Stable storyline relationship target.",
+        "status": "active",
+        "salience": 2,
+        "tags": [],
+        "subjects": [],
+        "evidence": [],
+        "related_storylines": [],
+    }
+
+
+def _content(
+    domain: StorylineDomain,
+    *,
+    replacement: bool = False,
+) -> StorylineContent:
+    evidence: list[dict[str, object]] = [
+        {
+            "kind": "fact",
+            "version_id": domain.historical_fact_version_id,
+            "role": "support",
+        }
+    ]
+    related: list[dict[str, object]] = []
+    if not replacement:
+        evidence.append(
+            {
+                "kind": "event",
+                "version_id": domain.event_version_id,
+                "role": "origin",
+            }
+        )
+        related.append(
+            {
+                "item_id": domain.related_storyline_item_id,
+                "role": "continuation",
+            }
+        )
+    return StorylineContent.model_validate(
+        {
+            "headline": "The Sharks seek revenge" if not replacement else "Revenge paid",
+            "summary": "A rivalry continues." if not replacement else "The arc closed.",
+            "status": "active" if not replacement else "resolved",
+            "arc_type": "rivalry",
+            "salience": 5,
+            "tags": ["Rivalry", "Playoffs"],
+            "subjects": [
+                {
+                    "kind": "franchise",
+                    "id": domain.franchise_id,
+                    "role": "focus",
+                    "display_name": "Sharks",
+                }
+            ],
+            "evidence": evidence,
+            "related_storylines": related,
+            "callback_condition": None if replacement else "Revisit after rematch.",
+            "resolution_summary": "The Sharks won." if replacement else None,
+        }
+    )
+
+
+def _manager(database_engine: Engine, competition_id: UUID) -> StorylineManager:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "competition", "competition_id": competition_id},
+            "correlation_id": uuid4(),
+        }
+    )
+    return StorylineManager(create_session_factory(database_engine), context)
+
+
+def test_storyline_lifecycle_preserves_exact_evidence_and_complete_replacement(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    first_version_id = uuid4()
+    first_revision_id = uuid4()
+    second_version_id = uuid4()
+    second_revision_id = uuid4()
+
+    with session_factory.begin() as session:
+        revision = MemoryRevision(
+            id=first_revision_id,
+            competition_id=domain.competition_id,
+            sequence_number=2,
+            previous_revision_id=domain.current_revision_id,
+            competition_season_id=domain.season_id,
+            week=3,
+            state_content_hash="storyline-state-one",
+        )
+        item = MemoryItem(
+            id=item_id,
+            competition_id=domain.competition_id,
+            kind="storyline",
+        )
+        version = MemoryVersion(
+            id=first_version_id,
+            item_id=item_id,
+            competition_id=domain.competition_id,
+            revision_number=1,
+            content_schema_version=1,
+            introduced_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=3,
+            creating_generation_id=domain.generation_id,
+        )
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=(item,),
+            new_versions=(version,),
+        )
+        prepared = prepare_storyline_write(
+            session,
+            domain.competition_id,
+            _content(domain),
+        )
+        insert_storyline_version(session, version, prepared)
+        session.execute(
+            sa.update(CurrentRevision)
+            .where(CurrentRevision.competition_id == domain.competition_id)
+            .values(current_revision_id=first_revision_id, lock_version=2)
+        )
+
+    with session_factory.begin() as session:
+        replacement_content = _content(domain, replacement=True)
+        with pytest.raises(StaleItemVersionError):
+            prepare_storyline_replacement(
+                session,
+                domain.competition_id,
+                item_id,
+                0,
+                replacement_content,
+            )
+        replacement = prepare_storyline_replacement(
+            session,
+            domain.competition_id,
+            item_id,
+            1,
+            replacement_content,
+        )
+        revision = MemoryRevision(
+            id=second_revision_id,
+            competition_id=domain.competition_id,
+            sequence_number=3,
+            previous_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=4,
+            state_content_hash="storyline-state-two",
+        )
+        version = MemoryVersion(
+            id=second_version_id,
+            item_id=item_id,
+            competition_id=domain.competition_id,
+            revision_number=replacement.next_revision_number,
+            content_schema_version=1,
+            introduced_revision_id=second_revision_id,
+            competition_season_id=domain.season_id,
+            week=4,
+            creating_generation_id=domain.generation_id,
+        )
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=(),
+            new_versions=(version,),
+            retired_versions=(replacement.previous_version,),
+        )
+        insert_storyline_version(session, version, replacement.validated)
+
+    manager = _manager(database_engine, domain.competition_id)
+    original = manager.exact(first_version_id)
+    current, historical = manager.history(item_id)
+
+    assert original.version.retired_revision_id == second_revision_id
+    assert historical.version.version_id == first_version_id
+    assert current.version.version_id == second_version_id
+    assert current.content.status == "resolved"
+    assert current.content.related_storylines == []
+    assert [evidence.version_id for evidence in current.content.evidence] == [
+        domain.historical_fact_version_id
+    ]
+    assert domain.current_fact_version_id not in {
+        evidence.version_id for evidence in original.content.evidence
+    }
+
+    with session_factory() as session:
+        projections = session.scalars(
+            sa.select(MemorySearchDocument)
+            .where(MemorySearchDocument.item_id == item_id)
+            .order_by(MemorySearchDocument.week)
+        ).all()
+    assert len(projections) == 2
+    assert projections[0].builder_version == STORYLINE_DOCUMENT_BUILDER_VERSION
+    assert projections[0].evidence_version_ids == sorted(
+        [domain.historical_fact_version_id, domain.event_version_id],
+        key=str,
+    )
+
+    with pytest.raises(TargetNotFoundError):
+        manager.exact(domain.cross_storyline_version_id)
+
+
+def test_storyline_reference_validation_enforces_kind_and_competition(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    content = _content(domain)
+    wrong_evidence = content.model_copy(
+        update={
+            "evidence": [
+                content.evidence[0].model_copy(
+                    update={"version_id": domain.related_storyline_version_id}
+                )
+            ]
+        }
+    )
+    cross_competition_relationship = content.model_copy(
+        update={
+            "related_storylines": [
+                content.related_storylines[0].model_copy(
+                    update={"item_id": domain.cross_storyline_item_id}
+                )
+            ]
+        }
+    )
+
+    with session_factory() as session:
+        with pytest.raises(WrongTargetKindError):
+            prepare_storyline_write(session, domain.competition_id, wrong_evidence)
+        with pytest.raises(CrossCompetitionReferenceError):
+            prepare_storyline_write(
+                session,
+                domain.competition_id,
+                cross_competition_relationship,
+            )
+        with pytest.raises(WrongTargetKindError):
+            prepare_storyline_replacement(
+                session,
+                domain.competition_id,
+                domain.event_item_id,
+                1,
+                content,
+            )
+
+
+def test_storyline_write_rolls_back_typed_content_and_projection(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    version_id = uuid4()
+    revision_id = uuid4()
+
+    with pytest.raises(RuntimeError, match="abort canonical write"):
+        with session_factory.begin() as session:
+            revision = MemoryRevision(
+                id=revision_id,
+                competition_id=domain.competition_id,
+                sequence_number=2,
+                previous_revision_id=domain.current_revision_id,
+                competition_season_id=domain.season_id,
+                week=3,
+                state_content_hash="must-roll-back",
+            )
+            item = MemoryItem(
+                id=item_id,
+                competition_id=domain.competition_id,
+                kind="storyline",
+            )
+            version = MemoryVersion(
+                id=version_id,
+                item_id=item_id,
+                competition_id=domain.competition_id,
+                revision_number=1,
+                content_schema_version=1,
+                introduced_revision_id=revision_id,
+                competition_season_id=domain.season_id,
+                week=3,
+                creating_generation_id=domain.generation_id,
+            )
+            persist_version_envelopes(
+                session,
+                revision,
+                new_items=(item,),
+                new_versions=(version,),
+            )
+            prepared = prepare_storyline_write(
+                session,
+                domain.competition_id,
+                _content(domain),
+            )
+            insert_storyline_version(session, version, prepared)
+            session.flush()
+            raise RuntimeError("abort canonical write")
+
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(StorylineVersion)
+            .where(StorylineVersion.version_id == version_id)
+        ) == 0
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemorySearchDocument)
+            .where(MemorySearchDocument.version_id == version_id)
+        ) == 0

--- a/backend/tests/resources/memory/test_storyline_search_builder.py
+++ b/backend/tests/resources/memory/test_storyline_search_builder.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.search_documents import (
+    STORYLINE_DOCUMENT_BUILDER_VERSION,
+    build_storyline_document,
+)
+from backend.resources.memory.storylines import StorylineContent
+
+
+FRANCHISE_ID = UUID("11111111-1111-1111-1111-111111111111")
+ROSTER_ID = UUID("22222222-2222-2222-2222-222222222222")
+FACT_VERSION_ID = UUID("33333333-3333-3333-3333-333333333333")
+EVENT_VERSION_ID = UUID("44444444-4444-4444-4444-444444444444")
+RELATED_A = UUID("55555555-5555-5555-5555-555555555555")
+RELATED_B = UUID("66666666-6666-6666-6666-666666666666")
+
+
+def _storyline(*, reversed_references: bool = False) -> StorylineContent:
+    subjects = [
+        {
+            "kind": "franchise",
+            "id": FRANCHISE_ID,
+            "role": "focus",
+            "display_name": "Sharks",
+        },
+        {
+            "kind": "season_roster",
+            "id": ROSTER_ID,
+            "role": "counterparty",
+            "display_name": "Owls 2026",
+        },
+    ]
+    evidence = [
+        {"kind": "event", "version_id": EVENT_VERSION_ID, "role": "origin"},
+        {"kind": "fact", "version_id": FACT_VERSION_ID, "role": "support"},
+    ]
+    related = [
+        {"item_id": RELATED_B, "role": "counterpoint"},
+        {"item_id": RELATED_A, "role": "continuation"},
+    ]
+    tags = ["Rivalry", "Playoffs"]
+    if reversed_references:
+        subjects.reverse()
+        evidence.reverse()
+        related.reverse()
+        tags.reverse()
+    return StorylineContent.model_validate(
+        {
+            "headline": "The rivalry reaches its reckoning.",
+            "summary": "Sharks and Owls meet again in the postseason.",
+            "status": "resolved",
+            "arc_type": "rivalry",
+            "salience": 5,
+            "tags": tags,
+            "subjects": subjects,
+            "evidence": evidence,
+            "related_storylines": related,
+            "callback_condition": "Return after the semifinal.",
+            "resolution_summary": "The Sharks finally won the rematch.",
+        }
+    )
+
+
+def test_storyline_projection_normalizes_order_and_flattens_references() -> None:
+    projection = build_storyline_document(_storyline())
+    reordered = build_storyline_document(_storyline(reversed_references=True))
+
+    assert projection == reordered
+    assert projection.kind is MemoryKind.STORYLINE
+    assert projection.status == "resolved"
+    assert projection.salience == 5
+    assert projection.entity_keys == (
+        f"franchise:{FRANCHISE_ID}",
+        f"roster:{ROSTER_ID}",
+    )
+    assert projection.evidence_version_ids == (FACT_VERSION_ID, EVENT_VERSION_ID)
+    assert projection.related_item_ids == (RELATED_A, RELATED_B)
+    assert projection.tags == ("playoffs", "rivalry")
+    assert projection.builder_version == STORYLINE_DOCUMENT_BUILDER_VERSION
+    assert "focus Sharks" in projection.document_text
+    assert f"origin event:{EVENT_VERSION_ID}" in projection.document_text
+
+
+def test_storyline_projection_hash_covers_complete_content() -> None:
+    content = _storyline()
+    original = build_storyline_document(content)
+    changed_callback = build_storyline_document(
+        content.model_copy(update={"callback_condition": "Return after the final."})
+    )
+
+    assert original.content_hash != changed_callback.content_hash
+    assert original.document_text != changed_callback.document_text

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,10 +2,10 @@
 
 ## Current Phase
 
-**Active layer:** `memory-5` complete; publication pending
-**Current branch:** `codex/memory-5-events`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5`
-**Publication:** Stack #108 is published through draft PR #112 (`memory-5`).
+**Active layer:** `memory-6` complete; publication pending
+**Current branch:** `codex/memory-6-storylines`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6`
+**Publication:** Stack #108 is published through draft PR #112 (`memory-5`); `memory-6` remains local.
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -21,7 +21,7 @@ The completed database stack remains tracked separately in
 | `memory-3` revisions | `codex/memory-3-revisions` | Complete | `root` + `contracts_audit` + reviewers | 3 focused PostgreSQL tests; backend: 104 passed; basedpyright: clean | `d70cb4c`; draft PR #110 |
 | `memory-4` facts | `codex/memory-4-facts` | Complete | `root` + `plan_mapper` + `stack_audit` + `contracts_audit` | 8 focused tests; memory: 40 passed; backend: 112 passed; basedpyright: clean | `5b71628`; draft PR #111 |
 | `memory-5` events | `codex/memory-5-events` | Complete | `root` | 9 focused event tests; memory: 49 passed; backend: 121 passed; basedpyright 1.39.10 found no new errors and 16 pre-existing backend errors | Active branch head; draft PR #112 |
-| `memory-6` storylines | `codex/memory-6-storylines` | Pending | Unassigned | Not started | — |
+| `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | Active branch head; not published |
 | `memory-7` triggers | `codex/memory-7-triggers` | Pending | Unassigned | Not started | — |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Pending | Unassigned | Not started | — |
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Pending | Unassigned | Not started | — |
@@ -42,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-6` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | shared entity validation, `backend/resources/memory/storylines/`, storyline projection builder/exports, storyline tests, `docs/memory/status.md` | Storyline manager reads, v1 codec, exact evidence and stable relationship validation, canonical-write helpers, deterministic projection, verification, and coordination ownership |
 
 ## `memory-5` Assignments
 
@@ -161,6 +167,30 @@ design and correctness pass.
   and its search projection remain part of the caller-owned canonical
   transaction. Public mutation operations remain deferred to `memory-9`.
 
+## `memory-6` Boundary Notes
+
+- `StorylineManager` exposes competition-scoped exact-version hydration and
+  newest-first item history. Exact reads include retired immutable versions and
+  do not disclose cross-competition targets.
+- Storyline v1 codecs preserve complete subjects, exact fact/event evidence,
+  stable related-storyline references, callback conditions, and resolution
+  summaries. Retained canonical state preserves exact list order.
+- Shared entity-reference validation now owns the identical franchise,
+  season-roster, season, player, and Sleeper-user scope rules used by facts and
+  storylines; fact behavior is unchanged.
+- Evidence validation targets exact immutable fact/event versions, including
+  retired history, and verifies declared kind, typed-row presence, and
+  competition scope. Related storyline validation targets stable same-scope
+  storyline items without imposing an undocumented self-reference policy.
+- Storyline projections normalize order-insensitive subjects, evidence,
+  relationships, and tags. They include typed entity keys, exact evidence IDs,
+  stable related-item IDs, and deterministic narrative, participant, evidence,
+  relationship, callback, and resolution text.
+- Resource-local create/replacement helpers enforce complete replacement,
+  expected item revision, persisted envelope ordering, schema agreement, and
+  atomic typed-row plus projection insertion. Public mutations remain deferred
+  to `memory-9`.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -189,10 +219,10 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-5` run
-  passed all 49 memory tests and all 121 backend tests; the test container and
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-6` run
+  passed all 56 memory tests and all 128 backend tests; the test container and
   its tmpfs data were removed afterward.
-- `uvx basedpyright backend` with basedpyright 1.39.10 reports 16 diagnostics
-  already present at the `memory-4` parent, including the existing Pydantic
-  `schema_version` narrowing pattern. No new diagnostic originates in the
-  `memory-5` implementation or tests.
+- `uvx basedpyright backend` reports the same 16 diagnostics already present at
+  the `memory-5` parent, including the existing Pydantic `schema_version`
+  narrowing pattern. No new diagnostic originates in the `memory-6`
+  implementation or tests.


### PR DESCRIPTION
## Summary

- add competition-scoped exact and history reads for immutable storyline versions
- add storyline v1 codecs, exact retained-schema hashing payloads, and canonical-write helpers
- validate scoped subjects, exact immutable fact/event evidence, and stable related storylines
- add deterministic storyline search projection with normalized order-insensitive collections
- export storyline resource interfaces and mark memory-6 complete in the status ledger
- keep coverage lean and contract-focused

## Verification

- 7 focused storyline tests passed
- 56 memory-resource tests passed
- 128 backend tests passed
- basedpyright reported no new errors; the same 16 pre-existing backend errors remain

## Stack

- Base: codex/memory-5-events
- Head: codex/memory-6-storylines
- Follow-up: PR #113