### PR TITLE
feat(memory): add atomic mutation bundles

### DIFF
--- a/backend/resources/memory/common/__init__.py
+++ b/backend/resources/memory/common/__init__.py
@@ -1,7 +1,11 @@
 from backend.resources.memory.common.errors import (
+    CanonicalStateHashMismatchError,
     CrossCompetitionEntityReferenceError,
     CrossCompetitionReferenceError,
+    DuplicateContextNoteError,
     EntityReferenceNotFoundError,
+    GenerationMemoryContextClosedError,
+    MemoryIdentityConflictError,
     MemoryApplicationError,
     RevisionNotFoundError,
     StaleCanonicalRevisionError,
@@ -29,11 +33,15 @@ from backend.resources.memory.common.versioning import (
 )
 
 __all__ = [
+    "CanonicalStateHashMismatchError",
     "CrossCompetitionReferenceError",
     "CrossCompetitionEntityReferenceError",
+    "DuplicateContextNoteError",
     "EntityReferenceNotFoundError",
     "FranchiseRef",
+    "GenerationMemoryContextClosedError",
     "MemoryApplicationError",
+    "MemoryIdentityConflictError",
     "MemoryContent",
     "MemoryItemIdentity",
     "MemoryKind",

--- a/backend/resources/memory/common/errors.py
+++ b/backend/resources/memory/common/errors.py
@@ -9,6 +9,37 @@ class MemoryApplicationError(Exception):
     """Base class for stable memory application failures."""
 
 
+class GenerationMemoryContextClosedError(MemoryApplicationError):
+    def __init__(self, generation_id: UUID) -> None:
+        self.generation_id = generation_id
+        super().__init__(
+            f"generation memory context {generation_id} has already been finalized"
+        )
+
+
+class DuplicateContextNoteError(MemoryApplicationError):
+    def __init__(self, scope: str, note_key: str) -> None:
+        self.scope = scope
+        self.note_key = note_key
+        super().__init__(f"context note {scope}:{note_key} already exists")
+
+
+class CanonicalStateHashMismatchError(MemoryApplicationError):
+    def __init__(self, expected_hash: str, actual_hash: str) -> None:
+        self.expected_hash = expected_hash
+        self.actual_hash = actual_hash
+        super().__init__(
+            "canonical state hash mismatch: "
+            f"expected {expected_hash}, got {actual_hash}"
+        )
+
+
+class MemoryIdentityConflictError(MemoryApplicationError):
+    def __init__(self, identity_id: UUID) -> None:
+        self.identity_id = identity_id
+        super().__init__(f"memory identity {identity_id} is already in use")
+
+
 class EntityReferenceNotFoundError(MemoryApplicationError):
     def __init__(self, entity_kind: str, entity_id: UUID | str) -> None:
         self.entity_kind = entity_kind

--- a/backend/resources/memory/context_notes/shared.py
+++ b/backend/resources/memory/context_notes/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -18,15 +19,19 @@ from backend.database.models.memory.context_notes import (
 )
 from backend.resources.memory.common.errors import (
     CrossCompetitionReferenceError,
+    DuplicateContextNoteError,
     StaleItemVersionError,
     TargetNotFoundError,
     WrongTargetKindError,
 )
 from backend.resources.memory.common.kinds import MemoryKind
 from backend.resources.memory.context_notes.codec import (
+    context_note_rows_statement,
+    decode_context_note,
     decode_context_note_identity,
     encode_context_note,
     encode_context_note_identity,
+    stored_context_note_content,
 )
 from backend.resources.memory.context_notes.objects import (
     ContextNoteContent,
@@ -36,6 +41,7 @@ from backend.resources.memory.context_notes.validation import (
     ValidatedContextNote,
     validate_context_note,
 )
+from backend.resources.memory.revisions.hashing import StateHashItem, state_hash_item
 from backend.resources.memory.search_documents.builders.context_note import (
     build_context_note_document,
 )
@@ -137,6 +143,22 @@ def insert_context_note_identity(
         )
     if not inspect(item).persistent:
         raise ValueError("context-note item envelope must be persisted before identity")
+    duplicate = session.scalar(
+        sa.select(ContextNoteRow.item_id).where(
+            ContextNoteRow.scope == prepared.identity.scope,
+            ContextNoteRow.note_key == prepared.identity.note_key,
+            ContextNoteRow.competition_id == prepared.competition_id,
+            ContextNoteRow.competition_season_id
+            == getattr(prepared.identity, "competition_season_id", None),
+            ContextNoteRow.franchise_id
+            == getattr(prepared.identity, "franchise_id", None),
+        )
+    )
+    if duplicate is not None:
+        raise DuplicateContextNoteError(
+            prepared.identity.scope,
+            prepared.identity.note_key,
+        )
     identity_row = ContextNoteRow(
         item_id=item.id,
         competition_id=item.competition_id,
@@ -182,3 +204,61 @@ def insert_context_note_version(
         version,
         build_context_note_document(prepared.identity, content),
     )
+
+
+def context_note_persister(
+    operation: str,
+    identity: ContextNoteIdentity | None,
+    content: ContextNoteContent,
+) -> Callable[[Session, MemoryItem, MemoryVersion], None]:
+    def persist(session: Session, item: MemoryItem, version: MemoryVersion) -> None:
+        resolved_identity = identity
+        if operation == "replace":
+            identity_row = session.get(ContextNoteRow, item.id)
+            if identity_row is None:
+                raise TargetNotFoundError(item.id, (MemoryKind.CONTEXT_NOTE,))
+            resolved_identity = decode_context_note_identity(identity_row)
+        if resolved_identity is None:
+            raise ValueError("context-note create is missing its stable identity")
+        prepared = prepare_context_note_write(
+            session,
+            version.competition_id,
+            resolved_identity,
+            content,
+        )
+        if operation == "create":
+            insert_context_note_identity(session, item, prepared)
+        insert_context_note_version(session, version, prepared)
+
+    return persist
+
+
+def read_context_note_state(
+    session: Session,
+    competition_id: UUID,
+) -> tuple[StateHashItem, ...]:
+    rows = session.execute(
+        context_note_rows_statement().where(
+            MemoryItem.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all()
+    result: list[StateHashItem] = []
+    for item, version, identity_row, stored in rows:
+        note = decode_context_note(item, version, identity_row, stored)
+        result.append(
+            state_hash_item(
+                item_id=item.id,
+                kind=MemoryKind.CONTEXT_NOTE,
+                agent_key=item.agent_key,
+                version_id=version.id,
+                revision_number=version.revision_number,
+                content_schema_version=version.content_schema_version,
+                competition_season_id=version.competition_season_id,
+                week=version.week,
+                occurred_at=version.occurred_at,
+                content=stored_context_note_content(note.content),
+                context_note_identity=note.note_identity,
+            )
+        )
+    return tuple(result)

--- a/backend/resources/memory/events/shared.py
+++ b/backend/resources/memory/events/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -17,12 +18,18 @@ from backend.resources.memory.common.errors import (
     WrongTargetKindError,
 )
 from backend.resources.memory.common.kinds import MemoryKind
-from backend.resources.memory.events.codec import encode_event
+from backend.resources.memory.events.codec import (
+    decode_event,
+    encode_event,
+    event_rows_statement,
+    stored_event_content,
+)
 from backend.resources.memory.events.objects import EventContent
 from backend.resources.memory.events.validation import (
     ValidatedEventContent,
     validate_event_content,
 )
+from backend.resources.memory.revisions.hashing import StateHashItem, state_hash_item
 from backend.resources.memory.search_documents.builders.event import (
     build_event_document,
 )
@@ -123,3 +130,42 @@ def insert_event_version(
         )
     )
     insert_search_document(session, version, build_event_document(content))
+
+
+def event_persister(
+    content: EventContent,
+) -> Callable[[Session, MemoryItem, MemoryVersion], None]:
+    def persist(session: Session, _item: MemoryItem, version: MemoryVersion) -> None:
+        prepared = prepare_event_write(session, version.competition_id, content)
+        insert_event_version(session, version, prepared)
+
+    return persist
+
+
+def read_event_state(
+    session: Session,
+    competition_id: UUID,
+) -> tuple[StateHashItem, ...]:
+    rows = session.execute(
+        event_rows_statement().where(
+            MemoryItem.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all()
+    return tuple(
+        state_hash_item(
+            item_id=item.id,
+            kind=MemoryKind.EVENT,
+            agent_key=item.agent_key,
+            version_id=version.id,
+            revision_number=version.revision_number,
+            content_schema_version=version.content_schema_version,
+            competition_season_id=version.competition_season_id,
+            week=version.week,
+            occurred_at=version.occurred_at,
+            content=stored_event_content(
+                decode_event(item, version, stored).content
+            ),
+        )
+        for item, version, stored in rows
+    )

--- a/backend/resources/memory/facts/shared.py
+++ b/backend/resources/memory/facts/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -17,12 +18,18 @@ from backend.resources.memory.common.errors import (
     WrongTargetKindError,
 )
 from backend.resources.memory.common.kinds import MemoryKind
-from backend.resources.memory.facts.codec import encode_fact
+from backend.resources.memory.facts.codec import (
+    decode_fact,
+    encode_fact,
+    fact_rows_statement,
+    stored_fact_content,
+)
 from backend.resources.memory.facts.objects import FactContent
 from backend.resources.memory.facts.validation import (
     ValidatedFactContent,
     validate_fact_content,
 )
+from backend.resources.memory.revisions.hashing import StateHashItem, state_hash_item
 from backend.resources.memory.search_documents.builders.fact import (
     build_fact_document,
 )
@@ -126,3 +133,45 @@ def insert_fact_version(
         )
     )
     insert_search_document(session, version, build_fact_document(content))
+
+
+def fact_persister(
+    content: FactContent,
+) -> Callable[[Session, MemoryItem, MemoryVersion], None]:
+    """Bind typed fact preparation behind the generic revision writer."""
+
+    def persist(session: Session, _item: MemoryItem, version: MemoryVersion) -> None:
+        prepared = prepare_fact_write(session, version.competition_id, content)
+        insert_fact_version(session, version, prepared)
+
+    return persist
+
+
+def read_fact_state(
+    session: Session,
+    competition_id: UUID,
+) -> tuple[StateHashItem, ...]:
+    rows = session.execute(
+        fact_rows_statement().where(
+            MemoryItem.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all()
+    result: list[StateHashItem] = []
+    for item, version, stored in rows:
+        fact = decode_fact(item, version, stored)
+        result.append(
+            state_hash_item(
+                item_id=item.id,
+                kind=MemoryKind.FACT,
+                agent_key=item.agent_key,
+                version_id=version.id,
+                revision_number=version.revision_number,
+                content_schema_version=version.content_schema_version,
+                competition_season_id=version.competition_season_id,
+                week=version.week,
+                occurred_at=version.occurred_at,
+                content=stored_fact_content(fact.content),
+            )
+        )
+    return tuple(result)

--- a/backend/resources/memory/revisions/hashing.py
+++ b/backend/resources/memory/revisions/hashing.py
@@ -84,6 +84,37 @@ def compute_state_content_hash(
     return f"{STATE_HASH_PREFIX}{sha256(encoded).hexdigest()}"
 
 
+def state_hash_item(
+    *,
+    item_id: UUID,
+    kind: MemoryKind,
+    agent_key: str | None,
+    version_id: UUID,
+    revision_number: int,
+    content_schema_version: int,
+    competition_season_id: UUID | None,
+    week: int | None,
+    occurred_at: datetime | None,
+    content: StoredSchemaContent,
+    context_note_identity: ContextNoteIdentity | None = None,
+) -> StateHashItem:
+    """Construct one logical state value without exposing ORM rows."""
+
+    return StateHashItem(
+        item_id=item_id,
+        kind=kind,
+        agent_key=agent_key,
+        context_note_identity=context_note_identity,
+        version_id=version_id,
+        revision_number=revision_number,
+        content_schema_version=content_schema_version,
+        competition_season_id=competition_season_id,
+        week=week,
+        occurred_at=occurred_at,
+        content=content,
+    )
+
+
 def _state_item_payload(item: StateHashItem) -> dict[str, Any]:
     return {
         "item_id": _canonical_uuid(item.item_id),

--- a/backend/resources/memory/revisions/manager.py
+++ b/backend/resources/memory/revisions/manager.py
@@ -1,14 +1,42 @@
 from __future__ import annotations
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Session
 
-from backend.database.models.memory import CurrentRevision, MemoryRevision
-from backend.database.sessions import SessionFactory, read_only_session
+from backend.database.models.memory import (
+    CurrentRevision,
+    MemoryItem,
+    MemoryRevision,
+    MemoryVersion,
+)
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
 from backend.resources.context import CompetitionScope, ManagerContext
-from backend.resources.memory.common.errors import RevisionNotFoundError
+from backend.resources.memory.common.errors import (
+    CanonicalStateHashMismatchError,
+    RevisionNotFoundError,
+)
+from backend.resources.memory.revisions.hashing import (
+    StateHashItem,
+    compute_state_content_hash,
+    state_hash_item,
+)
 from backend.resources.memory.revisions.objects import CanonicalRevision
+from backend.resources.memory.revisions.writers import (
+    CanonicalResourceWrite,
+    CanonicalWriteBundle,
+    StateReader,
+    advance_current_revision,
+    build_version_envelopes,
+    lock_current_revision,
+    persist_version_envelopes,
+    validate_reference_targets,
+)
 
 
 class RevisionManager:
@@ -21,6 +49,10 @@ class RevisionManager:
     ) -> None:
         self._session_factory: SessionFactory = session_factory
         self._competition_id: UUID = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
 
     def current(self) -> CanonicalRevision:
         """Return the competition's current canonical revision."""
@@ -67,6 +99,81 @@ class RevisionManager:
             rows = session.scalars(statement).all()
         return tuple(_to_revision(row) for row in rows)
 
+    def commit(
+        self,
+        bundle: CanonicalWriteBundle,
+    ) -> CanonicalRevision | None:
+        """Commit one complete typed bundle as a single canonical transition."""
+
+        if bundle.competition_id != self._competition_id:
+            raise ValueError("mutation bundle is outside the manager competition")
+        if not bundle.writes:
+            return None
+
+        state_readers = _state_readers()
+        with transaction_session(self._session_factory) as session:
+            parent = lock_current_revision(
+                session,
+                self._competition_id,
+                bundle.expected_revision_id,
+            )
+            parent_state = _read_state(
+                session,
+                self._competition_id,
+                state_readers,
+            )
+            validate_reference_targets(session, self._competition_id, bundle.writes)
+            revision = MemoryRevision(
+                id=uuid4(),
+                competition_id=self._competition_id,
+                sequence_number=parent.next_sequence_number,
+                previous_revision_id=parent.current_revision_id,
+                producing_generation_id=bundle.generation_id,
+                competition_season_id=bundle.competition_season_id,
+                week=bundle.week,
+                knowledge_cutoff_at=bundle.knowledge_cutoff_at,
+                state_content_hash="pending",
+            )
+            resolved, retired = build_version_envelopes(session, revision, bundle)
+            expected_hash = compute_state_content_hash(
+                self._competition_id,
+                _resulting_state(parent_state, resolved),
+            )
+            revision.state_content_hash = expected_hash
+            persist_version_envelopes(
+                session,
+                revision,
+                new_items=(
+                    item
+                    for write, item, _ in resolved
+                    if write.operation == "create"
+                ),
+                new_versions=(version for _, _, version in resolved),
+                retired_versions=retired,
+            )
+            for write, item, version in sorted(
+                resolved,
+                key=lambda entry: entry[0].dependency_order,
+            ):
+                write.persist_typed(session, item, version)
+                session.flush()
+
+            actual_hash = compute_state_content_hash(
+                self._competition_id,
+                _read_state(session, self._competition_id, state_readers),
+            )
+            if actual_hash != expected_hash:
+                raise CanonicalStateHashMismatchError(expected_hash, actual_hash)
+            advance_current_revision(
+                session,
+                self._competition_id,
+                parent,
+                revision.id,
+            )
+            session.flush()
+
+        return _to_revision(revision)
+
 
 def _to_revision(row: MemoryRevision) -> CanonicalRevision:
     return CanonicalRevision(
@@ -81,3 +188,65 @@ def _to_revision(row: MemoryRevision) -> CanonicalRevision:
         state_content_hash=row.state_content_hash,
         created_at=row.created_at,
     )
+
+
+def _read_state(
+    session: Session,
+    competition_id: UUID,
+    state_readers: tuple[StateReader, ...],
+) -> tuple[StateHashItem, ...]:
+    return tuple(
+        item
+        for reader in state_readers
+        for item in reader(session, competition_id)
+    )
+
+
+def _state_readers() -> tuple[StateReader, ...]:
+    # Lazy imports avoid the codecs -> revision hashing package initialization
+    # cycle while keeping the complete state-reader registry revision-owned.
+    from backend.resources.memory.context_notes.shared import read_context_note_state
+    from backend.resources.memory.events.shared import read_event_state
+    from backend.resources.memory.facts.shared import read_fact_state
+    from backend.resources.memory.storylines.shared import read_storyline_state
+    from backend.resources.memory.triggers.shared import read_trigger_state
+
+    return (
+        read_fact_state,
+        read_event_state,
+        read_storyline_state,
+        read_trigger_state,
+        read_context_note_state,
+    )
+
+
+def _resulting_state(
+    parent_state: tuple[StateHashItem, ...],
+    resolved: tuple[
+        tuple[CanonicalResourceWrite, MemoryItem, MemoryVersion], ...
+    ],
+) -> tuple[StateHashItem, ...]:
+    writes_by_item = {entry[0].item_id for entry in resolved}
+    previous_by_item = {item.item_id: item for item in parent_state}
+    result = [item for item in parent_state if item.item_id not in writes_by_item]
+    for write, item, version in resolved:
+        previous = previous_by_item.get(write.item_id)
+        note_identity = write.context_note_identity
+        if note_identity is None and previous is not None:
+            note_identity = previous.context_note_identity
+        result.append(
+            state_hash_item(
+                item_id=item.id,
+                kind=write.kind,
+                agent_key=item.agent_key,
+                version_id=version.id,
+                revision_number=version.revision_number,
+                content_schema_version=version.content_schema_version,
+                competition_season_id=version.competition_season_id,
+                week=version.week,
+                occurred_at=version.occurred_at,
+                content=write.stored_content,
+                context_note_identity=note_identity,
+            )
+        )
+    return tuple(result)

--- a/backend/resources/memory/revisions/writers.py
+++ b/backend/resources/memory/revisions/writers.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
 from typing import cast
 from uuid import UUID
 
@@ -17,8 +19,19 @@ from backend.database.models.memory import (
     MemoryVersion,
 )
 from backend.resources.memory.common.errors import (
+    CrossCompetitionReferenceError,
+    MemoryIdentityConflictError,
     RevisionNotFoundError,
+    StaleItemVersionError,
     StaleCanonicalRevisionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.objects import ContextNoteIdentity
+from backend.resources.memory.revisions.hashing import (
+    StateHashItem,
+    StoredSchemaContent,
 )
 
 
@@ -27,6 +40,50 @@ class LockedRevisionParent:
     current_revision_id: UUID
     next_sequence_number: int
     next_lock_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalReferenceTarget:
+    reference_id: UUID
+    target: Literal["item", "version"]
+    expected_kinds: tuple[MemoryKind, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalResourceWrite:
+    """Opaque resource-local write accepted by revision orchestration."""
+
+    operation: Literal["create", "replace"]
+    kind: MemoryKind
+    dependency_order: int
+    item_id: UUID
+    version_id: UUID
+    expected_item_revision: int | None
+    content_schema_version: int
+    agent_key: str | None
+    competition_season_id: UUID | None
+    week: int | None
+    occurred_at: datetime | None
+    creating_tool_call_id: UUID | None
+    change_reason: str | None
+    stored_content: StoredSchemaContent
+    context_note_identity: ContextNoteIdentity | None
+    references: tuple[CanonicalReferenceTarget, ...]
+    persist_typed: Callable[[Session, MemoryItem, MemoryVersion], None]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalWriteBundle:
+    competition_id: UUID
+    generation_id: UUID
+    expected_revision_id: UUID
+    competition_season_id: UUID | None
+    week: int | None
+    knowledge_cutoff_at: datetime | None
+    writes: tuple[CanonicalResourceWrite, ...]
+
+
+StateReader = Callable[[Session, UUID], tuple[StateHashItem, ...]]
 
 
 def persist_version_envelopes(
@@ -112,3 +169,229 @@ def lock_current_revision(
         next_sequence_number=sequence_number + 1,
         next_lock_version=lock_version + 1,
     )
+
+
+def validate_reference_targets(
+    session: Session,
+    competition_id: UUID,
+    writes: tuple[CanonicalResourceWrite, ...],
+) -> None:
+    """Batch-load stable and exact targets, including proposal-local identities."""
+
+    local_items = {
+        write.item_id: write.kind
+        for write in writes
+        if write.operation == "create"
+    }
+    local_versions = {write.version_id: write.kind for write in writes}
+    requirements = tuple(
+        reference for write in writes for reference in write.references
+    )
+    item_ids = {
+        reference.reference_id
+        for reference in requirements
+        if reference.target == "item" and reference.reference_id not in local_items
+    }
+    version_ids = {
+        reference.reference_id
+        for reference in requirements
+        if reference.target == "version"
+        and reference.reference_id not in local_versions
+    }
+    item_rows = session.execute(
+        sa.select(MemoryItem.id, MemoryItem.competition_id, MemoryItem.kind).where(
+            MemoryItem.id.in_(item_ids)
+        )
+    ) if item_ids else ()
+    found_items = {
+        item_id: (scope, MemoryKind(kind)) for item_id, scope, kind in item_rows
+    }
+    version_rows = session.execute(
+        sa.select(
+            MemoryVersion.id,
+            MemoryVersion.competition_id,
+            MemoryItem.kind,
+        )
+        .join(MemoryItem, MemoryItem.id == MemoryVersion.item_id)
+        .where(MemoryVersion.id.in_(version_ids))
+    ) if version_ids else ()
+    found_versions = {
+        version_id: (scope, MemoryKind(kind))
+        for version_id, scope, kind in version_rows
+    }
+
+    for reference in requirements:
+        local = (
+            local_items.get(reference.reference_id)
+            if reference.target == "item"
+            else local_versions.get(reference.reference_id)
+        )
+        if local is not None:
+            if local not in reference.expected_kinds:
+                raise WrongTargetKindError(
+                    reference.reference_id,
+                    reference.expected_kinds,
+                    local,
+                )
+            continue
+        found = (
+            found_items.get(reference.reference_id)
+            if reference.target == "item"
+            else found_versions.get(reference.reference_id)
+        )
+        if found is None:
+            raise TargetNotFoundError(
+                reference.reference_id,
+                reference.expected_kinds,
+            )
+        actual_scope, actual_kind = found
+        if actual_scope != competition_id:
+            raise CrossCompetitionReferenceError(
+                reference.reference_id,
+                competition_id,
+                actual_scope,
+            )
+        if actual_kind not in reference.expected_kinds:
+            raise WrongTargetKindError(
+                reference.reference_id,
+                reference.expected_kinds,
+                actual_kind,
+            )
+
+
+def build_version_envelopes(
+    session: Session,
+    revision: MemoryRevision,
+    bundle: CanonicalWriteBundle,
+) -> tuple[
+    tuple[tuple[CanonicalResourceWrite, MemoryItem, MemoryVersion], ...],
+    tuple[MemoryVersion, ...],
+]:
+    """Batch-resolve replacements and construct every generic envelope."""
+
+    replacement_writes = tuple(
+        write for write in bundle.writes if write.operation == "replace"
+    )
+    replacement_ids = {write.item_id for write in replacement_writes}
+    item_rows = session.scalars(
+        sa.select(MemoryItem).where(MemoryItem.id.in_(replacement_ids))
+    ).all() if replacement_ids else []
+    existing_items = {item.id: item for item in item_rows}
+    current_rows = session.scalars(
+        sa.select(MemoryVersion).where(
+            MemoryVersion.item_id.in_(replacement_ids),
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all() if replacement_ids else []
+    current_versions = {version.item_id: version for version in current_rows}
+
+    create_ids = {
+        write.item_id for write in bundle.writes if write.operation == "create"
+    }
+    conflicting_id = session.scalar(
+        sa.select(MemoryItem.id).where(MemoryItem.id.in_(create_ids)).limit(1)
+    ) if create_ids else None
+    if conflicting_id is not None:
+        raise MemoryIdentityConflictError(conflicting_id)
+    version_ids = {write.version_id for write in bundle.writes}
+    conflicting_version_id = session.scalar(
+        sa.select(MemoryVersion.id).where(MemoryVersion.id.in_(version_ids)).limit(1)
+    ) if version_ids else None
+    if conflicting_version_id is not None:
+        raise MemoryIdentityConflictError(conflicting_version_id)
+
+    resolved: list[tuple[CanonicalResourceWrite, MemoryItem, MemoryVersion]] = []
+    retired: list[MemoryVersion] = []
+    for write in bundle.writes:
+        if write.operation == "create":
+            item = MemoryItem(
+                id=write.item_id,
+                competition_id=bundle.competition_id,
+                kind=write.kind.value,
+                agent_key=write.agent_key,
+            )
+            revision_number = 1
+        else:
+            item = existing_items.get(write.item_id)
+            if item is None:
+                raise TargetNotFoundError(write.item_id, (write.kind,))
+            if item.competition_id != bundle.competition_id:
+                raise CrossCompetitionReferenceError(
+                    write.item_id,
+                    bundle.competition_id,
+                    item.competition_id,
+                )
+            if item.kind != write.kind.value:
+                raise WrongTargetKindError(
+                    write.item_id,
+                    (write.kind,),
+                    MemoryKind(item.kind),
+                )
+            previous = current_versions.get(write.item_id)
+            if previous is None:
+                raise TargetNotFoundError(write.item_id, (write.kind,))
+            expected = write.expected_item_revision
+            if expected is None:
+                raise ValueError("replacement write is missing its expected revision")
+            if previous.revision_number != expected:
+                raise StaleItemVersionError(
+                    write.item_id,
+                    expected,
+                    previous.revision_number,
+                )
+            revision_number = previous.revision_number + 1
+            retired.append(previous)
+
+        version = MemoryVersion(
+            id=write.version_id,
+            item_id=write.item_id,
+            competition_id=bundle.competition_id,
+            revision_number=revision_number,
+            content_schema_version=write.content_schema_version,
+            introduced_revision_id=revision.id,
+            competition_season_id=(
+                write.competition_season_id or bundle.competition_season_id
+            ),
+            week=write.week if write.week is not None else bundle.week,
+            occurred_at=write.occurred_at,
+            creating_generation_id=bundle.generation_id,
+            creating_tool_call_id=write.creating_tool_call_id,
+            change_reason=write.change_reason,
+        )
+        resolved.append((write, item, version))
+    return tuple(resolved), tuple(retired)
+
+
+def advance_current_revision(
+    session: Session,
+    competition_id: UUID,
+    parent: LockedRevisionParent,
+    revision_id: UUID,
+) -> None:
+    updated_competition_id = session.scalar(
+        sa.update(CurrentRevision)
+        .where(
+            CurrentRevision.competition_id == competition_id,
+            CurrentRevision.current_revision_id == parent.current_revision_id,
+            CurrentRevision.lock_version == parent.next_lock_version - 1,
+        )
+        .values(
+            current_revision_id=revision_id,
+            lock_version=parent.next_lock_version,
+            updated_at=sa.func.now(),
+        )
+        .returning(CurrentRevision.competition_id)
+    )
+    if updated_competition_id is None:
+        actual = session.scalar(
+            sa.select(CurrentRevision.current_revision_id).where(
+                CurrentRevision.competition_id == competition_id
+            )
+        )
+        if actual is None:
+            raise RevisionNotFoundError(competition_id)
+        raise StaleCanonicalRevisionError(
+            competition_id,
+            parent.current_revision_id,
+            actual,
+        )

--- a/backend/resources/memory/storylines/shared.py
+++ b/backend/resources/memory/storylines/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -22,11 +23,17 @@ from backend.resources.memory.search_documents.builders.storyline import (
 )
 from backend.resources.memory.search_documents.shared import insert_search_document
 from backend.resources.memory.storylines.codec import encode_storyline
+from backend.resources.memory.storylines.codec import (
+    decode_storyline,
+    storyline_rows_statement,
+    stored_storyline_content,
+)
 from backend.resources.memory.storylines.objects import StorylineContent
 from backend.resources.memory.storylines.validation import (
     ValidatedStorylineContent,
     validate_storyline_content,
 )
+from backend.resources.memory.revisions.hashing import StateHashItem, state_hash_item
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,3 +126,42 @@ def insert_storyline_version(
         )
     )
     insert_search_document(session, version, build_storyline_document(content))
+
+
+def storyline_persister(
+    content: StorylineContent,
+) -> Callable[[Session, MemoryItem, MemoryVersion], None]:
+    def persist(session: Session, _item: MemoryItem, version: MemoryVersion) -> None:
+        prepared = prepare_storyline_write(session, version.competition_id, content)
+        insert_storyline_version(session, version, prepared)
+
+    return persist
+
+
+def read_storyline_state(
+    session: Session,
+    competition_id: UUID,
+) -> tuple[StateHashItem, ...]:
+    rows = session.execute(
+        storyline_rows_statement().where(
+            MemoryItem.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all()
+    return tuple(
+        state_hash_item(
+            item_id=item.id,
+            kind=MemoryKind.STORYLINE,
+            agent_key=item.agent_key,
+            version_id=version.id,
+            revision_number=version.revision_number,
+            content_schema_version=version.content_schema_version,
+            competition_season_id=version.competition_season_id,
+            week=version.week,
+            occurred_at=version.occurred_at,
+            content=stored_storyline_content(
+                decode_storyline(item, version, stored).content
+            ),
+        )
+        for item, version, stored in rows
+    )

--- a/backend/resources/memory/triggers/shared.py
+++ b/backend/resources/memory/triggers/shared.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -21,12 +22,18 @@ from backend.resources.memory.search_documents.builders.trigger import (
     build_trigger_document,
 )
 from backend.resources.memory.search_documents.shared import insert_search_document
-from backend.resources.memory.triggers.codec import encode_trigger
+from backend.resources.memory.triggers.codec import (
+    decode_trigger,
+    encode_trigger,
+    stored_trigger_content,
+    trigger_rows_statement,
+)
 from backend.resources.memory.triggers.objects import TriggerContent
 from backend.resources.memory.triggers.validation import (
     ValidatedTriggerContent,
     validate_trigger_content,
 )
+from backend.resources.memory.revisions.hashing import StateHashItem, state_hash_item
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,3 +127,42 @@ def insert_trigger_version(
         )
     )
     insert_search_document(session, version, build_trigger_document(content))
+
+
+def trigger_persister(
+    content: TriggerContent,
+) -> Callable[[Session, MemoryItem, MemoryVersion], None]:
+    def persist(session: Session, _item: MemoryItem, version: MemoryVersion) -> None:
+        prepared = prepare_trigger_write(session, version.competition_id, content)
+        insert_trigger_version(session, version, prepared)
+
+    return persist
+
+
+def read_trigger_state(
+    session: Session,
+    competition_id: UUID,
+) -> tuple[StateHashItem, ...]:
+    rows = session.execute(
+        trigger_rows_statement().where(
+            MemoryItem.competition_id == competition_id,
+            MemoryVersion.retired_revision_id.is_(None),
+        )
+    ).all()
+    return tuple(
+        state_hash_item(
+            item_id=item.id,
+            kind=MemoryKind.TRIGGER,
+            agent_key=item.agent_key,
+            version_id=version.id,
+            revision_number=version.revision_number,
+            content_schema_version=version.content_schema_version,
+            competition_season_id=version.competition_season_id,
+            week=version.week,
+            occurred_at=version.occurred_at,
+            content=stored_trigger_content(
+                decode_trigger(item, version, stored).content
+            ),
+        )
+        for item, version, stored in rows
+    )

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application services coordinating resource boundaries."""

--- a/backend/services/memory/__init__.py
+++ b/backend/services/memory/__init__.py
@@ -1,0 +1,25 @@
+from backend.services.memory.generation_context import (
+    GenerationMemoryContext,
+    PinnedMemoryRetrieval,
+)
+from backend.services.memory.mutation_service import MemoryMutationService
+from backend.services.memory.proposals import (
+    MemoryMutationBundle,
+    MemoryMutationMetadata,
+    MemoryMutationOrigin,
+    MemoryMutationResult,
+    MemoryProposal,
+    ProposedMemoryRef,
+)
+
+__all__ = [
+    "GenerationMemoryContext",
+    "MemoryMutationBundle",
+    "MemoryMutationMetadata",
+    "MemoryMutationOrigin",
+    "MemoryMutationResult",
+    "MemoryMutationService",
+    "MemoryProposal",
+    "PinnedMemoryRetrieval",
+    "ProposedMemoryRef",
+]

--- a/backend/services/memory/generation_context.py
+++ b/backend/services/memory/generation_context.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID, uuid4
+
+from backend.resources.memory.common.errors import (
+    GenerationMemoryContextClosedError,
+)
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.facts.objects import FactContent
+from backend.resources.memory.storylines.objects import StorylineContent
+from backend.resources.memory.triggers.objects import TriggerContent
+from backend.services.memory.proposals import (
+    MemoryMutationBundle,
+    MemoryMutationMetadata,
+    MemoryProposal,
+    MemoryProposalContent,
+    ProposedMemoryRef,
+)
+
+
+class PinnedMemoryRetrieval(Protocol):
+    """Temporary boundary implemented by the retrieval service in MEMORY-11."""
+
+    def search(
+        self,
+        *,
+        competition_id: UUID,
+        revision_id: UUID,
+        request: object,
+    ) -> object: ...
+
+
+class GenerationMemoryContext:
+    """One generation's pinned retrieval facade and in-memory proposal buffer."""
+
+    def __init__(
+        self,
+        *,
+        competition_id: UUID,
+        generation_id: UUID,
+        pinned_revision_id: UUID,
+        retrieval: PinnedMemoryRetrieval,
+        competition_season_id: UUID | None = None,
+        week: int | None = None,
+        knowledge_cutoff_at: datetime | None = None,
+    ) -> None:
+        self.competition_id = competition_id
+        self.generation_id = generation_id
+        self.pinned_revision_id = pinned_revision_id
+        self._retrieval = retrieval
+        self._competition_season_id = competition_season_id
+        self._week = week
+        self._knowledge_cutoff_at = knowledge_cutoff_at
+        self._proposals: list[MemoryProposal] = []
+        self._closed = False
+
+    def search(self, request: object) -> object:
+        """Search only the immutable canonical input revision."""
+
+        self._require_open()
+        return self._retrieval.search(
+            competition_id=self.competition_id,
+            revision_id=self.pinned_revision_id,
+            request=request,
+        )
+
+    def propose_fact(
+        self,
+        content: FactContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._create(MemoryKind.FACT, content, metadata=metadata)
+
+    def propose_event(
+        self,
+        content: EventContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._create(MemoryKind.EVENT, content, metadata=metadata)
+
+    def propose_storyline(
+        self,
+        content: StorylineContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._create(MemoryKind.STORYLINE, content, metadata=metadata)
+
+    def propose_trigger(
+        self,
+        content: TriggerContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._create(MemoryKind.TRIGGER, content, metadata=metadata)
+
+    def propose_context_note(
+        self,
+        identity: ContextNoteIdentity,
+        content: ContextNoteContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._create(
+            MemoryKind.CONTEXT_NOTE,
+            content,
+            context_note_identity=identity,
+            metadata=metadata,
+        )
+
+    def replace_fact(
+        self,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: FactContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._replace(
+            MemoryKind.FACT,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_event(
+        self,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: EventContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._replace(
+            MemoryKind.EVENT,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_storyline(
+        self,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: StorylineContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._replace(
+            MemoryKind.STORYLINE,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_trigger(
+        self,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: TriggerContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._replace(
+            MemoryKind.TRIGGER,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_context_note(
+        self,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: ContextNoteContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        return self._replace(
+            MemoryKind.CONTEXT_NOTE,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def take_completed_bundle(self) -> MemoryMutationBundle:
+        """Close the buffer and return its immutable contents exactly once."""
+
+        self._require_open()
+        bundle = MemoryMutationBundle.model_validate(
+            {
+                "competition_id": self.competition_id,
+                "generation_id": self.generation_id,
+                "expected_revision_id": self.pinned_revision_id,
+                "competition_season_id": self._competition_season_id,
+                "week": self._week,
+                "knowledge_cutoff_at": self._knowledge_cutoff_at,
+                "proposals": tuple(self._proposals),
+            }
+        )
+        self._closed = True
+        return bundle
+
+    def _create(
+        self,
+        kind: MemoryKind,
+        content: MemoryProposalContent,
+        *,
+        context_note_identity: ContextNoteIdentity | None = None,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        self._require_open()
+        proposal = MemoryProposal(
+            proposal_id=uuid4(),
+            operation="create",
+            kind=kind,
+            item_id=uuid4(),
+            version_id=uuid4(),
+            content=content,
+            context_note_identity=context_note_identity,
+            metadata=metadata or MemoryMutationMetadata(),
+        )
+        self._proposals.append(proposal)
+        return proposal.proposed_ref()
+
+    def _replace(
+        self,
+        kind: MemoryKind,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: MemoryProposalContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> ProposedMemoryRef:
+        self._require_open()
+        proposal = MemoryProposal(
+            proposal_id=uuid4(),
+            operation="replace",
+            kind=kind,
+            item_id=item_id,
+            version_id=uuid4(),
+            expected_item_revision=expected_item_revision,
+            content=content,
+            metadata=metadata or MemoryMutationMetadata(),
+        )
+        self._proposals.append(proposal)
+        return proposal.proposed_ref()
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise GenerationMemoryContextClosedError(self.generation_id)

--- a/backend/services/memory/mutation_service.py
+++ b/backend/services/memory/mutation_service.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.codec import stored_context_note_content
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.context_notes.shared import (
+    context_note_persister,
+)
+from backend.resources.memory.events.codec import stored_event_content
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.events.shared import event_persister
+from backend.resources.memory.facts.codec import stored_fact_content
+from backend.resources.memory.facts.objects import FactContent
+from backend.resources.memory.facts.shared import fact_persister
+from backend.resources.memory.revisions.manager import RevisionManager
+from backend.resources.memory.revisions.writers import (
+    CanonicalReferenceTarget,
+    CanonicalResourceWrite,
+    CanonicalWriteBundle,
+)
+from backend.resources.memory.storylines.codec import stored_storyline_content
+from backend.resources.memory.storylines.objects import StorylineContent
+from backend.resources.memory.storylines.shared import (
+    storyline_persister,
+)
+from backend.resources.memory.triggers.codec import stored_trigger_content
+from backend.resources.memory.triggers.objects import TriggerContent
+from backend.resources.memory.triggers.shared import (
+    trigger_persister,
+)
+from backend.services.memory.proposals import (
+    MemoryMutationBundle,
+    MemoryMutationMetadata,
+    MemoryMutationOrigin,
+    MemoryMutationResult,
+    MemoryProposal,
+    MemoryProposalContent,
+)
+
+
+_WRITE_ORDER = {
+    MemoryKind.EVENT: 0,
+    MemoryKind.FACT: 1,
+    MemoryKind.STORYLINE: 2,
+    MemoryKind.TRIGGER: 3,
+    MemoryKind.CONTEXT_NOTE: 4,
+}
+
+
+class MemoryMutationService:
+    """Translate complete public proposals into one canonical revision commit."""
+
+    def __init__(self, revision_manager: RevisionManager) -> None:
+        self._revision_manager = revision_manager
+
+    def apply(self, bundle: MemoryMutationBundle) -> MemoryMutationResult:
+        """Apply a completed generation bundle exactly as one mutation unit."""
+
+        writes = tuple(_canonical_write(proposal) for proposal in bundle.proposals)
+        revision = self._revision_manager.commit(
+            CanonicalWriteBundle(
+                competition_id=bundle.competition_id,
+                generation_id=bundle.generation_id,
+                expected_revision_id=bundle.expected_revision_id,
+                competition_season_id=bundle.competition_season_id,
+                week=bundle.week,
+                knowledge_cutoff_at=bundle.knowledge_cutoff_at,
+                writes=writes,
+            )
+        )
+        return MemoryMutationResult(
+            revision=revision,
+            changes=tuple(
+                proposal.proposed_ref() for proposal in bundle.proposals
+            ),
+        )
+
+    def create_fact(
+        self,
+        origin: MemoryMutationOrigin,
+        content: FactContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_create(origin, MemoryKind.FACT, content, metadata=metadata)
+
+    def replace_fact(
+        self,
+        origin: MemoryMutationOrigin,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: FactContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_replace(
+            origin,
+            MemoryKind.FACT,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def create_event(
+        self,
+        origin: MemoryMutationOrigin,
+        content: EventContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_create(origin, MemoryKind.EVENT, content, metadata=metadata)
+
+    def replace_event(
+        self,
+        origin: MemoryMutationOrigin,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: EventContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_replace(
+            origin,
+            MemoryKind.EVENT,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def create_storyline(
+        self,
+        origin: MemoryMutationOrigin,
+        content: StorylineContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_create(
+            origin,
+            MemoryKind.STORYLINE,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_storyline(
+        self,
+        origin: MemoryMutationOrigin,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: StorylineContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_replace(
+            origin,
+            MemoryKind.STORYLINE,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def create_trigger(
+        self,
+        origin: MemoryMutationOrigin,
+        content: TriggerContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_create(
+            origin,
+            MemoryKind.TRIGGER,
+            content,
+            metadata=metadata,
+        )
+
+    def replace_trigger(
+        self,
+        origin: MemoryMutationOrigin,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: TriggerContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_replace(
+            origin,
+            MemoryKind.TRIGGER,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def create_context_note(
+        self,
+        origin: MemoryMutationOrigin,
+        identity: ContextNoteIdentity,
+        content: ContextNoteContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_create(
+            origin,
+            MemoryKind.CONTEXT_NOTE,
+            content,
+            context_note_identity=identity,
+            metadata=metadata,
+        )
+
+    def replace_context_note(
+        self,
+        origin: MemoryMutationOrigin,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: ContextNoteContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        return self._single_replace(
+            origin,
+            MemoryKind.CONTEXT_NOTE,
+            item_id,
+            expected_item_revision,
+            content,
+            metadata=metadata,
+        )
+
+    def _single_create(
+        self,
+        origin: MemoryMutationOrigin,
+        kind: MemoryKind,
+        content: MemoryProposalContent,
+        *,
+        context_note_identity: ContextNoteIdentity | None = None,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        proposal = MemoryProposal(
+            proposal_id=uuid4(),
+            operation="create",
+            kind=kind,
+            item_id=uuid4(),
+            version_id=uuid4(),
+            content=content,
+            context_note_identity=context_note_identity,
+            metadata=metadata or MemoryMutationMetadata(),
+        )
+        return self.apply(_single_bundle(self._revision_manager, origin, proposal))
+
+    def _single_replace(
+        self,
+        origin: MemoryMutationOrigin,
+        kind: MemoryKind,
+        item_id: UUID,
+        expected_item_revision: int,
+        content: MemoryProposalContent,
+        *,
+        metadata: MemoryMutationMetadata | None = None,
+    ) -> MemoryMutationResult:
+        proposal = MemoryProposal(
+            proposal_id=uuid4(),
+            operation="replace",
+            kind=kind,
+            item_id=item_id,
+            version_id=uuid4(),
+            expected_item_revision=expected_item_revision,
+            content=content,
+            metadata=metadata or MemoryMutationMetadata(),
+        )
+        return self.apply(_single_bundle(self._revision_manager, origin, proposal))
+
+
+def _single_bundle(
+    revision_manager: RevisionManager,
+    origin: MemoryMutationOrigin,
+    proposal: MemoryProposal,
+) -> MemoryMutationBundle:
+    return MemoryMutationBundle(
+        competition_id=revision_manager.competition_id,
+        generation_id=origin.generation_id,
+        expected_revision_id=origin.expected_revision_id,
+        competition_season_id=origin.competition_season_id,
+        week=origin.week,
+        knowledge_cutoff_at=origin.knowledge_cutoff_at,
+        proposals=(proposal,),
+    )
+
+
+def _canonical_write(proposal: MemoryProposal) -> CanonicalResourceWrite:
+    content = proposal.content
+    if isinstance(content, FactContent):
+        persist = fact_persister(content)
+        stored_content = stored_fact_content(content)
+    elif isinstance(content, EventContent):
+        persist = event_persister(content)
+        stored_content = stored_event_content(content)
+    elif isinstance(content, StorylineContent):
+        persist = storyline_persister(content)
+        stored_content = stored_storyline_content(content)
+    elif isinstance(content, TriggerContent):
+        persist = trigger_persister(content)
+        stored_content = stored_trigger_content(content)
+    elif isinstance(content, ContextNoteContent):
+        persist = context_note_persister(
+            proposal.operation,
+            proposal.context_note_identity,
+            content,
+        )
+        stored_content = stored_context_note_content(content)
+    else:
+        raise TypeError(f"unsupported memory content {type(content).__name__}")
+
+    metadata = proposal.metadata
+    return CanonicalResourceWrite(
+        operation=proposal.operation,
+        kind=proposal.kind,
+        dependency_order=_WRITE_ORDER[proposal.kind],
+        item_id=proposal.item_id,
+        version_id=proposal.version_id,
+        expected_item_revision=proposal.expected_item_revision,
+        content_schema_version=content.schema_version,
+        agent_key=metadata.agent_key,
+        competition_season_id=metadata.competition_season_id,
+        week=metadata.week,
+        occurred_at=metadata.occurred_at,
+        creating_tool_call_id=metadata.creating_tool_call_id,
+        change_reason=metadata.change_reason,
+        stored_content=stored_content,
+        context_note_identity=proposal.context_note_identity,
+        references=_references(content),
+        persist_typed=persist,
+    )
+
+
+def _references(
+    content: MemoryProposalContent,
+) -> tuple[CanonicalReferenceTarget, ...]:
+    references: list[CanonicalReferenceTarget] = []
+    if isinstance(content, FactContent):
+        references.extend(
+            CanonicalReferenceTarget(
+                reference_id=version_id,
+                target="version",
+                expected_kinds=(MemoryKind.EVENT,),
+            )
+            for version_id in content.originating_event_version_ids
+        )
+    elif isinstance(content, StorylineContent):
+        references.extend(
+            CanonicalReferenceTarget(
+                reference_id=evidence.version_id,
+                target="version",
+                expected_kinds=(MemoryKind(evidence.kind),),
+            )
+            for evidence in content.evidence
+        )
+        references.extend(
+            CanonicalReferenceTarget(
+                reference_id=related.item_id,
+                target="item",
+                expected_kinds=(MemoryKind.STORYLINE,),
+            )
+            for related in content.related_storylines
+        )
+    elif isinstance(content, TriggerContent):
+        if content.target_storyline_item_id is not None:
+            references.append(
+                CanonicalReferenceTarget(
+                    reference_id=content.target_storyline_item_id,
+                    target="item",
+                    expected_kinds=(MemoryKind.STORYLINE,),
+                )
+            )
+        if content.origin_event_item_id is not None:
+            references.append(
+                CanonicalReferenceTarget(
+                    reference_id=content.origin_event_item_id,
+                    target="item",
+                    expected_kinds=(MemoryKind.EVENT,),
+                )
+            )
+    return tuple(references)

--- a/backend/services/memory/proposals.py
+++ b/backend/services/memory/proposals.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.facts.objects import FactContent
+from backend.resources.memory.revisions.objects import CanonicalRevision
+from backend.resources.memory.storylines.objects import StorylineContent
+from backend.resources.memory.triggers.objects import TriggerContent
+
+
+MemoryProposalContent = (
+    FactContent
+    | EventContent
+    | StorylineContent
+    | TriggerContent
+    | ContextNoteContent
+)
+
+
+class MemoryMutationMetadata(ContractModel):
+    """Version-envelope values supplied with one complete proposal."""
+
+    agent_key: NonBlankStr | None = None
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    occurred_at: AwareDatetime | None = None
+    creating_tool_call_id: UUID | None = None
+    change_reason: NonBlankStr | None = None
+
+
+class ProposedMemoryRef(ContractModel):
+    """Preallocated canonical identity returned to a proposal caller."""
+
+    proposal_id: UUID
+    kind: MemoryKind
+    item_id: UUID
+    version_id: UUID
+
+
+class MemoryProposal(ContractModel):
+    """One complete create or replacement inside an atomic bundle."""
+
+    proposal_id: UUID
+    operation: Literal["create", "replace"]
+    kind: MemoryKind
+    item_id: UUID
+    version_id: UUID
+    expected_item_revision: int | None = Field(default=None, gt=0, strict=True)
+    content: MemoryProposalContent
+    context_note_identity: ContextNoteIdentity | None = None
+    metadata: MemoryMutationMetadata = MemoryMutationMetadata()
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> MemoryProposal:
+        if self.content.memory_kind is not self.kind:
+            raise ValueError("proposal kind does not match its typed content")
+        if self.operation == "create" and self.expected_item_revision is not None:
+            raise ValueError("create proposal cannot expect an item revision")
+        if self.operation == "replace" and self.expected_item_revision is None:
+            raise ValueError("replacement proposal requires an expected item revision")
+        has_note_identity = self.context_note_identity is not None
+        if has_note_identity != (
+            self.operation == "create" and self.kind is MemoryKind.CONTEXT_NOTE
+        ):
+            raise ValueError(
+                "context-note identity is required exactly for context-note creates"
+            )
+        if self.operation == "replace" and self.metadata.agent_key is not None:
+            raise ValueError("replacement proposal cannot change an agent key")
+        return self
+
+    def proposed_ref(self) -> ProposedMemoryRef:
+        return ProposedMemoryRef(
+            proposal_id=self.proposal_id,
+            kind=self.kind,
+            item_id=self.item_id,
+            version_id=self.version_id,
+        )
+
+
+class MemoryMutationBundle(ContractModel):
+    """The immutable, generation-completed canonical mutation unit."""
+
+    competition_id: UUID
+    generation_id: UUID
+    expected_revision_id: UUID
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    knowledge_cutoff_at: AwareDatetime | None = None
+    proposals: tuple[MemoryProposal, ...]
+
+    @model_validator(mode="after")
+    def validate_distinct_proposals(self) -> MemoryMutationBundle:
+        _require_unique(
+            (proposal.proposal_id for proposal in self.proposals),
+            "proposal IDs",
+        )
+        _require_unique(
+            (proposal.version_id for proposal in self.proposals),
+            "proposed version IDs",
+        )
+        _require_unique(
+            (proposal.item_id for proposal in self.proposals),
+            "proposed item targets",
+        )
+        return self
+
+
+class MemoryMutationOrigin(ContractModel):
+    """Canonical parent and reporting provenance for a public mutation."""
+
+    generation_id: UUID
+    expected_revision_id: UUID
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    knowledge_cutoff_at: AwareDatetime | None = None
+
+
+class MemoryMutationResult(ContractModel):
+    """Committed revision and the canonical identities introduced within it."""
+
+    revision: CanonicalRevision | None
+    changes: tuple[ProposedMemoryRef, ...]
+
+
+def _require_unique(values: Iterable[UUID], label: str) -> None:
+    materialized = tuple(values)
+    if len(materialized) != len(set(materialized)):
+        raise ValueError(f"{label} must be distinct within a mutation bundle")

--- a/backend/tests/services/memory/test_generation_context.py
+++ b/backend/tests/services/memory/test_generation_context.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.resources.memory.common.errors import GenerationMemoryContextClosedError
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.facts.objects import FactContent
+from backend.services.memory import GenerationMemoryContext
+
+
+class RecordingRetrieval:
+    def __init__(self) -> None:
+        self.calls: list[tuple[UUID, UUID, object]] = []
+
+    def search(
+        self,
+        *,
+        competition_id: UUID,
+        revision_id: UUID,
+        request: object,
+    ) -> object:
+        self.calls.append((competition_id, revision_id, request))
+        return {"canonical": True}
+
+
+def _event() -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "matchup",
+            "headline": "A rivalry game changed the table.",
+            "summary": "The favorite lost a close matchup.",
+            "salience": 4,
+            "confidence": "inferred",
+            "status": "active",
+            "details": {
+                "kind": "matchup",
+                "winner_franchise_id": uuid4(),
+                "loser_franchise_id": uuid4(),
+                "sleeper_matchup_id": "week-7-a",
+            },
+        }
+    )
+
+
+def _fact(event_version_id: UUID) -> FactContent:
+    return FactContent.model_validate(
+        {
+            "claim": "The underdog won the rivalry game.",
+            "category": "result",
+            "numbers": {"wins": 1},
+            "confidence": "inferred",
+            "status": "active",
+            "subjects": [],
+            "originating_event_version_ids": [event_version_id],
+        }
+    )
+
+
+def test_context_keeps_search_pinned_and_finalizes_its_buffer_once() -> None:
+    competition_id = uuid4()
+    generation_id = uuid4()
+    revision_id = uuid4()
+    retrieval = RecordingRetrieval()
+    context = GenerationMemoryContext(
+        competition_id=competition_id,
+        generation_id=generation_id,
+        pinned_revision_id=revision_id,
+        retrieval=retrieval,
+    )
+
+    event_ref = context.propose_event(_event())
+    fact_ref = context.propose_fact(_fact(event_ref.version_id))
+    assert context.search({"text": "rivalry"}) == {"canonical": True}
+    assert retrieval.calls == [
+        (competition_id, revision_id, {"text": "rivalry"})
+    ]
+
+    bundle = context.take_completed_bundle()
+    assert [proposal.proposed_ref() for proposal in bundle.proposals] == [
+        event_ref,
+        fact_ref,
+    ]
+    fact_content = bundle.proposals[1].content
+    assert isinstance(fact_content, FactContent)
+    assert fact_content.originating_event_version_ids == [
+        event_ref.version_id
+    ]
+    with pytest.raises(GenerationMemoryContextClosedError):
+        context.take_completed_bundle()
+    with pytest.raises(GenerationMemoryContextClosedError):
+        context.search({"text": "buffered fact"})

--- a/backend/tests/services/memory/test_mutation_service.py
+++ b/backend/tests/services/memory/test_mutation_service.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from pydantic import TypeAdapter
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason, Franchise
+from backend.database.models.memory import (
+    CurrentRevision,
+    EventVersion,
+    FactVersion,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+    StorylineVersion,
+    TriggerVersion,
+)
+from backend.database.models.memory.context_notes import (
+    ContextNote as ContextNoteRow,
+)
+from backend.database.models.memory.context_notes import ContextNoteVersion
+from backend.database.models.reporting import Generation
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import (
+    DuplicateContextNoteError,
+    StaleCanonicalRevisionError,
+    WrongTargetKindError,
+)
+from backend.resources.memory.context_notes.objects import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.memory.events.objects import EventContent
+from backend.resources.memory.facts.objects import FactContent
+from backend.resources.memory.revisions import RevisionManager
+from backend.resources.memory.storylines.objects import StorylineContent
+from backend.resources.memory.triggers.objects import TriggerContent
+from backend.services.memory import (
+    GenerationMemoryContext,
+    MemoryMutationBundle,
+    MemoryMutationOrigin,
+    MemoryMutationService,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+class EmptyRetrieval:
+    def search(self, **_kwargs: object) -> object:
+        return ()
+
+
+class Domain:
+    def __init__(self) -> None:
+        self.competition_id = uuid4()
+        self.season_id = uuid4()
+        self.winner_id = uuid4()
+        self.loser_id = uuid4()
+        self.generation_id = uuid4()
+        self.root_revision_id = uuid4()
+
+
+def _seed_domain(engine: Engine) -> Domain:
+    domain = Domain()
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {
+                "id": domain.competition_id,
+                "display_name": "Mutation Bundle League",
+            },
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": domain.season_id,
+                "competition_id": domain.competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{domain.competition_id}",
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": domain.winner_id,
+                    "competition_id": domain.competition_id,
+                    "display_name": "Owls",
+                },
+                {
+                    "id": domain.loser_id,
+                    "competition_id": domain.competition_id,
+                    "display_name": "Foxes",
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": domain.generation_id,
+                "competition_id": domain.competition_id,
+                "competition_season_id": domain.season_id,
+                "kind": "test",
+                "status": "pending",
+                "request_text": "commit a memory bundle",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": domain.root_revision_id,
+                "competition_id": domain.competition_id,
+                "sequence_number": 0,
+                "competition_season_id": domain.season_id,
+                "week": 0,
+                "state_content_hash": "seed-root",
+            },
+        )
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": domain.competition_id,
+                "current_revision_id": domain.root_revision_id,
+                "lock_version": 0,
+            },
+        )
+    return domain
+
+
+def _add_generation(engine: Engine, domain: Domain) -> UUID:
+    generation_id = uuid4()
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": domain.competition_id,
+                "competition_season_id": domain.season_id,
+                "kind": "test",
+                "status": "pending",
+                "request_text": "commit another memory bundle",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 0,
+            },
+        )
+    return generation_id
+
+
+def _service(engine: Engine, domain: Domain) -> MemoryMutationService:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {
+                "kind": "generation",
+                "generation_id": domain.generation_id,
+            },
+            "scope": {
+                "kind": "competition",
+                "competition_id": domain.competition_id,
+            },
+            "correlation_id": uuid4(),
+        }
+    )
+    return MemoryMutationService(
+        RevisionManager(create_session_factory(engine), context)
+    )
+
+
+def _generation_context(domain: Domain) -> GenerationMemoryContext:
+    return GenerationMemoryContext(
+        competition_id=domain.competition_id,
+        generation_id=domain.generation_id,
+        pinned_revision_id=domain.root_revision_id,
+        retrieval=EmptyRetrieval(),
+        competition_season_id=domain.season_id,
+        week=7,
+        knowledge_cutoff_at=datetime(2026, 10, 20, tzinfo=UTC),
+    )
+
+
+def _event(domain: Domain) -> EventContent:
+    return EventContent.model_validate(
+        {
+            "event_type": "matchup",
+            "headline": "The Owls upset the Foxes.",
+            "summary": "A one-point finish reset the playoff race.",
+            "salience": 5,
+            "confidence": "inferred",
+            "status": "active",
+            "details": {
+                "kind": "matchup",
+                "winner_franchise_id": domain.winner_id,
+                "loser_franchise_id": domain.loser_id,
+                "sleeper_matchup_id": "week-7-main",
+            },
+        }
+    )
+
+
+def _fact(domain: Domain, event_version_id: UUID, *, archived: bool = False) -> FactContent:
+    return FactContent.model_validate(
+        {
+            "claim": (
+                "The Owls' upset is now archived."
+                if archived
+                else "The Owls defeated the Foxes by one point."
+            ),
+            "category": "result",
+            "numbers": {"margin": 1},
+            "confidence": "inferred",
+            "status": "archived" if archived else "active",
+            "subjects": [
+                {
+                    "kind": "franchise",
+                    "id": domain.winner_id,
+                    "role": "subject",
+                    "display_name": "Owls",
+                }
+            ],
+            "originating_event_version_ids": [event_version_id],
+        }
+    )
+
+
+def _storyline(
+    domain: Domain,
+    event_version_id: UUID,
+    fact_version_id: UUID,
+) -> StorylineContent:
+    return StorylineContent.model_validate(
+        {
+            "headline": "The Owls opened a playoff path",
+            "summary": "The upset turned a long shot into a live race.",
+            "status": "active",
+            "arc_type": "playoff_race",
+            "salience": 5,
+            "tags": ["playoffs"],
+            "subjects": [
+                {
+                    "kind": "franchise",
+                    "id": domain.winner_id,
+                    "role": "focus",
+                    "display_name": "Owls",
+                }
+            ],
+            "evidence": [
+                {"kind": "event", "version_id": event_version_id, "role": "origin"},
+                {"kind": "fact", "version_id": fact_version_id, "role": "support"},
+            ],
+            "related_storylines": [],
+            "callback_condition": "Revisit after week 8.",
+        }
+    )
+
+
+def _trigger(
+    event_item_id: UUID,
+    storyline_item_id: UUID,
+) -> TriggerContent:
+    return TriggerContent.model_validate(
+        {
+            "trigger_type": "trade_evaluation",
+            "status": "open",
+            "fire_policy": "until_resolved",
+            "target_storyline_item_id": storyline_item_id,
+            "origin_event_item_id": event_item_id,
+            "target_week": 8,
+            "condition": {"kind": "trade_evaluation"},
+        }
+    )
+
+
+def _note() -> ContextNoteContent:
+    return ContextNoteContent.model_validate(
+        {
+            "narrative": "The league has entered a volatile playoff race.",
+            "outlook": "Treat every week as an elimination game.",
+            "status": "active",
+            "tags": ["playoffs"],
+        }
+    )
+
+
+def _note_identity(domain: Domain) -> ContextNoteIdentity:
+    return TypeAdapter(ContextNoteIdentity).validate_python(
+        {
+            "scope": "competition_season",
+            "competition_season_id": domain.season_id,
+            "note_key": "playoff_race",
+        }
+    )
+
+
+def _complete_bundle(domain: Domain) -> tuple[MemoryMutationBundle, dict[str, UUID]]:
+    context = _generation_context(domain)
+    event_ref = context.propose_event(_event(domain))
+    fact_ref = context.propose_fact(_fact(domain, event_ref.version_id))
+    storyline_ref = context.propose_storyline(
+        _storyline(domain, event_ref.version_id, fact_ref.version_id)
+    )
+    trigger_ref = context.propose_trigger(
+        _trigger(event_ref.item_id, storyline_ref.item_id)
+    )
+    note_ref = context.propose_context_note(_note_identity(domain), _note())
+    return context.take_completed_bundle(), {
+        "event_item": event_ref.item_id,
+        "event_version": event_ref.version_id,
+        "fact_item": fact_ref.item_id,
+        "fact_version": fact_ref.version_id,
+        "storyline_item": storyline_ref.item_id,
+        "storyline_version": storyline_ref.version_id,
+        "trigger_version": trigger_ref.version_id,
+        "note_version": note_ref.version_id,
+    }
+
+
+def test_multi_resource_bundle_commits_one_revision_with_local_references(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    bundle, ids = _complete_bundle(domain)
+    result = _service(database_engine, domain).apply(bundle)
+
+    assert result.revision is not None
+    assert result.revision.sequence_number == 1
+    assert result.revision.previous_revision_id == domain.root_revision_id
+    assert result.revision.state_content_hash.startswith("sha256-cbor-v1:")
+    with create_session_factory(database_engine)() as session:
+        current = session.get(CurrentRevision, domain.competition_id)
+        assert current is not None
+        assert current.current_revision_id == result.revision.revision_id
+        assert current.lock_version == 1
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.competition_id == domain.competition_id
+            )
+        ) == 2
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryItem).where(
+                MemoryItem.competition_id == domain.competition_id
+            )
+        ) == 5
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryVersion).where(
+                MemoryVersion.competition_id == domain.competition_id
+            )
+        ) == 5
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemorySearchDocument).where(
+                MemorySearchDocument.competition_id == domain.competition_id
+            )
+        ) == 5
+        assert session.get(EventVersion, ids["event_version"]) is not None
+        fact = session.get(FactVersion, ids["fact_version"])
+        assert fact is not None
+        assert fact.originating_event_version_ids == [ids["event_version"]]
+        storyline = session.get(StorylineVersion, ids["storyline_version"])
+        assert storyline is not None
+        assert {entry["version_id"] for entry in storyline.evidence} == {
+            str(ids["event_version"]),
+            str(ids["fact_version"]),
+        }
+        assert session.get(TriggerVersion, ids["trigger_version"]) is not None
+        assert session.get(ContextNoteVersion, ids["note_version"]) is not None
+
+
+def test_public_complete_replacement_retires_prior_version(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    bundle, ids = _complete_bundle(domain)
+    created = _service(database_engine, domain).apply(bundle)
+    assert created.revision is not None
+    replacement_generation_id = _add_generation(database_engine, domain)
+    origin = MemoryMutationOrigin(
+        generation_id=replacement_generation_id,
+        expected_revision_id=created.revision.revision_id,
+        competition_season_id=domain.season_id,
+        week=8,
+    )
+    replaced = _service(database_engine, domain).replace_fact(
+        origin,
+        ids["fact_item"],
+        1,
+        _fact(domain, ids["event_version"], archived=True),
+    )
+    assert replaced.revision is not None
+    assert replaced.revision.sequence_number == 2
+    with create_session_factory(database_engine)() as session:
+        versions = session.scalars(
+            sa.select(MemoryVersion)
+            .where(MemoryVersion.item_id == ids["fact_item"])
+            .order_by(MemoryVersion.revision_number)
+        ).all()
+        assert [version.revision_number for version in versions] == [1, 2]
+        assert versions[0].retired_revision_id == replaced.revision.revision_id
+        assert versions[1].retired_revision_id is None
+
+
+def test_stale_bundle_and_late_typed_failure_leave_no_partial_state(
+    database_engine: Engine,
+) -> None:
+    domain = _seed_domain(database_engine)
+    first_bundle, _ = _complete_bundle(domain)
+    service = _service(database_engine, domain)
+    committed = service.apply(first_bundle)
+    assert committed.revision is not None
+
+    stale_generation_id = _add_generation(database_engine, domain)
+    stale_context = GenerationMemoryContext(
+        competition_id=domain.competition_id,
+        generation_id=stale_generation_id,
+        pinned_revision_id=domain.root_revision_id,
+        retrieval=EmptyRetrieval(),
+        competition_season_id=domain.season_id,
+        week=8,
+    )
+    stale_context.propose_context_note(
+        TypeAdapter(ContextNoteIdentity).validate_python(
+            {"scope": "competition", "note_key": "stale"}
+        ),
+        _note(),
+    )
+    with pytest.raises(StaleCanonicalRevisionError):
+        service.apply(stale_context.take_completed_bundle())
+
+    failure_generation_id = _add_generation(database_engine, domain)
+    current_context = GenerationMemoryContext(
+        competition_id=domain.competition_id,
+        generation_id=failure_generation_id,
+        pinned_revision_id=committed.revision.revision_id,
+        retrieval=EmptyRetrieval(),
+        competition_season_id=domain.season_id,
+        week=8,
+    )
+    duplicate_identity = TypeAdapter(ContextNoteIdentity).validate_python(
+        {"scope": "competition", "note_key": "duplicate"}
+    )
+    first_ref = current_context.propose_context_note(duplicate_identity, _note())
+    second_ref = current_context.propose_context_note(duplicate_identity, _note())
+    with pytest.raises(DuplicateContextNoteError):
+        service.apply(current_context.take_completed_bundle())
+
+    with create_session_factory(database_engine)() as session:
+        current = session.get(CurrentRevision, domain.competition_id)
+        assert current is not None
+        assert current.current_revision_id == committed.revision.revision_id
+        assert current.lock_version == 1
+        assert session.get(ContextNoteRow, first_ref.item_id) is None
+        assert session.get(ContextNoteRow, second_ref.item_id) is None
+        assert session.get(MemoryVersion, first_ref.version_id) is None
+        assert session.get(MemoryVersion, second_ref.version_id) is None
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.competition_id == domain.competition_id
+            )
+        ) == 2
+
+
+def test_empty_completed_bundle_creates_no_revision(database_engine: Engine) -> None:
+    domain = _seed_domain(database_engine)
+    result = _service(database_engine, domain).apply(
+        _generation_context(domain).take_completed_bundle()
+    )
+    assert result.revision is None
+    assert result.changes == ()
+    with create_session_factory(database_engine)() as session:
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.competition_id == domain.competition_id
+            )
+        ) == 1
+
+
+def test_same_bundle_reference_keeps_its_required_kind(database_engine: Engine) -> None:
+    domain = _seed_domain(database_engine)
+    context = _generation_context(domain)
+    note_ref = context.propose_context_note(_note_identity(domain), _note())
+    context.propose_fact(_fact(domain, note_ref.version_id))
+
+    with pytest.raises(WrongTargetKindError):
+        _service(database_engine, domain).apply(context.take_completed_bundle())
+
+    with create_session_factory(database_engine)() as session:
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.competition_id == domain.competition_id
+            )
+        ) == 1
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(MemoryItem).where(
+                MemoryItem.competition_id == domain.competition_id
+            )
+        ) == 0

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,9 +2,9 @@
 
 ## Current Phase
 
-**Active layer:** `memory-8` complete; `memory-9` is next
-**Current branch:** `codex/memory-8-context-notes`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8`
+**Active layer:** `memory-9` complete; `memory-10` is next
+**Current branch:** `codex/memory-9-mutation-bundles`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9`
 **Publication:** Stack #116 is published through `memory-8` (PR #115).
 
 This file is the coordination ledger for the typed-memory application stack.
@@ -24,7 +24,7 @@ The completed database stack remains tracked separately in
 | `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | `e4c7831`; PR #114 |
 | `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | `5788729`; PR #113 |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Complete | `root` | 9 focused context-note tests; memory: 73 passed; backend: 145 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR #115 |
-| `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Pending | Unassigned | Not started | — |
+| `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR pending |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |
@@ -42,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-9` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/services/memory/`, canonical revision write orchestration, resource-local state readers/persisters, mutation-service tests, `docs/memory/status.md` | Generation-scoped typed proposal buffer, public mutation service, batch reference validation, same-bundle identity resolution, atomic multi-resource persistence, resulting-state hashing, stale-writer and rollback coverage |
 
 ## `memory-8` Assignments
 
@@ -248,6 +254,38 @@ design and correctness pass.
   Public mutation orchestration, uniqueness conflict translation, retrieval,
   and reporter integration remain deferred to later layers.
 
+## `memory-9` Boundary Notes
+
+- `GenerationMemoryContext` owns an in-memory, generation-scoped proposal
+  buffer. It preallocates canonical item and version UUIDs, returns those typed
+  proposal references to callers, keeps every search pinned to the immutable
+  input revision, and yields its completed bundle exactly once.
+- `MemoryMutationService` exposes complete create and replacement operations for
+  every implemented kind and accepts a completed multi-resource bundle. It
+  translates proposals into opaque resource-local persisters without importing
+  SQLAlchemy sessions or ORM models.
+- Proposal-local item and version UUIDs retain the existing canonical content
+  contracts. The bundle validates their declared kinds before persistence, and
+  typed resource validation runs again after generic envelopes are present.
+  Event, fact, storyline, trigger, and context-note writes use a dependency-safe
+  order so exact same-bundle evidence is fully typed before its consumer.
+- `RevisionManager` owns one short transaction: it locks and verifies the
+  canonical parent, batch-loads stable and exact reference targets, resolves
+  replacement envelopes, retires prior versions, inserts every item/version,
+  invokes typed persisters and projection builders, and advances the current
+  pointer only after all validation succeeds.
+- The resulting hash is computed from the pinned visible state plus the accepted
+  writes before the immutable revision row is inserted. After typed rows and
+  projections are flushed, all five resource readers independently reconstruct
+  the visible state and must produce the same hash before pointer advancement.
+- Empty bundles create no revision. Stale parents, wrong-kind local references,
+  stale item revisions, duplicate context-note identities, typed validation
+  failures, projection failures, and hash mismatches all leave revision history,
+  typed content, search documents, retirements, and the current pointer
+  unchanged.
+- Search query/rebuild APIs, hydrated retrieval, HTTP routes, and reporter
+  lifecycle integration remain deferred to `memory-10` through `memory-14`.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -276,10 +314,10 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-8` run
-  passed all 73 memory tests and all 145 backend tests; the test container and
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-9` run
+  passed all 79 memory tests and all 151 backend tests; the test container and
   its tmpfs data were removed afterward.
 - `uvx basedpyright backend` reports the same 16 diagnostics already present at
   the `memory-5` parent, including the existing Pydantic `schema_version`
-  narrowing pattern. No new error originates in the `memory-8`
+  narrowing pattern. No new error originates in the `memory-9`
   implementation or tests.

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -5,7 +5,7 @@
 **Active layer:** `memory-9` complete; `memory-10` is next
 **Current branch:** `codex/memory-9-mutation-bundles`
 **Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9`
-**Publication:** Stack #116 is published through `memory-8` (PR #115).
+**Publication:** `memory-9` is published as PR #117 atop `memory-8` (PR #115).
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -24,7 +24,7 @@ The completed database stack remains tracked separately in
 | `memory-6` storylines | `codex/memory-6-storylines` | Complete | `root` | 7 focused storyline tests; memory: 56 passed; backend: 128 passed; basedpyright found no new errors and 16 pre-existing backend errors | `e4c7831`; PR #114 |
 | `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | `5788729`; PR #113 |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Complete | `root` | 9 focused context-note tests; memory: 73 passed; backend: 145 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR #115 |
-| `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR pending |
+| `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `0260366`; PR #117 |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |


### PR DESCRIPTION
## Summary

- add a generation-scoped, one-shot typed proposal buffer with pinned retrieval
- expose complete create and replacement mutations for all five canonical memory kinds
- commit multi-resource bundles through one locked revision transaction with batch reference validation and same-bundle references
- persist typed versions and search documents atomically, verify the resulting-state hash, and advance the canonical pointer only after success
- cover empty bundles, stale writers, wrong-kind local references, complete replacement, and late-write rollback

## Verification

- `pytest backend -q` — 151 passed
- memory-focused suite — 79 passed
- `uvx basedpyright backend` — no new errors; 16 pre-existing diagnostics remain

## Stack

Depends on MEMORY-8 / PR #115.
