### PR TITLE
feat(datalayer): establish core contracts

### DIFF
--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -1,0 +1,54 @@
+"""Pure contracts shared by datalayer workflows and later adapters."""
+
+from backend.services.datalayer.contracts import (
+    ApplyDisposition,
+    CompletenessWarning,
+    NormalizationStatus,
+    RefreshOutcome,
+    RefreshRequest,
+    RefreshStatus,
+    RefreshTrigger,
+    RequestStatus,
+    ScopeRefreshResult,
+    SnapshotRequest,
+    WarningCode,
+)
+from backend.services.datalayer.errors import (
+    DatalayerError,
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+    EndpointPayloadRejected,
+    InternalDatalayerFailure,
+    InvalidDatalayerRequest,
+    SnapshotUnavailable,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+from backend.services.datalayer.versions import (
+    INGESTION_NORMALIZER_VERSION,
+    SNAPSHOT_PROJECTION_VERSION,
+)
+
+__all__ = [
+    "ApplyDisposition",
+    "CompletenessWarning",
+    "DatalayerError",
+    "DatalayerResourceNotFound",
+    "DatalayerScopeConflict",
+    "EndpointKind",
+    "EndpointPayloadRejected",
+    "INGESTION_NORMALIZER_VERSION",
+    "InternalDatalayerFailure",
+    "InvalidDatalayerRequest",
+    "NormalizationStatus",
+    "RefreshOutcome",
+    "RefreshRequest",
+    "RefreshStatus",
+    "RefreshTrigger",
+    "RequestStatus",
+    "SNAPSHOT_PROJECTION_VERSION",
+    "ScopeKey",
+    "ScopeRefreshResult",
+    "SnapshotRequest",
+    "SnapshotUnavailable",
+    "WarningCode",
+]

--- a/backend/services/datalayer/canonical_json.py
+++ b/backend/services/datalayer/canonical_json.py
@@ -1,0 +1,76 @@
+"""Decimal-first JSON parsing, canonical encoding, and payload identity."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import hashlib
+import json
+from typing import NoReturn, TypeAlias
+
+
+JsonValue: TypeAlias = (
+    type(None)
+    | bool
+    | int
+    | Decimal
+    | str
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+
+
+def parse_json_bytes(content: bytes) -> JsonValue:
+    """Parse JSON without routing fractional source values through float."""
+
+    return json.loads(
+        content,
+        parse_float=Decimal,
+        parse_int=int,
+        parse_constant=_reject_non_finite,
+    )
+
+
+def canonical_json_bytes(value: JsonValue) -> bytes:
+    """Encode one JSON value as deterministic compact UTF-8 bytes."""
+
+    return _encode(value).encode("utf-8")
+
+
+def canonical_json_sha256(value: JsonValue) -> str:
+    """Return the lowercase SHA-256 identity of canonical JSON bytes."""
+
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _encode(value: JsonValue) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("JSON numbers must be finite")
+        if value.is_zero():
+            return "0"
+        return format(value.normalize(), "f")
+    if isinstance(value, float):
+        raise TypeError("binary floats are not accepted at the Sleeper boundary")
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, list):
+        return "[" + ",".join(_encode(item) for item in value) + "]"
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("JSON object keys must be strings")
+        return "{" + ",".join(
+            f"{_encode(key)}:{_encode(value[key])}" for key in sorted(value)
+        ) + "}"
+    raise TypeError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def _reject_non_finite(value: str) -> NoReturn:
+    raise ValueError(f"non-finite JSON number is not allowed: {value}")

--- a/backend/services/datalayer/contracts.py
+++ b/backend/services/datalayer/contracts.py
@@ -1,0 +1,105 @@
+"""Immutable, storage-independent datalayer workflow values."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+from backend.services.datalayer.sleeper.scope import ScopeKey
+
+
+class _WorkflowValue(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+WarningCode = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=100,
+        pattern=r"^[a-z0-9][a-z0-9_.-]*$",
+    ),
+]
+
+WarningSummary = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=500),
+]
+
+
+class RefreshTrigger(StrEnum):
+    MANUAL = "manual"
+    GENERATION = "generation"
+    SCHEDULED = "scheduled"
+    BACKFILL = "backfill"
+
+
+class RefreshStatus(StrEnum):
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    PARTIAL = "partial"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class RequestStatus(StrEnum):
+    SUCCEEDED = "succeeded"
+    HTTP_ERROR = "http_error"
+    TRANSPORT_ERROR = "transport_error"
+    INVALID_PAYLOAD = "invalid_payload"
+
+
+class NormalizationStatus(StrEnum):
+    PENDING = "pending"
+    SUCCEEDED = "succeeded"
+    REJECTED = "rejected"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class ApplyDisposition(StrEnum):
+    APPLIED = "applied"
+    STALE_IGNORED = "stale_ignored"
+    ALREADY_APPLIED = "already_applied"
+    IDENTICAL_HEAD_ADVANCED = "identical_head_advanced"
+
+
+class RefreshRequest(_WorkflowValue):
+    competition_season_id: UUID
+    through_week: int | None = Field(default=None, ge=1, le=18, strict=True)
+    trigger: RefreshTrigger
+
+
+class ScopeRefreshResult(_WorkflowValue):
+    scope_key: ScopeKey
+    api_request_id: UUID
+    fetch_status: RequestStatus
+    normalization_status: NormalizationStatus
+    changed_current_view: bool = Field(strict=True)
+    warning_codes: tuple[WarningCode, ...] = ()
+
+
+class RefreshOutcome(_WorkflowValue):
+    refresh_run_id: UUID
+    status: RefreshStatus
+    requested_scope_count: int = Field(ge=0, strict=True)
+    succeeded_scope_count: int = Field(ge=0, strict=True)
+    failed_scope_count: int = Field(ge=0, strict=True)
+    scope_results: tuple[ScopeRefreshResult, ...]
+
+
+class SnapshotRequest(_WorkflowValue):
+    competition_season_id: UUID
+    through_week: int = Field(ge=1, le=18, strict=True)
+    as_of_date: date
+
+
+class CompletenessWarning(_WorkflowValue):
+    """Safe structured warning retained with a snapshot or workflow result."""
+
+    code: WarningCode
+    summary: WarningSummary
+    scope_key: ScopeKey | None = None

--- a/backend/services/datalayer/errors.py
+++ b/backend/services/datalayer/errors.py
@@ -1,0 +1,61 @@
+"""Stable, sanitized datalayer application failures."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+class DatalayerError(RuntimeError):
+    """Base class for failures safe to translate at an application boundary."""
+
+
+class InvalidDatalayerRequest(DatalayerError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class DatalayerResourceNotFound(DatalayerError):
+    def __init__(self, resource_kind: str, resource_id: str) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        super().__init__(f"{resource_kind} {resource_id} was not found")
+
+
+class DatalayerScopeConflict(DatalayerError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class EndpointPayloadRejected(DatalayerError):
+    """A source payload cannot be normalized without inventing facts."""
+
+    def __init__(self, endpoint_kind: EndpointKind, code: str, summary: str) -> None:
+        self.endpoint_kind = endpoint_kind
+        self.code = code
+        self.summary = summary
+        super().__init__(summary)
+
+
+class SnapshotUnavailable(DatalayerError):
+    """Required factual inputs or a healthy ready artifact are unavailable."""
+
+    def __init__(
+        self,
+        message: str,
+        missing_scopes: Iterable[ScopeKey] = (),
+    ) -> None:
+        self.message = message
+        self.missing_scopes = tuple(missing_scopes)
+        super().__init__(message)
+
+
+class InternalDatalayerFailure(DatalayerError):
+    """Sanitized unexpected failure carrying only a correlation identifier."""
+
+    def __init__(self, correlation_id: str) -> None:
+        self.correlation_id = correlation_id
+        super().__init__(f"datalayer operation failed ({correlation_id})")

--- a/backend/services/datalayer/sleeper/__init__.py
+++ b/backend/services/datalayer/sleeper/__init__.py
@@ -1,0 +1,5 @@
+"""Shared Sleeper endpoint identity vocabulary."""
+
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+__all__ = ["EndpointKind", "ScopeKey"]

--- a/backend/services/datalayer/sleeper/scope.py
+++ b/backend/services/datalayer/sleeper/scope.py
@@ -1,0 +1,57 @@
+"""Canonical Sleeper endpoint kinds and deterministic scope identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+from typing import Self
+from uuid import UUID
+
+
+_SCOPE_PART = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class EndpointKind(StrEnum):
+    LEAGUE = "league"
+    LEAGUE_USERS = "league_users"
+    LEAGUE_ROSTERS = "league_rosters"
+    NFL_STATE = "nfl_state"
+    PLAYER_CATALOG = "player_catalog"
+    MATCHUPS = "matchups"
+    TRANSACTIONS = "transactions"
+    TRADED_PICKS = "traded_picks"
+    WINNERS_BRACKET = "winners_bracket"
+    LOSERS_BRACKET = "losers_bracket"
+
+
+ScopePart = str | int | UUID | EndpointKind
+
+
+@dataclass(frozen=True, slots=True)
+class ScopeKey:
+    """Validated stable identity for one complete endpoint response scope."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        parts = self.value.split(":")
+        if len(parts) < 2 or any(not _SCOPE_PART.fullmatch(part) for part in parts):
+            raise ValueError(f"invalid scope key: {self.value!r}")
+
+    @classmethod
+    def from_parts(cls, *parts: ScopePart) -> Self:
+        if len(parts) < 2:
+            raise ValueError("a scope key requires at least two parts")
+        if any(isinstance(part, bool) for part in parts):
+            raise TypeError("boolean values are not valid scope-key parts")
+        return cls(":".join(str(part) for part in parts))
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Validate a scope key loaded at a persistence or transport boundary."""
+
+        return cls(value)
+
+    def __str__(self) -> str:
+        return self.value

--- a/backend/services/datalayer/versions.py
+++ b/backend/services/datalayer/versions.py
@@ -1,0 +1,4 @@
+"""Compatibility versions for normalized facts and frozen projections."""
+
+INGESTION_NORMALIZER_VERSION = "1"
+SNAPSHOT_PROJECTION_VERSION = "1"

--- a/backend/tests/services/datalayer/__init__.py
+++ b/backend/tests/services/datalayer/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pure datalayer service contracts."""

--- a/backend/tests/services/datalayer/test_canonical_json.py
+++ b/backend/tests/services/datalayer/test_canonical_json.py
@@ -1,0 +1,68 @@
+from decimal import Decimal
+
+import pytest
+
+from backend.services.datalayer.canonical_json import (
+    canonical_json_bytes,
+    canonical_json_sha256,
+    parse_json_bytes,
+)
+
+
+def test_parse_and_canonicalize_preserve_exact_fractional_values() -> None:
+    parsed = parse_json_bytes(
+        b'{"score":123.456700,"negative_zero":-0.00,"players":[2,1]}'
+    )
+
+    assert isinstance(parsed, dict)
+    assert parsed["score"] == Decimal("123.456700")
+    assert canonical_json_bytes(parsed) == (
+        b'{"negative_zero":0,"players":[2,1],"score":123.4567}'
+    )
+
+
+def test_canonical_json_has_stable_unicode_key_order_and_hash() -> None:
+    value = {
+        "z": Decimal("1E+3"),
+        "message": "caf\u00e9",
+        "nested": {"truth": True, "nothing": None},
+    }
+
+    assert canonical_json_bytes(value) == (
+        b'{"message":"caf\xc3\xa9","nested":{"nothing":null,"truth":true},"z":1000}'
+    )
+    assert canonical_json_sha256(value) == (
+        "981209b0fd19f37d3e69abf9cb69984576a3c285a7d7088812320fcad3ec3376"
+    )
+
+
+def test_parse_preserves_large_integers() -> None:
+    parsed = parse_json_bytes(b'{"value":123456789012345678901234567890}')
+
+    assert parsed == {"value": 123456789012345678901234567890}
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ({"score": 0.1}, "binary floats"),
+        ({1: "value"}, "keys must be strings"),
+        ({"value": Decimal("NaN")}, "must be finite"),
+        ({"value": (1, 2)}, "unsupported JSON value"),
+    ],
+)
+def test_canonical_json_rejects_values_outside_the_contract(
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        canonical_json_bytes(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [b'{"score":NaN}', b'{"score":Infinity}', b'{"score":-Infinity}'],
+)
+def test_parse_rejects_non_finite_numbers(raw: bytes) -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        parse_json_bytes(raw)

--- a/backend/tests/services/datalayer/test_contracts.py
+++ b/backend/tests/services/datalayer/test_contracts.py
@@ -1,0 +1,136 @@
+from datetime import date
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from backend.services.datalayer import (
+    CompletenessWarning,
+    EndpointKind,
+    NormalizationStatus,
+    RefreshOutcome,
+    RefreshRequest,
+    RefreshStatus,
+    RefreshTrigger,
+    RequestStatus,
+    ScopeKey,
+    ScopeRefreshResult,
+    SnapshotRequest,
+)
+
+
+SEASON_ID = UUID("10000000-0000-0000-0000-000000000001")
+REQUEST_ID = UUID("20000000-0000-0000-0000-000000000002")
+REFRESH_ID = UUID("30000000-0000-0000-0000-000000000003")
+
+
+def test_scope_key_round_trips_canonical_parts() -> None:
+    key = ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8)
+
+    assert str(key) == f"matchups:{SEASON_ID}:8"
+    assert ScopeKey.parse(str(key)) == key
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "matchups",
+        ":week",
+        "matchups:../secret",
+        "Matchups:season:8",
+        "matchups:season:8?raw=true",
+    ],
+)
+def test_scope_key_rejects_noncanonical_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        ScopeKey.parse(value)
+
+
+def test_scope_key_rejects_ambiguous_parts() -> None:
+    with pytest.raises(ValueError, match="at least two"):
+        ScopeKey.from_parts(EndpointKind.MATCHUPS)
+    with pytest.raises(TypeError, match="boolean"):
+        ScopeKey.from_parts(EndpointKind.MATCHUPS, True)
+
+
+def test_workflow_requests_are_frozen_and_validate_week_boundaries() -> None:
+    refresh = RefreshRequest(
+        competition_season_id=SEASON_ID,
+        through_week=8,
+        trigger=RefreshTrigger.MANUAL,
+    )
+    snapshot = SnapshotRequest(
+        competition_season_id=SEASON_ID,
+        through_week=8,
+        as_of_date=date(2025, 10, 28),
+    )
+
+    assert refresh.through_week == snapshot.through_week == 8
+    assert snapshot.as_of_date == date(2025, 10, 28)
+    with pytest.raises(ValidationError, match="frozen"):
+        refresh.through_week = 9
+    with pytest.raises(ValidationError):
+        SnapshotRequest(
+            competition_season_id=SEASON_ID,
+            through_week=0,
+            as_of_date=date(2025, 10, 28),
+        )
+    with pytest.raises(ValidationError, match="extra"):
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=8,
+            trigger=RefreshTrigger.MANUAL,
+            endpoint_kinds=(),
+        )
+
+
+def test_refresh_outcome_retains_immutable_scope_results() -> None:
+    scope_result = ScopeRefreshResult(
+        scope_key=ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8),
+        api_request_id=REQUEST_ID,
+        fetch_status=RequestStatus.SUCCEEDED,
+        normalization_status=NormalizationStatus.SUCCEEDED,
+        changed_current_view=True,
+        warning_codes=("late_reference_data",),
+    )
+
+    outcome = RefreshOutcome(
+        refresh_run_id=REFRESH_ID,
+        status=RefreshStatus.PARTIAL,
+        requested_scope_count=2,
+        succeeded_scope_count=1,
+        failed_scope_count=1,
+        scope_results=(scope_result,),
+    )
+
+    assert outcome.scope_results == (scope_result,)
+    assert outcome.scope_results[0].warning_codes == ("late_reference_data",)
+
+
+def test_completeness_warning_is_safe_structured_context() -> None:
+    scope_key = ScopeKey.from_parts(EndpointKind.TRANSACTIONS, SEASON_ID, 8)
+
+    warning = CompletenessWarning(
+        code="late_reference_data",
+        summary="Current names supplied display-only reference fields.",
+        scope_key=scope_key,
+    )
+
+    assert warning.scope_key == scope_key
+    assert warning.summary == "Current names supplied display-only reference fields."
+    with pytest.raises(ValidationError):
+        CompletenessWarning(code="Not Canonical", summary="unsafe code")
+    with pytest.raises(ValidationError):
+        CompletenessWarning(code="empty_summary", summary="   ")
+
+
+def test_scope_result_rejects_unstructured_warning_codes() -> None:
+    with pytest.raises(ValidationError):
+        ScopeRefreshResult(
+            scope_key=ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8),
+            api_request_id=REQUEST_ID,
+            fetch_status=RequestStatus.SUCCEEDED,
+            normalization_status=NormalizationStatus.SUCCEEDED,
+            changed_current_view=True,
+            warning_codes=("Not Canonical",),
+        )

--- a/backend/tests/services/datalayer/test_errors.py
+++ b/backend/tests/services/datalayer/test_errors.py
@@ -1,0 +1,43 @@
+from uuid import UUID
+
+from backend.services.datalayer import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+    EndpointKind,
+    EndpointPayloadRejected,
+    InternalDatalayerFailure,
+    InvalidDatalayerRequest,
+    ScopeKey,
+    SnapshotUnavailable,
+)
+
+
+SEASON_ID = UUID("10000000-0000-0000-0000-000000000001")
+
+
+def test_boundary_errors_retain_only_safe_typed_context() -> None:
+    missing = ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8)
+    unavailable = SnapshotUnavailable("required snapshot inputs are unavailable", [missing])
+    rejected = EndpointPayloadRejected(
+        EndpointKind.LEAGUE_ROSTERS,
+        "identity_mapping_missing",
+        "roster identity mapping is incomplete",
+    )
+
+    assert unavailable.missing_scopes == (missing,)
+    assert str(unavailable) == "required snapshot inputs are unavailable"
+    assert rejected.endpoint_kind is EndpointKind.LEAGUE_ROSTERS
+    assert rejected.code == "identity_mapping_missing"
+    assert str(rejected) == "roster identity mapping is incomplete"
+
+
+def test_http_translation_categories_have_stable_messages() -> None:
+    invalid = InvalidDatalayerRequest("through_week must be in the active season")
+    missing = DatalayerResourceNotFound("data snapshot", "snapshot-1")
+    conflict = DatalayerScopeConflict("season belongs to another competition")
+    internal = InternalDatalayerFailure("correlation-123")
+
+    assert str(invalid) == "through_week must be in the active season"
+    assert str(missing) == "data snapshot snapshot-1 was not found"
+    assert str(conflict) == "season belongs to another competition"
+    assert str(internal) == "datalayer operation failed (correlation-123)"

--- a/backend/tests/services/datalayer/test_versions.py
+++ b/backend/tests/services/datalayer/test_versions.py
@@ -1,0 +1,9 @@
+from backend.services.datalayer import (
+    INGESTION_NORMALIZER_VERSION,
+    SNAPSHOT_PROJECTION_VERSION,
+)
+
+
+def test_compatibility_versions_are_explicit_nonempty_strings() -> None:
+    assert INGESTION_NORMALIZER_VERSION == "1"
+    assert SNAPSHOT_PROJECTION_VERSION == "1"

--- a/datalayer/tests/__init__.py
+++ b/datalayer/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Datalayer test package."""

--- a/datalayer/tests/characterization/__init__.py
+++ b/datalayer/tests/characterization/__init__.py
@@ -1,0 +1,1 @@
+"""Golden characterization of legacy behavior selected for reuse."""

--- a/datalayer/tests/characterization/golden/legacy_normalized_tables.json
+++ b/datalayer/tests/characterization/golden/legacy_normalized_tables.json
@@ -1,0 +1,599 @@
+{
+  "bracket_records": {
+    "losers": [],
+    "winners": [
+      {
+        "bracket_type": "winners",
+        "league_id": "123",
+        "loser_roster_id": 2,
+        "matchup_id": 1,
+        "placement": null,
+        "round": 1,
+        "season": "2024",
+        "t1_from_matchup_id": null,
+        "t1_from_outcome": null,
+        "t1_roster_id": 1,
+        "t2_from_matchup_id": null,
+        "t2_from_outcome": null,
+        "t2_roster_id": 2,
+        "winner_roster_id": 1
+      },
+      {
+        "bracket_type": "winners",
+        "league_id": "123",
+        "loser_roster_id": null,
+        "matchup_id": 2,
+        "placement": 1,
+        "round": 2,
+        "season": "2024",
+        "t1_from_matchup_id": 1,
+        "t1_from_outcome": "w",
+        "t1_roster_id": null,
+        "t2_from_matchup_id": 1,
+        "t2_from_outcome": "l",
+        "t2_roster_id": null,
+        "winner_roster_id": null
+      }
+    ]
+  },
+  "record_string_weeks": {
+    "median_double_result": [
+      [
+        1,
+        2,
+        0,
+        0
+      ],
+      [
+        2,
+        2,
+        1,
+        1
+      ],
+      [
+        3,
+        3,
+        1,
+        2
+      ]
+    ],
+    "single_result": [
+      [
+        1,
+        1,
+        0,
+        0
+      ],
+      [
+        2,
+        1,
+        1,
+        0
+      ],
+      [
+        3,
+        1,
+        1,
+        1
+      ],
+      [
+        4,
+        2,
+        1,
+        1
+      ]
+    ]
+  },
+  "tables": {
+    "draft_picks": [
+      {
+        "current_roster_id": 1,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 1,
+        "season": "2026",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 1,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 1,
+        "season": "2027",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 1,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 2,
+        "season": "2025",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 1,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 2,
+        "season": "2026",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 1,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 2,
+        "season": "2027",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 1,
+        "pick_id": null,
+        "round": 1,
+        "season": "2025",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 1,
+        "season": "2025",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 1,
+        "season": "2026",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 1,
+        "season": "2027",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 2,
+        "season": "2025",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 2,
+        "season": "2026",
+        "source": "seed"
+      },
+      {
+        "current_roster_id": 2,
+        "league_id": "123",
+        "original_roster_id": 2,
+        "pick_id": null,
+        "round": 2,
+        "season": "2027",
+        "source": "seed"
+      }
+    ],
+    "games": [
+      {
+        "is_playoffs": 0,
+        "league_id": "123",
+        "matchup_id": 1,
+        "points_a": 100.5,
+        "points_b": 90.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "season": "2024",
+        "week": 1,
+        "winner_roster_id": 1
+      },
+      {
+        "is_playoffs": 0,
+        "league_id": "123",
+        "matchup_id": 1,
+        "points_a": 110.0,
+        "points_b": 105.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "season": "2024",
+        "week": 2,
+        "winner_roster_id": 1
+      }
+    ],
+    "leagues": [
+      {
+        "league_average_match": null,
+        "league_id": "123",
+        "name": "Test League",
+        "playoff_teams": 4,
+        "playoff_week_start": 15,
+        "roster_positions_json": "[\"QB\", \"RB\", \"WR\", \"TE\", \"FLEX\"]",
+        "scoring_settings_json": "{\"pass_td\": 4}",
+        "season": "2024",
+        "sport": "nfl"
+      }
+    ],
+    "matchups": [
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "points": 100.5,
+        "roster_id": 1,
+        "season": "2024",
+        "week": 1
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "points": 105.0,
+        "roster_id": 2,
+        "season": "2024",
+        "week": 2
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "points": 110.0,
+        "roster_id": 1,
+        "season": "2024",
+        "week": 2
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "points": 90.0,
+        "roster_id": 2,
+        "season": "2024",
+        "week": 1
+      }
+    ],
+    "player_performances": [
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p1",
+        "points": 60.5,
+        "role": "starter",
+        "roster_id": 1,
+        "season": "2024",
+        "week": 1
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p1",
+        "points": 70.0,
+        "role": "starter",
+        "roster_id": 1,
+        "season": "2024",
+        "week": 2
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p2",
+        "points": 40.0,
+        "role": "bench",
+        "roster_id": 1,
+        "season": "2024",
+        "week": 1
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p2",
+        "points": 40.0,
+        "role": "bench",
+        "roster_id": 1,
+        "season": "2024",
+        "week": 2
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p3",
+        "points": 55.0,
+        "role": "starter",
+        "roster_id": 2,
+        "season": "2024",
+        "week": 1
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p3",
+        "points": 60.0,
+        "role": "starter",
+        "roster_id": 2,
+        "season": "2024",
+        "week": 2
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p4",
+        "points": 35.0,
+        "role": "bench",
+        "roster_id": 2,
+        "season": "2024",
+        "week": 1
+      },
+      {
+        "league_id": "123",
+        "matchup_id": 1,
+        "player_id": "p4",
+        "points": 45.0,
+        "role": "bench",
+        "roster_id": 2,
+        "season": "2024",
+        "week": 2
+      }
+    ],
+    "players": [
+      {
+        "age": 24,
+        "full_name": "Player Two",
+        "injury_status": null,
+        "metadata_json": "{\"player_id\": \"p2\", \"full_name\": \"Player Two\", \"position\": \"RB\", \"team\": \"BBB\", \"status\": \"Active\", \"injury_status\": null, \"age\": 24, \"years_exp\": 2, \"updated_at\": \"2024-09-01\"}",
+        "nfl_team": "BBB",
+        "player_id": "p2",
+        "position": "RB",
+        "status": "Active",
+        "updated_at": "2024-09-01",
+        "years_exp": 2
+      },
+      {
+        "age": 25,
+        "full_name": "Player One",
+        "injury_status": null,
+        "metadata_json": "{\"player_id\": \"p1\", \"full_name\": \"Player One\", \"position\": \"QB\", \"team\": \"AAA\", \"status\": \"Active\", \"injury_status\": null, \"age\": 25, \"years_exp\": 3, \"updated_at\": \"2024-09-01\"}",
+        "nfl_team": "AAA",
+        "player_id": "p1",
+        "position": "QB",
+        "status": "Active",
+        "updated_at": "2024-09-01",
+        "years_exp": 3
+      },
+      {
+        "age": 26,
+        "full_name": "Player Four",
+        "injury_status": null,
+        "metadata_json": "{\"player_id\": \"p4\", \"full_name\": \"Player Four\", \"position\": \"TE\", \"team\": \"DDD\", \"status\": \"Active\", \"injury_status\": null, \"age\": 26, \"years_exp\": 4, \"updated_at\": \"2024-09-01\"}",
+        "nfl_team": "DDD",
+        "player_id": "p4",
+        "position": "TE",
+        "status": "Active",
+        "updated_at": "2024-09-01",
+        "years_exp": 4
+      },
+      {
+        "age": 27,
+        "full_name": "Player Three",
+        "injury_status": null,
+        "metadata_json": "{\"player_id\": \"p3\", \"full_name\": \"Player Three\", \"position\": \"WR\", \"team\": \"CCC\", \"status\": \"Active\", \"injury_status\": null, \"age\": 27, \"years_exp\": 5, \"updated_at\": \"2024-09-01\"}",
+        "nfl_team": "CCC",
+        "player_id": "p3",
+        "position": "WR",
+        "status": "Active",
+        "updated_at": "2024-09-01",
+        "years_exp": 5
+      }
+    ],
+    "playoff_matchups": [],
+    "roster_players": [
+      {
+        "league_id": "123",
+        "player_id": "p1",
+        "role": "starter",
+        "roster_id": 1
+      },
+      {
+        "league_id": "123",
+        "player_id": "p2",
+        "role": "bench",
+        "roster_id": 1
+      },
+      {
+        "league_id": "123",
+        "player_id": "p3",
+        "role": "starter",
+        "roster_id": 2
+      },
+      {
+        "league_id": "123",
+        "player_id": "p4",
+        "role": "bench",
+        "roster_id": 2
+      }
+    ],
+    "rosters": [
+      {
+        "league_id": "123",
+        "metadata_json": "{\"team_name\": \"Alpha\"}",
+        "owner_user_id": "u1",
+        "record_string": null,
+        "roster_id": 1,
+        "settings_json": "{\"wins\": 1, \"losses\": 0, \"ties\": 0, \"fpts\": 200, \"fpts_decimal\": 10, \"fpts_against\": 180, \"fpts_against_decimal\": 5, \"rank\": 1, \"streak_type\": \"W\", \"streak_length\": 1}"
+      },
+      {
+        "league_id": "123",
+        "metadata_json": "{\"team_name\": \"Beta\"}",
+        "owner_user_id": "u2",
+        "record_string": null,
+        "roster_id": 2,
+        "settings_json": "{\"wins\": 0, \"losses\": 1, \"ties\": 0, \"fpts\": 180, \"fpts_decimal\": 5, \"fpts_against\": 200, \"fpts_against_decimal\": 10, \"rank\": 2, \"streak_type\": \"L\", \"streak_length\": 1}"
+      }
+    ],
+    "season_context": [
+      {
+        "computed_week": 2,
+        "effective_week": 2,
+        "league_id": "123",
+        "override_week": null
+      }
+    ],
+    "standings": [
+      {
+        "league_id": "123",
+        "losses": 0,
+        "points_against": 180.05,
+        "points_for": 200.1,
+        "rank": 1,
+        "roster_id": 1,
+        "season": "2024",
+        "streak_len": 1,
+        "streak_type": "W",
+        "ties": 0,
+        "week": 2,
+        "wins": 1
+      },
+      {
+        "league_id": "123",
+        "losses": 1,
+        "points_against": 200.1,
+        "points_for": 180.05,
+        "rank": 2,
+        "roster_id": 2,
+        "season": "2024",
+        "streak_len": 1,
+        "streak_type": "L",
+        "ties": 0,
+        "week": 2,
+        "wins": 0
+      }
+    ],
+    "team_profiles": [
+      {
+        "avatar_url": "https://sleepercdn.com/avatars/avatar1",
+        "league_id": "123",
+        "manager_name": "Alice",
+        "roster_id": 1,
+        "team_name": "Alpha"
+      },
+      {
+        "avatar_url": "https://sleepercdn.com/avatars/avatar2",
+        "league_id": "123",
+        "manager_name": "Bob",
+        "roster_id": 2,
+        "team_name": "Beta"
+      }
+    ],
+    "transaction_moves": [
+      {
+        "asset_type": "pick",
+        "bid_amount": null,
+        "direction": "pick_in",
+        "from_roster_id": 1,
+        "pick_id": "pick1",
+        "pick_original_roster_id": 1,
+        "pick_round": 1,
+        "pick_season": "2025",
+        "player_id": null,
+        "roster_id": 2,
+        "to_roster_id": 2,
+        "transaction_id": "tx2"
+      },
+      {
+        "asset_type": "pick",
+        "bid_amount": null,
+        "direction": "pick_out",
+        "from_roster_id": 1,
+        "pick_id": "pick1",
+        "pick_original_roster_id": 1,
+        "pick_round": 1,
+        "pick_season": "2025",
+        "player_id": null,
+        "roster_id": 1,
+        "to_roster_id": 2,
+        "transaction_id": "tx2"
+      },
+      {
+        "asset_type": "player",
+        "bid_amount": 5,
+        "direction": "add",
+        "from_roster_id": null,
+        "pick_id": null,
+        "pick_original_roster_id": null,
+        "pick_round": null,
+        "pick_season": null,
+        "player_id": "p2",
+        "roster_id": 1,
+        "to_roster_id": null,
+        "transaction_id": "tx1"
+      },
+      {
+        "asset_type": "player",
+        "bid_amount": 5,
+        "direction": "drop",
+        "from_roster_id": null,
+        "pick_id": null,
+        "pick_original_roster_id": null,
+        "pick_round": null,
+        "pick_season": null,
+        "player_id": "p3",
+        "roster_id": 2,
+        "to_roster_id": null,
+        "transaction_id": "tx1"
+      }
+    ],
+    "transactions": [
+      {
+        "created_ts": 1700000000,
+        "league_id": "123",
+        "metadata_json": "{\"notes\": \"waiver add\"}",
+        "season": "2024",
+        "settings_json": "{\"waiver_bid\": 5}",
+        "status": "complete",
+        "transaction_id": "tx1",
+        "type": "waiver",
+        "week": 1
+      },
+      {
+        "created_ts": 1700003600,
+        "league_id": "123",
+        "metadata_json": "{\"notes\": \"trade with pick\"}",
+        "season": "2024",
+        "settings_json": "{}",
+        "status": "complete",
+        "transaction_id": "tx2",
+        "type": "trade",
+        "week": 2
+      }
+    ],
+    "users": [
+      {
+        "avatar": "avatar1",
+        "display_name": "Alice",
+        "metadata_json": null,
+        "user_id": "u1"
+      },
+      {
+        "avatar": "avatar2",
+        "display_name": "Bob",
+        "metadata_json": null,
+        "user_id": "u2"
+      }
+    ]
+  }
+}

--- a/datalayer/tests/characterization/golden/legacy_query_outputs.json
+++ b/datalayer/tests/characterization/golden/legacy_query_outputs.json
@@ -1,0 +1,1149 @@
+{
+  "bench_analysis_league": [
+    {
+      "bench_points": 45.0,
+      "starter_points": 60.0,
+      "team_name": "Beta",
+      "total_points": 105.0
+    },
+    {
+      "bench_points": 40.0,
+      "starter_points": 70.0,
+      "team_name": "Alpha",
+      "total_points": 110.0
+    }
+  ],
+  "bench_analysis_team": {
+    "as_of_week": 2,
+    "bench_players": [
+      {
+        "nfl_team": "BBB",
+        "player_name": "Player Two",
+        "points": 40.0,
+        "position": "RB"
+      }
+    ],
+    "bench_points": 40.0,
+    "found": true,
+    "starter_points": 70.0,
+    "team_name": "Alpha",
+    "total_points": 110.0
+  },
+  "league_snapshot": {
+    "as_of_week": 2,
+    "found": true,
+    "games": [
+      {
+        "points_a": 110.0,
+        "points_b": 105.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 2,
+        "winner": "Alpha"
+      }
+    ],
+    "league": {
+      "name": "Test League",
+      "playoff_week_start": 15,
+      "season": "2024",
+      "sport": "nfl"
+    },
+    "standings": [
+      {
+        "losses": 0,
+        "points_against": 180.05,
+        "points_for": 200.1,
+        "rank": 1,
+        "team_name": "Alpha",
+        "ties": 0,
+        "wins": 1
+      },
+      {
+        "losses": 1,
+        "points_against": 200.1,
+        "points_for": 180.05,
+        "rank": 2,
+        "team_name": "Beta",
+        "ties": 0,
+        "wins": 0
+      }
+    ],
+    "transactions": [
+      {
+        "created_ts": 1700003600,
+        "details": [
+          {
+            "assets_received": [],
+            "assets_sent": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "team_name": "Alpha"
+          },
+          {
+            "assets_received": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "assets_sent": [],
+            "team_name": "Beta"
+          }
+        ],
+        "status": "complete",
+        "type": "trade",
+        "week": 2
+      }
+    ]
+  },
+  "player_summary_by_id": {
+    "found": true,
+    "player": {
+      "injury_status": null,
+      "nfl_team": "AAA",
+      "player_name": "Player One",
+      "position": "QB",
+      "status": "Active"
+    }
+  },
+  "player_summary_by_name": {
+    "found": true,
+    "player": {
+      "injury_status": null,
+      "nfl_team": "AAA",
+      "player_name": "Player One",
+      "position": "QB",
+      "status": "Active"
+    }
+  },
+  "player_summary_not_found": {
+    "found": false,
+    "player_key": "missing"
+  },
+  "player_weekly_log": {
+    "avg_points": 65.25,
+    "found": true,
+    "performances": [
+      {
+        "points": 60.5,
+        "role": "starter",
+        "team_name": "Alpha",
+        "week": 1
+      },
+      {
+        "points": 70.0,
+        "role": "starter",
+        "team_name": "Alpha",
+        "week": 2
+      }
+    ],
+    "player_name": "Player One",
+    "total_points": 130.5,
+    "weeks_played": 2
+  },
+  "player_weekly_log_filtered": {
+    "avg_points": 70.0,
+    "found": true,
+    "performances": [
+      {
+        "points": 70.0,
+        "role": "starter",
+        "team_name": "Alpha",
+        "week": 2
+      }
+    ],
+    "player_name": "Player One",
+    "total_points": 70.0,
+    "week_from": 2,
+    "week_to": 2,
+    "weeks_played": 1
+  },
+  "playoff_brackets": {
+    "brackets": {
+      "winners": {
+        "champion": null,
+        "placements": [],
+        "rounds": {
+          "1": [
+            {
+              "loser": "Beta",
+              "matchup_id": 1,
+              "round": 1,
+              "status": "complete",
+              "team_1": "Alpha",
+              "team_2": "Beta",
+              "winner": "Alpha"
+            }
+          ],
+          "2": [
+            {
+              "loser": null,
+              "matchup_id": 2,
+              "placement": 1,
+              "round": 2,
+              "status": "pending",
+              "team_1": "Winner of Match 1",
+              "team_2": "Loser of Match 1",
+              "winner": null
+            }
+          ]
+        }
+      }
+    },
+    "found": true
+  },
+  "playoff_winners": {
+    "brackets": {
+      "winners": {
+        "champion": null,
+        "placements": [],
+        "rounds": {
+          "1": [
+            {
+              "loser": "Beta",
+              "matchup_id": 1,
+              "round": 1,
+              "status": "complete",
+              "team_1": "Alpha",
+              "team_2": "Beta",
+              "winner": "Alpha"
+            }
+          ],
+          "2": [
+            {
+              "loser": null,
+              "matchup_id": 2,
+              "placement": 1,
+              "round": 2,
+              "status": "pending",
+              "team_1": "Winner of Match 1",
+              "team_2": "Loser of Match 1",
+              "winner": null
+            }
+          ]
+        }
+      }
+    },
+    "found": true
+  },
+  "roster_current_by_manager": {
+    "found": true,
+    "picks": [
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2025"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 1,
+        "season": "2026"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2026"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 1,
+        "season": "2027"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2027"
+      }
+    ],
+    "roster": {
+      "bench": {
+        "def": [],
+        "k": [],
+        "qb": [],
+        "rb": [
+          {
+            "full_name": "Player Two",
+            "injury_status": null,
+            "nfl_team": "BBB",
+            "player_name": "Player Two",
+            "position": "RB",
+            "role": "bench",
+            "status": "Active"
+          }
+        ],
+        "te": [],
+        "wr": []
+      },
+      "starters": {
+        "def": [],
+        "k": [],
+        "qb": [
+          {
+            "full_name": "Player One",
+            "injury_status": null,
+            "nfl_team": "AAA",
+            "player_name": "Player One",
+            "position": "QB",
+            "role": "starter",
+            "status": "Active"
+          }
+        ],
+        "rb": [],
+        "te": [],
+        "wr": []
+      }
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "roster_current_by_name": {
+    "found": true,
+    "picks": [
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2025"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 1,
+        "season": "2026"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2026"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 1,
+        "season": "2027"
+      },
+      {
+        "current_team_name": "Alpha",
+        "original_team_name": "Alpha",
+        "round": 2,
+        "season": "2027"
+      }
+    ],
+    "roster": {
+      "bench": {
+        "def": [],
+        "k": [],
+        "qb": [],
+        "rb": [
+          {
+            "full_name": "Player Two",
+            "injury_status": null,
+            "nfl_team": "BBB",
+            "player_name": "Player Two",
+            "position": "RB",
+            "role": "bench",
+            "status": "Active"
+          }
+        ],
+        "te": [],
+        "wr": []
+      },
+      "starters": {
+        "def": [],
+        "k": [],
+        "qb": [
+          {
+            "full_name": "Player One",
+            "injury_status": null,
+            "nfl_team": "AAA",
+            "player_name": "Player One",
+            "position": "QB",
+            "role": "starter",
+            "status": "Active"
+          }
+        ],
+        "rb": [],
+        "te": [],
+        "wr": []
+      }
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "roster_snapshot": {
+    "as_of_week": 1,
+    "found": true,
+    "roster": {
+      "bench": {
+        "def": [],
+        "k": [],
+        "qb": [],
+        "rb": [
+          {
+            "nfl_team": "BBB",
+            "player_name": "Player Two",
+            "points": 40.0,
+            "position": "RB",
+            "role": "bench"
+          }
+        ],
+        "te": [],
+        "wr": []
+      },
+      "starters": {
+        "def": [],
+        "k": [],
+        "qb": [
+          {
+            "nfl_team": "AAA",
+            "player_name": "Player One",
+            "points": 60.5,
+            "position": "QB",
+            "role": "starter"
+          }
+        ],
+        "rb": [],
+        "te": [],
+        "wr": []
+      }
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "season_leaders": [
+    {
+      "avg_points": 65.25,
+      "best_week": 70.0,
+      "nfl_team": "AAA",
+      "player_name": "Player One",
+      "position": "QB",
+      "rank": 1,
+      "team_name": "Alpha",
+      "total_points": 130.5,
+      "weeks_played": 2,
+      "worst_week": 60.5
+    },
+    {
+      "avg_points": 57.5,
+      "best_week": 60.0,
+      "nfl_team": "CCC",
+      "player_name": "Player Three",
+      "position": "WR",
+      "rank": 2,
+      "team_name": "Beta",
+      "total_points": 115.0,
+      "weeks_played": 2,
+      "worst_week": 55.0
+    },
+    {
+      "avg_points": 40.0,
+      "best_week": 45.0,
+      "nfl_team": "DDD",
+      "player_name": "Player Four",
+      "position": "TE",
+      "rank": 3,
+      "team_name": "Beta",
+      "total_points": 80.0,
+      "weeks_played": 2,
+      "worst_week": 35.0
+    }
+  ],
+  "season_leaders_filtered": [
+    {
+      "avg_points": 70.0,
+      "best_week": 70.0,
+      "nfl_team": "AAA",
+      "player_name": "Player One",
+      "position": "QB",
+      "rank": 1,
+      "team_name": "Alpha",
+      "total_points": 70.0,
+      "weeks_played": 1,
+      "worst_week": 70.0
+    }
+  ],
+  "sql_named_params_and_limit": {
+    "columns": [
+      "roster_id",
+      "points"
+    ],
+    "row_count": 1,
+    "rows": [
+      [
+        1,
+        110.0
+      ]
+    ]
+  },
+  "standings": {
+    "as_of_week": 2,
+    "found": true,
+    "league_average_match": false,
+    "standings": [
+      {
+        "losses": 0,
+        "points_against": 180.05,
+        "points_for": 200.1,
+        "rank": 1,
+        "record": "1-0",
+        "streak_len": 1,
+        "streak_type": "W",
+        "team_name": "Alpha",
+        "ties": 0,
+        "wins": 1
+      },
+      {
+        "losses": 1,
+        "points_against": 200.1,
+        "points_for": 180.05,
+        "rank": 2,
+        "record": "0-1",
+        "streak_len": 1,
+        "streak_type": "L",
+        "team_name": "Beta",
+        "ties": 0,
+        "wins": 0
+      }
+    ]
+  },
+  "team_dossier_by_id": {
+    "as_of_week": 2,
+    "found": true,
+    "recent_games": [
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 110.0,
+        "points_b": 105.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 2
+      },
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 100.5,
+        "points_b": 90.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 1
+      }
+    ],
+    "standings": {
+      "losses": 0,
+      "points_against": 180.05,
+      "points_for": 200.1,
+      "rank": 1,
+      "record": "1-0",
+      "streak_len": 1,
+      "streak_type": "W",
+      "ties": 0,
+      "wins": 1
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "team_dossier_by_manager": {
+    "as_of_week": 2,
+    "found": true,
+    "recent_games": [
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 110.0,
+        "points_b": 105.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 2
+      },
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 100.5,
+        "points_b": 90.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 1
+      }
+    ],
+    "standings": {
+      "losses": 0,
+      "points_against": 180.05,
+      "points_for": 200.1,
+      "rank": 1,
+      "record": "1-0",
+      "streak_len": 1,
+      "streak_type": "W",
+      "ties": 0,
+      "wins": 1
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "team_dossier_by_name": {
+    "as_of_week": 2,
+    "found": true,
+    "recent_games": [
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 110.0,
+        "points_b": 105.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 2
+      },
+      {
+        "manager_a": "Alice",
+        "manager_b": "Bob",
+        "points_a": 100.5,
+        "points_b": 90.0,
+        "roster_id_a": 1,
+        "roster_id_b": 2,
+        "team_a": "Alpha",
+        "team_b": "Beta",
+        "week": 1
+      }
+    ],
+    "standings": {
+      "losses": 0,
+      "points_against": 180.05,
+      "points_for": 200.1,
+      "rank": 1,
+      "record": "1-0",
+      "streak_len": 1,
+      "streak_type": "W",
+      "ties": 0,
+      "wins": 1
+    },
+    "team": {
+      "manager_name": "Alice",
+      "team_name": "Alpha"
+    }
+  },
+  "team_dossier_not_found": {
+    "as_of_week": 2,
+    "found": false,
+    "roster_key": "missing"
+  },
+  "team_game": {
+    "as_of_week": 2,
+    "found": true,
+    "game": {
+      "points_a": 110.0,
+      "points_b": 105.0,
+      "roster_id_a": 1,
+      "roster_id_b": 2,
+      "team_a": "Alpha",
+      "team_b": "Beta",
+      "week": 2,
+      "winner": "Alpha"
+    }
+  },
+  "team_game_with_players": {
+    "as_of_week": 2,
+    "found": true,
+    "game": {
+      "points_a": 110.0,
+      "points_b": 105.0,
+      "roster_id_a": 1,
+      "roster_id_b": 2,
+      "team_a": "Alpha",
+      "team_a_players": {
+        "bench": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [
+            {
+              "nfl_team": "BBB",
+              "player_name": "Player Two",
+              "points": 40.0,
+              "position": "RB",
+              "role": "bench"
+            }
+          ],
+          "te": [],
+          "wr": []
+        },
+        "starters": {
+          "def": [],
+          "k": [],
+          "qb": [
+            {
+              "nfl_team": "AAA",
+              "player_name": "Player One",
+              "points": 70.0,
+              "position": "QB",
+              "role": "starter"
+            }
+          ],
+          "rb": [],
+          "te": [],
+          "wr": []
+        }
+      },
+      "team_b": "Beta",
+      "team_b_players": {
+        "bench": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [],
+          "te": [
+            {
+              "nfl_team": "DDD",
+              "player_name": "Player Four",
+              "points": 45.0,
+              "position": "TE",
+              "role": "bench"
+            }
+          ],
+          "wr": []
+        },
+        "starters": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [],
+          "te": [],
+          "wr": [
+            {
+              "nfl_team": "CCC",
+              "player_name": "Player Three",
+              "points": 60.0,
+              "position": "WR",
+              "role": "starter"
+            }
+          ]
+        }
+      },
+      "week": 2,
+      "winner": "Alpha"
+    }
+  },
+  "team_playoff_path": {
+    "bracket_type": "winners",
+    "final_placement": null,
+    "found": true,
+    "is_champion": false,
+    "is_eliminated": false,
+    "matchups": [
+      {
+        "matchup_id": 1,
+        "opponent": "Beta",
+        "result": "win",
+        "round": 1
+      }
+    ],
+    "team_name": "Alpha"
+  },
+  "team_schedule": {
+    "as_of_week": 2,
+    "found": true,
+    "playoff_games": [],
+    "regular_season_games": [
+      {
+        "opponent_name": "Beta",
+        "opponent_points": 90.0,
+        "result": "W",
+        "team_points": 100.5,
+        "week": 1
+      },
+      {
+        "opponent_name": "Beta",
+        "opponent_points": 105.0,
+        "result": "W",
+        "team_points": 110.0,
+        "week": 2
+      }
+    ],
+    "team_name": "Alpha"
+  },
+  "team_transactions": {
+    "found": true,
+    "team_name": "Alpha",
+    "transactions": [
+      {
+        "created_ts": 1700003600,
+        "details": [
+          {
+            "assets_received": [],
+            "assets_sent": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "team_name": "Alpha"
+          },
+          {
+            "assets_received": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "assets_sent": [],
+            "team_name": "Beta"
+          }
+        ],
+        "status": "complete",
+        "type": "trade",
+        "week": 2
+      },
+      {
+        "bid_amount": 5,
+        "created_ts": 1700000000,
+        "details": [
+          {
+            "assets_received": [
+              {
+                "age": 24,
+                "asset_type": "player",
+                "player_name": "Player Two",
+                "position": "RB",
+                "years_exp": 2
+              }
+            ],
+            "assets_sent": [],
+            "team_name": "Alpha"
+          },
+          {
+            "assets_received": [],
+            "assets_sent": [
+              {
+                "age": 27,
+                "asset_type": "player",
+                "player_name": "Player Three",
+                "position": "WR",
+                "years_exp": 5
+              }
+            ],
+            "team_name": "Beta"
+          }
+        ],
+        "status": "complete",
+        "type": "waiver",
+        "week": 1
+      }
+    ],
+    "week_from": 1,
+    "week_to": 2
+  },
+  "team_week_transactions": {
+    "found": true,
+    "team_name": "Alpha",
+    "transactions": [
+      {
+        "created_ts": 1700003600,
+        "details": [
+          {
+            "assets_received": [],
+            "assets_sent": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "team_name": "Alpha"
+          },
+          {
+            "assets_received": [
+              {
+                "asset_type": "pick",
+                "pick_original_team_name": "Alpha",
+                "pick_round": 1,
+                "pick_season": "2025"
+              }
+            ],
+            "assets_sent": [],
+            "team_name": "Beta"
+          }
+        ],
+        "status": "complete",
+        "type": "trade",
+        "week": 2
+      }
+    ],
+    "week_from": 2,
+    "week_to": 2
+  },
+  "transactions": [
+    {
+      "created_ts": 1700003600,
+      "details": [
+        {
+          "assets_received": [],
+          "assets_sent": [
+            {
+              "asset_type": "pick",
+              "pick_original_team_name": "Alpha",
+              "pick_round": 1,
+              "pick_season": "2025"
+            }
+          ],
+          "team_name": "Alpha"
+        },
+        {
+          "assets_received": [
+            {
+              "asset_type": "pick",
+              "pick_original_team_name": "Alpha",
+              "pick_round": 1,
+              "pick_season": "2025"
+            }
+          ],
+          "assets_sent": [],
+          "team_name": "Beta"
+        }
+      ],
+      "status": "complete",
+      "type": "trade",
+      "week": 2
+    },
+    {
+      "bid_amount": 5,
+      "created_ts": 1700000000,
+      "details": [
+        {
+          "assets_received": [
+            {
+              "age": 24,
+              "asset_type": "player",
+              "player_name": "Player Two",
+              "position": "RB",
+              "years_exp": 2
+            }
+          ],
+          "assets_sent": [],
+          "team_name": "Alpha"
+        },
+        {
+          "assets_received": [],
+          "assets_sent": [
+            {
+              "age": 27,
+              "asset_type": "player",
+              "player_name": "Player Three",
+              "position": "WR",
+              "years_exp": 5
+            }
+          ],
+          "team_name": "Beta"
+        }
+      ],
+      "status": "complete",
+      "type": "waiver",
+      "week": 1
+    }
+  ],
+  "week_games": [
+    {
+      "points_a": 110.0,
+      "points_b": 105.0,
+      "roster_id_a": 1,
+      "roster_id_b": 2,
+      "team_a": "Alpha",
+      "team_b": "Beta",
+      "week": 2,
+      "winner": "Alpha"
+    }
+  ],
+  "week_games_default": [
+    {
+      "points_a": 110.0,
+      "points_b": 105.0,
+      "roster_id_a": 1,
+      "roster_id_b": 2,
+      "team_a": "Alpha",
+      "team_b": "Beta",
+      "week": 2,
+      "winner": "Alpha"
+    }
+  ],
+  "week_games_with_players": [
+    {
+      "points_a": 110.0,
+      "points_b": 105.0,
+      "roster_id_a": 1,
+      "roster_id_b": 2,
+      "team_a": "Alpha",
+      "team_a_players": {
+        "bench": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [
+            {
+              "nfl_team": "BBB",
+              "player_name": "Player Two",
+              "points": 40.0,
+              "position": "RB",
+              "role": "bench"
+            }
+          ],
+          "te": [],
+          "wr": []
+        },
+        "starters": {
+          "def": [],
+          "k": [],
+          "qb": [
+            {
+              "nfl_team": "AAA",
+              "player_name": "Player One",
+              "points": 70.0,
+              "position": "QB",
+              "role": "starter"
+            }
+          ],
+          "rb": [],
+          "te": [],
+          "wr": []
+        }
+      },
+      "team_b": "Beta",
+      "team_b_players": {
+        "bench": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [],
+          "te": [
+            {
+              "nfl_team": "DDD",
+              "player_name": "Player Four",
+              "points": 45.0,
+              "position": "TE",
+              "role": "bench"
+            }
+          ],
+          "wr": []
+        },
+        "starters": {
+          "def": [],
+          "k": [],
+          "qb": [],
+          "rb": [],
+          "te": [],
+          "wr": [
+            {
+              "nfl_team": "CCC",
+              "player_name": "Player Three",
+              "points": 60.0,
+              "position": "WR",
+              "role": "starter"
+            }
+          ]
+        }
+      },
+      "week": 2,
+      "winner": "Alpha"
+    }
+  ],
+  "week_player_leaderboard": [
+    {
+      "nfl_team": "AAA",
+      "player_name": "Player One",
+      "points": 70.0,
+      "position": "QB",
+      "rank": 1,
+      "role": "starter",
+      "team_name": "Alpha"
+    },
+    {
+      "nfl_team": "CCC",
+      "player_name": "Player Three",
+      "points": 60.0,
+      "position": "WR",
+      "rank": 2,
+      "role": "starter",
+      "team_name": "Beta"
+    },
+    {
+      "nfl_team": "DDD",
+      "player_name": "Player Four",
+      "points": 45.0,
+      "position": "TE",
+      "rank": 3,
+      "role": "bench",
+      "team_name": "Beta"
+    }
+  ],
+  "week_transactions": [
+    {
+      "created_ts": 1700003600,
+      "details": [
+        {
+          "assets_received": [],
+          "assets_sent": [
+            {
+              "asset_type": "pick",
+              "pick_original_team_name": "Alpha",
+              "pick_round": 1,
+              "pick_season": "2025"
+            }
+          ],
+          "team_name": "Alpha"
+        },
+        {
+          "assets_received": [
+            {
+              "asset_type": "pick",
+              "pick_original_team_name": "Alpha",
+              "pick_round": 1,
+              "pick_season": "2025"
+            }
+          ],
+          "assets_sent": [],
+          "team_name": "Beta"
+        }
+      ],
+      "status": "complete",
+      "type": "trade",
+      "week": 2
+    }
+  ]
+}

--- a/datalayer/tests/characterization/legacy_outputs.py
+++ b/datalayer/tests/characterization/legacy_outputs.py
@@ -1,0 +1,138 @@
+"""Deterministic collectors for the legacy fixture-backed golden contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from typing import Any
+
+from sqlalchemy import text
+
+from datalayer.sleeper_data.load import _record_string_to_weeks
+from datalayer.sleeper_data.normalize import normalize_bracket
+from datalayer.sleeper_data.schema import metadata
+from datalayer.sleeper_data.sleeper_league_data import SleeperLeagueData
+
+
+def collect_normalization_golden(
+    data: SleeperLeagueData,
+    sleeper_fixtures: dict[str, Any],
+) -> dict[str, Any]:
+    """Capture every loaded legacy row plus skipped bracket derivations."""
+
+    connection = data._conn()
+    tables: dict[str, list[dict[str, Any]]] = {}
+    for table_name in sorted(metadata.tables):
+        rows = [
+            dict(row)
+            for row in connection.execute(
+                text(f'SELECT * FROM "{table_name}"')
+            ).mappings()
+        ]
+        if table_name == "season_context":
+            for row in rows:
+                row.pop("generated_at", None)
+        tables[table_name] = sorted(rows, key=_stable_json)
+
+    brackets: dict[str, list[dict[str, Any]]] = {}
+    for bracket_type in ("winners", "losers"):
+        rows = normalize_bracket(
+            sleeper_fixtures[f"{bracket_type}_bracket"],
+            league_id="123",
+            season="2024",
+            bracket_type=bracket_type,
+        )
+        brackets[bracket_type] = [asdict(row) for row in rows]
+
+    return _json_round_trip(
+        {
+            "tables": tables,
+            "bracket_records": brackets,
+            "record_string_weeks": {
+                "single_result": _record_string_to_weeks("WLTW", chars_per_week=1),
+                "median_double_result": _record_string_to_weeks(
+                    "WWLTTW",
+                    chars_per_week=2,
+                ),
+            },
+        }
+    )
+
+
+def collect_query_golden(
+    data: SleeperLeagueData,
+    playoff_data: SleeperLeagueData,
+) -> dict[str, Any]:
+    """Capture every curated legacy query family and resolver route."""
+
+    return _json_round_trip(
+        {
+            "league_snapshot": data.get_league_snapshot(week=2),
+            "bench_analysis_league": data.get_bench_analysis(week=2),
+            "bench_analysis_team": data.get_bench_analysis("Alpha", week=2),
+            "standings": data.get_standings(week=2),
+            "team_dossier_by_name": data.get_team_dossier("alpha", week=2),
+            "team_dossier_by_manager": data.get_team_dossier("Alice", week=2),
+            "team_dossier_by_id": data.get_team_dossier("1", week=2),
+            "team_dossier_not_found": data.get_team_dossier("missing", week=2),
+            "team_schedule": data.get_team_schedule("Alpha"),
+            "week_games": data.get_week_games(week=2),
+            "week_games_default": data.get_week_games(),
+            "week_games_with_players": data.get_week_games_with_players(week=2),
+            "team_game": data.get_team_game("Alpha", week=2),
+            "team_game_with_players": data.get_team_game_with_players(
+                "Alpha",
+                week=2,
+            ),
+            "week_player_leaderboard": data.get_week_player_leaderboard(
+                week=2,
+                limit=3,
+            ),
+            "season_leaders": data.get_season_leaders(limit=3),
+            "season_leaders_filtered": data.get_season_leaders(
+                week_from=2,
+                week_to=2,
+                position="QB",
+                roster_key="Alice",
+                role="starter",
+                sort_by="avg",
+                limit=3,
+            ),
+            "transactions": data.get_transactions(1, 2),
+            "team_transactions": data.get_team_transactions("Alpha", 1, 2),
+            "week_transactions": data.get_week_transactions(week=2),
+            "team_week_transactions": data.get_team_week_transactions(
+                "Alpha",
+                week_from=2,
+            ),
+            "player_summary_by_name": data.get_player_summary("player one"),
+            "player_summary_by_id": data.get_player_summary("p1"),
+            "player_summary_not_found": data.get_player_summary("missing"),
+            "player_weekly_log": data.get_player_weekly_log("Player One"),
+            "player_weekly_log_filtered": data.get_player_weekly_log(
+                "p1",
+                week_from=2,
+                week_to=2,
+            ),
+            "roster_current_by_name": data.get_roster_current("Alpha"),
+            "roster_current_by_manager": data.get_roster_current("Alice"),
+            "roster_snapshot": data.get_roster_snapshot("1", week=1),
+            "playoff_brackets": playoff_data.get_playoff_bracket(),
+            "playoff_winners": playoff_data.get_playoff_bracket("winners"),
+            "team_playoff_path": playoff_data.get_team_playoff_path("Alice"),
+            "sql_named_params_and_limit": data.run_sql(
+                "SELECT roster_id, points FROM matchups "
+                "WHERE week = :week ORDER BY roster_id",
+                {"week": 2},
+                limit=1,
+            ),
+        }
+    )
+
+
+def _stable_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _json_round_trip(value: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(value, sort_keys=True))

--- a/datalayer/tests/characterization/test_legacy_normalization_golden.py
+++ b/datalayer/tests/characterization/test_legacy_normalization_golden.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from datalayer.sleeper_data.config import SleeperConfig
+from datalayer.sleeper_data.sleeper_league_data import SleeperLeagueData
+from datalayer.tests.characterization.legacy_outputs import (
+    collect_normalization_golden,
+)
+
+
+GOLDEN_PATH = Path(__file__).parent / "golden" / "legacy_normalized_tables.json"
+
+
+def test_legacy_normalization_and_derivations_match_golden(
+    monkeypatch_sleeper_api,
+    sleeper_fixtures,
+) -> None:
+    data = SleeperLeagueData(
+        config=SleeperConfig(league_id="123", week_override=None)
+    )
+    data.load()
+    try:
+        actual = collect_normalization_golden(data, sleeper_fixtures)
+    finally:
+        _close(data)
+
+    expected = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+    assert actual == expected
+
+
+def _close(data: SleeperLeagueData) -> None:
+    data._conn().close()
+    if data.engine is not None:
+        data.engine.dispose()

--- a/datalayer/tests/characterization/test_legacy_queries_golden.py
+++ b/datalayer/tests/characterization/test_legacy_queries_golden.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from datalayer.sleeper_data.config import SleeperConfig
+from datalayer.sleeper_data.sleeper_league_data import SleeperLeagueData
+from datalayer.tests.characterization.legacy_outputs import collect_query_golden
+
+
+GOLDEN_PATH = Path(__file__).parent / "golden" / "legacy_query_outputs.json"
+
+
+def test_legacy_curated_queries_and_resolution_match_golden(
+    monkeypatch_sleeper_api,
+) -> None:
+    data = _load(week_override=None)
+    playoff_data = _load(week_override=15)
+    try:
+        actual = collect_query_golden(data, playoff_data)
+    finally:
+        _close(data)
+        _close(playoff_data)
+
+    expected = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "DELETE FROM players",
+        "PRAGMA table_info(players)",
+        "SELECT * FROM players; DROP TABLE players",
+    ],
+)
+def test_legacy_sql_guard_rejects_non_select_behavior(
+    monkeypatch_sleeper_api,
+    statement: str,
+) -> None:
+    data = _load(week_override=None)
+    try:
+        with pytest.raises(ValueError):
+            data.run_sql(statement)
+    finally:
+        _close(data)
+
+
+def _load(*, week_override: int | None) -> SleeperLeagueData:
+    data = SleeperLeagueData(
+        config=SleeperConfig(league_id="123", week_override=week_override)
+    )
+    data.load()
+    return data
+
+
+def _close(data: SleeperLeagueData) -> None:
+    data._conn().close()
+    if data.engine is not None:
+        data.engine.dispose()


### PR DESCRIPTION
## Stack

Stacked on #122. Review this PR as the incremental diff from
`codex/datalayer-1-snapshot-schema`.

## Summary

- add immutable refresh and date-based snapshot workflow values
- define the closed Sleeper endpoint-kind and validated scope-key vocabulary
- add structured warning codes and sanitized typed datalayer errors
- add Decimal-first JSON parsing, canonical encoding, and SHA-256 identity
- define ingestion-normalizer and snapshot-projection compatibility versions
- freeze legacy normalization/derivation behavior in a complete 15-table golden
- freeze all curated query families, name resolution, not-found results,
  playoff behavior, and guarded SQL in a 33-case golden

## Scope

This PR contains only pure, storage-independent contracts and fixture-backed
legacy characterization. It intentionally does not add HTTP transport, local
artifact storage, endpoint-family records or normalization, ORM/resource
access, composition, managers, or workflow orchestration.

## Verification

- pure contracts plus all legacy datalayer tests: 83 passed
- exact PostgreSQL migration lifecycle passed at sole head `0007`
- Alembic metadata drift check reported no new upgrade operations
- live PostgreSQL backend suite: 201 passed
- complete repository suite against disposable PostgreSQL: 443 passed
- package compilation, import-boundary scan, and staged diff check passed
