### PR TITLE
feat(datalayer): align snapshot persistence contract

### DIFF
--- a/backend/database/models/sleeper/snapshots.py
+++ b/backend/database/models/sleeper/snapshots.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any
 
 from sqlalchemy import (
     BigInteger,
+    Date,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -16,6 +17,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -39,11 +41,16 @@ class DataSnapshot(Base):
             name="uq_data_snapshots_id_primary_season",
         ),
         Index(
-            "ix_data_snapshots_season_mode_cutoff_created",
+            "ix_data_snapshots_season_as_of_created",
             "primary_competition_season_id",
-            "mode",
-            "knowledge_cutoff_at",
+            "as_of_date",
             "created_at",
+        ),
+        Index(
+            "uq_data_snapshots_active_build_key",
+            "build_key",
+            unique=True,
+            postgresql_where=text("status IN ('building', 'ready')"),
         ),
         Index("ix_data_snapshots_competition_status", "competition_id", "status"),
         {"schema": "sleeper"},
@@ -56,16 +63,15 @@ class DataSnapshot(Base):
         UUID(as_uuid=True), ForeignKey("core.competitions.id", ondelete="RESTRICT")
     )
     primary_competition_season_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
-    mode: Mapped[str] = mapped_column(Text)
+    build_key: Mapped[str] = mapped_column(Text)
     domain_cutoff_week: Mapped[int | None] = mapped_column(SmallInteger)
     domain_cutoff_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    knowledge_cutoff_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    as_of_date: Mapped[date] = mapped_column(Date)
     status: Mapped[str] = mapped_column(Text)
-    materializer_version: Mapped[str] = mapped_column(Text)
-    sqlite_schema_version: Mapped[str] = mapped_column(Text)
+    snapshot_projection_version: Mapped[str] = mapped_column(Text)
     code_version: Mapped[str] = mapped_column(Text)
     completeness_warnings: Mapped[list[Any]] = mapped_column(JSONB)
-    selected_request_set_sha256: Mapped[str | None] = mapped_column(Text)
+    failure_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
     sqlite_artifact_sha256: Mapped[str | None] = mapped_column(Text)
     sqlite_artifact_byte_length: Mapped[int | None] = mapped_column(BigInteger)
     sqlite_artifact_storage_key: Mapped[str | None] = mapped_column(Text)
@@ -79,9 +85,13 @@ class DataSnapshotRequest(Base):
     __tablename__ = "data_snapshot_requests"
     __table_args__ = (
         ForeignKeyConstraint(
-            ["api_request_id", "scope_key"],
-            ["sleeper.api_requests.id", "sleeper.api_requests.scope_key"],
-            name="fk_data_snapshot_requests_request_scope",
+            ["api_request_id", "scope_key", "response_sha256"],
+            [
+                "sleeper.api_requests.id",
+                "sleeper.api_requests.scope_key",
+                "sleeper.api_requests.response_sha256",
+            ],
+            name="fk_data_snapshot_requests_request_scope_hash",
             ondelete="RESTRICT",
         ),
         UniqueConstraint(
@@ -98,4 +108,5 @@ class DataSnapshotRequest(Base):
     )
     api_request_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
     scope_key: Mapped[str] = mapped_column(Text)
+    response_sha256: Mapped[str] = mapped_column(Text)
     selection_role: Mapped[str] = mapped_column(Text)

--- a/backend/migrations/versions/0007_datalayer_snapshot_contract.py
+++ b/backend/migrations/versions/0007_datalayer_snapshot_contract.py
@@ -1,0 +1,438 @@
+"""Align frozen snapshot persistence with the datalayer contract.
+
+Revision ID: 0007
+Revises: 0006
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Text
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _drop_snapshot_guards() -> None:
+    op.execute("DROP FUNCTION sleeper.protect_snapshot_request_membership() CASCADE")
+    op.execute("DROP FUNCTION sleeper.protect_sealed_data_snapshot() CASCADE")
+
+
+def _create_snapshot_guards() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_sealed_data_snapshot()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshots cannot be deleted';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.status = 'expired' AND NEW IS DISTINCT FROM OLD THEN
+                RAISE EXCEPTION 'expired Sleeper data snapshots are terminal';
+            END IF;
+
+            IF OLD.status = 'ready' THEN
+                IF NEW.status NOT IN ('ready', 'expired')
+                   OR ROW(
+                       NEW.id, NEW.competition_id,
+                       NEW.primary_competition_season_id, NEW.build_key,
+                       NEW.domain_cutoff_week, NEW.domain_cutoff_at,
+                       NEW.as_of_date, NEW.snapshot_projection_version,
+                       NEW.code_version, NEW.completeness_warnings,
+                       NEW.failure_summary, NEW.sqlite_artifact_sha256,
+                       NEW.sqlite_artifact_byte_length,
+                       NEW.sqlite_artifact_storage_key, NEW.created_at,
+                       NEW.completed_at
+                   ) IS DISTINCT FROM ROW(
+                       OLD.id, OLD.competition_id,
+                       OLD.primary_competition_season_id, OLD.build_key,
+                       OLD.domain_cutoff_week, OLD.domain_cutoff_at,
+                       OLD.as_of_date, OLD.snapshot_projection_version,
+                       OLD.code_version, OLD.completeness_warnings,
+                       OLD.failure_summary, OLD.sqlite_artifact_sha256,
+                       OLD.sqlite_artifact_byte_length,
+                       OLD.sqlite_artifact_storage_key, OLD.created_at,
+                       OLD.completed_at
+                   ) THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshot meaning is immutable';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshots_protect_sealed
+        BEFORE UPDATE OR DELETE ON sleeper.data_snapshots
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_sealed_data_snapshot()
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_snapshot_request_membership()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        DECLARE
+            snapshot_status text;
+            snapshot_season_id uuid;
+            request_season_id uuid;
+        BEGIN
+            IF TG_OP IN ('UPDATE', 'DELETE') THEN
+                SELECT status INTO snapshot_status
+                FROM sleeper.data_snapshots
+                WHERE id = OLD.data_snapshot_id;
+                IF snapshot_status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+                END IF;
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+
+            SELECT status, primary_competition_season_id
+            INTO snapshot_status, snapshot_season_id
+            FROM sleeper.data_snapshots
+            WHERE id = NEW.data_snapshot_id
+            FOR UPDATE;
+            IF snapshot_status IN ('ready', 'expired') THEN
+                RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+            END IF;
+
+            SELECT competition_season_id INTO request_season_id
+            FROM sleeper.api_requests
+            WHERE id = NEW.api_request_id;
+            IF request_season_id IS NOT NULL
+               AND request_season_id <> snapshot_season_id THEN
+                RAISE EXCEPTION 'snapshot request belongs to another competition season';
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshot_requests_protect_membership
+        BEFORE INSERT OR UPDATE OR DELETE ON sleeper.data_snapshot_requests
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_snapshot_request_membership()
+        """
+    )
+
+
+def _create_legacy_snapshot_guards() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_sealed_data_snapshot()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                IF OLD.status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshots cannot be deleted';
+                END IF;
+                RETURN OLD;
+            END IF;
+
+            IF OLD.status IN ('ready', 'expired') THEN
+                IF NEW.status NOT IN ('ready', 'expired')
+                   OR ROW(
+                       NEW.competition_id, NEW.primary_competition_season_id,
+                       NEW.mode, NEW.domain_cutoff_week, NEW.domain_cutoff_at,
+                       NEW.knowledge_cutoff_at, NEW.materializer_version,
+                       NEW.sqlite_schema_version, NEW.code_version,
+                       NEW.completeness_warnings,
+                       NEW.selected_request_set_sha256,
+                       NEW.sqlite_artifact_sha256,
+                       NEW.sqlite_artifact_byte_length,
+                       NEW.sqlite_artifact_storage_key, NEW.created_at,
+                       NEW.completed_at
+                   ) IS DISTINCT FROM ROW(
+                       OLD.competition_id, OLD.primary_competition_season_id,
+                       OLD.mode, OLD.domain_cutoff_week, OLD.domain_cutoff_at,
+                       OLD.knowledge_cutoff_at, OLD.materializer_version,
+                       OLD.sqlite_schema_version, OLD.code_version,
+                       OLD.completeness_warnings,
+                       OLD.selected_request_set_sha256,
+                       OLD.sqlite_artifact_sha256,
+                       OLD.sqlite_artifact_byte_length,
+                       OLD.sqlite_artifact_storage_key, OLD.created_at,
+                       OLD.completed_at
+                   ) THEN
+                    RAISE EXCEPTION 'sealed Sleeper data snapshot meaning is immutable';
+                END IF;
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshots_protect_sealed
+        BEFORE UPDATE OR DELETE ON sleeper.data_snapshots
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_sealed_data_snapshot()
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION sleeper.protect_snapshot_request_membership()
+        RETURNS trigger LANGUAGE plpgsql AS $aida$
+        DECLARE
+            snapshot_status text;
+            snapshot_season_id uuid;
+            request_season_id uuid;
+        BEGIN
+            IF TG_OP IN ('UPDATE', 'DELETE') THEN
+                SELECT status INTO snapshot_status
+                FROM sleeper.data_snapshots
+                WHERE id = OLD.data_snapshot_id;
+                IF snapshot_status IN ('ready', 'expired') THEN
+                    RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+                END IF;
+            END IF;
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+
+            SELECT status, primary_competition_season_id
+            INTO snapshot_status, snapshot_season_id
+            FROM sleeper.data_snapshots
+            WHERE id = NEW.data_snapshot_id
+            FOR UPDATE;
+            IF snapshot_status IN ('ready', 'expired') THEN
+                RAISE EXCEPTION 'sealed data snapshot request membership is immutable';
+            END IF;
+
+            SELECT competition_season_id INTO request_season_id
+            FROM sleeper.api_requests
+            WHERE id = NEW.api_request_id;
+            IF request_season_id IS NOT NULL
+               AND request_season_id <> snapshot_season_id THEN
+                RAISE EXCEPTION 'snapshot request belongs to another competition season';
+            END IF;
+            RETURN NEW;
+        END;
+        $aida$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER data_snapshot_requests_protect_membership
+        BEFORE INSERT OR UPDATE OR DELETE ON sleeper.data_snapshot_requests
+        FOR EACH ROW EXECUTE FUNCTION sleeper.protect_snapshot_request_membership()
+        """
+    )
+
+
+def upgrade() -> None:
+    _drop_snapshot_guards()
+
+    op.add_column(
+        "data_snapshots",
+        sa.Column("build_key", sa.Text(), nullable=True),
+        schema="sleeper",
+    )
+    op.execute(
+        "UPDATE sleeper.data_snapshots "
+        "SET build_key = 'legacy:' || id::text WHERE build_key IS NULL"
+    )
+    op.alter_column("data_snapshots", "build_key", nullable=False, schema="sleeper")
+
+    op.add_column(
+        "data_snapshots",
+        sa.Column("as_of_date", sa.Date(), nullable=True),
+        schema="sleeper",
+    )
+    op.execute(
+        "UPDATE sleeper.data_snapshots "
+        "SET as_of_date = (knowledge_cutoff_at AT TIME ZONE 'UTC')::date "
+        "WHERE as_of_date IS NULL"
+    )
+    op.alter_column("data_snapshots", "as_of_date", nullable=False, schema="sleeper")
+
+    op.alter_column(
+        "data_snapshots",
+        "materializer_version",
+        new_column_name="snapshot_projection_version",
+        schema="sleeper",
+    )
+    op.add_column(
+        "data_snapshots",
+        sa.Column("failure_summary", postgresql.JSONB(astext_type=Text()), nullable=True),
+        schema="sleeper",
+    )
+
+    op.add_column(
+        "data_snapshot_requests",
+        sa.Column("response_sha256", sa.Text(), nullable=True),
+        schema="sleeper",
+    )
+    op.execute(
+        """
+        UPDATE sleeper.data_snapshot_requests AS membership
+        SET response_sha256 = request.response_sha256
+        FROM sleeper.api_requests AS request
+        WHERE request.id = membership.api_request_id
+        """
+    )
+    op.alter_column(
+        "data_snapshot_requests",
+        "response_sha256",
+        nullable=False,
+        schema="sleeper",
+    )
+    op.drop_constraint(
+        "fk_data_snapshot_requests_request_scope",
+        "data_snapshot_requests",
+        type_="foreignkey",
+        schema="sleeper",
+    )
+    op.create_foreign_key(
+        "fk_data_snapshot_requests_request_scope_hash",
+        "data_snapshot_requests",
+        "api_requests",
+        ["api_request_id", "scope_key", "response_sha256"],
+        ["id", "scope_key", "response_sha256"],
+        source_schema="sleeper",
+        referent_schema="sleeper",
+        ondelete="RESTRICT",
+    )
+
+    op.drop_index(
+        "ix_data_snapshots_season_mode_cutoff_created",
+        table_name="data_snapshots",
+        schema="sleeper",
+    )
+    op.create_index(
+        "ix_data_snapshots_season_as_of_created",
+        "data_snapshots",
+        ["primary_competition_season_id", "as_of_date", "created_at"],
+        schema="sleeper",
+    )
+    op.create_index(
+        "uq_data_snapshots_active_build_key",
+        "data_snapshots",
+        ["build_key"],
+        unique=True,
+        schema="sleeper",
+        postgresql_where=sa.text("status IN ('building', 'ready')"),
+    )
+
+    op.drop_column("data_snapshots", "selected_request_set_sha256", schema="sleeper")
+    op.drop_column("data_snapshots", "sqlite_schema_version", schema="sleeper")
+    op.drop_column("data_snapshots", "knowledge_cutoff_at", schema="sleeper")
+    op.drop_column("data_snapshots", "mode", schema="sleeper")
+
+    _create_snapshot_guards()
+
+
+def downgrade() -> None:
+    _drop_snapshot_guards()
+
+    op.drop_constraint(
+        "fk_data_snapshot_requests_request_scope_hash",
+        "data_snapshot_requests",
+        type_="foreignkey",
+        schema="sleeper",
+    )
+    op.create_foreign_key(
+        "fk_data_snapshot_requests_request_scope",
+        "data_snapshot_requests",
+        "api_requests",
+        ["api_request_id", "scope_key"],
+        ["id", "scope_key"],
+        source_schema="sleeper",
+        referent_schema="sleeper",
+        ondelete="RESTRICT",
+    )
+    op.drop_column("data_snapshot_requests", "response_sha256", schema="sleeper")
+
+    op.drop_index(
+        "uq_data_snapshots_active_build_key",
+        table_name="data_snapshots",
+        schema="sleeper",
+    )
+    op.drop_index(
+        "ix_data_snapshots_season_as_of_created",
+        table_name="data_snapshots",
+        schema="sleeper",
+    )
+
+    op.add_column(
+        "data_snapshots",
+        sa.Column("mode", sa.Text(), nullable=True),
+        schema="sleeper",
+    )
+    op.execute("UPDATE sleeper.data_snapshots SET mode = 'legacy' WHERE mode IS NULL")
+    op.alter_column("data_snapshots", "mode", nullable=False, schema="sleeper")
+
+    op.add_column(
+        "data_snapshots",
+        sa.Column("knowledge_cutoff_at", sa.DateTime(timezone=True), nullable=True),
+        schema="sleeper",
+    )
+    op.execute(
+        "UPDATE sleeper.data_snapshots "
+        "SET knowledge_cutoff_at = as_of_date::timestamp AT TIME ZONE 'UTC' "
+        "WHERE knowledge_cutoff_at IS NULL"
+    )
+    op.alter_column(
+        "data_snapshots",
+        "knowledge_cutoff_at",
+        nullable=False,
+        schema="sleeper",
+    )
+
+    op.add_column(
+        "data_snapshots",
+        sa.Column("sqlite_schema_version", sa.Text(), nullable=True),
+        schema="sleeper",
+    )
+    op.execute(
+        "UPDATE sleeper.data_snapshots "
+        "SET sqlite_schema_version = snapshot_projection_version "
+        "WHERE sqlite_schema_version IS NULL"
+    )
+    op.alter_column(
+        "data_snapshots",
+        "sqlite_schema_version",
+        nullable=False,
+        schema="sleeper",
+    )
+    op.add_column(
+        "data_snapshots",
+        sa.Column("selected_request_set_sha256", sa.Text(), nullable=True),
+        schema="sleeper",
+    )
+    op.alter_column(
+        "data_snapshots",
+        "snapshot_projection_version",
+        new_column_name="materializer_version",
+        schema="sleeper",
+    )
+
+    op.create_index(
+        "ix_data_snapshots_season_mode_cutoff_created",
+        "data_snapshots",
+        [
+            "primary_competition_season_id",
+            "mode",
+            "knowledge_cutoff_at",
+            "created_at",
+        ],
+        schema="sleeper",
+    )
+
+    op.drop_column("data_snapshots", "failure_summary", schema="sleeper")
+    op.drop_column("data_snapshots", "as_of_date", schema="sleeper")
+    op.drop_column("data_snapshots", "build_key", schema="sleeper")
+
+    _create_legacy_snapshot_guards()

--- a/backend/tests/database/constraints/test_cross_namespace_integrity.py
+++ b/backend/tests/database/constraints/test_cross_namespace_integrity.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from uuid import UUID, uuid4
 
 import pytest
@@ -327,11 +327,11 @@ def test_generation_snapshot_must_match_the_exact_competition_season(
                 "id": snapshot_id,
                 "competition_id": domain["competition"],
                 "primary_competition_season_id": domain["season"],
-                "mode": "test",
-                "knowledge_cutoff_at": datetime.now(timezone.utc),
+                "build_key": f"test:{snapshot_id}",
+                "domain_cutoff_week": 8,
+                "as_of_date": date(2026, 10, 27),
                 "status": "building",
-                "materializer_version": "test",
-                "sqlite_schema_version": "test",
+                "snapshot_projection_version": "test",
                 "code_version": "test",
                 "completeness_warnings": [],
             },

--- a/backend/tests/database/constraints/test_sleeper_constraints.py
+++ b/backend/tests/database/constraints/test_sleeper_constraints.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from uuid import UUID, uuid4
 
@@ -168,6 +168,57 @@ def test_sleeper_model_contract_is_structural_and_uses_exact_scores() -> None:
         column_type = Base.metadata.tables[table_name].c[column_name].type
         assert isinstance(column_type, Numeric)
         assert (column_type.precision, column_type.scale) == (12, 4)
+
+
+def test_snapshot_orm_matches_the_daily_persistence_contract() -> None:
+    snapshot = DataSnapshot.__table__
+    membership = DataSnapshotRequest.__table__
+
+    assert {column.name for column in snapshot.c} == {
+        "id",
+        "competition_id",
+        "primary_competition_season_id",
+        "build_key",
+        "domain_cutoff_week",
+        "domain_cutoff_at",
+        "as_of_date",
+        "status",
+        "snapshot_projection_version",
+        "code_version",
+        "completeness_warnings",
+        "failure_summary",
+        "sqlite_artifact_sha256",
+        "sqlite_artifact_byte_length",
+        "sqlite_artifact_storage_key",
+        "created_at",
+        "completed_at",
+    }
+    assert {column.name for column in membership.c} == {
+        "data_snapshot_id",
+        "api_request_id",
+        "scope_key",
+        "response_sha256",
+        "selection_role",
+    }
+    active_build_index = next(
+        index
+        for index in snapshot.indexes
+        if index.name == "uq_data_snapshots_active_build_key"
+    )
+    assert active_build_index.unique is True
+    assert str(active_build_index.dialect_options["postgresql"]["where"]) == (
+        "status IN ('building', 'ready')"
+    )
+    request_fk = next(
+        constraint
+        for constraint in membership.foreign_key_constraints
+        if constraint.name == "fk_data_snapshot_requests_request_scope_hash"
+    )
+    assert [element.parent.name for element in request_fk.elements] == [
+        "api_request_id",
+        "scope_key",
+        "response_sha256",
+    ]
 
 
 def test_api_payload_requires_exactly_one_content_location(
@@ -355,11 +406,11 @@ def test_sealed_snapshot_and_membership_are_immutable_and_scope_safe(
                 "id": snapshot_id,
                 "competition_id": first_scope["competition"],
                 "primary_competition_season_id": first_scope["season"],
-                "mode": "test",
-                "knowledge_cutoff_at": datetime.now(timezone.utc),
+                "build_key": f"test:{snapshot_id}",
+                "domain_cutoff_week": 8,
+                "as_of_date": date(2026, 10, 27),
                 "status": "building",
-                "materializer_version": "test",
-                "sqlite_schema_version": "test",
+                "snapshot_projection_version": "test",
                 "code_version": "test",
                 "completeness_warnings": [],
             },
@@ -370,6 +421,7 @@ def test_sealed_snapshot_and_membership_are_immutable_and_scope_safe(
                 "data_snapshot_id": snapshot_id,
                 "api_request_id": first_request["request"],
                 "scope_key": first_request["scope_key"],
+                "response_sha256": first_request["hash"],
                 "selection_role": "test",
             },
         )
@@ -380,6 +432,7 @@ def test_sealed_snapshot_and_membership_are_immutable_and_scope_safe(
             data_snapshot_id=snapshot_id,
             api_request_id=second_request["request"],
             scope_key=second_request["scope_key"],
+            response_sha256=second_request["hash"],
             selection_role="test",
         ),
     )
@@ -401,9 +454,103 @@ def test_sealed_snapshot_and_membership_are_immutable_and_scope_safe(
         database_engine,
         sa.update(DataSnapshot)
         .where(DataSnapshot.id == snapshot_id)
-        .values(materializer_version="rewritten"),
+        .values(snapshot_projection_version="rewritten"),
+    )
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(DataSnapshot)
+            .where(DataSnapshot.id == snapshot_id)
+            .values(status="expired")
+        )
+    _assert_database_error(
+        database_engine,
+        sa.update(DataSnapshot)
+        .where(DataSnapshot.id == snapshot_id)
+        .values(status="ready"),
     )
     _assert_database_error(
         database_engine,
         sa.delete(DataSnapshot).where(DataSnapshot.id == snapshot_id),
+    )
+
+
+def test_only_active_snapshots_reserve_a_build_key(database_engine: Engine) -> None:
+    scope = _insert_competition_scope(database_engine)
+    build_key = f"snapshot:{uuid4()}"
+
+    def values(status: str) -> dict[str, object]:
+        return {
+            "id": uuid4(),
+            "competition_id": scope["competition"],
+            "primary_competition_season_id": scope["season"],
+            "build_key": build_key,
+            "domain_cutoff_week": 8,
+            "as_of_date": date(2026, 10, 27),
+            "status": status,
+            "snapshot_projection_version": "test",
+            "code_version": "test",
+            "completeness_warnings": [],
+        }
+
+    active = values("building")
+    with database_engine.begin() as connection:
+        connection.execute(sa.insert(DataSnapshot), values("failed"))
+        connection.execute(sa.insert(DataSnapshot), active)
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(DataSnapshot).values(**values("ready")),
+    )
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(DataSnapshot)
+            .where(DataSnapshot.id == active["id"])
+            .values(status="failed")
+        )
+        ready = values("ready")
+        connection.execute(sa.insert(DataSnapshot), ready)
+        connection.execute(
+            sa.update(DataSnapshot)
+            .where(DataSnapshot.id == ready["id"])
+            .values(status="expired")
+        )
+        connection.execute(sa.insert(DataSnapshot), values("building"))
+
+
+def test_snapshot_membership_pins_the_request_response_hash(
+    database_engine: Engine,
+) -> None:
+    scope = _insert_competition_scope(database_engine)
+    request = _insert_request(
+        database_engine,
+        scope,
+        scope_key=f"league:{scope['season']}",
+    )
+    snapshot_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(DataSnapshot),
+            {
+                "id": snapshot_id,
+                "competition_id": scope["competition"],
+                "primary_competition_season_id": scope["season"],
+                "build_key": f"test:{snapshot_id}",
+                "domain_cutoff_week": 8,
+                "as_of_date": date(2026, 10, 27),
+                "status": "building",
+                "snapshot_projection_version": "test",
+                "code_version": "test",
+                "completeness_warnings": [],
+            },
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.insert(DataSnapshotRequest).values(
+            data_snapshot_id=snapshot_id,
+            api_request_id=request["request"],
+            scope_key=request["scope_key"],
+            response_sha256="0" * 64,
+            selection_role="league",
+        ),
     )

--- a/backend/tests/database/migrations/test_datalayer_snapshot_contract.py
+++ b/backend/tests/database/migrations/test_datalayer_snapshot_contract.py
@@ -1,0 +1,176 @@
+from datetime import date, datetime, timezone
+from io import StringIO
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, inspect, text
+
+from backend.database.models.core import Competition, CompetitionSeason
+
+
+def _config(database_url: str, *, output_buffer: StringIO | None = None) -> Config:
+    root = Path(__file__).resolve().parents[4]
+    config = Config(
+        str(root / "backend" / "migrations" / "alembic.ini"),
+        output_buffer=output_buffer,
+    )
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
+    return config
+
+
+def test_snapshot_contract_upgrade_and_downgrade_compile_offline() -> None:
+    upgrade_sql = StringIO()
+    command.upgrade(
+        _config("postgresql+psycopg://unused:unused@localhost/unused", output_buffer=upgrade_sql),
+        "0007",
+        sql=True,
+    )
+    upgrade = upgrade_sql.getvalue()
+    assert "ADD COLUMN build_key" in upgrade
+    assert "ADD COLUMN as_of_date DATE" in upgrade
+    assert "uq_data_snapshots_active_build_key" in upgrade
+    assert "fk_data_snapshot_requests_request_scope_hash" in upgrade
+
+    downgrade_sql = StringIO()
+    command.downgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=downgrade_sql,
+        ),
+        "0007:0006",
+        sql=True,
+    )
+    downgrade = downgrade_sql.getvalue()
+    assert "DROP COLUMN build_key" in downgrade
+    assert "ADD COLUMN mode TEXT" in downgrade
+    assert "fk_data_snapshot_requests_request_scope" in downgrade
+
+
+def test_snapshot_contract_migrates_legacy_rows_and_reverses(
+    database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_MIGRATION_REQUIRE_TLS", "false")
+    monkeypatch.setenv("AIDAM_MIGRATION_ROLE", "aidam_owner")
+    config = _config(database_url)
+    command.upgrade(config, "0006")
+
+    competition_id = uuid4()
+    season_id = uuid4()
+    snapshot_id = uuid4()
+    legacy_cutoff = datetime(2026, 10, 27, 23, 45, tzinfo=timezone.utc)
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Migration Test League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO sleeper.data_snapshots (
+                    id, competition_id, primary_competition_season_id, mode,
+                    domain_cutoff_week, knowledge_cutoff_at, status,
+                    materializer_version, sqlite_schema_version, code_version,
+                    completeness_warnings
+                ) VALUES (
+                    :id, :competition_id, :season_id, 'historical', 8,
+                    :knowledge_cutoff_at, 'building', 'projection-v1',
+                    'sqlite-v1', 'code-v1', '[]'::jsonb
+                )
+                """
+            ),
+            {
+                "id": snapshot_id,
+                "competition_id": competition_id,
+                "season_id": season_id,
+                "knowledge_cutoff_at": legacy_cutoff,
+            },
+        )
+
+    command.upgrade(config, "0007")
+    with engine.connect() as connection:
+        columns = {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "data_snapshots", schema="sleeper"
+            )
+        }
+        row = connection.execute(
+            text(
+                """
+                SELECT build_key, as_of_date, snapshot_projection_version,
+                       failure_summary
+                FROM sleeper.data_snapshots
+                WHERE id = :snapshot_id
+                """
+            ),
+            {"snapshot_id": snapshot_id},
+        ).one()
+    assert {
+        "build_key",
+        "as_of_date",
+        "snapshot_projection_version",
+        "failure_summary",
+    } <= columns
+    assert {
+        "mode",
+        "knowledge_cutoff_at",
+        "materializer_version",
+        "sqlite_schema_version",
+        "selected_request_set_sha256",
+    }.isdisjoint(columns)
+    assert row.build_key == f"legacy:{snapshot_id}"
+    assert row.as_of_date == date(2026, 10, 27)
+    assert row.snapshot_projection_version == "projection-v1"
+    assert row.failure_summary is None
+
+    command.downgrade(config, "0006")
+    with engine.connect() as connection:
+        columns = {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "data_snapshots", schema="sleeper"
+            )
+        }
+        row = connection.execute(
+            text(
+                """
+                SELECT mode, knowledge_cutoff_at, materializer_version,
+                       sqlite_schema_version, selected_request_set_sha256
+                FROM sleeper.data_snapshots
+                WHERE id = :snapshot_id
+                """
+            ),
+            {"snapshot_id": snapshot_id},
+        ).one()
+    assert {
+        "mode",
+        "knowledge_cutoff_at",
+        "materializer_version",
+        "sqlite_schema_version",
+        "selected_request_set_sha256",
+    } <= columns
+    assert row.mode == "legacy"
+    assert row.knowledge_cutoff_at == datetime(2026, 10, 27, tzinfo=timezone.utc)
+    assert row.materializer_version == "projection-v1"
+    assert row.sqlite_schema_version == "projection-v1"
+    assert row.selected_request_set_sha256 is None
+
+    command.upgrade(config, "0007")
+    command.downgrade(config, "base")
+    engine.dispose()


### PR DESCRIPTION
## Stack

Stacked on #102. Review this PR as the incremental diff from
`codex/datalayer-foundation`.

## Summary

- add Alembic revision `0007` for the snapshot persistence contract
- replace generation-mode/knowledge-time identity with canonical `build_key`
  and plain `as_of_date`
- consolidate materializer and SQLite schema versions into
  `snapshot_projection_version`
- remove the aggregate selected-request-set hash and pin each membership row to
  its request's `response_sha256`
- enforce one active `building` or `ready` row per build key
- seal ready snapshot meaning and membership, allowing only `ready -> expired`;
  expired snapshots are terminal
- keep the SQLAlchemy ORM metadata aligned with the migration

## Scope

This PR contains only snapshot persistence, ORM alignment, and database tests.
It intentionally does not add managers, services, selection, materialization,
or HTTP behavior.

## Verification

- Alembic offline upgrade/downgrade compilation passed
- exact CI migration lifecycle passed: upgrade head, head check, downgrade base,
  re-upgrade head, metadata drift check
- Alembic reported no new upgrade operations
- focused PostgreSQL migration/constraint suite: 18 passed
- full backend suite against disposable PostgreSQL: 178 passed
