### PR TITLE
feat(datalayer): add source I/O boundary

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -83,3 +83,30 @@ class DatabaseSettings:
             require_tls=self.require_tls if require_tls is None else require_tls,
             statement_timeout_ms=self.statement_timeout_ms,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class DatalayerSettings:
+    """Local storage and Sleeper source settings for datalayer composition."""
+
+    data_root: Path
+    sleeper_base_url: str
+    sleeper_timeout_seconds: int
+
+    @classmethod
+    def from_environment(cls) -> "DatalayerSettings":
+        data_root = os.getenv("AIDAM_DATALAYER_ROOT", ".data/datalayer").strip()
+        if not data_root:
+            raise ValueError("AIDAM_DATALAYER_ROOT must not be empty")
+        base_url = os.getenv(
+            "AIDAM_SLEEPER_BASE_URL", "https://api.sleeper.app/v1"
+        ).strip().rstrip("/")
+        if not base_url:
+            raise ValueError("AIDAM_SLEEPER_BASE_URL must not be empty")
+        return cls(
+            data_root=Path(data_root).expanduser(),
+            sleeper_base_url=base_url,
+            sleeper_timeout_seconds=_positive_int(
+                "AIDAM_SLEEPER_TIMEOUT_SECONDS", 10
+            ),
+        )

--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -22,6 +22,21 @@ from backend.services.datalayer.errors import (
     InvalidDatalayerRequest,
     SnapshotUnavailable,
 )
+from backend.services.datalayer.local_files import (
+    LocalArtifactKind,
+    LocalArtifactVerificationError,
+    LocalDatalayerFileStore,
+    StoredLocalArtifact,
+    VerifiedLocalArtifact,
+)
+from backend.services.datalayer.sleeper.client import SleeperSourceClient
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SanitizedSourceError,
+    SourceAttempt,
+    SuccessfulSourceAttempt,
+)
 from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
 from backend.services.datalayer.versions import (
     INGESTION_NORMALIZER_VERSION,
@@ -35,20 +50,31 @@ __all__ = [
     "DatalayerResourceNotFound",
     "DatalayerScopeConflict",
     "EndpointKind",
+    "EndpointRequest",
     "EndpointPayloadRejected",
+    "FailedSourceAttempt",
     "INGESTION_NORMALIZER_VERSION",
     "InternalDatalayerFailure",
     "InvalidDatalayerRequest",
+    "LocalArtifactKind",
+    "LocalArtifactVerificationError",
+    "LocalDatalayerFileStore",
     "NormalizationStatus",
     "RefreshOutcome",
     "RefreshRequest",
     "RefreshStatus",
     "RefreshTrigger",
+    "SanitizedSourceError",
     "RequestStatus",
     "SNAPSHOT_PROJECTION_VERSION",
     "ScopeKey",
     "ScopeRefreshResult",
     "SnapshotRequest",
     "SnapshotUnavailable",
+    "SleeperSourceClient",
+    "SourceAttempt",
+    "StoredLocalArtifact",
+    "SuccessfulSourceAttempt",
+    "VerifiedLocalArtifact",
     "WarningCode",
 ]

--- a/backend/services/datalayer/canonical_json.py
+++ b/backend/services/datalayer/canonical_json.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 from decimal import Decimal
 import hashlib
 import json
-from typing import NoReturn, TypeAlias
+from typing import NoReturn
+
+from typing_extensions import TypeAliasType
 
 
-JsonValue: TypeAlias = (
-    type(None)
-    | bool
-    | int
-    | Decimal
-    | str
-    | list["JsonValue"]
-    | dict[str, "JsonValue"]
+JsonValue = TypeAliasType(
+    "JsonValue",
+    (
+        type(None)
+        | bool
+        | int
+        | Decimal
+        | str
+        | list["JsonValue"]
+        | dict[str, "JsonValue"]
+    ),
 )
 
 

--- a/backend/services/datalayer/local_files.py
+++ b/backend/services/datalayer/local_files.py
@@ -1,0 +1,245 @@
+"""Concrete content-addressed local storage for datalayer artifacts."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import re
+import tempfile
+
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_STORAGE_KEY = re.compile(
+    r"^(payloads|snapshots)/sha256/([0-9a-f]{2})/"
+    r"([0-9a-f]{64})(\.json|\.sqlite)$"
+)
+_CHUNK_SIZE = 1024 * 1024
+
+
+class LocalArtifactKind(StrEnum):
+    PAYLOAD = "payloads"
+    SNAPSHOT = "snapshots"
+
+    @property
+    def suffix(self) -> str:
+        return ".json" if self is LocalArtifactKind.PAYLOAD else ".sqlite"
+
+
+@dataclass(frozen=True, slots=True)
+class StoredLocalArtifact:
+    storage_key: str
+    sha256: str
+    byte_length: int
+
+    def __post_init__(self) -> None:
+        _validate_receipt(self.storage_key, self.sha256, self.byte_length)
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedLocalArtifact:
+    path: Path
+    storage_key: str
+    sha256: str
+    byte_length: int
+
+    def __post_init__(self) -> None:
+        _validate_receipt(self.storage_key, self.sha256, self.byte_length)
+        if not self.path.is_absolute():
+            raise ValueError("verified local artifact path must be absolute")
+
+
+class LocalArtifactVerificationError(RuntimeError):
+    """Stored bytes are unavailable or do not match their immutable receipt."""
+
+
+class LocalDatalayerFileStore:
+    """Own content addressing, atomic publication, and verified local reads."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root.expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def store_bytes(
+        self,
+        kind: LocalArtifactKind,
+        content: bytes,
+    ) -> StoredLocalArtifact:
+        if not isinstance(content, bytes):
+            raise TypeError("local artifact content must be bytes")
+        return self._store_chunks(kind, (content,))
+
+    def store_file(
+        self,
+        kind: LocalArtifactKind,
+        source: Path,
+    ) -> StoredLocalArtifact:
+        def chunks() -> Iterable[bytes]:
+            with source.open("rb") as input_file:
+                while chunk := input_file.read(_CHUNK_SIZE):
+                    yield chunk
+
+        return self._store_chunks(kind, chunks())
+
+    def open_verified(
+        self,
+        storage_key: str,
+        *,
+        expected_sha256: str,
+        expected_byte_length: int,
+    ) -> VerifiedLocalArtifact:
+        _validate_receipt(storage_key, expected_sha256, expected_byte_length)
+        target = self._resolve_key(storage_key)
+        self._verify_file(target, expected_sha256, expected_byte_length)
+        return VerifiedLocalArtifact(
+            path=target,
+            storage_key=storage_key,
+            sha256=expected_sha256,
+            byte_length=expected_byte_length,
+        )
+
+    def _store_chunks(
+        self,
+        kind: LocalArtifactKind,
+        chunks: Iterable[bytes],
+    ) -> StoredLocalArtifact:
+        if not isinstance(kind, LocalArtifactKind):
+            raise TypeError("kind must be a LocalArtifactKind")
+        staging_root = self._root / ".staging"
+        staging_root.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(dir=staging_root)
+        temporary_path = Path(temporary_name)
+        digest = hashlib.sha256()
+        byte_length = 0
+        try:
+            with os.fdopen(descriptor, "wb") as output_file:
+                for chunk in chunks:
+                    if not isinstance(chunk, bytes):
+                        raise TypeError("local artifact chunks must be bytes")
+                    digest.update(chunk)
+                    byte_length += len(chunk)
+                    output_file.write(chunk)
+                output_file.flush()
+                os.fsync(output_file.fileno())
+
+            sha256 = digest.hexdigest()
+            self._verify_file(temporary_path, sha256, byte_length)
+            storage_key = _content_key(kind, sha256)
+            target = self._resolve_key(storage_key)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            self._publish_exclusive(
+                temporary_path,
+                target,
+                expected_sha256=sha256,
+                expected_byte_length=byte_length,
+            )
+            return StoredLocalArtifact(
+                storage_key=storage_key,
+                sha256=sha256,
+                byte_length=byte_length,
+            )
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    def _publish_exclusive(
+        self,
+        temporary_path: Path,
+        target: Path,
+        *,
+        expected_sha256: str,
+        expected_byte_length: int,
+    ) -> None:
+        try:
+            os.link(temporary_path, target)
+        except FileExistsError:
+            self._verify_file(target, expected_sha256, expected_byte_length)
+            target.chmod(0o444)
+            return
+
+        try:
+            temporary_path.unlink()
+            target.chmod(0o444)
+            self._verify_file(target, expected_sha256, expected_byte_length)
+        except Exception:
+            try:
+                target.chmod(0o666)
+                target.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+    def _resolve_key(self, storage_key: str) -> Path:
+        if "\\" in storage_key:
+            raise ValueError("storage key must use POSIX separators")
+        relative = PurePosixPath(storage_key)
+        if relative.is_absolute() or ".." in relative.parts or not relative.parts:
+            raise ValueError("storage key must be a contained relative path")
+        candidate = self._root.joinpath(*relative.parts)
+        current = self._root
+        for part in relative.parts[:-1]:
+            current /= part
+            if _is_link_or_junction(current):
+                raise ValueError("storage key must not traverse symbolic links")
+        if _is_link_or_junction(candidate):
+            raise ValueError("storage key must not resolve through a symbolic link")
+        return candidate
+
+    @staticmethod
+    def _verify_file(
+        path: Path,
+        expected_sha256: str,
+        expected_byte_length: int,
+    ) -> None:
+        actual_sha256, actual_byte_length = _hash_file(path)
+        if (
+            actual_sha256 != expected_sha256
+            or actual_byte_length != expected_byte_length
+        ):
+            raise LocalArtifactVerificationError(
+                "stored content does not match its hash and size receipt"
+            )
+
+
+def _content_key(kind: LocalArtifactKind, sha256: str) -> str:
+    return f"{kind.value}/sha256/{sha256[:2]}/{sha256}{kind.suffix}"
+
+
+def _validate_receipt(storage_key: str, sha256: str, byte_length: int) -> None:
+    if not _SHA256.fullmatch(sha256):
+        raise ValueError("artifact SHA-256 must be 64 lowercase hexadecimal digits")
+    if isinstance(byte_length, bool) or not isinstance(byte_length, int):
+        raise TypeError("artifact byte length must be an integer")
+    if byte_length < 0:
+        raise ValueError("artifact byte length must be non-negative")
+    match = _STORAGE_KEY.fullmatch(storage_key)
+    if match is None:
+        raise ValueError("storage key is not a canonical datalayer artifact key")
+    namespace, prefix, key_sha256, suffix = match.groups()
+    expected_suffix = ".json" if namespace == "payloads" else ".sqlite"
+    if prefix != sha256[:2] or key_sha256 != sha256 or suffix != expected_suffix:
+        raise ValueError("storage key does not match the artifact receipt")
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    byte_length = 0
+    try:
+        with path.open("rb") as content:
+            while chunk := content.read(_CHUNK_SIZE):
+                digest.update(chunk)
+                byte_length += len(chunk)
+    except OSError as error:
+        raise LocalArtifactVerificationError("stored content is unavailable") from error
+    return digest.hexdigest(), byte_length
+
+
+def _is_link_or_junction(path: Path) -> bool:
+    is_junction = getattr(path, "is_junction", None)
+    return path.is_symlink() or (is_junction is not None and is_junction())

--- a/backend/services/datalayer/sleeper/__init__.py
+++ b/backend/services/datalayer/sleeper/__init__.py
@@ -1,4 +1,4 @@
-"""Shared Sleeper endpoint identity vocabulary."""
+"""Sleeper provider boundary and shared endpoint identity vocabulary."""
 
 from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
 

--- a/backend/services/datalayer/sleeper/client.py
+++ b/backend/services/datalayer/sleeper/client.py
@@ -1,0 +1,180 @@
+"""One-attempt Sleeper HTTP client with complete, sanitized outcomes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+import hashlib
+import math
+from time import perf_counter
+from typing import Protocol
+from urllib.parse import urlsplit
+
+import requests
+
+from backend.services.datalayer.canonical_json import (
+    canonical_json_bytes,
+    parse_json_bytes,
+)
+from backend.services.datalayer.contracts import RequestStatus
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    RequestParameter,
+    SanitizedSourceError,
+    SourceAttempt,
+    SuccessfulSourceAttempt,
+)
+
+
+WallClock = Callable[[], datetime]
+MonotonicClock = Callable[[], float]
+
+
+class HttpResponse(Protocol):
+    status_code: int
+
+    @property
+    def content(self) -> bytes: ...
+
+
+class SleeperTransport(Protocol):
+    def get(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, RequestParameter],
+        headers: Mapping[str, str],
+        timeout: float,
+        allow_redirects: bool,
+    ) -> HttpResponse: ...
+
+
+class SleeperSourceClient:
+    """Execute exactly one request; callers own retry and persistence policy."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.sleeper.app/v1",
+        timeout_seconds: float = 10,
+        transport: SleeperTransport | None = None,
+        clock: WallClock | None = None,
+        monotonic_clock: MonotonicClock | None = None,
+    ) -> None:
+        self._base_url = _validated_base_url(base_url)
+        if (
+            isinstance(timeout_seconds, bool)
+            or not isinstance(timeout_seconds, (int, float))
+            or not math.isfinite(timeout_seconds)
+            or timeout_seconds <= 0
+        ):
+            raise ValueError("Sleeper timeout must be positive")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport if transport is not None else requests.Session()
+        self._owns_transport = transport is None
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._monotonic_clock = monotonic_clock or perf_counter
+
+    def execute(self, request: EndpointRequest) -> SourceAttempt:
+        requested_at = self._clock()
+        started = self._monotonic_clock()
+        try:
+            response = self._transport.get(
+                f"{self._base_url}{request.path}",
+                params=request.parameters,
+                headers={"User-Agent": "aidam-datalayer"},
+                timeout=self._timeout_seconds,
+                allow_redirects=False,
+            )
+        except requests.RequestException:
+            return self._failed_attempt(
+                request,
+                requested_at=requested_at,
+                started=started,
+                status=RequestStatus.TRANSPORT_ERROR,
+                http_status=None,
+                code="sleeper_transport_error",
+                summary="Sleeper could not be reached",
+            )
+
+        if response.status_code < 200 or response.status_code >= 300:
+            return self._failed_attempt(
+                request,
+                requested_at=requested_at,
+                started=started,
+                status=RequestStatus.HTTP_ERROR,
+                http_status=response.status_code,
+                code="sleeper_http_error",
+                summary=f"Sleeper returned HTTP {response.status_code}",
+            )
+
+        try:
+            payload = parse_json_bytes(response.content)
+            canonical = canonical_json_bytes(payload)
+        except (TypeError, ValueError):
+            return self._failed_attempt(
+                request,
+                requested_at=requested_at,
+                started=started,
+                status=RequestStatus.INVALID_PAYLOAD,
+                http_status=response.status_code,
+                code="sleeper_invalid_json",
+                summary="Sleeper returned an invalid JSON payload",
+            )
+
+        return SuccessfulSourceAttempt(
+            endpoint=request,
+            requested_at=requested_at,
+            completed_at=self._clock(),
+            http_status=response.status_code,
+            latency_ms=self._elapsed_ms(started),
+            payload=payload,
+            raw_sha256=hashlib.sha256(canonical).hexdigest(),
+            byte_length=len(canonical),
+            media_type="application/json",
+        )
+
+    def close(self) -> None:
+        if self._owns_transport:
+            self._transport.close()  # type: ignore[attr-defined]
+
+    def _failed_attempt(
+        self,
+        endpoint: EndpointRequest,
+        *,
+        requested_at: datetime,
+        started: float,
+        status: RequestStatus,
+        http_status: int | None,
+        code: str,
+        summary: str,
+    ) -> FailedSourceAttempt:
+        return FailedSourceAttempt(
+            endpoint=endpoint,
+            requested_at=requested_at,
+            completed_at=self._clock(),
+            status=status,
+            http_status=http_status,
+            latency_ms=self._elapsed_ms(started),
+            error=SanitizedSourceError(code=code, summary=summary),
+        )
+
+    def _elapsed_ms(self, started: float) -> int:
+        return max(0, round((self._monotonic_clock() - started) * 1000))
+
+
+def _validated_base_url(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    parsed = urlsplit(normalized)
+    if (
+        any(character.isspace() for character in normalized)
+        or parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("Sleeper base URL must be an HTTP(S) URL without credentials")
+    return normalized

--- a/backend/services/datalayer/sleeper/responses.py
+++ b/backend/services/datalayer/sleeper/responses.py
@@ -1,0 +1,177 @@
+"""Immutable values crossing the Sleeper HTTP boundary."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+from typing import Annotated, Literal, TypeAlias
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictInt,
+    StrictStr,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from backend.services.datalayer.canonical_json import (
+    JsonValue,
+    canonical_json_bytes,
+)
+from backend.services.datalayer.contracts import RequestStatus
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+RequestParameter: TypeAlias = None | StrictBool | StrictInt | StrictStr
+SourceErrorCode = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=100,
+        pattern=r"^[a-z0-9][a-z0-9_.-]*$",
+    ),
+]
+SourceErrorSummary = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=500),
+]
+
+
+class _SourceValue(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+class EndpointRequest(_SourceValue):
+    endpoint_kind: EndpointKind
+    scope_key: ScopeKey
+    path: str
+    parameters: dict[str, RequestParameter] = Field(default_factory=dict)
+    week: int | None = Field(default=None, ge=1, le=18, strict=True)
+    bracket_kind: Literal["winners", "losers"] | None = None
+
+    @field_validator("path")
+    @classmethod
+    def require_sanitized_relative_api_path(cls, value: str) -> str:
+        if (
+            not value.startswith("/")
+            or value.startswith("//")
+            or "?" in value
+            or "#" in value
+            or "://" in value
+            or "\\" in value
+            or any(character.isspace() for character in value)
+        ):
+            raise ValueError(
+                "Sleeper path must be a sanitized absolute API path without a query"
+            )
+        if any(part in {".", ".."} for part in value.split("/")):
+            raise ValueError("Sleeper path must not contain traversal segments")
+        return value
+
+    @field_validator("parameters")
+    @classmethod
+    def reject_binary_float_parameters(
+        cls,
+        value: dict[str, RequestParameter],
+    ) -> dict[str, RequestParameter]:
+        if any(
+            not key or any(character.isspace() for character in key)
+            for key in value
+        ):
+            raise ValueError(
+                "Sleeper parameter names must be non-empty and contain no whitespace"
+            )
+        return value
+
+
+class SanitizedSourceError(_SourceValue):
+    code: SourceErrorCode
+    summary: SourceErrorSummary
+
+
+class _TimedSourceAttempt(_SourceValue):
+    requested_at: datetime
+    completed_at: datetime
+    latency_ms: int = Field(ge=0, strict=True)
+
+    @model_validator(mode="after")
+    def validate_timing(self) -> "_TimedSourceAttempt":
+        for timestamp in (self.requested_at, self.completed_at):
+            if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+                raise ValueError("source attempt timestamps must include a timezone")
+        if self.completed_at < self.requested_at:
+            raise ValueError("source attempt cannot complete before it was requested")
+        return self
+
+
+class SuccessfulSourceAttempt(_TimedSourceAttempt):
+    outcome: Literal["succeeded"] = "succeeded"
+    endpoint: EndpointRequest
+    http_status: int = Field(ge=200, le=299, strict=True)
+    payload: JsonValue
+    raw_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    byte_length: int = Field(ge=0, strict=True)
+    media_type: Literal["application/json"] = "application/json"
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def reject_binary_float_payloads(cls, value: object) -> object:
+        _reject_binary_floats(value)
+        return value
+
+    @model_validator(mode="after")
+    def validate_payload_receipt(self) -> "SuccessfulSourceAttempt":
+        canonical = canonical_json_bytes(self.payload)
+        if self.byte_length != len(canonical):
+            raise ValueError("source payload byte length does not match canonical JSON")
+        if self.raw_sha256 != hashlib.sha256(canonical).hexdigest():
+            raise ValueError("source payload SHA-256 does not match canonical JSON")
+        return self
+
+
+class FailedSourceAttempt(_TimedSourceAttempt):
+    outcome: Literal["failed"] = "failed"
+    endpoint: EndpointRequest
+    status: RequestStatus
+    http_status: int | None = Field(default=None, ge=100, le=599, strict=True)
+    error: SanitizedSourceError
+
+    @model_validator(mode="after")
+    def validate_failure_status(self) -> "FailedSourceAttempt":
+        if self.status is RequestStatus.SUCCEEDED:
+            raise ValueError("failed source attempt cannot have succeeded status")
+        if self.status is RequestStatus.HTTP_ERROR and self.http_status is None:
+            raise ValueError("HTTP source failure requires an HTTP status")
+        if (
+            self.status is RequestStatus.TRANSPORT_ERROR
+            and self.http_status is not None
+        ):
+            raise ValueError("transport source failure cannot have an HTTP status")
+        if self.status is RequestStatus.INVALID_PAYLOAD and (
+            self.http_status is None or not 200 <= self.http_status <= 299
+        ):
+            raise ValueError(
+                "invalid payload failure requires a successful HTTP status"
+            )
+        return self
+
+
+SourceAttempt = Annotated[
+    SuccessfulSourceAttempt | FailedSourceAttempt,
+    Field(discriminator="outcome"),
+]
+
+
+def _reject_binary_floats(value: object) -> None:
+    if isinstance(value, float):
+        raise ValueError("binary floats are not accepted at the Sleeper boundary")
+    if isinstance(value, list):
+        for item in value:
+            _reject_binary_floats(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _reject_binary_floats(item)

--- a/backend/tests/services/datalayer/test_config.py
+++ b/backend/tests/services/datalayer/test_config.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from backend.config import DatalayerSettings
+
+
+_ENVIRONMENT_NAMES = (
+    "AIDAM_DATALAYER_ROOT",
+    "AIDAM_SLEEPER_BASE_URL",
+    "AIDAM_SLEEPER_TIMEOUT_SECONDS",
+)
+
+
+def test_datalayer_settings_have_local_source_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for name in _ENVIRONMENT_NAMES:
+        monkeypatch.delenv(name, raising=False)
+
+    settings = DatalayerSettings.from_environment()
+
+    assert settings.data_root == Path(".data/datalayer")
+    assert settings.sleeper_base_url == "https://api.sleeper.app/v1"
+    assert settings.sleeper_timeout_seconds == 10
+
+
+def test_datalayer_settings_read_environment_and_normalize_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_DATALAYER_ROOT", "custom-data")
+    monkeypatch.setenv("AIDAM_SLEEPER_BASE_URL", "https://source.example/v1///")
+    monkeypatch.setenv("AIDAM_SLEEPER_TIMEOUT_SECONDS", "25")
+
+    settings = DatalayerSettings.from_environment()
+
+    assert settings.data_root == Path("custom-data")
+    assert settings.sleeper_base_url == "https://source.example/v1"
+    assert settings.sleeper_timeout_seconds == 25
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_datalayer_settings_reject_nonpositive_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("AIDAM_SLEEPER_TIMEOUT_SECONDS", value)
+
+    with pytest.raises(ValueError, match="must be positive"):
+        DatalayerSettings.from_environment()
+
+
+def test_datalayer_settings_reject_empty_source_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_SLEEPER_BASE_URL", "///")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        DatalayerSettings.from_environment()
+
+
+def test_datalayer_settings_reject_empty_data_root(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_DATALAYER_ROOT", "   ")
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        DatalayerSettings.from_environment()

--- a/backend/tests/services/datalayer/test_local_files.py
+++ b/backend/tests/services/datalayer/test_local_files.py
@@ -1,0 +1,189 @@
+from concurrent.futures import ThreadPoolExecutor
+import hashlib
+from pathlib import Path
+import stat
+
+import pytest
+
+from backend.services.datalayer.local_files import (
+    LocalArtifactKind,
+    LocalArtifactVerificationError,
+    LocalDatalayerFileStore,
+    StoredLocalArtifact,
+)
+
+
+def test_store_bytes_is_content_addressed_idempotent_and_read_only(
+    tmp_path: Path,
+) -> None:
+    store = LocalDatalayerFileStore(tmp_path)
+    content = b'{"week":8}'
+
+    first = store.store_bytes(LocalArtifactKind.PAYLOAD, content)
+    second = store.store_bytes(LocalArtifactKind.PAYLOAD, content)
+    opened = store.open_verified(
+        first.storage_key,
+        expected_sha256=first.sha256,
+        expected_byte_length=first.byte_length,
+    )
+
+    assert second == first
+    assert first.storage_key == (
+        f"payloads/sha256/{first.sha256[:2]}/{first.sha256}.json"
+    )
+    assert opened.path.read_bytes() == content
+    assert opened.path.is_relative_to(tmp_path.resolve())
+    assert opened.path.stat().st_mode & stat.S_IWRITE == 0
+
+
+def test_store_file_streams_into_snapshot_namespace(tmp_path: Path) -> None:
+    source = tmp_path / "build.sqlite"
+    content = b"sqlite" + b"x" * (1024 * 1024 + 17)
+    source.write_bytes(content)
+    store = LocalDatalayerFileStore(tmp_path / "artifacts")
+
+    receipt = store.store_file(LocalArtifactKind.SNAPSHOT, source)
+    opened = store.open_verified(
+        receipt.storage_key,
+        expected_sha256=receipt.sha256,
+        expected_byte_length=receipt.byte_length,
+    )
+
+    assert receipt.storage_key == (
+        f"snapshots/sha256/{receipt.sha256[:2]}/{receipt.sha256}.sqlite"
+    )
+    assert opened.path.read_bytes() == content
+
+
+def test_concurrent_same_content_writers_share_one_verified_target(
+    tmp_path: Path,
+) -> None:
+    store = LocalDatalayerFileStore(tmp_path)
+    content = b'{"same":true}'
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        receipts = list(
+            executor.map(
+                lambda _: store.store_bytes(LocalArtifactKind.PAYLOAD, content),
+                range(24),
+            )
+        )
+
+    assert all(receipt == receipts[0] for receipt in receipts)
+    targets = [path for path in tmp_path.rglob("*.json") if path.is_file()]
+    assert len(targets) == 1
+    assert targets[0].read_bytes() == content
+    assert not any(path.is_file() for path in (tmp_path / ".staging").iterdir())
+
+
+def test_store_rejects_existing_content_address_collision(tmp_path: Path) -> None:
+    store = LocalDatalayerFileStore(tmp_path)
+    intended = b"intended content"
+    sha256 = hashlib.sha256(intended).hexdigest()
+    target = (
+        tmp_path
+        / "payloads"
+        / "sha256"
+        / sha256[:2]
+        / f"{sha256}.json"
+    )
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"different content")
+
+    with pytest.raises(LocalArtifactVerificationError, match="does not match"):
+        store.store_bytes(LocalArtifactKind.PAYLOAD, intended)
+
+    assert target.read_bytes() == b"different content"
+    assert not any(path.is_file() for path in (tmp_path / ".staging").iterdir())
+
+
+def test_open_verified_rejects_tampered_missing_and_mismatched_content(
+    tmp_path: Path,
+) -> None:
+    store = LocalDatalayerFileStore(tmp_path)
+    receipt = store.store_bytes(LocalArtifactKind.PAYLOAD, b"original")
+    target = tmp_path / receipt.storage_key
+    target.chmod(0o666)
+    target.write_bytes(b"tampered")
+
+    with pytest.raises(LocalArtifactVerificationError, match="does not match"):
+        store.open_verified(
+            receipt.storage_key,
+            expected_sha256=receipt.sha256,
+            expected_byte_length=receipt.byte_length,
+        )
+
+    target.chmod(0o666)
+    target.write_bytes(b"original")
+    with pytest.raises(LocalArtifactVerificationError, match="does not match"):
+        store.open_verified(
+            receipt.storage_key,
+            expected_sha256=receipt.sha256,
+            expected_byte_length=receipt.byte_length + 1,
+        )
+
+    target.unlink()
+    with pytest.raises(LocalArtifactVerificationError, match="unavailable"):
+        store.open_verified(
+            receipt.storage_key,
+            expected_sha256=receipt.sha256,
+            expected_byte_length=receipt.byte_length,
+        )
+
+
+@pytest.mark.parametrize(
+    ("storage_key", "sha256", "byte_length"),
+    [
+        ("../outside.json", "0" * 64, 0),
+        ("/absolute.json", "0" * 64, 0),
+        ("payloads\\sha256\\00\\value.json", "0" * 64, 0),
+        ("payloads/sha256/00/value.json", "0" * 64, 0),
+        ("payloads/sha256/ff/" + "0" * 64 + ".json", "0" * 64, 0),
+        ("snapshots/sha256/00/" + "0" * 64 + ".json", "0" * 64, 0),
+        ("payloads/sha256/00/" + "0" * 64 + ".json", "A" * 64, 0),
+        ("payloads/sha256/00/" + "0" * 64 + ".json", "0" * 64, -1),
+    ],
+)
+def test_artifact_receipts_reject_noncanonical_or_inconsistent_values(
+    storage_key: str,
+    sha256: str,
+    byte_length: int,
+) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        StoredLocalArtifact(
+            storage_key=storage_key,
+            sha256=sha256,
+            byte_length=byte_length,
+        )
+
+
+def test_open_verified_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    link = root / "payloads"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symbolic links are unavailable in this environment")
+    store = LocalDatalayerFileStore(root)
+    sha256 = "0" * 64
+
+    with pytest.raises(ValueError, match="symbolic links"):
+        store.open_verified(
+            f"payloads/sha256/00/{sha256}.json",
+            expected_sha256=sha256,
+            expected_byte_length=0,
+        )
+
+
+def test_staging_file_is_cleaned_when_input_stream_fails(tmp_path: Path) -> None:
+    store = LocalDatalayerFileStore(tmp_path / "artifacts")
+
+    with pytest.raises(FileNotFoundError):
+        store.store_file(LocalArtifactKind.SNAPSHOT, tmp_path / "missing.sqlite")
+
+    assert not any(
+        path.is_file() for path in (store.root / ".staging").iterdir()
+    )

--- a/backend/tests/services/datalayer/test_sleeper_client.py
+++ b/backend/tests/services/datalayer/test_sleeper_client.py
@@ -1,0 +1,226 @@
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+import hashlib
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+import requests
+
+from backend.services.datalayer.canonical_json import canonical_json_bytes
+from backend.services.datalayer.contracts import RequestStatus
+from backend.services.datalayer.local_files import (
+    LocalArtifactKind,
+    LocalDatalayerFileStore,
+)
+from backend.services.datalayer.sleeper.client import SleeperSourceClient
+from backend.services.datalayer.sleeper.responses import EndpointRequest
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+SEASON_ID = UUID("10000000-0000-0000-0000-000000000001")
+REQUESTED_AT = datetime(2025, 10, 28, 12, tzinfo=timezone.utc)
+COMPLETED_AT = REQUESTED_AT + timedelta(milliseconds=25)
+
+
+class StubResponse:
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self._content = content
+        self.content_reads = 0
+
+    @property
+    def content(self) -> bytes:
+        self.content_reads += 1
+        return self._content
+
+
+class StubTransport:
+    def __init__(
+        self,
+        result: StubResponse | requests.RequestException,
+    ) -> None:
+        self.result = result
+        self.calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    def get(self, url: str, **kwargs: Any) -> StubResponse:
+        self.calls.append({"url": url, **kwargs})
+        if isinstance(self.result, requests.RequestException):
+            raise self.result
+        return self.result
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _endpoint() -> EndpointRequest:
+    return EndpointRequest(
+        endpoint_kind=EndpointKind.MATCHUPS,
+        scope_key=ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8),
+        path="/league/123/matchups/8",
+        parameters={"sport": "nfl"},
+        week=8,
+    )
+
+
+def _values(values: list[Any]) -> Iterator[Any]:
+    return iter(values)
+
+
+def _client(
+    transport: StubTransport,
+    *,
+    base_url: str = "https://source.example/v1/",
+    timeout_seconds: float = 7,
+) -> SleeperSourceClient:
+    timestamps = _values([REQUESTED_AT, COMPLETED_AT])
+    monotonic_values = _values([10.0, 10.025])
+    return SleeperSourceClient(
+        base_url=base_url,
+        timeout_seconds=timeout_seconds,
+        transport=transport,
+        clock=lambda: next(timestamps),
+        monotonic_clock=lambda: next(monotonic_values),
+    )
+
+
+def test_successful_attempt_captures_decimal_first_canonical_receipt() -> None:
+    response = StubResponse(200, b'{"z":2,"score":123.4500,"a":1}')
+    transport = StubTransport(response)
+    client = _client(transport)
+
+    result = client.execute(_endpoint())
+
+    expected_payload = {"z": 2, "score": Decimal("123.4500"), "a": 1}
+    canonical = canonical_json_bytes(expected_payload)
+    assert result.outcome == "succeeded"
+    assert result.payload == expected_payload
+    assert result.raw_sha256 == hashlib.sha256(canonical).hexdigest()
+    assert result.byte_length == len(canonical)
+    assert result.media_type == "application/json"
+    assert result.requested_at == REQUESTED_AT
+    assert result.completed_at == COMPLETED_AT
+    assert result.latency_ms == 25
+    assert len(transport.calls) == 1
+    assert transport.calls[0] == {
+        "url": "https://source.example/v1/league/123/matchups/8",
+        "params": {"sport": "nfl"},
+        "headers": {"User-Agent": "aidam-datalayer"},
+        "timeout": 7,
+        "allow_redirects": False,
+    }
+
+
+def test_successful_payload_round_trips_through_local_store(
+    tmp_path: Path,
+) -> None:
+    transport = StubTransport(StubResponse(200, b'{"score":12.3400,"week":8}'))
+    result = _client(transport).execute(_endpoint())
+    assert result.outcome == "succeeded"
+    canonical = canonical_json_bytes(result.payload)
+    store = LocalDatalayerFileStore(tmp_path)
+
+    receipt = store.store_bytes(LocalArtifactKind.PAYLOAD, canonical)
+    opened = store.open_verified(
+        receipt.storage_key,
+        expected_sha256=result.raw_sha256,
+        expected_byte_length=result.byte_length,
+    )
+
+    assert receipt.sha256 == result.raw_sha256
+    assert opened.path.read_bytes() == canonical
+
+
+def test_transport_failure_is_sanitized_and_not_retried() -> None:
+    transport = StubTransport(
+        requests.ConnectionError("secret.internal.example token=private")
+    )
+    result = _client(transport).execute(_endpoint())
+
+    assert result.outcome == "failed"
+    assert result.status is RequestStatus.TRANSPORT_ERROR
+    assert result.http_status is None
+    assert len(transport.calls) == 1
+    serialized = result.model_dump_json()
+    assert "secret.internal.example" not in serialized
+    assert "private" not in serialized
+
+
+@pytest.mark.parametrize("status", [301, 404, 503])
+def test_http_failure_does_not_read_or_record_response_body(status: int) -> None:
+    response = StubResponse(status, b"secret provider response body")
+    transport = StubTransport(response)
+
+    result = _client(transport).execute(_endpoint())
+
+    assert result.outcome == "failed"
+    assert result.status is RequestStatus.HTTP_ERROR
+    assert result.http_status == status
+    assert response.content_reads == 0
+    assert "secret provider response body" not in result.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    "content",
+    [b"", b"not json", b'{"score":NaN}', b'{"score":Infinity}'],
+)
+def test_invalid_json_is_a_recordable_sanitized_failure(content: bytes) -> None:
+    transport = StubTransport(StubResponse(200, content))
+
+    result = _client(transport).execute(_endpoint())
+
+    assert result.outcome == "failed"
+    assert result.status is RequestStatus.INVALID_PAYLOAD
+    assert result.http_status == 200
+    assert result.error.code == "sleeper_invalid_json"
+    if content:
+        assert content.decode(errors="ignore") not in result.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "api.sleeper.app/v1",
+        "ftp://api.sleeper.app/v1",
+        "https://user:password@api.sleeper.app/v1",
+        "https://api.sleeper.app/v1?token=secret",
+        "https://api.sleeper.app/has space",
+    ],
+)
+def test_client_rejects_unsafe_base_urls(base_url: str) -> None:
+    with pytest.raises(ValueError):
+        SleeperSourceClient(
+            base_url=base_url,
+            transport=StubTransport(StubResponse(200, b"{}")),
+        )
+
+
+@pytest.mark.parametrize("timeout", [0, -1, True, float("inf"), float("nan")])
+def test_client_rejects_invalid_timeout(timeout: float) -> None:
+    with pytest.raises(ValueError):
+        SleeperSourceClient(
+            timeout_seconds=timeout,
+            transport=StubTransport(StubResponse(200, b"{}")),
+        )
+
+
+def test_client_closes_only_an_internally_owned_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owned = StubTransport(StubResponse(200, b"{}"))
+    monkeypatch.setattr(
+        "backend.services.datalayer.sleeper.client.requests.Session",
+        lambda: owned,
+    )
+    owned_client = SleeperSourceClient()
+    injected = StubTransport(StubResponse(200, b"{}"))
+    injected_client = SleeperSourceClient(transport=injected)
+
+    owned_client.close()
+    injected_client.close()
+
+    assert owned.closed is True
+    assert injected.closed is False

--- a/backend/tests/services/datalayer/test_source_contracts.py
+++ b/backend/tests/services/datalayer/test_source_contracts.py
@@ -1,0 +1,194 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+import hashlib
+from uuid import UUID
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from backend.services.datalayer.canonical_json import canonical_json_bytes
+from backend.services.datalayer.contracts import RequestStatus
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SanitizedSourceError,
+    SourceAttempt,
+    SuccessfulSourceAttempt,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+SEASON_ID = UUID("10000000-0000-0000-0000-000000000001")
+REQUESTED_AT = datetime(2025, 10, 28, 12, tzinfo=timezone.utc)
+COMPLETED_AT = REQUESTED_AT + timedelta(milliseconds=12)
+
+
+def _endpoint(**overrides: object) -> EndpointRequest:
+    values: dict[str, object] = {
+        "endpoint_kind": EndpointKind.MATCHUPS,
+        "scope_key": ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 8),
+        "path": "/league/123/matchups/8",
+        "parameters": {"sport": "nfl", "week": 8, "active": True},
+        "week": 8,
+    }
+    values.update(overrides)
+    return EndpointRequest(**values)  # type: ignore[arg-type]
+
+
+def _success() -> SuccessfulSourceAttempt:
+    payload = {"score": Decimal("123.4500"), "players": ["1", "2"]}
+    canonical = canonical_json_bytes(payload)
+    return SuccessfulSourceAttempt(
+        endpoint=_endpoint(),
+        requested_at=REQUESTED_AT,
+        completed_at=COMPLETED_AT,
+        latency_ms=12,
+        http_status=200,
+        payload=payload,
+        raw_sha256=hashlib.sha256(canonical).hexdigest(),
+        byte_length=len(canonical),
+    )
+
+
+def test_source_attempt_union_round_trips_both_discriminated_outcomes() -> None:
+    adapter = TypeAdapter(SourceAttempt)
+    success = _success()
+    failure = FailedSourceAttempt(
+        endpoint=_endpoint(),
+        requested_at=REQUESTED_AT,
+        completed_at=COMPLETED_AT,
+        latency_ms=12,
+        status=RequestStatus.HTTP_ERROR,
+        http_status=503,
+        error=SanitizedSourceError(
+            code="sleeper_http_error",
+            summary="Sleeper returned HTTP 503",
+        ),
+    )
+
+    assert adapter.validate_python(success.model_dump()).outcome == "succeeded"
+    assert adapter.validate_python(failure.model_dump()).outcome == "failed"
+
+
+def test_source_contracts_are_frozen_and_forbid_unknown_fields() -> None:
+    endpoint = _endpoint()
+
+    with pytest.raises(ValidationError, match="frozen"):
+        endpoint.week = 9
+    with pytest.raises(ValidationError, match="extra"):
+        EndpointRequest(
+            endpoint_kind=EndpointKind.MATCHUPS,
+            scope_key=endpoint.scope_key,
+            path=endpoint.path,
+            secret_header="value",
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "league/123",
+        "//evil.example/path",
+        "/league/123?token=secret",
+        "/league/123#fragment",
+        "https://evil.example/path",
+        "/league/../secret",
+        "/league\\123",
+        "/league/has space",
+    ],
+)
+def test_endpoint_request_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(ValidationError):
+        _endpoint(path=path)
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"score": 0.1},
+        {"week": "8", "nested": {"secret": "value"}},
+        {"has space": "value"},
+    ],
+)
+def test_endpoint_request_rejects_unsafe_parameters(
+    parameters: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        _endpoint(parameters=parameters)
+
+
+@pytest.mark.parametrize(
+    ("requested_at", "completed_at"),
+    [
+        (datetime(2025, 10, 28), COMPLETED_AT),
+        (REQUESTED_AT, datetime(2025, 10, 28)),
+        (COMPLETED_AT, REQUESTED_AT),
+    ],
+)
+def test_source_attempt_rejects_invalid_timing(
+    requested_at: datetime,
+    completed_at: datetime,
+) -> None:
+    success = _success()
+
+    with pytest.raises(ValidationError):
+        SuccessfulSourceAttempt(
+            **success.model_dump(exclude={"requested_at", "completed_at"}),
+            requested_at=requested_at,
+            completed_at=completed_at,
+        )
+
+
+def test_successful_attempt_requires_exact_canonical_receipt() -> None:
+    success = _success()
+
+    with pytest.raises(ValidationError, match="byte length"):
+        SuccessfulSourceAttempt(
+            **success.model_dump(exclude={"byte_length"}),
+            byte_length=success.byte_length + 1,
+        )
+    with pytest.raises(ValidationError, match="SHA-256"):
+        SuccessfulSourceAttempt(
+            **success.model_dump(exclude={"raw_sha256"}),
+            raw_sha256="0" * 64,
+        )
+    with pytest.raises(ValidationError, match="binary floats"):
+        SuccessfulSourceAttempt(
+            **success.model_dump(exclude={"payload"}),
+            payload={"score": 0.1},
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "http_status"),
+    [
+        (RequestStatus.SUCCEEDED, None),
+        (RequestStatus.HTTP_ERROR, None),
+        (RequestStatus.TRANSPORT_ERROR, 503),
+        (RequestStatus.INVALID_PAYLOAD, None),
+        (RequestStatus.INVALID_PAYLOAD, 503),
+    ],
+)
+def test_failed_attempt_rejects_inconsistent_status(
+    status: RequestStatus,
+    http_status: int | None,
+) -> None:
+    with pytest.raises(ValidationError):
+        FailedSourceAttempt(
+            endpoint=_endpoint(),
+            requested_at=REQUESTED_AT,
+            completed_at=COMPLETED_AT,
+            latency_ms=12,
+            status=status,
+            http_status=http_status,
+            error=SanitizedSourceError(code="safe_code", summary="Safe summary"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("code", "summary"),
+    [("Not Canonical", "Safe"), ("safe_code", "   "), ("safe_code", "x" * 501)],
+)
+def test_source_error_rejects_unstructured_values(code: str, summary: str) -> None:
+    with pytest.raises(ValidationError):
+        SanitizedSourceError(code=code, summary=summary)


### PR DESCRIPTION
## Stack

Stacked on #124. Review this PR as the incremental diff from
`codex/datalayer-2-core-contracts`.

## Summary

- add immutable, discriminated successful and failed Sleeper source attempts
- execute exactly one injected-transport HTTP request with sanitized failures
- preserve fractional JSON values as Decimal and hash canonical response bytes
- add verified content-addressed payload and SQLite artifact storage
- make same-content writes idempotent and safe under concurrent publication
- add local data-root, Sleeper base-URL, and source-timeout configuration

## Scope

This PR contains only source request/response contracts, the Sleeper HTTP
boundary, concrete local artifact storage, configuration, exports, and direct
tests. It intentionally does not add endpoint-family normalization, refresh
retries or planning, PostgreSQL resource access, snapshot lifecycle, or
workflow orchestration.

## Verification

- focused source/store/config plus inherited datalayer suite: 149 passed
- concurrent 24-writer publication test: 30 consecutive stress runs passed
- exact PostgreSQL migration lifecycle passed at sole head `0007`
- Alembic metadata drift check reported no new upgrade operations
- inherited live snapshot/constraint gate: 18 passed
- complete repository suite against disposable PostgreSQL: 509 passed
- package compilation, import-boundary scan, and staged diff check passed

One local test skips because this Windows environment does not permit symbolic
link creation; traversal/junction rejection remains implemented and all other
containment tests pass.
