### PR TITLE
feat(memory): add search projection queries and rebuild

### DIFF
--- a/backend/resources/memory/search_documents/__init__.py
+++ b/backend/resources/memory/search_documents/__init__.py
@@ -20,13 +20,27 @@ from backend.resources.memory.search_documents.builders.trigger import (
     TRIGGER_DOCUMENT_BUILDER_VERSION,
     build_trigger_document,
 )
-from backend.resources.memory.search_documents.objects import SearchDocumentProjection
+from backend.resources.memory.search_documents.manager import SearchDocumentManager
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentCandidate,
+    SearchDocumentProjection,
+    SearchDocumentQuery,
+    SearchMatchReason,
+    SearchProjectionRebuildResult,
+    SearchScoreComponents,
+)
 
 __all__ = [
     "CONTEXT_NOTE_DOCUMENT_BUILDER_VERSION",
     "EVENT_DOCUMENT_BUILDER_VERSION",
     "FACT_DOCUMENT_BUILDER_VERSION",
+    "SearchDocumentCandidate",
+    "SearchDocumentManager",
     "SearchDocumentProjection",
+    "SearchDocumentQuery",
+    "SearchMatchReason",
+    "SearchProjectionRebuildResult",
+    "SearchScoreComponents",
     "STORYLINE_DOCUMENT_BUILDER_VERSION",
     "TRIGGER_DOCUMENT_BUILDER_VERSION",
     "build_context_note_document",

--- a/backend/resources/memory/search_documents/manager.py
+++ b/backend/resources/memory/search_documents/manager.py
@@ -1,0 +1,275 @@
+"""Competition-scoped search-document queries and deterministic rebuilds."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import (
+    CurrentRevision,
+    MemoryItem,
+    MemoryRevision,
+    MemorySearchDocument,
+    MemoryVersion,
+)
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common.errors import RevisionNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.context_notes.codec import (
+    context_note_rows_statement,
+    decode_context_note,
+)
+from backend.resources.memory.events.codec import decode_event, event_rows_statement
+from backend.resources.memory.facts.codec import decode_fact, fact_rows_statement
+from backend.resources.memory.search_documents.builders import (
+    build_context_note_document,
+    build_event_document,
+    build_fact_document,
+    build_storyline_document,
+    build_trigger_document,
+)
+from backend.resources.memory.search_documents.objects import (
+    SearchDocumentCandidate,
+    SearchDocumentProjection,
+    SearchDocumentQuery,
+    SearchMatchReason,
+    SearchProjectionRebuildResult,
+    SearchScoreComponents,
+)
+from backend.resources.memory.search_documents.query import query_search_documents
+from backend.resources.memory.search_documents.shared import insert_search_document
+from backend.resources.memory.storylines.codec import (
+    decode_storyline,
+    storyline_rows_statement,
+)
+from backend.resources.memory.triggers.codec import (
+    decode_trigger,
+    trigger_rows_statement,
+)
+
+
+class SearchDocumentManager:
+    """Candidate discovery and projection maintenance for one competition."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory: SessionFactory = session_factory
+        self._competition_id: UUID = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def search(
+        self,
+        revision_id: UUID,
+        query: SearchDocumentQuery,
+    ) -> tuple[SearchDocumentCandidate, ...]:
+        """Return compact candidates visible at one exact canonical revision."""
+
+        with read_only_session(self._session_factory) as session:
+            self._require_revision(session, revision_id)
+            rows = query_search_documents(
+                session,
+                self._competition_id,
+                revision_id,
+                query,
+            )
+        candidates = tuple(self._candidate(row, rank, query) for row, rank in rows)
+        ordered = sorted(
+            candidates,
+            key=lambda candidate: (
+                -candidate.score,
+                candidate.kind.value,
+                str(candidate.version_id),
+            ),
+        )
+        return tuple(ordered[: query.limit])
+
+    def rebuild(self) -> SearchProjectionRebuildResult:
+        """Atomically replace every historical projection in the competition."""
+
+        with transaction_session(self._session_factory) as session:
+            current = session.scalar(
+                sa.select(CurrentRevision)
+                .where(CurrentRevision.competition_id == self._competition_id)
+                .with_for_update()
+            )
+            if current is None:
+                raise RevisionNotFoundError(self._competition_id)
+
+            projections = self._build_all_projections(session)
+            session.execute(
+                sa.delete(MemorySearchDocument).where(
+                    MemorySearchDocument.competition_id == self._competition_id
+                )
+            )
+            for version, projection in projections:
+                insert_search_document(session, version, projection)
+            session.flush()
+
+            result = SearchProjectionRebuildResult(
+                competition_id=self._competition_id,
+                canonical_revision_id=current.current_revision_id,
+                documents_rebuilt=len(projections),
+            )
+        return result
+
+    def _require_revision(self, session: Session, revision_id: UUID) -> None:
+        exists = session.scalar(
+            sa.select(MemoryRevision.id).where(
+                MemoryRevision.id == revision_id,
+                MemoryRevision.competition_id == self._competition_id,
+            )
+        )
+        if exists is None:
+            raise RevisionNotFoundError(self._competition_id, revision_id)
+
+    def _candidate(
+        self,
+        row: MemorySearchDocument,
+        lexical_rank: float,
+        query: SearchDocumentQuery,
+    ) -> SearchDocumentCandidate:
+        matched_entities = _text_overlap(row.entity_keys, query.entity_keys)
+        matched_evidence = _uuid_overlap(
+            row.evidence_version_ids,
+            query.evidence_version_ids,
+        )
+        matched_related = _uuid_overlap(
+            row.related_item_ids,
+            query.related_item_ids,
+        )
+        matched_tags = _text_overlap(row.tags, query.tags)
+        components = SearchScoreComponents(
+            entity_overlap=float(len(matched_entities)),
+            evidence_overlap=float(len(matched_evidence)),
+            related_item_overlap=float(len(matched_related)),
+            tag_overlap=float(len(matched_tags)),
+            lexical_rank=lexical_rank,
+            salience=float(row.salience or 0) * 0.1,
+        )
+        reasons: list[SearchMatchReason] = []
+        if matched_entities:
+            reasons.append(SearchMatchReason.ENTITY_OVERLAP)
+        if matched_evidence:
+            reasons.append(SearchMatchReason.EVIDENCE_OVERLAP)
+        if matched_related:
+            reasons.append(SearchMatchReason.RELATED_ITEM_OVERLAP)
+        if matched_tags:
+            reasons.append(SearchMatchReason.TAG_OVERLAP)
+        if lexical_rank > 0:
+            reasons.append(SearchMatchReason.LEXICAL_MATCH)
+        if not query.has_discovery_signals:
+            reasons.append(SearchMatchReason.BROWSE_MATCH)
+        return SearchDocumentCandidate(
+            version_id=row.version_id,
+            item_id=row.item_id,
+            kind=MemoryKind(row.kind),
+            status=row.status,
+            salience=row.salience,
+            competition_season_id=row.competition_season_id,
+            week=row.week,
+            score=components.total,
+            score_components=components,
+            matched_entity_keys=matched_entities,
+            matched_evidence_version_ids=matched_evidence,
+            matched_related_item_ids=matched_related,
+            matched_tags=matched_tags,
+            match_reasons=tuple(reasons),
+        )
+
+    def _build_all_projections(
+        self,
+        session: Session,
+    ) -> tuple[tuple[MemoryVersion, SearchDocumentProjection], ...]:
+        projections: list[tuple[MemoryVersion, SearchDocumentProjection]] = []
+
+        for item, version, stored in session.execute(
+            fact_rows_statement().where(
+                MemoryItem.competition_id == self._competition_id
+            )
+        ):
+            fact = decode_fact(item, version, stored)
+            projections.append((version, build_fact_document(fact.content)))
+        for item, version, stored in session.execute(
+            event_rows_statement().where(
+                MemoryItem.competition_id == self._competition_id
+            )
+        ):
+            event = decode_event(item, version, stored)
+            projections.append((version, build_event_document(event.content)))
+        for item, version, stored in session.execute(
+            storyline_rows_statement().where(
+                MemoryItem.competition_id == self._competition_id
+            )
+        ):
+            storyline = decode_storyline(item, version, stored)
+            projections.append(
+                (version, build_storyline_document(storyline.content))
+            )
+        for item, version, stored in session.execute(
+            trigger_rows_statement().where(
+                MemoryItem.competition_id == self._competition_id
+            )
+        ):
+            trigger = decode_trigger(item, version, stored)
+            projections.append((version, build_trigger_document(trigger.content)))
+        for item, version, identity, stored in session.execute(
+            context_note_rows_statement().where(
+                MemoryItem.competition_id == self._competition_id
+            )
+        ):
+            note = decode_context_note(item, version, identity, stored)
+            projections.append(
+                (
+                    version,
+                    build_context_note_document(note.note_identity, note.content),
+                )
+            )
+
+        canonical_version_ids = set(
+            session.scalars(
+                sa.select(MemoryVersion.id).where(
+                    MemoryVersion.competition_id == self._competition_id
+                )
+            )
+        )
+        projected_version_ids = {version.id for version, _ in projections}
+        if canonical_version_ids != projected_version_ids:
+            missing = sorted(canonical_version_ids - projected_version_ids, key=str)
+            raise ValueError(
+                "cannot rebuild search projection; canonical typed rows are missing "
+                f"for versions: {', '.join(map(str, missing))}"
+            )
+        return tuple(
+            sorted(
+                projections,
+                key=lambda entry: (entry[1].kind.value, str(entry[0].id)),
+            )
+        )
+
+
+def _text_overlap(
+    stored: Iterable[str],
+    requested: Iterable[str],
+) -> tuple[str, ...]:
+    return tuple(sorted(set(stored).intersection(requested)))
+
+
+def _uuid_overlap(
+    stored: Iterable[UUID],
+    requested: Iterable[UUID],
+) -> tuple[UUID, ...]:
+    return tuple(sorted(set(stored).intersection(requested), key=str))

--- a/backend/resources/memory/search_documents/objects.py
+++ b/backend/resources/memory/search_documents/objects.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Annotated
 from uuid import UUID
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, field_validator
 
 from backend.resources._contracts import ContractModel, NonBlankStr
 from backend.resources.memory.common.kinds import MemoryKind
@@ -28,3 +29,99 @@ class SearchDocumentProjection(ContractModel):
     document_text: NonBlankStr
     builder_version: int = Field(gt=0, strict=True)
     content_hash: Sha256Hex
+
+
+class SearchMatchReason(StrEnum):
+    ENTITY_OVERLAP = "entity_overlap"
+    EVIDENCE_OVERLAP = "evidence_overlap"
+    RELATED_ITEM_OVERLAP = "related_item_overlap"
+    TAG_OVERLAP = "tag_overlap"
+    LEXICAL_MATCH = "lexical_match"
+    BROWSE_MATCH = "browse_match"
+
+
+class SearchDocumentQuery(ContractModel):
+    """Revision-grounded discovery signals and structured result filters."""
+
+    entity_keys: tuple[NonBlankStr, ...] = ()
+    evidence_version_ids: tuple[UUID, ...] = ()
+    related_item_ids: tuple[UUID, ...] = ()
+    tags: tuple[NonBlankStr, ...] = ()
+    text: NonBlankStr | None = None
+    kinds: tuple[MemoryKind, ...] = ()
+    statuses: tuple[NonBlankStr, ...] = ()
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    limit: int = Field(default=20, ge=1, le=100, strict=True)
+
+    @field_validator(
+        "entity_keys",
+        "evidence_version_ids",
+        "related_item_ids",
+        "kinds",
+        "statuses",
+        mode="after",
+    )
+    @classmethod
+    def _deduplicate_values(cls, values: tuple[object, ...]) -> tuple[object, ...]:
+        return tuple(dict.fromkeys(values))
+
+    @field_validator("tags", mode="after")
+    @classmethod
+    def _normalize_tags(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(dict.fromkeys(value.casefold() for value in values))
+
+    @property
+    def has_discovery_signals(self) -> bool:
+        return bool(
+            self.entity_keys
+            or self.evidence_version_ids
+            or self.related_item_ids
+            or self.tags
+            or self.text
+        )
+
+
+class SearchScoreComponents(ContractModel):
+    entity_overlap: float = Field(default=0.0, ge=0)
+    evidence_overlap: float = Field(default=0.0, ge=0)
+    related_item_overlap: float = Field(default=0.0, ge=0)
+    tag_overlap: float = Field(default=0.0, ge=0)
+    lexical_rank: float = Field(default=0.0, ge=0)
+    salience: float = Field(default=0.0, ge=0)
+
+    @property
+    def total(self) -> float:
+        return (
+            self.entity_overlap
+            + self.evidence_overlap
+            + self.related_item_overlap
+            + self.tag_overlap
+            + self.lexical_rank
+            + self.salience
+        )
+
+
+class SearchDocumentCandidate(ContractModel):
+    """Compact projection match; canonical content is deliberately absent."""
+
+    version_id: UUID
+    item_id: UUID
+    kind: MemoryKind
+    status: NonBlankStr | None = None
+    salience: int | None = Field(default=None, ge=1, le=5, strict=True)
+    competition_season_id: UUID | None = None
+    week: int | None = Field(default=None, ge=0, strict=True)
+    score: float = Field(ge=0)
+    score_components: SearchScoreComponents
+    matched_entity_keys: tuple[NonBlankStr, ...] = ()
+    matched_evidence_version_ids: tuple[UUID, ...] = ()
+    matched_related_item_ids: tuple[UUID, ...] = ()
+    matched_tags: tuple[NonBlankStr, ...] = ()
+    match_reasons: tuple[SearchMatchReason, ...]
+
+
+class SearchProjectionRebuildResult(ContractModel):
+    competition_id: UUID
+    canonical_revision_id: UUID
+    documents_rebuilt: int = Field(ge=0, strict=True)

--- a/backend/resources/memory/search_documents/query.py
+++ b/backend/resources/memory/search_documents/query.py
@@ -1,0 +1,94 @@
+"""PostgreSQL candidate discovery over revision-visible search documents."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, UUID as PGUUID
+from sqlalchemy.orm import Session
+
+from backend.database.models.memory import MemorySearchDocument
+from backend.resources.memory.revisions.shared import visible_versions_statement
+from backend.resources.memory.search_documents.objects import SearchDocumentQuery
+
+
+def query_search_documents(
+    session: Session,
+    competition_id: UUID,
+    revision_id: UUID,
+    query: SearchDocumentQuery,
+) -> tuple[tuple[MemorySearchDocument, float], ...]:
+    """Return visible rows matching any discovery signal and every filter."""
+
+    visible = visible_versions_statement(competition_id, revision_id).subquery(
+        "visible_memory_versions"
+    )
+    lexical_query = (
+        sa.func.websearch_to_tsquery("english", query.text)
+        if query.text is not None
+        else None
+    )
+    lexical_rank = (
+        sa.func.ts_rank_cd(MemorySearchDocument.search_vector, lexical_query)
+        if lexical_query is not None
+        else sa.literal(0.0)
+    ).label("lexical_rank")
+    statement = (
+        sa.select(MemorySearchDocument, lexical_rank)
+        .join(visible, visible.c.id == MemorySearchDocument.version_id)
+        .where(MemorySearchDocument.competition_id == competition_id)
+    )
+
+    if query.kinds:
+        statement = statement.where(
+            MemorySearchDocument.kind.in_(kind.value for kind in query.kinds)
+        )
+    if query.statuses:
+        statement = statement.where(MemorySearchDocument.status.in_(query.statuses))
+    if query.competition_season_id is not None:
+        statement = statement.where(
+            MemorySearchDocument.competition_season_id
+            == query.competition_season_id
+        )
+    if query.week is not None:
+        statement = statement.where(MemorySearchDocument.week == query.week)
+
+    signals: list[sa.ColumnElement[bool]] = []
+    if query.entity_keys:
+        signals.append(
+            MemorySearchDocument.entity_keys.op("&&")(
+                sa.cast(list(query.entity_keys), ARRAY(sa.Text()))
+            )
+        )
+    if query.evidence_version_ids:
+        signals.append(
+            MemorySearchDocument.evidence_version_ids.op("&&")(
+                sa.cast(
+                    list(query.evidence_version_ids),
+                    ARRAY(PGUUID(as_uuid=True)),
+                )
+            )
+        )
+    if query.related_item_ids:
+        signals.append(
+            MemorySearchDocument.related_item_ids.op("&&")(
+                sa.cast(
+                    list(query.related_item_ids),
+                    ARRAY(PGUUID(as_uuid=True)),
+                )
+            )
+        )
+    if query.tags:
+        signals.append(
+            MemorySearchDocument.tags.op("&&")(
+                sa.cast(list(query.tags), ARRAY(sa.Text()))
+            )
+        )
+    if lexical_query is not None:
+        signals.append(MemorySearchDocument.search_vector.op("@@")(lexical_query))
+    if signals:
+        statement = statement.where(sa.or_(*signals))
+
+    rows = session.execute(statement).all()
+    return tuple((row[0], float(row[1])) for row in rows)

--- a/backend/tests/resources/memory/test_search_document_manager.py
+++ b/backend/tests/resources/memory/test_search_document_manager.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.memory import (
+    CurrentRevision,
+    MemoryRevision,
+    MemorySearchDocument,
+)
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.common import RevisionNotFoundError
+from backend.resources.memory.common.kinds import MemoryKind
+from backend.resources.memory.search_documents import (
+    SearchDocumentManager,
+    SearchDocumentQuery,
+    SearchMatchReason,
+)
+from backend.services.memory import MemoryMutationOrigin
+from backend.tests.database.conftest import database_engine, migrated_database
+from backend.tests.services.memory.test_mutation_service import (
+    Domain,
+    _add_generation,
+    _complete_bundle,
+    _fact,
+    _seed_domain,
+    _service,
+)
+
+
+def _manager(engine: Engine, domain: Domain) -> SearchDocumentManager:
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "system_process", "process_name": "projection-test"},
+            "scope": {
+                "kind": "competition",
+                "competition_id": domain.competition_id,
+            },
+            "correlation_id": uuid4(),
+        }
+    )
+    return SearchDocumentManager(create_session_factory(engine), context)
+
+
+def _committed_bundle(
+    engine: Engine,
+) -> tuple[Domain, dict[str, UUID], UUID]:
+    domain = _seed_domain(engine)
+    bundle, ids = _complete_bundle(domain)
+    result = _service(engine, domain).apply(bundle)
+    assert result.revision is not None
+    return domain, ids, result.revision.revision_id
+
+
+def test_search_combines_discovery_signals_filters_and_named_scores(
+    database_engine: Engine,
+) -> None:
+    domain, ids, revision_id = _committed_bundle(database_engine)
+    manager = _manager(database_engine, domain)
+
+    candidates = manager.search(
+        revision_id,
+        SearchDocumentQuery(
+            entity_keys=(f"franchise:{domain.winner_id}",),
+            evidence_version_ids=(ids["fact_version"],),
+            related_item_ids=(ids["event_item"],),
+            tags=("PLAYOFFS",),
+            text="volatile playoff race",
+            statuses=("active", "open"),
+            competition_season_id=domain.season_id,
+            week=7,
+        ),
+    )
+
+    by_kind = {candidate.kind: candidate for candidate in candidates}
+    assert set(by_kind) == set(MemoryKind)
+    assert by_kind[MemoryKind.EVENT].matched_entity_keys == (
+        f"franchise:{domain.winner_id}",
+    )
+    assert by_kind[MemoryKind.STORYLINE].matched_evidence_version_ids == (
+        ids["fact_version"],
+    )
+    assert by_kind[MemoryKind.TRIGGER].matched_related_item_ids == (
+        ids["event_item"],
+    )
+    assert by_kind[MemoryKind.CONTEXT_NOTE].matched_tags == ("playoffs",)
+    assert SearchMatchReason.ENTITY_OVERLAP in by_kind[MemoryKind.EVENT].match_reasons
+    assert (
+        SearchMatchReason.EVIDENCE_OVERLAP
+        in by_kind[MemoryKind.STORYLINE].match_reasons
+    )
+    assert (
+        SearchMatchReason.RELATED_ITEM_OVERLAP
+        in by_kind[MemoryKind.TRIGGER].match_reasons
+    )
+    assert SearchMatchReason.TAG_OVERLAP in by_kind[MemoryKind.CONTEXT_NOTE].match_reasons
+    assert any(
+        SearchMatchReason.LEXICAL_MATCH in candidate.match_reasons
+        for candidate in candidates
+    )
+    assert by_kind[MemoryKind.EVENT].score_components.salience == 0.5
+    assert by_kind[MemoryKind.EVENT].score == pytest.approx(
+        by_kind[MemoryKind.EVENT].score_components.total
+    )
+    assert "document_text" not in by_kind[MemoryKind.EVENT].model_dump()
+
+
+def test_search_supports_filter_only_browsing_limits_and_scope(
+    database_engine: Engine,
+) -> None:
+    domain, _, revision_id = _committed_bundle(database_engine)
+    other = _seed_domain(database_engine)
+    manager = _manager(database_engine, domain)
+
+    candidates = manager.search(
+        revision_id,
+        SearchDocumentQuery(
+            kinds=(MemoryKind.STORYLINE, MemoryKind.EVENT),
+            statuses=("active",),
+            limit=1,
+        ),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].kind is MemoryKind.EVENT
+    assert candidates[0].match_reasons == (SearchMatchReason.BROWSE_MATCH,)
+    with pytest.raises(RevisionNotFoundError):
+        manager.search(uuid4(), SearchDocumentQuery())
+    with pytest.raises(RevisionNotFoundError):
+        manager.search(other.root_revision_id, SearchDocumentQuery())
+
+
+def test_search_visibility_is_pinned_to_the_exact_revision(
+    database_engine: Engine,
+) -> None:
+    domain, ids, first_revision_id = _committed_bundle(database_engine)
+    generation_id = _add_generation(database_engine, domain)
+    replaced = _service(database_engine, domain).replace_fact(
+        MemoryMutationOrigin(
+            generation_id=generation_id,
+            expected_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=8,
+        ),
+        ids["fact_item"],
+        1,
+        _fact(domain, ids["event_version"], archived=True),
+    )
+    assert replaced.revision is not None
+    replacement_version_id = replaced.changes[0].version_id
+    manager = _manager(database_engine, domain)
+    query = SearchDocumentQuery(
+        entity_keys=(f"franchise:{domain.winner_id}",),
+        kinds=(MemoryKind.FACT,),
+    )
+
+    before = manager.search(first_revision_id, query)
+    after = manager.search(replaced.revision.revision_id, query)
+
+    assert [candidate.version_id for candidate in before] == [ids["fact_version"]]
+    assert [candidate.version_id for candidate in after] == [replacement_version_id]
+    assert before[0].status == "active"
+    assert after[0].status == "archived"
+
+
+def test_rebuild_restores_all_historical_documents_without_changing_history(
+    database_engine: Engine,
+) -> None:
+    domain, ids, first_revision_id = _committed_bundle(database_engine)
+    generation_id = _add_generation(database_engine, domain)
+    replaced = _service(database_engine, domain).replace_fact(
+        MemoryMutationOrigin(
+            generation_id=generation_id,
+            expected_revision_id=first_revision_id,
+            competition_season_id=domain.season_id,
+            week=8,
+        ),
+        ids["fact_item"],
+        1,
+        _fact(domain, ids["event_version"], archived=True),
+    )
+    assert replaced.revision is not None
+    manager = _manager(database_engine, domain)
+
+    with database_engine.begin() as connection:
+        revision_snapshot = connection.execute(
+            sa.select(
+                MemoryRevision.id,
+                MemoryRevision.sequence_number,
+                MemoryRevision.state_content_hash,
+            )
+            .where(MemoryRevision.competition_id == domain.competition_id)
+            .order_by(MemoryRevision.sequence_number)
+        ).all()
+        current_snapshot = connection.execute(
+            sa.select(
+                CurrentRevision.current_revision_id,
+                CurrentRevision.lock_version,
+            ).where(CurrentRevision.competition_id == domain.competition_id)
+        ).one()
+        connection.execute(
+            sa.delete(MemorySearchDocument).where(
+                MemorySearchDocument.version_id == ids["event_version"]
+            )
+        )
+        connection.execute(
+            sa.update(MemorySearchDocument)
+            .where(MemorySearchDocument.version_id == ids["storyline_version"])
+            .values(document_text="corrupt projection", builder_version=99)
+        )
+
+    result = manager.rebuild()
+
+    assert result.canonical_revision_id == replaced.revision.revision_id
+    assert result.documents_rebuilt == 6
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemorySearchDocument)
+            .where(MemorySearchDocument.competition_id == domain.competition_id)
+        ) == 6
+        restored = connection.execute(
+            sa.select(
+                MemorySearchDocument.document_text,
+                MemorySearchDocument.builder_version,
+            ).where(
+                MemorySearchDocument.version_id == ids["storyline_version"]
+            )
+        ).one()
+        assert restored.builder_version == 1
+        assert "Owls opened a playoff path" in restored.document_text
+        assert connection.execute(
+            sa.select(
+                MemoryRevision.id,
+                MemoryRevision.sequence_number,
+                MemoryRevision.state_content_hash,
+            )
+            .where(MemoryRevision.competition_id == domain.competition_id)
+            .order_by(MemoryRevision.sequence_number)
+        ).all() == revision_snapshot
+        assert connection.execute(
+            sa.select(
+                CurrentRevision.current_revision_id,
+                CurrentRevision.lock_version,
+            ).where(CurrentRevision.competition_id == domain.competition_id)
+        ).one() == current_snapshot
+
+    historical = manager.search(
+        first_revision_id,
+        SearchDocumentQuery(
+            entity_keys=(f"franchise:{domain.winner_id}",),
+            kinds=(MemoryKind.FACT,),
+        ),
+    )
+    assert [candidate.version_id for candidate in historical] == [ids["fact_version"]]
+
+
+def test_failed_rebuild_preserves_the_previous_projection(
+    database_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    domain, _, _ = _committed_bundle(database_engine)
+    manager = _manager(database_engine, domain)
+    with database_engine.connect() as connection:
+        before = connection.execute(
+            sa.select(
+                MemorySearchDocument.version_id,
+                MemorySearchDocument.content_hash,
+            )
+            .where(MemorySearchDocument.competition_id == domain.competition_id)
+            .order_by(MemorySearchDocument.version_id)
+        ).all()
+
+    def fail_decode(*_args: object) -> object:
+        raise ValueError("unsupported fact content schema version 99")
+
+    monkeypatch.setattr(
+        "backend.resources.memory.search_documents.manager.decode_fact",
+        fail_decode,
+    )
+
+    with pytest.raises(ValueError, match="unsupported fact content schema version"):
+        manager.rebuild()
+
+    with database_engine.connect() as connection:
+        after = connection.execute(
+            sa.select(
+                MemorySearchDocument.version_id,
+                MemorySearchDocument.content_hash,
+            )
+            .where(MemorySearchDocument.competition_id == domain.competition_id)
+            .order_by(MemorySearchDocument.version_id)
+        ).all()
+    assert after == before

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -2,8 +2,9 @@
 
 **Decision status:** Accepted
 
-**Implementation status:** Database schema implemented in the current PR stack;
-application contracts and retrieval services remain follow-up work
+**Implementation status:** Canonical resources, atomic mutations, search-document
+builders, candidate queries, and deterministic rebuilds are implemented in the
+current PR stack; typed retrieval and integration remain follow-up work
 
 **Scope:** Canonical memory storage, application contracts, retrieval, and the
 generation lifecycle
@@ -12,9 +13,10 @@ generation lifecycle
 
 This directory records the detailed design behind the memory schema summarized
 in [`docs/database/memory.md`](../database/memory.md). The database migration and
-ORM models implement the canonical typed fields and search-document table. The
-Pydantic contracts, mutation manager, search builders, and reporter tools are
-specified here for the application stack that follows.
+ORM models implement the canonical typed fields and search-document table.
+Pydantic contracts, resource managers, atomic mutations, search builders,
+revision-grounded candidate queries, and projection rebuilds are implemented.
+Typed hydration and reporter integration follow in later stack layers.
 
 The redesign keeps the valuable parts of that baseline:
 

--- a/docs/memory/retrieval.md
+++ b/docs/memory/retrieval.md
@@ -1,6 +1,7 @@
 # Memory Retrieval Projection
 
-**Status:** Search-document schema implemented; builders and retrieval service pending
+**Status:** Search-document schema, builders, candidate queries, and rebuild implemented;
+typed hydration remains pending
 
 ## Purpose
 

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -5,7 +5,7 @@
 **Active layer:** `memory-10` complete; `memory-11` is next
 **Current branch:** `codex/memory-10-search-projection`
 **Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9` <- `memory-10`
-**Publication:** `memory-9` is published as PR #117 atop `memory-8` (PR #115).
+**Publication:** `memory-10` is published as PR #118 atop `memory-9` (PR #117).
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -25,7 +25,7 @@ The completed database stack remains tracked separately in
 | `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | `5788729`; PR #113 |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Complete | `root` | 9 focused context-note tests; memory: 73 passed; backend: 145 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR #115 |
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `0260366`; PR #117 |
-| `memory-10` search projection | `codex/memory-10-search-projection` | Complete | `root` | 5 focused PostgreSQL tests; memory: 84 passed; backend: 156 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR pending |
+| `memory-10` search projection | `codex/memory-10-search-projection` | Complete | `root` | 5 focused PostgreSQL tests; memory: 84 passed; backend: 156 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `915ddf4`; PR #118 |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |
 | `memory-13` reporter retrieval | `codex/memory-13-reporter-retrieval` | Pending | Unassigned | Not started | — |

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,9 +2,9 @@
 
 ## Current Phase
 
-**Active layer:** `memory-9` complete; `memory-10` is next
-**Current branch:** `codex/memory-9-mutation-bundles`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9`
+**Active layer:** `memory-10` complete; `memory-11` is next
+**Current branch:** `codex/memory-10-search-projection`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9` <- `memory-10`
 **Publication:** `memory-9` is published as PR #117 atop `memory-8` (PR #115).
 
 This file is the coordination ledger for the typed-memory application stack.
@@ -25,7 +25,7 @@ The completed database stack remains tracked separately in
 | `memory-7` triggers | `codex/memory-7-triggers` | Complete | `root` | 8 focused trigger tests; memory: 64 passed; backend: 136 passed; basedpyright found no new errors and 16 pre-existing backend errors | `5788729`; PR #113 |
 | `memory-8` context notes | `codex/memory-8-context-notes` | Complete | `root` | 9 focused context-note tests; memory: 73 passed; backend: 145 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR #115 |
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `0260366`; PR #117 |
-| `memory-10` search projection | `codex/memory-10-search-projection` | Pending | Unassigned | Not started | — |
+| `memory-10` search projection | `codex/memory-10-search-projection` | Complete | `root` | 5 focused PostgreSQL tests; memory: 84 passed; backend: 156 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | Active branch head; PR pending |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |
 | `memory-13` reporter retrieval | `codex/memory-13-reporter-retrieval` | Pending | Unassigned | Not started | — |
@@ -42,6 +42,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-10` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/resources/memory/search_documents/`, search-document manager tests, `docs/memory/` | Revision-grounded candidate discovery, deterministic additive scoring, atomic competition-scoped rebuilds, public projection contracts, verification, and coordination ownership |
 
 ## `memory-9` Assignments
 
@@ -113,9 +119,10 @@ design and correctness pass.
    season/week, timestamps, and database search-vector concerns remain inside
    the package-internal persistence adapter. Public query and rebuild APIs stay
    deferred to `memory-10`.
-4. **Projection rebuild ownership.** The transition design leaves command/API
-   ownership open. Resolve before `memory-10` without moving canonical mutation
-   ownership into the projection manager.
+4. **Projection rebuild ownership (resolved for `memory-10`).**
+   `SearchDocumentManager.rebuild()` is the competition-scoped application
+   capability. HTTP/CLI exposure remains deferred, and canonical mutation
+   ownership remains exclusively with `RevisionManager`.
 5. **Integration-tail stack split.** Layers `memory-12` through `memory-14` may
    become a second stack based on `memory-11`, but only with explicit approval.
 6. **Public mutation ownership (resolved for `memory-4`).** Public complete
@@ -286,6 +293,26 @@ design and correctness pass.
 - Search query/rebuild APIs, hydrated retrieval, HTTP routes, and reporter
   lifecycle integration remain deferred to `memory-10` through `memory-14`.
 
+## `memory-10` Boundary Notes
+
+- `SearchDocumentManager.search()` requires an exact competition-scoped
+  canonical revision and returns compact version candidates only. Canonical
+  content and flattened document text never cross the manager boundary.
+- Entity, evidence-version, related-item, tag, and PostgreSQL full-text signals
+  combine with OR semantics. Kind, status, competition-season, and week filters
+  combine with AND semantics; filter-only browsing remains supported.
+- Ranking is a deterministic additive explanation: exact-overlap counts,
+  PostgreSQL `ts_rank_cd`, and a `0.1 * salience` component are returned by
+  name with stable match reasons and UUID tie-breaking.
+- Rebuild locks the same competition current-pointer row used by canonical
+  mutation, decodes every historical typed version through its retained-schema
+  codec, and replaces all derived rows in one transaction. A failure preserves
+  the prior projection, while a success leaves canonical revisions, hashes,
+  typed content, and the pointer unchanged.
+- Rebuild is exposed only as a manager operation in this layer. Typed hydration,
+  HTTP/CLI exposure, reporter integration, trigger scheduling evaluation, and
+  embeddings remain deferred.
+
 ## `memory-3` Boundary Notes
 
 - The public revision boundary is deliberately read-only. The write skeleton is
@@ -314,10 +341,9 @@ design and correctness pass.
 - Unit/backend tests use `.cache/tmp` as `TMP` and `TEMP` to avoid the host
   pytest temp-directory permission issue.
 - PostgreSQL-backed tests use the repository's temporary PostgreSQL 17 Compose
-  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-9` run
-  passed all 79 memory tests and all 151 backend tests; the test container and
-  its tmpfs data were removed afterward.
+  service and command-scoped `AIDAM_TEST_DATABASE_URL`. The `memory-10` run
+  passed all 84 memory tests and all 156 backend tests.
 - `uvx basedpyright backend` reports the same 16 diagnostics already present at
   the `memory-5` parent, including the existing Pydantic `schema_version`
-  narrowing pattern. No new error originates in the `memory-9`
+  narrowing pattern. No new error originates in the `memory-10`
   implementation or tests.


### PR DESCRIPTION
Adds revision-grounded search-document candidate discovery, deterministic additive scoring, and atomic competition-scoped projection rebuilds. Covers historical visibility, competition isolation, rebuild restoration, and rollback. Verification: 5 focused tests, 84 memory tests, 156 backend tests; basedpyright has no new errors.