### PR TITLE
feat(memory): add context-note resource operations

### DIFF
--- a/backend/resources/memory/__init__.py
+++ b/backend/resources/memory/__init__.py
@@ -1,5 +1,11 @@
 """Typed memory resources, grouped by canonical resource kind."""
 
+from backend.resources.memory.context_notes import (
+    ContextNote,
+    ContextNoteContent,
+    ContextNoteManager,
+    ContextNoteStatus,
+)
 from backend.resources.memory.events import (
     Event,
     EventConfidence,
@@ -32,6 +38,10 @@ from backend.resources.memory.triggers import (
 )
 
 __all__ = [
+    "ContextNote",
+    "ContextNoteContent",
+    "ContextNoteManager",
+    "ContextNoteStatus",
     "Event",
     "EventConfidence",
     "EventContent",

--- a/backend/resources/memory/context_notes/__init__.py
+++ b/backend/resources/memory/context_notes/__init__.py
@@ -1,3 +1,4 @@
+from backend.resources.memory.context_notes.manager import ContextNoteManager
 from backend.resources.memory.context_notes.objects import (
     CompetitionContextNoteIdentity,
     CompetitionSeasonContextNoteIdentity,
@@ -14,6 +15,7 @@ __all__ = [
     "ContextNote",
     "ContextNoteContent",
     "ContextNoteIdentity",
+    "ContextNoteManager",
     "ContextNoteStatus",
     "FranchiseContextNoteIdentity",
 ]

--- a/backend/resources/memory/context_notes/codec.py
+++ b/backend/resources/memory/context_notes/codec.py
@@ -1,0 +1,167 @@
+"""Stored-schema codecs for context-note aggregates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.sql import Select
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.models.memory.context_notes import (
+    ContextNote as ContextNoteRow,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNoteVersion,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.objects import (
+    CompetitionContextNoteIdentity,
+    CompetitionSeasonContextNoteIdentity,
+    ContextNote,
+    ContextNoteContent,
+    ContextNoteIdentity,
+    FranchiseContextNoteIdentity,
+)
+from backend.resources.memory.revisions.hashing import StoredSchemaContent
+
+
+def context_note_rows_statement() -> Select[
+    tuple[MemoryItem, MemoryVersion, ContextNoteRow, ContextNoteVersion]
+]:
+    """Select complete context-note aggregates without exposing storage joins."""
+
+    return (
+        sa.select(MemoryItem, MemoryVersion, ContextNoteRow, ContextNoteVersion)
+        .join(MemoryVersion, MemoryVersion.item_id == MemoryItem.id)
+        .join(ContextNoteRow, ContextNoteRow.item_id == MemoryItem.id)
+        .join(ContextNoteVersion, ContextNoteVersion.version_id == MemoryVersion.id)
+        .where(MemoryItem.kind == MemoryKind.CONTEXT_NOTE.value)
+    )
+
+
+def decode_context_note(
+    item: MemoryItem,
+    version: MemoryVersion,
+    identity_row: ContextNoteRow,
+    stored: ContextNoteVersion,
+) -> ContextNote:
+    content = _decode_content(version.content_schema_version, stored)
+    return ContextNote.model_validate(
+        {
+            "item": {
+                "item_id": item.id,
+                "competition_id": item.competition_id,
+                "kind": item.kind,
+                "agent_key": item.agent_key,
+                "created_at": item.created_at,
+            },
+            "version": {
+                "version_id": version.id,
+                "revision_number": version.revision_number,
+                "content_schema_version": version.content_schema_version,
+                "introduced_revision_id": version.introduced_revision_id,
+                "retired_revision_id": version.retired_revision_id,
+                "competition_season_id": version.competition_season_id,
+                "week": version.week,
+                "occurred_at": version.occurred_at,
+                "creating_generation_id": version.creating_generation_id,
+                "creating_tool_call_id": version.creating_tool_call_id,
+                "change_reason": version.change_reason,
+                "recorded_at": version.recorded_at,
+            },
+            "note_identity": decode_context_note_identity(identity_row),
+            "content": content,
+        }
+    )
+
+
+def decode_context_note_identity(row: ContextNoteRow) -> ContextNoteIdentity:
+    """Decode the stable scope/key row into its discriminated identity."""
+
+    if row.scope == "competition":
+        return CompetitionContextNoteIdentity(note_key=row.note_key)
+    if row.scope == "competition_season":
+        if row.competition_season_id is None:
+            raise ValueError("competition-season note identity is missing its target")
+        return CompetitionSeasonContextNoteIdentity(
+            competition_season_id=row.competition_season_id,
+            note_key=row.note_key,
+        )
+    if row.scope == "franchise":
+        if row.franchise_id is None:
+            raise ValueError("franchise note identity is missing its target")
+        return FranchiseContextNoteIdentity(
+            franchise_id=row.franchise_id,
+            note_key=row.note_key,
+        )
+    raise ValueError(f"unsupported stored context-note scope {row.scope!r}")
+
+
+def encode_context_note_identity(identity: ContextNoteIdentity) -> dict[str, Any]:
+    """Translate one stable typed identity into its storage row fields."""
+
+    competition_season_id = None
+    franchise_id = None
+    if identity.scope == "competition_season":
+        competition_season_id = identity.competition_season_id
+    elif identity.scope == "franchise":
+        franchise_id = identity.franchise_id
+    return {
+        "scope": identity.scope,
+        "competition_season_id": competition_season_id,
+        "franchise_id": franchise_id,
+        "note_key": identity.note_key,
+    }
+
+
+def encode_context_note(content: ContextNoteContent) -> dict[str, Any]:
+    """Translate complete typed content into the current stored v1 row."""
+
+    return {
+        "narrative_text": content.narrative,
+        "outlook": content.outlook,
+        "status": content.status.value,
+        "tags": list(content.tags),
+    }
+
+
+def stored_context_note_content(
+    content: ContextNoteContent,
+) -> StoredSchemaContent:
+    """Encode exact retained v1 logical content for canonical state hashing."""
+
+    if content.schema_version != 1:
+        raise ValueError(
+            f"unsupported context-note content schema version {content.schema_version}"
+        )
+    return StoredSchemaContent(
+        memory_kind=MemoryKind.CONTEXT_NOTE,
+        schema_version=1,
+        payload={
+            "schema_version": 1,
+            "narrative": content.narrative,
+            "outlook": content.outlook,
+            "status": content.status.value,
+            "tags": list(content.tags),
+        },
+    )
+
+
+def _decode_content(
+    schema_version: int,
+    stored: ContextNoteVersion,
+) -> ContextNoteContent:
+    if schema_version != 1:
+        raise ValueError(
+            f"unsupported context-note content schema version {schema_version}"
+        )
+    return ContextNoteContent.model_validate(
+        {
+            "schema_version": 1,
+            "narrative": stored.narrative_text,
+            "outlook": stored.outlook,
+            "status": stored.status,
+            "tags": stored.tags,
+        }
+    )

--- a/backend/resources/memory/context_notes/manager.py
+++ b/backend/resources/memory/context_notes/manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common.errors import TargetNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.codec import (
+    context_note_rows_statement,
+    decode_context_note,
+)
+from backend.resources.memory.context_notes.objects import ContextNote
+
+
+class ContextNoteManager:
+    """Competition-scoped hydration of context-note aggregates."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def exact(self, version_id: UUID) -> ContextNote:
+        """Hydrate one exact note version with its stable scope/key identity."""
+
+        statement = context_note_rows_statement().where(
+            MemoryVersion.id == version_id,
+            MemoryVersion.competition_id == self._competition_id,
+        )
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(statement).one_or_none()
+        if row is None:
+            raise TargetNotFoundError(version_id, (MemoryKind.CONTEXT_NOTE,))
+        return decode_context_note(row[0], row[1], row[2], row[3])
+
+    def history(self, item_id: UUID) -> tuple[ContextNote, ...]:
+        """Return every version of one stable note identity, newest first."""
+
+        statement = (
+            context_note_rows_statement()
+            .where(
+                MemoryItem.id == item_id,
+                MemoryItem.competition_id == self._competition_id,
+            )
+            .order_by(sa.desc(MemoryVersion.revision_number))
+        )
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(statement).all()
+        if not rows:
+            raise TargetNotFoundError(item_id, (MemoryKind.CONTEXT_NOTE,))
+        return tuple(
+            decode_context_note(row[0], row[1], row[2], row[3]) for row in rows
+        )

--- a/backend/resources/memory/context_notes/shared.py
+++ b/backend/resources/memory/context_notes/shared.py
@@ -1,0 +1,184 @@
+"""Package-internal context-note validation and canonical persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import MemoryItem, MemoryVersion
+from backend.database.models.memory.context_notes import (
+    ContextNote as ContextNoteRow,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNoteVersion,
+)
+from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.codec import (
+    decode_context_note_identity,
+    encode_context_note,
+    encode_context_note_identity,
+)
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.context_notes.validation import (
+    ValidatedContextNote,
+    validate_context_note,
+)
+from backend.resources.memory.search_documents.builders.context_note import (
+    build_context_note_document,
+)
+from backend.resources.memory.search_documents.shared import insert_search_document
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedContextNoteReplacement:
+    validated: ValidatedContextNote
+    previous_version: MemoryVersion
+    next_revision_number: int
+
+
+def prepare_context_note_write(
+    session: Session,
+    competition_id: UUID,
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> ValidatedContextNote:
+    """Validate one complete create payload in the active transaction."""
+
+    return validate_context_note(session, competition_id, identity, content)
+
+
+def prepare_context_note_replacement(
+    session: Session,
+    competition_id: UUID,
+    item_id: UUID,
+    expected_item_revision: int,
+    content: ContextNoteContent,
+) -> PreparedContextNoteReplacement:
+    """Resolve a stable note identity and validate a complete replacement."""
+
+    item = session.get(MemoryItem, item_id)
+    if item is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.CONTEXT_NOTE,))
+    if item.competition_id != competition_id:
+        raise CrossCompetitionReferenceError(
+            item_id,
+            competition_id,
+            item.competition_id,
+        )
+    if item.kind != MemoryKind.CONTEXT_NOTE.value:
+        raise WrongTargetKindError(
+            item_id,
+            (MemoryKind.CONTEXT_NOTE,),
+            MemoryKind(item.kind),
+        )
+    identity_row = session.get(ContextNoteRow, item_id)
+    if identity_row is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.CONTEXT_NOTE,))
+    previous = session.scalar(
+        sa.select(MemoryVersion)
+        .join(ContextNoteVersion, ContextNoteVersion.version_id == MemoryVersion.id)
+        .where(
+            MemoryVersion.item_id == item_id,
+            MemoryVersion.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    )
+    if previous is None:
+        raise TargetNotFoundError(item_id, (MemoryKind.CONTEXT_NOTE,))
+    if previous.revision_number != expected_item_revision:
+        raise StaleItemVersionError(
+            item_id,
+            expected_item_revision,
+            previous.revision_number,
+        )
+    return PreparedContextNoteReplacement(
+        validated=validate_context_note(
+            session,
+            competition_id,
+            decode_context_note_identity(identity_row),
+            content,
+        ),
+        previous_version=previous,
+        next_revision_number=previous.revision_number + 1,
+    )
+
+
+def insert_context_note_identity(
+    session: Session,
+    item: MemoryItem,
+    prepared: ValidatedContextNote,
+) -> None:
+    """Insert the stable scope/key identity beside a new item envelope."""
+
+    if item.competition_id != prepared.competition_id:
+        raise CrossCompetitionReferenceError(
+            item.id,
+            prepared.competition_id,
+            item.competition_id,
+        )
+    if item.kind != MemoryKind.CONTEXT_NOTE.value:
+        raise WrongTargetKindError(
+            item.id,
+            (MemoryKind.CONTEXT_NOTE,),
+            MemoryKind(item.kind),
+        )
+    if not inspect(item).persistent:
+        raise ValueError("context-note item envelope must be persisted before identity")
+    identity_row = ContextNoteRow(
+        item_id=item.id,
+        competition_id=item.competition_id,
+        **encode_context_note_identity(prepared.identity),
+    )
+    session.add(identity_row)
+    session.flush((identity_row,))
+
+
+def insert_context_note_version(
+    session: Session,
+    version: MemoryVersion,
+    prepared: ValidatedContextNote,
+) -> None:
+    """Insert versioned content and its projection beside a new envelope."""
+
+    content = prepared.content
+    if version.competition_id != prepared.competition_id:
+        raise CrossCompetitionReferenceError(
+            version.id,
+            prepared.competition_id,
+            version.competition_id,
+        )
+    if version.content_schema_version != content.schema_version:
+        raise ValueError("context-note schema version does not match version envelope")
+    if not inspect(version).persistent:
+        raise ValueError(
+            "context-note version envelope must be persisted before content"
+        )
+    identity_row = session.get(ContextNoteRow, version.item_id)
+    if identity_row is None:
+        raise TargetNotFoundError(version.item_id, (MemoryKind.CONTEXT_NOTE,))
+    if decode_context_note_identity(identity_row) != prepared.identity:
+        raise ValueError("context-note prepared identity does not match its item")
+    session.add(
+        ContextNoteVersion(
+            version_id=version.id,
+            **encode_context_note(content),
+        )
+    )
+    insert_search_document(
+        session,
+        version,
+        build_context_note_document(prepared.identity, content),
+    )

--- a/backend/resources/memory/context_notes/validation.py
+++ b/backend/resources/memory/context_notes/validation.py
@@ -1,0 +1,75 @@
+"""Competition-scoped validation for stable context-note identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason, Franchise
+from backend.resources.memory.common.errors import (
+    CrossCompetitionEntityReferenceError,
+    EntityReferenceNotFoundError,
+)
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedContextNote:
+    competition_id: UUID
+    identity: ContextNoteIdentity
+    content: ContextNoteContent
+
+
+def validate_context_note(
+    session: Session,
+    competition_id: UUID,
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> ValidatedContextNote:
+    """Validate one complete context-note aggregate in the transaction."""
+
+    if identity.scope == "competition_season":
+        _validate_scope_target(
+            session,
+            competition_id,
+            "season",
+            identity.competition_season_id,
+        )
+    elif identity.scope == "franchise":
+        _validate_scope_target(
+            session,
+            competition_id,
+            "franchise",
+            identity.franchise_id,
+        )
+    return ValidatedContextNote(
+        competition_id=competition_id,
+        identity=identity,
+        content=content,
+    )
+
+
+def _validate_scope_target(
+    session: Session,
+    competition_id: UUID,
+    entity_kind: str,
+    entity_id: UUID,
+) -> None:
+    model = CompetitionSeason if entity_kind == "season" else Franchise
+    actual_scope = session.scalar(
+        sa.select(model.competition_id).where(model.id == entity_id)
+    )
+    if actual_scope is None:
+        raise EntityReferenceNotFoundError(entity_kind, entity_id)
+    if actual_scope != competition_id:
+        raise CrossCompetitionEntityReferenceError(
+            entity_kind,
+            entity_id,
+            competition_id,
+        )

--- a/backend/resources/memory/search_documents/__init__.py
+++ b/backend/resources/memory/search_documents/__init__.py
@@ -1,5 +1,9 @@
 """Derived search-document contracts shared by per-kind builders."""
 
+from backend.resources.memory.search_documents.builders.context_note import (
+    CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION,
+    build_context_note_document,
+)
 from backend.resources.memory.search_documents.builders.event import (
     EVENT_DOCUMENT_BUILDER_VERSION,
     build_event_document,
@@ -19,11 +23,13 @@ from backend.resources.memory.search_documents.builders.trigger import (
 from backend.resources.memory.search_documents.objects import SearchDocumentProjection
 
 __all__ = [
+    "CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION",
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
     "SearchDocumentProjection",
     "STORYLINE_DOCUMENT_BUILDER_VERSION",
     "TRIGGER_DOCUMENT_BUILDER_VERSION",
+    "build_context_note_document",
     "build_event_document",
     "build_fact_document",
     "build_storyline_document",

--- a/backend/resources/memory/search_documents/builders/__init__.py
+++ b/backend/resources/memory/search_documents/builders/__init__.py
@@ -1,3 +1,7 @@
+from backend.resources.memory.search_documents.builders.context_note import (
+    CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION,
+    build_context_note_document,
+)
 from backend.resources.memory.search_documents.builders.event import (
     EVENT_DOCUMENT_BUILDER_VERSION,
     build_event_document,
@@ -16,10 +20,12 @@ from backend.resources.memory.search_documents.builders.trigger import (
 )
 
 __all__ = [
+    "CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION",
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
     "STORYLINE_DOCUMENT_BUILDER_VERSION",
     "TRIGGER_DOCUMENT_BUILDER_VERSION",
+    "build_context_note_document",
     "build_event_document",
     "build_fact_document",
     "build_storyline_document",

--- a/backend/resources/memory/search_documents/builders/context_note.py
+++ b/backend/resources/memory/search_documents/builders/context_note.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Final, cast
+
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentProjection,
+)
+
+CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION: Final = 1
+
+
+def build_context_note_document(
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> SearchDocumentProjection:
+    """Deterministically flatten a complete context-note aggregate."""
+
+    entity_keys = _entity_keys(identity)
+    tags = tuple(sorted(set(content.tags)))
+    text_parts = [
+        content.narrative,
+        f"status: {content.status.value}",
+        f"scope: {_scope_text(identity)}",
+        f"note key: {identity.note_key}",
+    ]
+    if content.outlook is not None:
+        text_parts.append(f"outlook: {content.outlook}")
+    if tags:
+        text_parts.append(f"tags: {' '.join(tags)}")
+
+    return SearchDocumentProjection(
+        kind=MemoryKind.CONTEXT_NOTE,
+        status=content.status.value,
+        entity_keys=entity_keys,
+        tags=tags,
+        document_text="\n".join(text_parts),
+        builder_version=CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION,
+        content_hash=_context_note_content_hash(identity, content),
+    )
+
+
+def _entity_keys(identity: ContextNoteIdentity) -> tuple[str, ...]:
+    if identity.scope == "competition_season":
+        return (f"season:{identity.competition_season_id}",)
+    if identity.scope == "franchise":
+        return (f"franchise:{identity.franchise_id}",)
+    return ()
+
+
+def _scope_text(identity: ContextNoteIdentity) -> str:
+    if identity.scope == "competition_season":
+        return f"competition season {identity.competition_season_id}"
+    if identity.scope == "franchise":
+        return f"franchise {identity.franchise_id}"
+    return "competition"
+
+
+def _context_note_content_hash(
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> str:
+    serialized = _canonical_json(
+        _canonical_context_note_aggregate(identity, content)
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def _canonical_context_note_aggregate(
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> dict[str, Any]:
+    dumped = cast(dict[str, Any], content.model_dump(mode="json"))
+    tags = cast(list[str], dumped["tags"])
+    dumped["tags"] = sorted(set(tags))
+    return {
+        "memory_kind": content.memory_kind.value,
+        "identity": identity.model_dump(mode="json"),
+        "content": dumped,
+    }
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )

--- a/backend/tests/resources/memory/test_context_note_codec.py
+++ b/backend/tests/resources/memory/test_context_note_codec.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import TypeAdapter
+
+from backend.database.models.memory.context_notes import (
+    ContextNote as ContextNoteRow,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNoteVersion,
+)
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.context_notes import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+    ContextNoteStatus,
+)
+from backend.resources.memory.context_notes.codec import (
+    _decode_content,
+    decode_context_note_identity,
+    encode_context_note,
+    encode_context_note_identity,
+    stored_context_note_content,
+)
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+FRANCHISE_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.mark.parametrize(
+    "identity_payload",
+    [
+        {"scope": "competition", "note_key": "league_voice"},
+        {
+            "scope": "competition_season",
+            "competition_season_id": SEASON_ID,
+            "note_key": "playoff_race",
+        },
+        {
+            "scope": "franchise",
+            "franchise_id": FRANCHISE_ID,
+            "note_key": "outlook",
+        },
+    ],
+)
+def test_context_note_v1_codec_round_trips_each_identity_scope(
+    identity_payload: dict[str, object],
+) -> None:
+    identity = TypeAdapter(ContextNoteIdentity).validate_python(identity_payload)
+    content = ContextNoteContent(
+        narrative="The rebuild is ahead of schedule.",
+        outlook="Contend next season.",
+        status=ContextNoteStatus.ACTIVE,
+        tags=["rebuild", "young-core"],
+    )
+    identity_row = ContextNoteRow(
+        item_id=uuid4(),
+        competition_id=uuid4(),
+        **encode_context_note_identity(identity),
+    )
+    version_row = ContextNoteVersion(
+        version_id=uuid4(),
+        **encode_context_note(content),
+    )
+
+    assert decode_context_note_identity(identity_row) == identity
+    assert _decode_content(1, version_row) == content
+    retained = stored_context_note_content(content)
+    assert retained.memory_kind is MemoryKind.CONTEXT_NOTE
+    assert retained.schema_version == 1
+    assert retained.payload["tags"] == ["rebuild", "young-core"]
+
+
+def test_context_note_codec_rejects_unknown_retained_schema_version() -> None:
+    content = ContextNoteContent(
+        narrative="League-wide context.",
+        status=ContextNoteStatus.ACTIVE,
+        tags=[],
+    )
+    version_row = ContextNoteVersion(
+        version_id=uuid4(),
+        **encode_context_note(content),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="unsupported context-note content schema version 2",
+    ):
+        _decode_content(2, version_row)

--- a/backend/tests/resources/memory/test_context_note_manager.py
+++ b/backend/tests/resources/memory/test_context_note_manager.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from pydantic import TypeAdapter
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNote as ContextNoteRow,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNoteVersion,
+)
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import (
+    CrossCompetitionEntityReferenceError,
+    EntityReferenceNotFoundError,
+    TargetNotFoundError,
+)
+from backend.resources.memory.context_notes import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+    ContextNoteManager,
+    ContextNoteStatus,
+)
+from backend.resources.memory.context_notes.shared import (
+    insert_context_note_identity,
+    insert_context_note_version,
+    prepare_context_note_replacement,
+    prepare_context_note_write,
+)
+from backend.resources.memory.revisions.writers import persist_version_envelopes
+from backend.resources.memory.search_documents import (
+    CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@dataclass(frozen=True)
+class ContextNoteDomain:
+    competition_id: UUID
+    other_competition_id: UUID
+    season_id: UUID
+    other_season_id: UUID
+    franchise_id: UUID
+    other_franchise_id: UUID
+    generation_id: UUID
+    root_revision_id: UUID
+
+
+def _seed_domain(database_engine: Engine) -> ContextNoteDomain:
+    competition_id = uuid4()
+    other_competition_id = uuid4()
+    season_id = uuid4()
+    other_season_id = uuid4()
+    franchise_id = uuid4()
+    other_franchise_id = uuid4()
+    generation_id = uuid4()
+    root_revision_id = uuid4()
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            [
+                {"id": competition_id, "display_name": "Context League"},
+                {"id": other_competition_id, "display_name": "Other League"},
+            ],
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            [
+                _season(season_id, competition_id),
+                _season(other_season_id, other_competition_id),
+            ],
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                _franchise(franchise_id, competition_id, "Owls"),
+                _franchise(other_franchise_id, other_competition_id, "Foxes"),
+            ],
+        )
+        connection.execute(
+            sa.insert(Generation),
+            _generation(generation_id, competition_id, season_id),
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            _revision(root_revision_id, competition_id, 0, season_id),
+        )
+
+    return ContextNoteDomain(
+        competition_id=competition_id,
+        other_competition_id=other_competition_id,
+        season_id=season_id,
+        other_season_id=other_season_id,
+        franchise_id=franchise_id,
+        other_franchise_id=other_franchise_id,
+        generation_id=generation_id,
+        root_revision_id=root_revision_id,
+    )
+
+
+def _season(season_id: UUID, competition_id: UUID) -> dict[str, object]:
+    return {
+        "id": season_id,
+        "competition_id": competition_id,
+        "season_year": 2026,
+        "sequence_number": 1,
+        "sleeper_league_id": f"league-{season_id}",
+    }
+
+
+def _franchise(
+    franchise_id: UUID,
+    competition_id: UUID,
+    display_name: str,
+) -> dict[str, object]:
+    return {
+        "id": franchise_id,
+        "competition_id": competition_id,
+        "display_name": display_name,
+    }
+
+
+def _generation(
+    generation_id: UUID,
+    competition_id: UUID,
+    season_id: UUID,
+) -> dict[str, object]:
+    return {
+        "id": generation_id,
+        "competition_id": competition_id,
+        "competition_season_id": season_id,
+        "kind": "test",
+        "status": "pending",
+        "request_text": "seed context-note manager",
+        "requested_primary_model": "test-model",
+        "settings_jsonb": {},
+        "current_turn": 0,
+    }
+
+
+def _revision(
+    revision_id: UUID,
+    competition_id: UUID,
+    sequence_number: int,
+    season_id: UUID,
+    *,
+    previous_revision_id: UUID | None = None,
+) -> dict[str, object]:
+    return {
+        "id": revision_id,
+        "competition_id": competition_id,
+        "sequence_number": sequence_number,
+        "previous_revision_id": previous_revision_id,
+        "competition_season_id": season_id,
+        "week": sequence_number,
+        "state_content_hash": f"seed-{revision_id}",
+    }
+
+
+def _version(
+    version_id: UUID,
+    item_id: UUID,
+    domain: ContextNoteDomain,
+    revision_id: UUID,
+    revision_number: int = 1,
+) -> dict[str, object]:
+    return {
+        "id": version_id,
+        "item_id": item_id,
+        "competition_id": domain.competition_id,
+        "revision_number": revision_number,
+        "content_schema_version": 1,
+        "introduced_revision_id": revision_id,
+        "competition_season_id": domain.season_id,
+        "week": 1,
+        "creating_generation_id": domain.generation_id,
+    }
+
+
+def _identity(payload: dict[str, object]) -> ContextNoteIdentity:
+    return TypeAdapter(ContextNoteIdentity).validate_python(payload)
+
+
+def _content(*, archived: bool = False) -> ContextNoteContent:
+    return ContextNoteContent(
+        narrative=(
+            "The roster now needs a reset."
+            if archived
+            else "The young roster is ahead of schedule."
+        ),
+        outlook="Build around the current core.",
+        status=(ContextNoteStatus.ARCHIVED if archived else ContextNoteStatus.ACTIVE),
+        tags=["team-identity", "youth"],
+    )
+
+
+def _manager(database_engine: Engine, competition_id: UUID) -> ContextNoteManager:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "competition", "competition_id": competition_id},
+            "correlation_id": uuid4(),
+        }
+    )
+    return ContextNoteManager(create_session_factory(database_engine), context)
+
+
+def test_context_note_lifecycle_hydrates_stable_identity_and_history(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    first_revision_id = uuid4()
+    second_revision_id = uuid4()
+    identities = (
+        _identity({"scope": "competition", "note_key": "league_voice"}),
+        _identity(
+            {
+                "scope": "competition_season",
+                "competition_season_id": domain.season_id,
+                "note_key": "playoff_race",
+            }
+        ),
+        _identity(
+            {
+                "scope": "franchise",
+                "franchise_id": domain.franchise_id,
+                "note_key": "team_identity",
+            }
+        ),
+    )
+    item_ids = tuple(uuid4() for _ in identities)
+    version_ids = tuple(uuid4() for _ in identities)
+
+    with session_factory.begin() as session:
+        revision = MemoryRevision(
+            **_revision(
+                first_revision_id,
+                domain.competition_id,
+                1,
+                domain.season_id,
+                previous_revision_id=domain.root_revision_id,
+            )
+        )
+        items = tuple(
+            MemoryItem(
+                id=item_id,
+                competition_id=domain.competition_id,
+                kind="context_note",
+            )
+            for item_id in item_ids
+        )
+        versions = tuple(
+            MemoryVersion(**_version(version_id, item_id, domain, first_revision_id))
+            for item_id, version_id in zip(item_ids, version_ids, strict=True)
+        )
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=items,
+            new_versions=versions,
+        )
+        for item, version, identity in zip(
+            items,
+            versions,
+            identities,
+            strict=True,
+        ):
+            prepared = prepare_context_note_write(
+                session,
+                domain.competition_id,
+                identity,
+                _content(),
+            )
+            insert_context_note_identity(session, item, prepared)
+            insert_context_note_version(session, version, prepared)
+
+    replacement_version_id = uuid4()
+    with session_factory.begin() as session:
+        replacement = prepare_context_note_replacement(
+            session,
+            domain.competition_id,
+            item_ids[2],
+            1,
+            _content(archived=True),
+        )
+        revision = MemoryRevision(
+            **_revision(
+                second_revision_id,
+                domain.competition_id,
+                2,
+                domain.season_id,
+                previous_revision_id=first_revision_id,
+            )
+        )
+        version = MemoryVersion(
+            **_version(
+                replacement_version_id,
+                item_ids[2],
+                domain,
+                second_revision_id,
+                replacement.next_revision_number,
+            )
+        )
+        persist_version_envelopes(
+            session,
+            revision,
+            new_items=(),
+            new_versions=(version,),
+            retired_versions=(replacement.previous_version,),
+        )
+        insert_context_note_version(session, version, replacement.validated)
+
+    manager = _manager(database_engine, domain.competition_id)
+    assert manager.exact(version_ids[0]).note_identity == identities[0]
+    assert manager.exact(version_ids[1]).note_identity == identities[1]
+    current, previous = manager.history(item_ids[2])
+    assert current.note_identity == previous.note_identity == identities[2]
+    assert current.content.status == "archived"
+    assert previous.version.retired_revision_id == second_revision_id
+
+    with session_factory() as session:
+        projections = session.scalars(
+            sa.select(MemorySearchDocument).where(
+                MemorySearchDocument.item_id.in_(item_ids)
+            )
+        ).all()
+    assert len(projections) == 4
+    assert {projection.builder_version for projection in projections} == {
+        CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION
+    }
+    assert {
+        tuple(projection.entity_keys)
+        for projection in projections
+        if projection.item_id == item_ids[2]
+    } == {(f"franchise:{domain.franchise_id}",)}
+    with pytest.raises(TargetNotFoundError):
+        _manager(database_engine, domain.other_competition_id).exact(version_ids[0])
+
+
+def test_context_note_scope_validation_covers_all_identity_variants(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+
+    with session_factory() as session:
+        for identity in (
+            _identity({"scope": "competition", "note_key": "league_voice"}),
+            _identity(
+                {
+                    "scope": "competition_season",
+                    "competition_season_id": domain.season_id,
+                    "note_key": "playoff_race",
+                }
+            ),
+            _identity(
+                {
+                    "scope": "franchise",
+                    "franchise_id": domain.franchise_id,
+                    "note_key": "outlook",
+                }
+            ),
+        ):
+            prepare_context_note_write(
+                session,
+                domain.competition_id,
+                identity,
+                _content(),
+            )
+
+        with pytest.raises(EntityReferenceNotFoundError):
+            prepare_context_note_write(
+                session,
+                domain.competition_id,
+                _identity(
+                    {
+                        "scope": "competition_season",
+                        "competition_season_id": uuid4(),
+                        "note_key": "missing",
+                    }
+                ),
+                _content(),
+            )
+        with pytest.raises(CrossCompetitionEntityReferenceError):
+            prepare_context_note_write(
+                session,
+                domain.competition_id,
+                _identity(
+                    {
+                        "scope": "franchise",
+                        "franchise_id": domain.other_franchise_id,
+                        "note_key": "cross-scope",
+                    }
+                ),
+                _content(),
+            )
+
+
+def test_context_note_write_rolls_back_identity_content_and_projection(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    session_factory = create_session_factory(database_engine)
+    item_id = uuid4()
+    version_id = uuid4()
+    revision_id = uuid4()
+
+    with pytest.raises(RuntimeError, match="abort canonical write"):
+        with session_factory.begin() as session:
+            revision = MemoryRevision(
+                **_revision(
+                    revision_id,
+                    domain.competition_id,
+                    1,
+                    domain.season_id,
+                    previous_revision_id=domain.root_revision_id,
+                )
+            )
+            item = MemoryItem(
+                id=item_id,
+                competition_id=domain.competition_id,
+                kind="context_note",
+            )
+            version = MemoryVersion(
+                **_version(version_id, item_id, domain, revision_id)
+            )
+            persist_version_envelopes(
+                session,
+                revision,
+                new_items=(item,),
+                new_versions=(version,),
+            )
+            prepared = prepare_context_note_write(
+                session,
+                domain.competition_id,
+                _identity(
+                    {
+                        "scope": "franchise",
+                        "franchise_id": domain.franchise_id,
+                        "note_key": "team_identity",
+                    }
+                ),
+                _content(),
+            )
+            insert_context_note_identity(session, item, prepared)
+            insert_context_note_version(session, version, prepared)
+            session.flush()
+            raise RuntimeError("abort canonical write")
+
+    with database_engine.connect() as connection:
+        assert (
+            connection.scalar(
+                sa.select(sa.func.count())
+                .select_from(ContextNoteRow)
+                .where(ContextNoteRow.item_id == item_id)
+            )
+            == 0
+        )
+        assert (
+            connection.scalar(
+                sa.select(sa.func.count())
+                .select_from(ContextNoteVersion)
+                .where(ContextNoteVersion.version_id == version_id)
+            )
+            == 0
+        )
+        assert (
+            connection.scalar(
+                sa.select(sa.func.count())
+                .select_from(MemorySearchDocument)
+                .where(MemorySearchDocument.version_id == version_id)
+            )
+            == 0
+        )

--- a/backend/tests/resources/memory/test_context_note_search_builder.py
+++ b/backend/tests/resources/memory/test_context_note_search_builder.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import TypeAdapter
+
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.context_notes import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+    ContextNoteStatus,
+)
+from backend.resources.memory.search_documents import (
+    CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION,
+    build_context_note_document,
+)
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+FRANCHISE_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _identity(payload: dict[str, object]) -> ContextNoteIdentity:
+    return TypeAdapter(ContextNoteIdentity).validate_python(payload)
+
+
+def _content() -> ContextNoteContent:
+    return ContextNoteContent(
+        narrative="The roster is built around a young core.",
+        outlook="One move away from contention.",
+        status=ContextNoteStatus.ACTIVE,
+        tags=["identity", "contender"],
+    )
+
+
+def test_context_note_projection_flattens_scope_key_and_content() -> None:
+    projection = build_context_note_document(
+        _identity(
+            {
+                "scope": "franchise",
+                "franchise_id": FRANCHISE_ID,
+                "note_key": "team_identity",
+            }
+        ),
+        _content(),
+    )
+
+    assert projection.kind is MemoryKind.CONTEXT_NOTE
+    assert projection.status == "active"
+    assert projection.entity_keys == (f"franchise:{FRANCHISE_ID}",)
+    assert projection.tags == ("contender", "identity")
+    assert projection.builder_version == CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION
+    assert "note key: team_identity" in projection.document_text
+    assert "outlook: One move away from contention." in projection.document_text
+
+
+def test_context_note_projection_hash_covers_identity_and_complete_content() -> None:
+    competition = _identity({"scope": "competition", "note_key": "weekly_outlook"})
+    season = _identity(
+        {
+            "scope": "competition_season",
+            "competition_season_id": SEASON_ID,
+            "note_key": "weekly_outlook",
+        }
+    )
+    content = _content()
+
+    original = build_context_note_document(competition, content)
+    new_identity = build_context_note_document(season, content)
+    archived = build_context_note_document(
+        competition,
+        content.model_copy(update={"status": ContextNoteStatus.ARCHIVED}),
+    )
+
+    assert original.content_hash != new_identity.content_hash
+    assert original.content_hash != archived.content_hash
+    assert new_identity.entity_keys == (f"season:{SEASON_ID}",)

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -69,7 +69,10 @@ build_storyline_document(content: StorylineContent) -> SearchDocument
 build_fact_document(content: FactContent) -> SearchDocument
 build_event_document(content: EventContent) -> SearchDocument
 build_trigger_document(content: TriggerContent) -> SearchDocument
-build_context_note_document(content: ContextNoteContent) -> SearchDocument
+build_context_note_document(
+    identity: ContextNoteIdentity,
+    content: ContextNoteContent,
+) -> SearchDocument
 ```
 
 Builders flatten type-specific structure into a common shape and render useful

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,10 +2,10 @@
 
 ## Current Phase
 
-**Active layer:** `memory-7` complete; `memory-8` is next
-**Current branch:** `codex/memory-7-triggers`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7`
-**Publication:** Stack #108 is published through draft PR #112 (`memory-5`); `memory-6` and `memory-7` remain local.
+**Active layer:** `memory-8` complete; `memory-9` is next
+**Current branch:** `codex/memory-8-context-notes`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8`
+**Publication:** Stack #116 is published through `memory-8` (PR #115).
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -21,9 +21,9 @@ The completed database stack remains tracked separately in
 | `memory-3` revisions | `codex/memory-3-revisions` | Complete | `root` + `contracts_audit` + reviewers | 3 focused PostgreSQL tests; backend: 104 passed; basedpyright: clean | `d70cb4c`; draft PR #110 |
 | `memory-4` facts | `codex/memory-4-facts` | Complete | `root` + `plan_mapper` + `stack_audit` + `contracts_audit` | 8 focused tests; memory: 40 passed; backend: 112 passed; basedpyright: clean | `5b71628`; draft PR #111 |
 | `memory-5` events | `codex/memory-5-events` | Complete | `root` | 9 focused event tests; memory: 49 passed; backend: 121 passed; basedpyright 1.39.10 found no new errors and 16 pre-existing backend errors | Active branch head; draft PR #112 |
-| `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | Active branch head; not published |
-| `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | Active branch head; not published |
-| `memory-8` context notes | `codex/memory-8-context-notes` | Pending | Unassigned | Not started | — |
+| `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | `e4c7831`; PR #114 |
+| `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | `5788729`; PR #113 |
+| `memory-8` context notes | `codex/memory-8-context-notes` | Complete | `root` | 9 focused context-note tests; memory: 73 passed; backend: 145 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR #115 |
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Pending | Unassigned | Not started | — |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
@@ -42,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-8` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/resources/memory/context_notes/`, context-note projection builder/exports, context-note tests, `docs/memory/status.md`, context-note builder signature in `docs/memory/retrieval.md` | Context-note aggregate hydration, stable scope/key validation and persistence, v1 codec, deterministic projection, lean verification, and coordination ownership |
 
 ## `memory-7` Assignments
 
@@ -220,6 +226,28 @@ design and correctness pass.
   to `memory-9`; migrations, retrieval behavior, and reporter integration remain
   outside this layer.
 
+## `memory-8` Boundary Notes
+
+- `ContextNoteManager` hydrates the stable scope/key identity and immutable
+  versioned content as one competition-scoped aggregate. Exact reads include
+  retired versions, and history is newest-first without disclosing another
+  competition's notes.
+- Create preparation accepts a typed competition, competition-season, or
+  franchise identity plus complete v1 content. Season and franchise targets
+  must exist in the manager's competition; competition-scoped notes require no
+  additional target lookup.
+- Scope and note key are inserted once beside the stable memory item.
+  Replacements resolve that stored identity and accept only new complete
+  content, so a version change cannot silently move or rename the note.
+- Context-note projections include status, normalized tags, stable scope and
+  note key, narrative, outlook, and season/franchise entity keys. The derived
+  content hash covers both stable identity and complete content because the
+  context note is one resource aggregate.
+- Resource-local helpers preserve caller-owned transaction boundaries and
+  atomically persist stable identity, typed content, and derived projection.
+  Public mutation orchestration, uniqueness conflict translation, retrieval,
+  and reporter integration remain deferred to later layers.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -248,10 +276,10 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-7` run
-  passed all 64 memory tests and all 136 backend tests; the test container and
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-8` run
+  passed all 73 memory tests and all 145 backend tests; the test container and
   its tmpfs data were removed afterward.
 - `uvx basedpyright backend` reports the same 16 diagnostics already present at
   the `memory-5` parent, including the existing Pydantic `schema_version`
-  narrowing pattern. No new error originates in the `memory-7`
+  narrowing pattern. No new error originates in the `memory-8`
   implementation or tests.


### PR DESCRIPTION
Implements MEMORY-8 context-note resource operations: aggregate hydration, v1 codec, stable scope/key validation and persistence, deterministic search documents, and coverage for competition, competition-season, and franchise scopes. Verification: 145 backend tests passed; Ruff passed; basedpyright has no new errors (16 pre-existing diagnostics).