### PR TITLE
feat(memory): add typed HTTP API

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -1,14 +1,16 @@
 """FastAPI application factory and local server entry point."""
 
+import os
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
-import os
 
-from fastapi import FastAPI
 import uvicorn
+from fastapi import FastAPI
 
+from backend.api.errors import memory_application_error_handler
 from backend.api.routes import api_router, health_router
 from backend.composition import ApiRuntimeDependencies, build_api_runtime
+from backend.resources.memory.common import MemoryApplicationError
 
 RuntimeFactory = Callable[[], ApiRuntimeDependencies]
 
@@ -35,6 +37,10 @@ def create_app(
     )
     application.include_router(health_router)
     application.include_router(api_router, prefix="/api/v1")
+    application.add_exception_handler(
+        MemoryApplicationError,
+        memory_application_error_handler,
+    )
     return application
 
 

--- a/backend/api/dependencies/__init__.py
+++ b/backend/api/dependencies/__init__.py
@@ -1,1 +1,13 @@
 """FastAPI dependency providers."""
+
+from backend.api.dependencies.memory import (
+    get_correlation_id,
+    get_memory_api_dependencies,
+)
+from backend.api.dependencies.services import get_api_runtime
+
+__all__ = [
+    "get_api_runtime",
+    "get_correlation_id",
+    "get_memory_api_dependencies",
+]

--- a/backend/api/dependencies/memory.py
+++ b/backend/api/dependencies/memory.py
@@ -1,0 +1,46 @@
+"""Competition-scoped dependency composition for memory routes."""
+
+from typing import Annotated, cast
+from uuid import UUID, uuid4
+
+from fastapi import Depends, Header
+
+from backend.api.dependencies.services import get_api_runtime
+from backend.composition import (
+    ApiRuntimeDependencies,
+    MemoryApiDependencies,
+    MemoryApiRuntimeDependencies,
+    build_memory_api_dependencies,
+)
+from backend.resources.context import (
+    CompetitionScope,
+    LocalUserActor,
+    ManagerContext,
+)
+
+
+def get_correlation_id(
+    correlation_id: Annotated[
+        UUID | None,
+        Header(alias="X-Correlation-ID"),
+    ] = None,
+) -> UUID:
+    """Use a caller correlation ID when supplied, otherwise create one."""
+
+    return correlation_id or uuid4()
+
+
+def get_memory_api_dependencies(
+    competition_id: UUID,
+    correlation_id: Annotated[UUID, Depends(get_correlation_id)],
+    runtime: Annotated[ApiRuntimeDependencies, Depends(get_api_runtime)],
+) -> MemoryApiDependencies:
+    """Build one request's local-user memory boundary."""
+
+    memory_runtime = cast(MemoryApiRuntimeDependencies, runtime)
+    context = ManagerContext[CompetitionScope](
+        actor=LocalUserActor(),
+        scope=CompetitionScope(competition_id=competition_id),
+        correlation_id=correlation_id,
+    )
+    return build_memory_api_dependencies(memory_runtime.session_factory, context)

--- a/backend/api/errors/__init__.py
+++ b/backend/api/errors/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP error translation helpers."""
+
+from backend.api.errors.memory import memory_application_error_handler
+
+__all__ = ["memory_application_error_handler"]

--- a/backend/api/errors/memory.py
+++ b/backend/api/errors/memory.py
@@ -1,0 +1,111 @@
+"""Stable HTTP translation for typed memory application failures."""
+
+from typing import Literal
+
+from fastapi import Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from backend.resources.memory.common import (
+    CanonicalStateHashMismatchError,
+    CrossCompetitionEntityReferenceError,
+    CrossCompetitionReferenceError,
+    DuplicateContextNoteError,
+    EntityReferenceNotFoundError,
+    GenerationMemoryContextClosedError,
+    MemoryApplicationError,
+    MemoryIdentityConflictError,
+    RevisionNotFoundError,
+    SearchProjectionHydrationError,
+    StaleCanonicalRevisionError,
+    StaleItemVersionError,
+    TargetNotFoundError,
+    WrongTargetKindError,
+)
+
+MemoryErrorCode = Literal[
+    "canonical_state_inconsistent",
+    "context_note_conflict",
+    "cross_competition_entity",
+    "cross_competition_reference",
+    "generation_memory_closed",
+    "memory_identity_conflict",
+    "revision_not_found",
+    "search_projection_inconsistent",
+    "stale_canonical_revision",
+    "stale_item_version",
+    "target_not_found",
+    "wrong_target_kind",
+]
+
+
+class MemoryErrorDetail(BaseModel):
+    code: MemoryErrorCode
+    message: str
+
+
+class MemoryErrorResponse(BaseModel):
+    detail: MemoryErrorDetail
+
+
+async def memory_application_error_handler(
+    _request: Request,
+    error: Exception,
+) -> JSONResponse:
+    """Return a stable, safe status and code for a typed memory failure."""
+
+    if not isinstance(error, MemoryApplicationError):
+        raise TypeError("memory error handler received a non-memory exception")
+    status_code, code, message = _http_error(error)
+    payload = MemoryErrorResponse(
+        detail=MemoryErrorDetail(code=code, message=message)
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(payload),
+    )
+
+
+def _http_error(error: MemoryApplicationError) -> tuple[int, MemoryErrorCode, str]:
+    if isinstance(error, RevisionNotFoundError):
+        return status.HTTP_404_NOT_FOUND, "revision_not_found", str(error)
+    if isinstance(error, (TargetNotFoundError, EntityReferenceNotFoundError)):
+        return status.HTTP_404_NOT_FOUND, "target_not_found", str(error)
+    if isinstance(error, DuplicateContextNoteError):
+        return status.HTTP_409_CONFLICT, "context_note_conflict", str(error)
+    if isinstance(error, MemoryIdentityConflictError):
+        return status.HTTP_409_CONFLICT, "memory_identity_conflict", str(error)
+    if isinstance(error, StaleItemVersionError):
+        return status.HTTP_409_CONFLICT, "stale_item_version", str(error)
+    if isinstance(error, StaleCanonicalRevisionError):
+        return status.HTTP_409_CONFLICT, "stale_canonical_revision", str(error)
+    if isinstance(error, WrongTargetKindError):
+        return status.HTTP_400_BAD_REQUEST, "wrong_target_kind", str(error)
+    if isinstance(error, CrossCompetitionReferenceError):
+        return (
+            status.HTTP_400_BAD_REQUEST,
+            "cross_competition_reference",
+            str(error),
+        )
+    if isinstance(error, CrossCompetitionEntityReferenceError):
+        return (
+            status.HTTP_400_BAD_REQUEST,
+            "cross_competition_entity",
+            str(error),
+        )
+    if isinstance(error, GenerationMemoryContextClosedError):
+        return status.HTTP_409_CONFLICT, "generation_memory_closed", str(error)
+    if isinstance(error, SearchProjectionHydrationError):
+        return (
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "search_projection_inconsistent",
+            "memory search projection is inconsistent with canonical memory",
+        )
+    if isinstance(error, CanonicalStateHashMismatchError):
+        return (
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            "canonical_state_inconsistent",
+            "canonical memory state verification failed",
+        )
+    raise TypeError(f"unsupported memory application error {type(error).__name__}")

--- a/backend/api/routes/memory.py
+++ b/backend/api/routes/memory.py
@@ -1,8 +1,0 @@
-"""Reporter-memory HTTP routes.
-
-Handlers will be added with the canonical-memory manager and service boundary.
-"""
-
-from fastapi import APIRouter
-
-router = APIRouter(prefix="/memory", tags=["memory"])

--- a/backend/api/routes/memory/__init__.py
+++ b/backend/api/routes/memory/__init__.py
@@ -1,0 +1,32 @@
+"""Competition-scoped canonical-memory route assembly."""
+
+from fastapi import APIRouter
+
+from backend.api.errors.memory import MemoryErrorResponse
+from backend.api.routes.memory.context_notes import router as context_notes_router
+from backend.api.routes.memory.events import router as events_router
+from backend.api.routes.memory.facts import router as facts_router
+from backend.api.routes.memory.revisions import router as revisions_router
+from backend.api.routes.memory.search import router as search_router
+from backend.api.routes.memory.storylines import router as storylines_router
+from backend.api.routes.memory.triggers import router as triggers_router
+
+router = APIRouter(
+    prefix="/memory/competitions/{competition_id}",
+    tags=["memory"],
+    responses={
+        400: {"model": MemoryErrorResponse},
+        404: {"model": MemoryErrorResponse},
+        409: {"model": MemoryErrorResponse},
+        500: {"model": MemoryErrorResponse},
+    },
+)
+router.include_router(revisions_router)
+router.include_router(facts_router)
+router.include_router(events_router)
+router.include_router(storylines_router)
+router.include_router(triggers_router)
+router.include_router(context_notes_router)
+router.include_router(search_router)
+
+__all__ = ["router"]

--- a/backend/api/routes/memory/common.py
+++ b/backend/api/routes/memory/common.py
@@ -1,0 +1,17 @@
+"""Shared transport envelopes for canonical-memory routes."""
+
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict
+
+from backend.services.memory import MemoryMutationResult
+
+
+class MemoryApiModel(BaseModel):
+    """Strict HTTP model kept separate from persistence contracts."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+
+class MemoryMutationResponse(MemoryApiModel):
+    result: MemoryMutationResult

--- a/backend/api/routes/memory/context_notes.py
+++ b/backend/api/routes/memory/context_notes.py
@@ -1,0 +1,97 @@
+"""Context-note read and complete-replacement routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import Field
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel, MemoryMutationResponse
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.context_notes import (
+    ContextNote,
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.services.memory import MemoryMutationMetadata, MemoryMutationOrigin
+
+
+class ContextNoteCreateRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    identity: ContextNoteIdentity
+    content: ContextNoteContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class ContextNoteReplaceRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    expected_item_revision: int = Field(gt=0, strict=True)
+    content: ContextNoteContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class ContextNoteResponse(MemoryApiModel):
+    memory: ContextNote
+
+
+class ContextNoteHistoryResponse(MemoryApiModel):
+    items: tuple[ContextNote, ...]
+
+router = APIRouter(prefix="/context-notes")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/versions/{version_id}", response_model=ContextNoteResponse)
+def exact_context_note(
+    version_id: UUID,
+    memory: MemoryDependencies,
+) -> ContextNoteResponse:
+    return ContextNoteResponse(memory=memory.context_notes.exact(version_id))
+
+
+@router.get("/{item_id}/history", response_model=ContextNoteHistoryResponse)
+def context_note_history(
+    item_id: UUID,
+    memory: MemoryDependencies,
+) -> ContextNoteHistoryResponse:
+    return ContextNoteHistoryResponse(items=memory.context_notes.history(item_id))
+
+
+@router.post(
+    "",
+    response_model=MemoryMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_context_note(
+    request: ContextNoteCreateRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.create_context_note(
+            request.origin,
+            request.identity,
+            request.content,
+            metadata=request.metadata,
+        )
+    )
+
+
+@router.put("/{item_id}", response_model=MemoryMutationResponse)
+def replace_context_note(
+    item_id: UUID,
+    request: ContextNoteReplaceRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.replace_context_note(
+            request.origin,
+            item_id,
+            request.expected_item_revision,
+            request.content,
+            metadata=request.metadata,
+        )
+    )

--- a/backend/api/routes/memory/events.py
+++ b/backend/api/routes/memory/events.py
@@ -1,0 +1,82 @@
+"""Event read and complete-replacement routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import Field
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel, MemoryMutationResponse
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.events import Event, EventContent
+from backend.services.memory import MemoryMutationMetadata, MemoryMutationOrigin
+
+
+class EventCreateRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    content: EventContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class EventReplaceRequest(EventCreateRequest):
+    expected_item_revision: int = Field(gt=0, strict=True)
+
+
+class EventResponse(MemoryApiModel):
+    memory: Event
+
+
+class EventHistoryResponse(MemoryApiModel):
+    items: tuple[Event, ...]
+
+router = APIRouter(prefix="/events")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/versions/{version_id}", response_model=EventResponse)
+def exact_event(version_id: UUID, memory: MemoryDependencies) -> EventResponse:
+    return EventResponse(memory=memory.events.exact(version_id))
+
+
+@router.get("/{item_id}/history", response_model=EventHistoryResponse)
+def event_history(item_id: UUID, memory: MemoryDependencies) -> EventHistoryResponse:
+    return EventHistoryResponse(items=memory.events.history(item_id))
+
+
+@router.post(
+    "",
+    response_model=MemoryMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_event(
+    request: EventCreateRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.create_event(
+            request.origin,
+            request.content,
+            metadata=request.metadata,
+        )
+    )
+
+
+@router.put("/{item_id}", response_model=MemoryMutationResponse)
+def replace_event(
+    item_id: UUID,
+    request: EventReplaceRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.replace_event(
+            request.origin,
+            item_id,
+            request.expected_item_revision,
+            request.content,
+            metadata=request.metadata,
+        )
+    )

--- a/backend/api/routes/memory/facts.py
+++ b/backend/api/routes/memory/facts.py
@@ -1,0 +1,82 @@
+"""Fact read and complete-replacement routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import Field
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel, MemoryMutationResponse
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.facts import Fact, FactContent
+from backend.services.memory import MemoryMutationMetadata, MemoryMutationOrigin
+
+
+class FactCreateRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    content: FactContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class FactReplaceRequest(FactCreateRequest):
+    expected_item_revision: int = Field(gt=0, strict=True)
+
+
+class FactResponse(MemoryApiModel):
+    memory: Fact
+
+
+class FactHistoryResponse(MemoryApiModel):
+    items: tuple[Fact, ...]
+
+router = APIRouter(prefix="/facts")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/versions/{version_id}", response_model=FactResponse)
+def exact_fact(version_id: UUID, memory: MemoryDependencies) -> FactResponse:
+    return FactResponse(memory=memory.facts.exact(version_id))
+
+
+@router.get("/{item_id}/history", response_model=FactHistoryResponse)
+def fact_history(item_id: UUID, memory: MemoryDependencies) -> FactHistoryResponse:
+    return FactHistoryResponse(items=memory.facts.history(item_id))
+
+
+@router.post(
+    "",
+    response_model=MemoryMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_fact(
+    request: FactCreateRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.create_fact(
+            request.origin,
+            request.content,
+            metadata=request.metadata,
+        )
+    )
+
+
+@router.put("/{item_id}", response_model=MemoryMutationResponse)
+def replace_fact(
+    item_id: UUID,
+    request: FactReplaceRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.replace_fact(
+            request.origin,
+            item_id,
+            request.expected_item_revision,
+            request.content,
+            metadata=request.metadata,
+        )
+    )

--- a/backend/api/routes/memory/revisions.py
+++ b/backend/api/routes/memory/revisions.py
@@ -1,0 +1,43 @@
+"""Canonical revision read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.revisions import CanonicalRevision
+
+
+class RevisionResponse(MemoryApiModel):
+    revision: CanonicalRevision
+
+
+class RevisionHistoryResponse(MemoryApiModel):
+    revisions: tuple[CanonicalRevision, ...]
+
+router = APIRouter(prefix="/revisions")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/current", response_model=RevisionResponse)
+def current_revision(memory: MemoryDependencies) -> RevisionResponse:
+    return RevisionResponse(revision=memory.revisions.current())
+
+
+@router.get("", response_model=RevisionHistoryResponse)
+def revision_history(memory: MemoryDependencies) -> RevisionHistoryResponse:
+    return RevisionHistoryResponse(revisions=memory.revisions.history())
+
+
+@router.get("/{revision_id}", response_model=RevisionResponse)
+def exact_revision(
+    revision_id: UUID,
+    memory: MemoryDependencies,
+) -> RevisionResponse:
+    return RevisionResponse(revision=memory.revisions.pin(revision_id))

--- a/backend/api/routes/memory/search.py
+++ b/backend/api/routes/memory/search.py
@@ -1,0 +1,54 @@
+"""Revision-pinned hydrated memory search route."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.search_documents import SearchDocumentQuery
+from backend.services.memory import (
+    MemoryRetrievalRequest,
+    MemoryRetrievalResult,
+)
+
+
+class MemorySearchRequest(MemoryApiModel):
+    revision_id: UUID
+    query: SearchDocumentQuery
+    expand_exact_references: bool = False
+    expand_stable_references: bool = False
+
+    def retrieval_request(self) -> MemoryRetrievalRequest:
+        return MemoryRetrievalRequest(
+            query=self.query,
+            expand_exact_references=self.expand_exact_references,
+            expand_stable_references=self.expand_stable_references,
+        )
+
+
+class MemorySearchResponse(MemoryApiModel):
+    result: MemoryRetrievalResult
+
+router = APIRouter()
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.post("/search", response_model=MemorySearchResponse)
+def search_memory(
+    competition_id: UUID,
+    request: MemorySearchRequest,
+    memory: MemoryDependencies,
+) -> MemorySearchResponse:
+    return MemorySearchResponse(
+        result=memory.retrieval.search(
+            competition_id=competition_id,
+            revision_id=request.revision_id,
+            request=request.retrieval_request(),
+        )
+    )

--- a/backend/api/routes/memory/storylines.py
+++ b/backend/api/routes/memory/storylines.py
@@ -1,0 +1,88 @@
+"""Storyline read and complete-replacement routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import Field
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel, MemoryMutationResponse
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.storylines import Storyline, StorylineContent
+from backend.services.memory import MemoryMutationMetadata, MemoryMutationOrigin
+
+
+class StorylineCreateRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    content: StorylineContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class StorylineReplaceRequest(StorylineCreateRequest):
+    expected_item_revision: int = Field(gt=0, strict=True)
+
+
+class StorylineResponse(MemoryApiModel):
+    memory: Storyline
+
+
+class StorylineHistoryResponse(MemoryApiModel):
+    items: tuple[Storyline, ...]
+
+router = APIRouter(prefix="/storylines")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/versions/{version_id}", response_model=StorylineResponse)
+def exact_storyline(
+    version_id: UUID,
+    memory: MemoryDependencies,
+) -> StorylineResponse:
+    return StorylineResponse(memory=memory.storylines.exact(version_id))
+
+
+@router.get("/{item_id}/history", response_model=StorylineHistoryResponse)
+def storyline_history(
+    item_id: UUID,
+    memory: MemoryDependencies,
+) -> StorylineHistoryResponse:
+    return StorylineHistoryResponse(items=memory.storylines.history(item_id))
+
+
+@router.post(
+    "",
+    response_model=MemoryMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_storyline(
+    request: StorylineCreateRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.create_storyline(
+            request.origin,
+            request.content,
+            metadata=request.metadata,
+        )
+    )
+
+
+@router.put("/{item_id}", response_model=MemoryMutationResponse)
+def replace_storyline(
+    item_id: UUID,
+    request: StorylineReplaceRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.replace_storyline(
+            request.origin,
+            item_id,
+            request.expected_item_revision,
+            request.content,
+            metadata=request.metadata,
+        )
+    )

--- a/backend/api/routes/memory/triggers.py
+++ b/backend/api/routes/memory/triggers.py
@@ -1,0 +1,82 @@
+"""Trigger read and complete-replacement routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import Field
+
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.api.routes.memory.common import MemoryApiModel, MemoryMutationResponse
+from backend.composition import MemoryApiDependencies
+from backend.resources.memory.triggers import Trigger, TriggerContent
+from backend.services.memory import MemoryMutationMetadata, MemoryMutationOrigin
+
+
+class TriggerCreateRequest(MemoryApiModel):
+    origin: MemoryMutationOrigin
+    content: TriggerContent
+    metadata: MemoryMutationMetadata = Field(default_factory=MemoryMutationMetadata)
+
+
+class TriggerReplaceRequest(TriggerCreateRequest):
+    expected_item_revision: int = Field(gt=0, strict=True)
+
+
+class TriggerResponse(MemoryApiModel):
+    memory: Trigger
+
+
+class TriggerHistoryResponse(MemoryApiModel):
+    items: tuple[Trigger, ...]
+
+router = APIRouter(prefix="/triggers")
+MemoryDependencies = Annotated[
+    MemoryApiDependencies,
+    Depends(get_memory_api_dependencies),
+]
+
+
+@router.get("/versions/{version_id}", response_model=TriggerResponse)
+def exact_trigger(version_id: UUID, memory: MemoryDependencies) -> TriggerResponse:
+    return TriggerResponse(memory=memory.triggers.exact(version_id))
+
+
+@router.get("/{item_id}/history", response_model=TriggerHistoryResponse)
+def trigger_history(item_id: UUID, memory: MemoryDependencies) -> TriggerHistoryResponse:
+    return TriggerHistoryResponse(items=memory.triggers.history(item_id))
+
+
+@router.post(
+    "",
+    response_model=MemoryMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_trigger(
+    request: TriggerCreateRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.create_trigger(
+            request.origin,
+            request.content,
+            metadata=request.metadata,
+        )
+    )
+
+
+@router.put("/{item_id}", response_model=MemoryMutationResponse)
+def replace_trigger(
+    item_id: UUID,
+    request: TriggerReplaceRequest,
+    memory: MemoryDependencies,
+) -> MemoryMutationResponse:
+    return MemoryMutationResponse(
+        result=memory.mutations.replace_trigger(
+            request.origin,
+            item_id,
+            request.expected_item_revision,
+            request.content,
+            metadata=request.metadata,
+        )
+    )

--- a/backend/composition.py
+++ b/backend/composition.py
@@ -9,6 +9,16 @@ from sqlalchemy.engine import make_url
 from backend.config import DatabaseSettings
 from backend.database.engine import build_runtime_engine
 from backend.database.health import assert_database_ready, read_database_health
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.context_notes import ContextNoteManager
+from backend.resources.memory.events import EventManager
+from backend.resources.memory.facts import FactManager
+from backend.resources.memory.revisions import RevisionManager
+from backend.resources.memory.search_documents import SearchDocumentManager
+from backend.resources.memory.storylines import StorylineManager
+from backend.resources.memory.triggers import TriggerManager
+from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 
 
 class ApiRuntimeDependencies(Protocol):
@@ -19,11 +29,18 @@ class ApiRuntimeDependencies(Protocol):
     def close(self) -> None: ...
 
 
+class MemoryApiRuntimeDependencies(ApiRuntimeDependencies, Protocol):
+    """Runtime capabilities required by competition-scoped memory routes."""
+
+    session_factory: SessionFactory
+
+
 @dataclass(frozen=True, slots=True)
 class ApiRuntime:
     """Long-lived dependencies owned by one API process."""
 
     engine: Engine
+    session_factory: SessionFactory
     expected_database: str
     expected_role: str
     require_tls: bool
@@ -45,6 +62,52 @@ class ApiRuntime:
         self.engine.dispose()
 
 
+@dataclass(frozen=True, slots=True)
+class MemoryApiDependencies:
+    """One request's competition-scoped memory managers and services."""
+
+    revisions: RevisionManager
+    facts: FactManager
+    events: EventManager
+    storylines: StorylineManager
+    triggers: TriggerManager
+    context_notes: ContextNoteManager
+    retrieval: MemoryRetrievalService
+    mutations: MemoryMutationService
+
+
+def build_memory_api_dependencies(
+    session_factory: SessionFactory,
+    context: ManagerContext[CompetitionScope],
+) -> MemoryApiDependencies:
+    """Compose memory capabilities for one already-resolved request context."""
+
+    revisions = RevisionManager(session_factory, context)
+    facts = FactManager(session_factory, context)
+    events = EventManager(session_factory, context)
+    storylines = StorylineManager(session_factory, context)
+    triggers = TriggerManager(session_factory, context)
+    context_notes = ContextNoteManager(session_factory, context)
+    search_documents = SearchDocumentManager(session_factory, context)
+    return MemoryApiDependencies(
+        revisions=revisions,
+        facts=facts,
+        events=events,
+        storylines=storylines,
+        triggers=triggers,
+        context_notes=context_notes,
+        retrieval=MemoryRetrievalService(
+            search_documents=search_documents,
+            facts=facts,
+            events=events,
+            storylines=storylines,
+            triggers=triggers,
+            context_notes=context_notes,
+        ),
+        mutations=MemoryMutationService(revisions),
+    )
+
+
 def build_api_runtime() -> ApiRuntime:
     """Construct the API runtime from environment-backed configuration."""
 
@@ -55,6 +118,7 @@ def build_api_runtime() -> ApiRuntime:
     engine = build_runtime_engine(settings.engine_settings("api"))
     return ApiRuntime(
         engine=engine,
+        session_factory=create_session_factory(engine),
         expected_database=url.database,
         expected_role=url.username,
         require_tls=settings.require_tls,

--- a/backend/tests/api/memory/__init__.py
+++ b/backend/tests/api/memory/__init__.py
@@ -1,0 +1,1 @@
+"""Canonical-memory API tests."""

--- a/backend/tests/api/memory/test_routes.py
+++ b/backend/tests/api/memory/test_routes.py
@@ -1,0 +1,477 @@
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any, final
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.api.app import create_app
+from backend.api.dependencies import get_memory_api_dependencies
+from backend.composition import ApiRuntimeDependencies
+from backend.resources.memory.common import (
+    MemoryItemIdentity,
+    MemoryKind,
+    MemoryVersionMetadata,
+    SearchProjectionHydrationError,
+    StaleCanonicalRevisionError,
+    TargetNotFoundError,
+)
+from backend.resources.memory.facts import Fact, FactContent
+from backend.resources.memory.revisions import CanonicalRevision
+from backend.services.memory import MemoryMutationResult, MemoryRetrievalResult
+
+
+@final
+class StubRuntime:
+    def assert_ready(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def runtime_factory() -> Callable[[], ApiRuntimeDependencies]:
+    return StubRuntime
+
+
+class StubResourceManager:
+    def __init__(self, memory: Fact | None = None) -> None:
+        self.memory = memory
+        self.exact_ids: list[UUID] = []
+        self.history_ids: list[UUID] = []
+
+    def exact(self, version_id: UUID) -> Fact:
+        self.exact_ids.append(version_id)
+        if self.memory is None:
+            raise TargetNotFoundError(version_id, (MemoryKind.FACT,))
+        return self.memory
+
+    def history(self, item_id: UUID) -> tuple[Fact, ...]:
+        self.history_ids.append(item_id)
+        if self.memory is None:
+            raise TargetNotFoundError(item_id, (MemoryKind.FACT,))
+        return (self.memory,)
+
+
+class StubRevisionManager:
+    def __init__(self, revision: CanonicalRevision) -> None:
+        self.revision = revision
+
+    def current(self) -> CanonicalRevision:
+        return self.revision
+
+    def pin(self, _revision_id: UUID) -> CanonicalRevision:
+        return self.revision
+
+    def history(self) -> tuple[CanonicalRevision, ...]:
+        return (self.revision,)
+
+
+class StubMutationService:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+        self.error = error
+
+    def _call(self, name: str, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        self.calls.append((name, args, kwargs))
+        if self.error is not None:
+            raise self.error
+        return MemoryMutationResult(revision=None, changes=())
+
+    def create_fact(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("create_fact", *args, **kwargs)
+
+    def replace_fact(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("replace_fact", *args, **kwargs)
+
+    def create_event(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("create_event", *args, **kwargs)
+
+    def replace_event(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("replace_event", *args, **kwargs)
+
+    def create_storyline(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("create_storyline", *args, **kwargs)
+
+    def replace_storyline(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("replace_storyline", *args, **kwargs)
+
+    def create_trigger(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("create_trigger", *args, **kwargs)
+
+    def replace_trigger(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("replace_trigger", *args, **kwargs)
+
+    def create_context_note(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("create_context_note", *args, **kwargs)
+
+    def replace_context_note(self, *args: Any, **kwargs: Any) -> MemoryMutationResult:
+        return self._call("replace_context_note", *args, **kwargs)
+
+
+class StubRetrievalService:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.calls: list[tuple[UUID, UUID]] = []
+        self.error = error
+
+    def search(
+        self,
+        *,
+        competition_id: UUID,
+        revision_id: UUID,
+        request: object,
+    ) -> MemoryRetrievalResult:
+        del request
+        self.calls.append((competition_id, revision_id))
+        if self.error is not None:
+            raise self.error
+        return MemoryRetrievalResult(
+            competition_id=competition_id,
+            revision_id=revision_id,
+            matches=(),
+        )
+
+
+class StubMemoryDependencies:
+    def __init__(
+        self,
+        *,
+        competition_id: UUID,
+        fact: Fact | None = None,
+        mutation_error: Exception | None = None,
+        retrieval_error: Exception | None = None,
+    ) -> None:
+        self.revisions = StubRevisionManager(_revision(competition_id))
+        self.facts = StubResourceManager(fact)
+        self.events = StubResourceManager()
+        self.storylines = StubResourceManager()
+        self.triggers = StubResourceManager()
+        self.context_notes = StubResourceManager()
+        self.mutations = StubMutationService(error=mutation_error)
+        self.retrieval = StubRetrievalService(error=retrieval_error)
+
+
+def _revision(competition_id: UUID) -> CanonicalRevision:
+    return CanonicalRevision(
+        revision_id=uuid4(),
+        competition_id=competition_id,
+        sequence_number=0,
+        state_content_hash="seed-root",
+        created_at=datetime(2026, 8, 17, tzinfo=UTC),
+    )
+
+
+def _fact(competition_id: UUID) -> Fact:
+    generation_id = uuid4()
+    content = FactContent.model_validate(
+        {
+            "claim": "The Owls won the opener.",
+            "category": "result",
+            "numbers": {"margin": 3},
+            "confidence": "inferred",
+            "status": "active",
+            "subjects": [],
+            "originating_event_version_ids": [],
+        }
+    )
+    return Fact(
+        item=MemoryItemIdentity(
+            item_id=uuid4(),
+            competition_id=competition_id,
+            kind=MemoryKind.FACT,
+            created_at=datetime(2026, 8, 17, tzinfo=UTC),
+        ),
+        version=MemoryVersionMetadata(
+            version_id=uuid4(),
+            revision_number=1,
+            content_schema_version=1,
+            introduced_revision_id=uuid4(),
+            creating_generation_id=generation_id,
+            recorded_at=datetime(2026, 8, 17, tzinfo=UTC),
+        ),
+        content=content,
+    )
+
+
+async def _request(
+    dependencies: StubMemoryDependencies,
+    method: str,
+    path: str,
+    *,
+    json: dict[str, Any] | None = None,
+) -> Any:
+    app = create_app(runtime_factory=runtime_factory())
+    app.dependency_overrides[get_memory_api_dependencies] = lambda: dependencies
+    async with app.router.lifespan_context(app), AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        return await client.request(method, path, json=json)
+
+
+@pytest.mark.asyncio
+async def test_revision_and_fact_reads_return_transport_wrappers() -> None:
+    competition_id = uuid4()
+    fact = _fact(competition_id)
+    dependencies = StubMemoryDependencies(competition_id=competition_id, fact=fact)
+    base = f"/api/v1/memory/competitions/{competition_id}"
+
+    current = await _request(dependencies, "GET", f"{base}/revisions/current")
+    exact = await _request(
+        dependencies,
+        "GET",
+        f"{base}/facts/versions/{fact.version.version_id}",
+    )
+    history = await _request(
+        dependencies,
+        "GET",
+        f"{base}/facts/{fact.item.item_id}/history",
+    )
+
+    assert current.status_code == 200
+    assert current.json()["revision"]["competition_id"] == str(competition_id)
+    assert exact.status_code == 200
+    assert exact.json()["memory"]["content"]["claim"] == "The Owls won the opener."
+    assert history.status_code == 200
+    assert len(history.json()["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_requires_an_explicit_revision_and_returns_hydrated_result() -> None:
+    competition_id = uuid4()
+    revision_id = uuid4()
+    dependencies = StubMemoryDependencies(competition_id=competition_id)
+    response = await _request(
+        dependencies,
+        "POST",
+        f"/api/v1/memory/competitions/{competition_id}/search",
+        json={
+            "revision_id": str(revision_id),
+            "query": {"text": "rivalry"},
+            "expand_exact_references": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "result": {
+            "competition_id": str(competition_id),
+            "revision_id": str(revision_id),
+            "matches": [],
+        }
+    }
+    assert dependencies.retrieval.calls == [(competition_id, revision_id)]
+
+
+def _origin() -> dict[str, str]:
+    return {
+        "generation_id": str(uuid4()),
+        "expected_revision_id": str(uuid4()),
+    }
+
+
+def _write_cases() -> tuple[tuple[str, dict[str, Any], str], ...]:
+    franchise_a = uuid4()
+    franchise_b = uuid4()
+    season_id = uuid4()
+    return (
+        (
+            "facts",
+            {
+                "origin": _origin(),
+                "content": {
+                    "claim": "The Owls won.",
+                    "category": "result",
+                    "numbers": {},
+                    "confidence": "inferred",
+                    "status": "active",
+                    "subjects": [],
+                    "originating_event_version_ids": [],
+                },
+            },
+            "fact",
+        ),
+        (
+            "events",
+            {
+                "origin": _origin(),
+                "content": {
+                    "event_type": "matchup",
+                    "headline": "The Owls won.",
+                    "summary": "A close opener.",
+                    "salience": 3,
+                    "confidence": "inferred",
+                    "status": "active",
+                    "details": {
+                        "kind": "matchup",
+                        "winner_franchise_id": str(franchise_a),
+                        "loser_franchise_id": str(franchise_b),
+                        "sleeper_matchup_id": "week-1",
+                    },
+                },
+            },
+            "event",
+        ),
+        (
+            "storylines",
+            {
+                "origin": _origin(),
+                "content": {
+                    "headline": "A rivalry starts.",
+                    "summary": "The opener created tension.",
+                    "status": "active",
+                    "salience": 3,
+                    "tags": ["rivalry"],
+                    "subjects": [],
+                    "evidence": [],
+                    "related_storylines": [],
+                },
+            },
+            "storyline",
+        ),
+        (
+            "triggers",
+            {
+                "origin": _origin(),
+                "content": {
+                    "trigger_type": "rematch",
+                    "status": "open",
+                    "fire_policy": "one_shot",
+                    "target_competition_season_id": str(season_id),
+                    "target_week": 8,
+                    "condition": {
+                        "kind": "rematch",
+                        "franchise_ids": [str(franchise_a), str(franchise_b)],
+                    },
+                },
+            },
+            "trigger",
+        ),
+        (
+            "context-notes",
+            {
+                "origin": _origin(),
+                "identity": {
+                    "scope": "competition",
+                    "note_key": "league-tone",
+                },
+                "content": {
+                    "narrative": "The league rewards aggressive trades.",
+                    "status": "active",
+                    "tags": ["culture"],
+                },
+            },
+            "context_note",
+        ),
+    )
+
+
+@pytest.mark.parametrize(("resource", "payload", "method_suffix"), _write_cases())
+@pytest.mark.asyncio
+async def test_create_and_replace_routes_delegate_complete_typed_writes(
+    resource: str,
+    payload: dict[str, Any],
+    method_suffix: str,
+) -> None:
+    competition_id = uuid4()
+    dependencies = StubMemoryDependencies(competition_id=competition_id)
+    base = f"/api/v1/memory/competitions/{competition_id}/{resource}"
+
+    created = await _request(dependencies, "POST", base, json=payload)
+    replacement = dict(payload)
+    replacement.pop("identity", None)
+    replacement["expected_item_revision"] = 1
+    item_id = uuid4()
+    replaced = await _request(
+        dependencies,
+        "PUT",
+        f"{base}/{item_id}",
+        json=replacement,
+    )
+
+    assert created.status_code == 201, created.text
+    assert created.json() == {"result": {"revision": None, "changes": []}}
+    assert replaced.status_code == 200, replaced.text
+    assert replaced.json() == {"result": {"revision": None, "changes": []}}
+    assert [call[0] for call in dependencies.mutations.calls] == [
+        f"create_{method_suffix}",
+        f"replace_{method_suffix}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_typed_memory_errors_have_stable_status_codes_and_safe_messages() -> None:
+    competition_id = uuid4()
+    missing_id = uuid4()
+    stale_expected = uuid4()
+    stale_actual = uuid4()
+    missing = StubMemoryDependencies(competition_id=competition_id)
+    stale = StubMemoryDependencies(
+        competition_id=competition_id,
+        mutation_error=StaleCanonicalRevisionError(
+            competition_id,
+            stale_expected,
+            stale_actual,
+        ),
+    )
+    projection = StubMemoryDependencies(
+        competition_id=competition_id,
+        retrieval_error=SearchProjectionHydrationError(
+            uuid4(),
+            MemoryKind.FACT,
+            "sensitive storage detail",
+        ),
+    )
+    base = f"/api/v1/memory/competitions/{competition_id}"
+
+    not_found = await _request(
+        missing,
+        "GET",
+        f"{base}/facts/versions/{missing_id}",
+    )
+    stale_write = await _request(
+        stale,
+        "POST",
+        f"{base}/facts",
+        json=_write_cases()[0][1],
+    )
+    inconsistent = await _request(
+        projection,
+        "POST",
+        f"{base}/search",
+        json={"revision_id": str(uuid4()), "query": {}},
+    )
+
+    assert not_found.status_code == 404
+    assert not_found.json()["detail"]["code"] == "target_not_found"
+    assert stale_write.status_code == 409
+    assert stale_write.json()["detail"]["code"] == "stale_canonical_revision"
+    assert inconsistent.status_code == 500
+    assert inconsistent.json() == {
+        "detail": {
+            "code": "search_projection_inconsistent",
+            "message": (
+                "memory search projection is inconsistent with canonical memory"
+            ),
+        }
+    }
+    assert "sensitive storage detail" not in inconsistent.text
+
+
+def test_openapi_contains_every_memory_resource_boundary() -> None:
+    app = create_app(runtime_factory=runtime_factory())
+    paths = set(app.openapi()["paths"])
+    prefix = "/api/v1/memory/competitions/{competition_id}"
+
+    assert {
+        f"{prefix}/revisions/current",
+        f"{prefix}/revisions",
+        f"{prefix}/revisions/{{revision_id}}",
+        f"{prefix}/search",
+    }.issubset(paths)
+    for resource in ("facts", "events", "storylines", "triggers", "context-notes"):
+        assert f"{prefix}/{resource}" in paths
+        assert f"{prefix}/{resource}/{{item_id}}" in paths
+        assert f"{prefix}/{resource}/versions/{{version_id}}" in paths
+        assert f"{prefix}/{resource}/{{item_id}}/history" in paths

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -1,7 +1,13 @@
-from sqlalchemy.engine import make_url
-import pytest
+from uuid import uuid4
 
-from backend.composition import build_api_runtime
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
+
+from backend.composition import build_api_runtime, build_memory_api_dependencies
+from backend.database.sessions import create_session_factory
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 
 
 def test_build_api_runtime_uses_url_identity_and_local_tls_setting(
@@ -20,5 +26,32 @@ def test_build_api_runtime_uses_url_identity_and_local_tls_setting(
         assert runtime.expected_database == "aidam_test"
         assert runtime.expected_role == "aidam_api"
         assert runtime.require_tls is False
+        assert runtime.session_factory.kw["bind"] is runtime.engine
     finally:
         runtime.close()
+
+
+def test_memory_api_composition_is_scoped_without_opening_a_session() -> None:
+    competition_id = uuid4()
+    engine = create_engine("sqlite://")
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {
+                "kind": "competition",
+                "competition_id": competition_id,
+            },
+            "correlation_id": uuid4(),
+        }
+    )
+    try:
+        runtime = build_memory_api_dependencies(
+            create_session_factory(engine),
+            context,
+        )
+
+        assert runtime.revisions.competition_id == competition_id
+        assert isinstance(runtime.retrieval, MemoryRetrievalService)
+        assert isinstance(runtime.mutations, MemoryMutationService)
+    finally:
+        engine.dispose()

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -3,9 +3,9 @@
 **Decision status:** Accepted
 
 **Implementation status:** Canonical resources, atomic mutations, search-document
-builders, candidate queries, deterministic rebuilds, and typed retrieval are
-implemented in the current PR stack; HTTP and reporter integration remain
-follow-up work
+builders, candidate queries, deterministic rebuilds, typed retrieval, and the
+HTTP boundary are implemented in the current PR stack; reporter integration
+remains follow-up work
 
 **Scope:** Canonical memory storage, application contracts, retrieval, and the
 generation lifecycle
@@ -16,9 +16,9 @@ This directory records the detailed design behind the memory schema summarized
 in [`docs/database/memory.md`](../database/memory.md). The database migration and
 ORM models implement the canonical typed fields and search-document table.
 Pydantic contracts, resource managers, atomic mutations, search builders,
-revision-grounded candidate queries, projection rebuilds, and canonical typed
-hydration are implemented. HTTP and reporter integration follow in later stack
-layers.
+revision-grounded candidate queries, projection rebuilds, canonical typed
+hydration, and the HTTP boundary are implemented. Reporter integration follows
+in later stack layers.
 
 The redesign keeps the valuable parts of that baseline:
 

--- a/docs/memory/application-contracts.md
+++ b/docs/memory/application-contracts.md
@@ -1,6 +1,7 @@
 # Application Memory Contracts
 
-**Status:** Typed v1 contracts implemented; resource managers pending
+**Status:** Typed v1 contracts, resource managers, services, and HTTP boundary
+implemented
 
 ## Goal
 

--- a/docs/memory/implementation-plan.md
+++ b/docs/memory/implementation-plan.md
@@ -138,16 +138,10 @@ backend/
 │       └── retrieval_service.py
 │
 └── api/
-    ├── schemas/
-    │   └── memory/
-    │       ├── storylines.py
-    │       ├── facts.py
-    │       ├── events.py
-    │       ├── triggers.py
-    │       ├── context_notes.py
-    │       └── search.py
     └── routes/
         └── memory/
+            ├── common.py
+            ├── revisions.py
             ├── storylines.py
             ├── facts.py
             ├── events.py
@@ -158,6 +152,10 @@ backend/
 
 Tests mirror these boundaries under `backend/tests/resources/memory/`,
 `backend/tests/services/memory/`, and `backend/tests/api/memory/`.
+
+Memory transport models remain co-located with their routes while each module
+is small. They can move to a separate schema package if reuse or module size
+creates a concrete boundary later.
 
 Not every package needs every helper on its first commit. `objects.py` and
 `manager.py` define the stable resource boundary. `codec.py`, `validation.py`,

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -2,10 +2,11 @@
 
 ## Current Phase
 
-**Active layer:** `memory-11` complete; `memory-12` is next
-**Current branch:** `codex/memory-11-retrieval`
-**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9` <- `memory-10` <- `memory-11`
-**Publication:** `memory-11` is published as PR #119 atop `memory-10` (PR #118).
+**Active layer:** `memory-12` complete; `memory-13` is next
+**Current branch:** `codex/memory-12-api`
+**Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9` <- `memory-10` <- `memory-11` <- `memory-12`
+**Publication:** `memory-12` is implemented locally atop `memory-11` (PR #119)
+and is not yet published.
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -27,7 +28,7 @@ The completed database stack remains tracked separately in
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `0260366`; PR #117 |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Complete | `root` | 5 focused PostgreSQL tests; memory: 84 passed; backend: 156 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `915ddf4`; PR #118 |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Complete | `root` | 7 focused PostgreSQL tests; memory: 91 passed; backend: 163 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `a8a7250`; PR #119 |
-| `memory-12` HTTP API | `codex/memory-12-api` | Pending | Unassigned | Not started | — |
+| `memory-12` HTTP API | `codex/memory-12-api` | Complete | `root` | 10 focused API/composition tests; memory + API: 107 passed; backend: 173 passed; focused basedpyright clean and full backend retains the same 16 pre-existing errors; Ruff clean | Active branch head; not yet published |
 | `memory-13` reporter retrieval | `codex/memory-13-reporter-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-14` reporter mutations | `codex/memory-14-reporter-mutations` | Pending | Unassigned | Not started | — |
 
@@ -42,6 +43,12 @@ The completed database stack remains tracked separately in
 - Record uncovered design decisions here rather than resolving them implicitly.
 - Keep the integration tail on the same stack unless the optional split after
   `memory-11` is explicitly approved.
+
+## `memory-12` Assignments
+
+| Owner | Assigned paths | Work |
+| --- | --- | --- |
+| `root` | `backend/api/routes/memory/` (including co-located transport models), memory API dependencies/error translation, composition wiring, API tests, `docs/memory/` | Competition-scoped revision/resource reads, hydrated search, complete create/replacement writes, stable typed error responses, OpenAPI coverage, verification, and coordination ownership |
 
 ## `memory-11` Assignments
 
@@ -321,6 +328,28 @@ design and correctness pass.
   results.
 - HTTP schemas/routes, reporter tool integration, trigger scheduling,
   embeddings, and persistent hydration caches remain deferred.
+
+## `memory-12` Boundary Notes
+
+- The versioned HTTP boundary lives under
+  `/api/v1/memory/competitions/{competition_id}`. It exposes current, exact,
+  and historical canonical revision reads; exact-version and item-history reads
+  for all five typed memory resources; and revision-pinned hydrated search.
+- Each resource has distinct strict request and response schemas. `POST` creates
+  a complete typed resource and `PUT /{item_id}` performs a complete replacement
+  with an explicit expected item revision. Writes retain the application
+  service's required generation provenance and expected canonical parent.
+- A request-scoped dependency constructs one local-user `ManagerContext` from
+  the competition path and optional `X-Correlation-ID`, then composes the typed
+  managers, retrieval service, and mutation service over the process-owned
+  session factory. Routes never receive a session or ORM row.
+- Typed application failures map to stable HTTP status/code/message envelopes.
+  Missing scoped resources return 404, canonical or item conflicts return 409,
+  invalid reference semantics return 400, and canonical/projection integrity
+  failures return safe 500 responses without storage details.
+- Projection rebuild exposure, authentication/RBAC, reporter integration,
+  trigger scheduling, embeddings, and persistent hydration caches remain
+  deferred. FastAPI retains its standard 422 contract for transport validation.
 
 ## `memory-10` Boundary Notes
 

--- a/docs/memory/status.md
+++ b/docs/memory/status.md
@@ -5,8 +5,7 @@
 **Active layer:** `memory-12` complete; `memory-13` is next
 **Current branch:** `codex/memory-12-api`
 **Stack:** `main` <- `memory-0` <- `memory-1` <- `memory-2` <- `memory-3` <- `memory-4` <- `memory-5` <- `memory-6` <- `memory-7` <- `memory-8` <- `memory-9` <- `memory-10` <- `memory-11` <- `memory-12`
-**Publication:** `memory-12` is implemented locally atop `memory-11` (PR #119)
-and is not yet published.
+**Publication:** `memory-12` is published as PR #120 atop `memory-11` (PR #119).
 
 This file is the coordination ledger for the typed-memory application stack.
 The completed database stack remains tracked separately in
@@ -28,7 +27,7 @@ The completed database stack remains tracked separately in
 | `memory-9` mutation bundles | `codex/memory-9-mutation-bundles` | Complete | `root` | 6 focused service tests; memory: 79 passed; backend: 151 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `0260366`; PR #117 |
 | `memory-10` search projection | `codex/memory-10-search-projection` | Complete | `root` | 5 focused PostgreSQL tests; memory: 84 passed; backend: 156 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `915ddf4`; PR #118 |
 | `memory-11` retrieval | `codex/memory-11-retrieval` | Complete | `root` | 7 focused PostgreSQL tests; memory: 91 passed; backend: 163 passed; basedpyright found no new errors and the same 16 pre-existing backend errors | `a8a7250`; PR #119 |
-| `memory-12` HTTP API | `codex/memory-12-api` | Complete | `root` | 10 focused API/composition tests; memory + API: 107 passed; backend: 173 passed; focused basedpyright clean and full backend retains the same 16 pre-existing errors; Ruff clean | Active branch head; not yet published |
+| `memory-12` HTTP API | `codex/memory-12-api` | Complete | `root` | 10 focused API/composition tests; memory + API: 107 passed; backend: 173 passed; focused basedpyright clean and full backend retains the same 16 pre-existing errors; Ruff clean | `29474c4`; PR #120 |
 | `memory-13` reporter retrieval | `codex/memory-13-reporter-retrieval` | Pending | Unassigned | Not started | — |
 | `memory-14` reporter mutations | `codex/memory-14-reporter-mutations` | Pending | Unassigned | Not started | — |
 


### PR DESCRIPTION
## Summary

- add competition-scoped canonical revision reads, exact/history resource reads, and revision-pinned hydrated search
- add complete create and replacement routes for facts, events, storylines, triggers, and context notes
- compose request-scoped typed memory dependencies and translate application failures into stable HTTP responses
- keep the small request and response models co-located with their route modules

## Verification

- 10 focused API and composition tests passed
- 107 memory and API tests passed
- 173 backend tests passed
- Ruff passed on the changed API paths
- focused basedpyright found no errors; the same 16 pre-existing backend errors remain in the full check

## Stack

- based on MEMORY-11 / PR #119
