### PR TITLE
feat(datalayer): add sleeper audit resources

### DIFF
--- a/backend/resources/sleeper_data/__init__.py
+++ b/backend/resources/sleeper_data/__init__.py
@@ -1,0 +1,37 @@
+"""Typed Sleeper refresh and request audit resources."""
+
+from backend.resources.sleeper_data.common import Page
+from backend.resources.sleeper_data.refreshes import (
+    PlannedEndpointScope,
+    RefreshRun,
+    RefreshRunManager,
+    StartRefresh,
+)
+from backend.resources.sleeper_data.requests import (
+    ApiRequest,
+    ApiRequestCandidate,
+    ApiRequestManager,
+    InlineVerifiedPayload,
+    NormalizationRejection,
+    ObjectVerifiedPayload,
+    RecordApiAttempt,
+    SnapshotCandidateQuery,
+    VerifiedPayload,
+)
+
+__all__ = [
+    "ApiRequest",
+    "ApiRequestCandidate",
+    "ApiRequestManager",
+    "InlineVerifiedPayload",
+    "NormalizationRejection",
+    "ObjectVerifiedPayload",
+    "Page",
+    "PlannedEndpointScope",
+    "RecordApiAttempt",
+    "RefreshRun",
+    "RefreshRunManager",
+    "SnapshotCandidateQuery",
+    "StartRefresh",
+    "VerifiedPayload",
+]

--- a/backend/resources/sleeper_data/common/__init__.py
+++ b/backend/resources/sleeper_data/common/__init__.py
@@ -1,0 +1,5 @@
+"""Shared primitives for Sleeper resource packages."""
+
+from backend.resources.sleeper_data.common.objects import Page
+
+__all__ = ["Page"]

--- a/backend/resources/sleeper_data/common/codec.py
+++ b/backend/resources/sleeper_data/common/codec.py
@@ -1,0 +1,25 @@
+"""Decimal-safe JSON helpers shared by Sleeper resource packages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from backend.services.datalayer.canonical_json import (
+    JsonValue,
+    canonical_json_bytes,
+    parse_json_bytes,
+)
+
+
+def jsonb_expression(value: JsonValue) -> sa.ColumnElement[Any]:
+    """Bind exact canonical JSON text and let PostgreSQL parse it as JSONB."""
+
+    text_value = canonical_json_bytes(value).decode("utf-8")
+    return sa.cast(sa.literal(text_value, type_=sa.Text()), JSONB)
+
+
+def parse_jsonb_text(value: str) -> JsonValue:
+    return parse_json_bytes(value.encode("utf-8"))

--- a/backend/resources/sleeper_data/common/objects.py
+++ b/backend/resources/sleeper_data/common/objects.py
@@ -1,0 +1,21 @@
+"""Small immutable contracts shared by Sleeper resources."""
+
+from __future__ import annotations
+
+from typing import Annotated, Generic, TypeVar
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel
+
+PositiveLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+NonNegativeOffset = Annotated[int, Field(strict=True, ge=0)]
+
+ItemT = TypeVar("ItemT")
+
+
+class Page(ContractModel, Generic[ItemT]):
+    items: tuple[ItemT, ...]
+    total: int = Field(strict=True, ge=0)
+    limit: PositiveLimit
+    offset: NonNegativeOffset

--- a/backend/resources/sleeper_data/refreshes/__init__.py
+++ b/backend/resources/sleeper_data/refreshes/__init__.py
@@ -1,0 +1,13 @@
+from backend.resources.sleeper_data.refreshes.manager import RefreshRunManager
+from backend.resources.sleeper_data.refreshes.objects import (
+    PlannedEndpointScope,
+    RefreshRun,
+    StartRefresh,
+)
+
+__all__ = [
+    "PlannedEndpointScope",
+    "RefreshRun",
+    "RefreshRunManager",
+    "StartRefresh",
+]

--- a/backend/resources/sleeper_data/refreshes/codec.py
+++ b/backend/resources/sleeper_data/refreshes/codec.py
@@ -1,0 +1,50 @@
+"""Stored-schema codecs for Sleeper refresh runs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.database.models.sleeper import RefreshRun as StoredRefreshRun
+from backend.resources.sleeper_data.refreshes.objects import (
+    PlannedEndpointScope,
+    RefreshRun,
+)
+
+
+def encode_endpoint_scope(
+    scopes: tuple[PlannedEndpointScope, ...],
+) -> dict[str, Any]:
+    return {"scopes": [scope.model_dump(mode="json") for scope in scopes]}
+
+
+def decode_endpoint_scope(value: object) -> tuple[PlannedEndpointScope, ...]:
+    if not isinstance(value, dict) or set(value) != {"scopes"}:
+        raise ValueError("stored refresh endpoint scope has an invalid shape")
+    raw_scopes = value["scopes"]
+    if not isinstance(raw_scopes, list):
+        raise ValueError("stored refresh endpoint scope must contain a list")
+    return tuple(PlannedEndpointScope.model_validate(item) for item in raw_scopes)
+
+
+def decode_refresh(row: StoredRefreshRun) -> RefreshRun:
+    if row.competition_id is None or row.competition_season_id is None:
+        raise ValueError("competition-scoped refresh is missing its identity")
+    return RefreshRun.model_validate(
+        {
+            "id": row.id,
+            "competition_id": row.competition_id,
+            "competition_season_id": row.competition_season_id,
+            "requested_through_week": row.requested_through_week,
+            "endpoint_scope": decode_endpoint_scope(row.endpoint_scope),
+            "trigger": row.trigger_source,
+            "status": row.status,
+            "code_version": row.code_version,
+            "normalizer_version": row.normalizer_version,
+            "started_at": row.started_at,
+            "completed_at": row.completed_at,
+            "error": row.error_summary,
+            "request_count": row.request_count,
+            "succeeded_request_count": row.succeeded_request_count,
+            "failed_request_count": row.failed_request_count,
+        }
+    )

--- a/backend/resources/sleeper_data/refreshes/manager.py
+++ b/backend/resources/sleeper_data/refreshes/manager.py
@@ -1,0 +1,167 @@
+"""Competition-scoped manager for Sleeper refresh runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason
+from backend.database.models.sleeper import ApiRequest as StoredApiRequest
+from backend.database.models.sleeper import RefreshRun as StoredRefreshRun
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.refreshes.codec import (
+    decode_endpoint_scope,
+    decode_refresh,
+    encode_endpoint_scope,
+)
+from backend.resources.sleeper_data.refreshes.objects import RefreshRun, StartRefresh
+from backend.services.datalayer.contracts import (
+    NormalizationStatus,
+    RefreshStatus,
+    RequestStatus,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+
+
+class RefreshRunManager:
+    """Own competition-scoped refresh plans and their terminal status."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def start_refresh(self, command: StartRefresh) -> RefreshRun:
+        with transaction_session(self._session_factory) as session:
+            self._require_season(session, command.competition_season_id)
+            stored = StoredRefreshRun(
+                competition_id=self._competition_id,
+                competition_season_id=command.competition_season_id,
+                requested_through_week=command.requested_through_week,
+                endpoint_scope=encode_endpoint_scope(command.endpoint_scope),
+                trigger_source=command.trigger.value,
+                status=RefreshStatus.RUNNING.value,
+                code_version=command.code_version,
+                normalizer_version=command.normalizer_version,
+                error_summary=None,
+                request_count=0,
+                succeeded_request_count=0,
+                failed_request_count=0,
+            )
+            session.add(stored)
+            session.flush()
+            return decode_refresh(stored)
+
+    def finish_refresh(self, refresh_id: UUID) -> RefreshRun:
+        with transaction_session(self._session_factory) as session:
+            refresh = self._load(session, refresh_id, lock=True)
+            if refresh.status != RefreshStatus.RUNNING.value:
+                return decode_refresh(refresh)
+            plan = decode_endpoint_scope(refresh.endpoint_scope)
+            attempts = session.scalars(
+                sa.select(StoredApiRequest).where(
+                    StoredApiRequest.refresh_run_id == refresh.id
+                )
+            ).all()
+            latest: dict[str, StoredApiRequest] = {}
+            for attempt in attempts:
+                current = latest.get(attempt.scope_key)
+                if current is None or _request_order(attempt) > _request_order(
+                    current
+                ):
+                    latest[attempt.scope_key] = attempt
+
+            succeeded = 0
+            required_successes = 0
+            required_failures = 0
+            failed_scopes: list[str] = []
+            for planned in plan:
+                attempt = latest.get(planned.scope_key.value)
+                successful = attempt is not None and _request_is_normalized(attempt)
+                if successful:
+                    succeeded += 1
+                    if planned.required:
+                        required_successes += 1
+                else:
+                    failed_scopes.append(planned.scope_key.value)
+                    if planned.required:
+                        required_failures += 1
+
+            if required_failures == 0:
+                status = RefreshStatus.SUCCEEDED
+            elif required_successes:
+                status = RefreshStatus.PARTIAL
+            else:
+                status = RefreshStatus.FAILED
+            refresh.status = status.value
+            refresh.completed_at = sa.func.now()
+            refresh.request_count = len(plan)
+            refresh.succeeded_request_count = succeeded
+            refresh.failed_request_count = len(plan) - succeeded
+            refresh.error_summary = (
+                None
+                if not failed_scopes
+                else {"code": "refresh_scopes_failed", "scope_keys": failed_scopes}
+            )
+            session.flush()
+            return decode_refresh(refresh)
+
+    def get_refresh(self, refresh_id: UUID) -> RefreshRun:
+        with read_only_session(self._session_factory) as session:
+            return decode_refresh(self._load(session, refresh_id))
+
+    def _load(
+        self,
+        session: Session,
+        refresh_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> StoredRefreshRun:
+        statement = sa.select(StoredRefreshRun).where(
+            StoredRefreshRun.id == refresh_id,
+            StoredRefreshRun.competition_id == self._competition_id,
+        )
+        if lock:
+            statement = statement.with_for_update()
+        stored = session.scalar(statement)
+        if stored is None:
+            raise DatalayerResourceNotFound("refresh", str(refresh_id))
+        return stored
+
+    def _require_season(
+        self,
+        session: Session,
+        season_id: UUID,
+    ) -> CompetitionSeason:
+        season = session.scalar(
+            sa.select(CompetitionSeason).where(
+                CompetitionSeason.id == season_id,
+                CompetitionSeason.competition_id == self._competition_id,
+            )
+        )
+        if season is None:
+            raise DatalayerResourceNotFound("competition_season", str(season_id))
+        return season
+
+
+def _request_order(request: StoredApiRequest) -> tuple[datetime, int]:
+    return request.requested_at, request.id.int
+
+
+def _request_is_normalized(request: StoredApiRequest) -> bool:
+    return (
+        request.status == RequestStatus.SUCCEEDED.value
+        and request.is_complete
+        and request.normalization_status == NormalizationStatus.SUCCEEDED.value
+    )

--- a/backend/resources/sleeper_data/refreshes/objects.py
+++ b/backend/resources/sleeper_data/refreshes/objects.py
@@ -1,0 +1,78 @@
+"""Immutable contracts for Sleeper refresh runs."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, StrictBool, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+from backend.services.datalayer.canonical_json import JsonValue
+from backend.services.datalayer.contracts import RefreshStatus, RefreshTrigger
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+class PlannedEndpointScope(ContractModel):
+    scope_key: ScopeKey
+    endpoint_kind: EndpointKind
+    required: StrictBool = True
+    dependency_scope_keys: tuple[ScopeKey, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> "PlannedEndpointScope":
+        if self.scope_key.value.split(":", 1)[0] != self.endpoint_kind.value:
+            raise ValueError("planned scope key does not match its endpoint kind")
+        if len(set(self.dependency_scope_keys)) != len(self.dependency_scope_keys):
+            raise ValueError("planned scope dependencies must be unique")
+        if self.scope_key in self.dependency_scope_keys:
+            raise ValueError("planned scope cannot depend on itself")
+        return self
+
+
+class StartRefresh(ContractModel):
+    competition_season_id: UUID
+    requested_through_week: int | None = Field(
+        default=None,
+        strict=True,
+        ge=1,
+        le=18,
+    )
+    trigger: RefreshTrigger
+    endpoint_scope: tuple[PlannedEndpointScope, ...]
+    code_version: NonBlankStr
+    normalizer_version: NonBlankStr
+
+    @model_validator(mode="after")
+    def validate_plan(self) -> "StartRefresh":
+        if not self.endpoint_scope:
+            raise ValueError("refresh plan requires at least one scope")
+        keys = tuple(item.scope_key for item in self.endpoint_scope)
+        if len(set(keys)) != len(keys):
+            raise ValueError("refresh plan scope keys must be unique")
+        available: set[ScopeKey] = set()
+        for item in self.endpoint_scope:
+            missing = set(item.dependency_scope_keys) - available
+            if missing:
+                raise ValueError(
+                    "refresh plan dependencies must precede their consumers"
+                )
+            available.add(item.scope_key)
+        return self
+
+
+class RefreshRun(ContractModel):
+    id: UUID
+    competition_id: UUID
+    competition_season_id: UUID
+    requested_through_week: int | None
+    endpoint_scope: tuple[PlannedEndpointScope, ...]
+    trigger: RefreshTrigger
+    status: RefreshStatus
+    code_version: str
+    normalizer_version: str
+    started_at: AwareDatetime
+    completed_at: AwareDatetime | None
+    error: dict[str, JsonValue] | None
+    request_count: int = Field(strict=True, ge=0)
+    succeeded_request_count: int = Field(strict=True, ge=0)
+    failed_request_count: int = Field(strict=True, ge=0)

--- a/backend/resources/sleeper_data/requests/__init__.py
+++ b/backend/resources/sleeper_data/requests/__init__.py
@@ -1,0 +1,25 @@
+from backend.resources.sleeper_data.common.objects import Page
+from backend.resources.sleeper_data.requests.manager import ApiRequestManager
+from backend.resources.sleeper_data.requests.objects import (
+    ApiRequest,
+    ApiRequestCandidate,
+    InlineVerifiedPayload,
+    NormalizationRejection,
+    ObjectVerifiedPayload,
+    RecordApiAttempt,
+    SnapshotCandidateQuery,
+    VerifiedPayload,
+)
+
+__all__ = [
+    "ApiRequest",
+    "ApiRequestCandidate",
+    "ApiRequestManager",
+    "InlineVerifiedPayload",
+    "NormalizationRejection",
+    "ObjectVerifiedPayload",
+    "Page",
+    "RecordApiAttempt",
+    "SnapshotCandidateQuery",
+    "VerifiedPayload",
+]

--- a/backend/resources/sleeper_data/requests/codec.py
+++ b/backend/resources/sleeper_data/requests/codec.py
@@ -1,0 +1,40 @@
+"""Stored-schema and Decimal-safe payload codecs for Sleeper requests."""
+
+from __future__ import annotations
+
+from backend.database.models.sleeper import ApiRequest as StoredApiRequest
+from backend.resources.sleeper_data.common.codec import (
+    jsonb_expression,
+    parse_jsonb_text,
+)
+from backend.resources.sleeper_data.requests.objects import ApiRequest
+from backend.services.datalayer.sleeper.scope import ScopeKey
+
+
+def decode_api_request(row: StoredApiRequest) -> ApiRequest:
+    return ApiRequest.model_validate(
+        {
+            "id": row.id,
+            "refresh_run_id": row.refresh_run_id,
+            "competition_season_id": row.competition_season_id,
+            "endpoint_kind": row.endpoint_kind,
+            "scope_key": ScopeKey.parse(row.scope_key),
+            "request_path": row.request_path,
+            "request_parameters": row.request_parameters,
+            "week": row.week,
+            "bracket_kind": row.bracket_kind,
+            "requested_at": row.requested_at,
+            "completed_at": row.completed_at,
+            "latency_ms": row.latency_ms,
+            "status": row.status,
+            "http_status": row.http_status,
+            "error": row.error,
+            "is_complete": row.is_complete,
+            "completeness_reason": row.completeness_reason,
+            "payload_id": row.payload_id,
+            "response_sha256": row.response_sha256,
+            "normalization_status": row.normalization_status,
+            "normalizer_version": row.normalizer_version,
+            "normalized_at": row.normalized_at,
+        }
+    )

--- a/backend/resources/sleeper_data/requests/manager.py
+++ b/backend/resources/sleeper_data/requests/manager.py
@@ -1,0 +1,445 @@
+"""Competition-scoped manager for Sleeper request observations and payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason
+from backend.database.models.sleeper import ApiPayload as StoredApiPayload
+from backend.database.models.sleeper import ApiRequest as StoredApiRequest
+from backend.database.models.sleeper import RefreshRun as StoredRefreshRun
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.refreshes.codec import decode_endpoint_scope
+from backend.resources.sleeper_data.requests.codec import (
+    decode_api_request,
+    jsonb_expression,
+    parse_jsonb_text,
+)
+from backend.resources.sleeper_data.requests.objects import (
+    ApiRequest,
+    ApiRequestCandidate,
+    InlineVerifiedPayload,
+    NormalizationRejection,
+    ObjectVerifiedPayload,
+    Page,
+    RecordApiAttempt,
+    SnapshotCandidateQuery,
+    VerifiedPayload,
+)
+from backend.services.datalayer.canonical_json import canonical_json_sha256
+from backend.services.datalayer.contracts import (
+    NormalizationStatus,
+    RefreshStatus,
+    RequestStatus,
+)
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+    InvalidDatalayerRequest,
+)
+from backend.services.datalayer.sleeper.responses import (
+    SuccessfulSourceAttempt,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+_GLOBAL_ENDPOINTS = {EndpointKind.NFL_STATE, EndpointKind.PLAYER_CATALOG}
+
+
+class ApiRequestManager:
+    """Own request audit observations and content-addressed payload receipts."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def record_attempt(self, command: RecordApiAttempt) -> ApiRequest:
+        with transaction_session(self._session_factory) as session:
+            refresh = self._load_refresh(session, command.refresh_run_id, lock=True)
+            if refresh.status != RefreshStatus.RUNNING.value:
+                raise DatalayerScopeConflict(
+                    "attempts can only be added to a running refresh"
+                )
+            self._validate_attempt_scope(refresh, command)
+            attempt = command.attempt
+            payload_id: UUID | None = None
+            response_sha256: str | None = None
+            error: dict[str, Any] | None = None
+            if isinstance(attempt, SuccessfulSourceAttempt):
+                payload_id = self._record_payload(session, command)
+                response_sha256 = attempt.raw_sha256
+                request_status = RequestStatus.SUCCEEDED
+                normalization_status = (
+                    NormalizationStatus.PENDING
+                    if command.completeness.is_complete
+                    else NormalizationStatus.REJECTED
+                )
+            else:
+                request_status = attempt.status
+                normalization_status = NormalizationStatus.NOT_APPLICABLE
+                error = attempt.error.model_dump(mode="json")
+
+            stored = StoredApiRequest(
+                id=uuid4(),
+                refresh_run_id=refresh.id,
+                competition_season_id=(
+                    None
+                    if attempt.endpoint.endpoint_kind in _GLOBAL_ENDPOINTS
+                    else refresh.competition_season_id
+                ),
+                endpoint_kind=attempt.endpoint.endpoint_kind.value,
+                scope_key=attempt.endpoint.scope_key.value,
+                request_path=attempt.endpoint.path,
+                request_parameters=attempt.endpoint.parameters,
+                week=attempt.endpoint.week,
+                bracket_kind=attempt.endpoint.bracket_kind,
+                requested_at=attempt.requested_at,
+                completed_at=attempt.completed_at,
+                latency_ms=attempt.latency_ms,
+                status=request_status.value,
+                http_status=attempt.http_status,
+                error=error,
+                is_complete=command.completeness.is_complete,
+                completeness_reason=command.completeness.reason,
+                payload_id=payload_id,
+                response_sha256=response_sha256,
+                normalization_status=normalization_status.value,
+            )
+            session.add(stored)
+            session.flush()
+            return decode_api_request(stored)
+
+    def reject_normalization(
+        self,
+        request_id: UUID,
+        rejection: NormalizationRejection,
+    ) -> ApiRequest:
+        with transaction_session(self._session_factory) as session:
+            request, refresh = self._load_request_with_refresh(
+                session, request_id, lock=True
+            )
+            if request.normalization_status != NormalizationStatus.PENDING.value:
+                raise DatalayerScopeConflict(
+                    "only a pending complete request can be rejected"
+                )
+            request.normalization_status = NormalizationStatus.REJECTED.value
+            request.normalizer_version = refresh.normalizer_version
+            request.normalized_at = sa.func.now()
+            request.error = {
+                "stage": "normalization",
+                "code": rejection.code,
+                "summary": rejection.summary,
+            }
+            session.flush()
+            return decode_api_request(request)
+
+    def list_refresh_requests(
+        self,
+        refresh_id: UUID,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Page[ApiRequest]:
+        if not 1 <= limit <= 200 or offset < 0:
+            raise InvalidDatalayerRequest("invalid request page")
+        with read_only_session(self._session_factory) as session:
+            refresh = self._load_refresh(session, refresh_id)
+            where = StoredApiRequest.refresh_run_id == refresh.id
+            total = session.scalar(
+                sa.select(sa.func.count()).select_from(StoredApiRequest).where(where)
+            )
+            rows = session.scalars(
+                sa.select(StoredApiRequest)
+                .where(where)
+                .order_by(StoredApiRequest.requested_at, StoredApiRequest.id)
+                .limit(limit)
+                .offset(offset)
+            ).all()
+            return Page[ApiRequest](
+                items=tuple(decode_api_request(row) for row in rows),
+                total=cast(int, total),
+                limit=limit,
+                offset=offset,
+            )
+
+    def list_snapshot_candidates(
+        self,
+        query: SnapshotCandidateQuery,
+    ) -> tuple[ApiRequestCandidate, ...]:
+        with read_only_session(self._session_factory) as session:
+            self._require_season(session, query.competition_season_id)
+            scope_values = [scope.value for scope in query.scope_keys]
+            allowed_global = [kind.value for kind in _GLOBAL_ENDPOINTS]
+            rows = session.scalars(
+                sa.select(StoredApiRequest)
+                .join(
+                    StoredRefreshRun,
+                    StoredRefreshRun.id == StoredApiRequest.refresh_run_id,
+                )
+                .where(
+                    StoredApiRequest.scope_key.in_(scope_values),
+                    StoredApiRequest.status == RequestStatus.SUCCEEDED.value,
+                    StoredApiRequest.is_complete.is_(True),
+                    StoredApiRequest.payload_id.is_not(None),
+                    StoredApiRequest.response_sha256.is_not(None),
+                    sa.or_(
+                        StoredApiRequest.competition_season_id
+                        == query.competition_season_id,
+                        sa.and_(
+                            StoredApiRequest.competition_season_id.is_(None),
+                            StoredApiRequest.endpoint_kind.in_(allowed_global),
+                        ),
+                    ),
+                    sa.or_(
+                        StoredApiRequest.week.is_(None),
+                        StoredApiRequest.week <= query.through_week,
+                    ),
+                )
+                .order_by(
+                    StoredApiRequest.scope_key,
+                    StoredApiRequest.requested_at.desc(),
+                    StoredApiRequest.id.desc(),
+                )
+            ).all()
+            return tuple(
+                ApiRequestCandidate(
+                    request_id=row.id,
+                    competition_season_id=row.competition_season_id,
+                    endpoint_kind=EndpointKind(row.endpoint_kind),
+                    scope_key=ScopeKey.parse(row.scope_key),
+                    week=row.week,
+                    bracket_kind=cast(Any, row.bracket_kind),
+                    requested_at=row.requested_at,
+                    completed_at=row.completed_at,
+                    payload_id=cast(UUID, row.payload_id),
+                    response_sha256=cast(str, row.response_sha256),
+                )
+                for row in rows
+            )
+
+    def resolve_verified_payloads(
+        self,
+        request_ids: Collection[UUID],
+    ) -> tuple[VerifiedPayload, ...]:
+        ordered = tuple(request_ids)
+        if len(set(ordered)) != len(ordered):
+            raise InvalidDatalayerRequest("payload request IDs must be unique")
+        if not ordered:
+            return ()
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(
+                sa.select(
+                    StoredApiRequest,
+                    StoredApiPayload,
+                    sa.cast(StoredApiPayload.inline_payload, sa.Text).label(
+                        "inline_text"
+                    ),
+                    StoredRefreshRun.competition_id,
+                )
+                .join(
+                    StoredApiPayload,
+                    StoredApiPayload.id == StoredApiRequest.payload_id,
+                )
+                .join(
+                    StoredRefreshRun,
+                    StoredRefreshRun.id == StoredApiRequest.refresh_run_id,
+                )
+                .where(StoredApiRequest.id.in_(ordered))
+            ).all()
+            by_id = {row[0].id: row for row in rows}
+            result: list[VerifiedPayload] = []
+            for request_id in ordered:
+                row = by_id.get(request_id)
+                if row is None:
+                    raise DatalayerResourceNotFound(
+                        "api_request_payload", str(request_id)
+                    )
+                request, payload, inline_text, request_competition_id = row
+                if (
+                    request_competition_id != self._competition_id
+                    and request.endpoint_kind
+                    not in {kind.value for kind in _GLOBAL_ENDPOINTS}
+                ):
+                    raise DatalayerResourceNotFound(
+                        "api_request_payload", str(request_id)
+                    )
+                _require_eligible_request(request)
+                if request.response_sha256 != payload.sha256_hash:
+                    raise DatalayerScopeConflict(
+                        "request payload receipt is inconsistent"
+                    )
+                common = {
+                    "request_id": request.id,
+                    "scope_key": ScopeKey.parse(request.scope_key),
+                    "sha256": payload.sha256_hash,
+                    "byte_length": payload.byte_length,
+                    "media_type": payload.media_type,
+                }
+                if payload.storage_kind == "inline_json":
+                    if inline_text is None:
+                        raise DatalayerScopeConflict(
+                            "inline payload content is missing"
+                        )
+                    parsed = parse_jsonb_text(inline_text)
+                    if canonical_json_sha256(parsed) != payload.sha256_hash:
+                        raise DatalayerScopeConflict(
+                            "inline payload bytes do not match their receipt"
+                        )
+                    result.append(InlineVerifiedPayload(payload=parsed, **common))
+                elif payload.storage_kind == "object":
+                    if payload.object_storage_key is None:
+                        raise DatalayerScopeConflict("object payload key is missing")
+                    result.append(
+                        ObjectVerifiedPayload(
+                            storage_key=payload.object_storage_key,
+                            **common,
+                        )
+                    )
+                else:
+                    raise DatalayerScopeConflict("payload storage kind is unsupported")
+            return tuple(result)
+
+    def _load_refresh(
+        self,
+        session: Session,
+        refresh_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> StoredRefreshRun:
+        statement = sa.select(StoredRefreshRun).where(
+            StoredRefreshRun.id == refresh_id,
+            StoredRefreshRun.competition_id == self._competition_id,
+        )
+        if lock:
+            statement = statement.with_for_update()
+        stored = session.scalar(statement)
+        if stored is None:
+            raise DatalayerResourceNotFound("refresh", str(refresh_id))
+        return stored
+
+    def _load_request_with_refresh(
+        self,
+        session: Session,
+        request_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> tuple[StoredApiRequest, StoredRefreshRun]:
+        statement = (
+            sa.select(StoredApiRequest, StoredRefreshRun)
+            .join(
+                StoredRefreshRun,
+                StoredRefreshRun.id == StoredApiRequest.refresh_run_id,
+            )
+            .where(
+                StoredApiRequest.id == request_id,
+                StoredRefreshRun.competition_id == self._competition_id,
+            )
+        )
+        if lock:
+            statement = statement.with_for_update(of=StoredApiRequest)
+        row = session.execute(statement).one_or_none()
+        if row is None:
+            raise DatalayerResourceNotFound("api_request", str(request_id))
+        return row[0], row[1]
+
+    def _require_season(
+        self,
+        session: Session,
+        season_id: UUID,
+    ) -> CompetitionSeason:
+        season = session.scalar(
+            sa.select(CompetitionSeason).where(
+                CompetitionSeason.id == season_id,
+                CompetitionSeason.competition_id == self._competition_id,
+            )
+        )
+        if season is None:
+            raise DatalayerResourceNotFound("competition_season", str(season_id))
+        return season
+
+    @staticmethod
+    def _validate_attempt_scope(
+        refresh: StoredRefreshRun,
+        command: RecordApiAttempt,
+    ) -> None:
+        endpoint = command.attempt.endpoint
+        planned = {
+            item.scope_key: item
+            for item in decode_endpoint_scope(refresh.endpoint_scope)
+        }.get(endpoint.scope_key)
+        if planned is None or planned.endpoint_kind is not endpoint.endpoint_kind:
+            raise DatalayerScopeConflict(
+                "source attempt is not part of the refresh plan"
+            )
+        parts = endpoint.scope_key.value.split(":")
+        if endpoint.endpoint_kind in _GLOBAL_ENDPOINTS:
+            if parts != [endpoint.endpoint_kind.value, "nfl"]:
+                raise DatalayerScopeConflict("global endpoint has an invalid scope")
+        elif len(parts) < 2 or parts[1] != str(refresh.competition_season_id):
+            raise DatalayerScopeConflict(
+                "source attempt is outside the refresh season"
+            )
+
+    @staticmethod
+    def _record_payload(session: Session, command: RecordApiAttempt) -> UUID:
+        attempt = cast(SuccessfulSourceAttempt, command.attempt)
+        receipt = command.object_receipt
+        payload_id = uuid4()
+        values: dict[str, Any] = {
+            "id": payload_id,
+            "sha256_hash": attempt.raw_sha256,
+            "byte_length": attempt.byte_length,
+            "media_type": attempt.media_type,
+            "storage_kind": "object" if receipt is not None else "inline_json",
+            "inline_payload": (
+                sa.null() if receipt is not None else jsonb_expression(attempt.payload)
+            ),
+            "object_storage_key": None if receipt is None else receipt.storage_key,
+        }
+        statement = (
+            pg_insert(StoredApiPayload.__table__)
+            .values(**values)
+            .on_conflict_do_nothing(index_elements=[StoredApiPayload.sha256_hash])
+        )
+        session.execute(statement)
+        stored = session.scalar(
+            sa.select(StoredApiPayload).where(
+                StoredApiPayload.sha256_hash == attempt.raw_sha256
+            )
+        )
+        if stored is None:
+            raise RuntimeError("payload upsert did not produce a stored receipt")
+        if (
+            stored.byte_length != attempt.byte_length
+            or stored.media_type != attempt.media_type
+        ):
+            raise DatalayerScopeConflict(
+                "stored payload receipt conflicts with its hash"
+            )
+        if stored.storage_kind == "object" and stored.object_storage_key is None:
+            raise RuntimeError("stored object payload has no storage key")
+        return stored.id
+
+
+def _require_eligible_request(request: StoredApiRequest) -> None:
+    if (
+        request.status != RequestStatus.SUCCEEDED.value
+        or not request.is_complete
+        or request.payload_id is None
+        or request.response_sha256 is None
+    ):
+        raise DatalayerScopeConflict("request is not eligible for normalization")

--- a/backend/resources/sleeper_data/requests/objects.py
+++ b/backend/resources/sleeper_data/requests/objects.py
@@ -1,0 +1,157 @@
+"""Immutable contracts for Sleeper request observations and payloads."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, TypeAlias
+from uuid import UUID
+
+from pydantic import (
+    AwareDatetime,
+    Field,
+    StrictBool,
+    StringConstraints,
+    model_validator,
+)
+
+from backend.resources._contracts import ContractModel
+from backend.resources.sleeper_data.common.objects import Page
+from backend.services.datalayer.canonical_json import JsonValue
+from backend.services.datalayer.contracts import NormalizationStatus, RequestStatus
+from backend.services.datalayer.local_files import StoredLocalArtifact
+from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.services.datalayer.sleeper.responses import (
+    FailedSourceAttempt,
+    RequestParameter,
+    SourceAttempt,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{64}$")]
+SafeCode = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=100,
+        pattern=r"^[a-z0-9][a-z0-9_.-]*$",
+    ),
+]
+SafeSummary = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=500),
+]
+
+
+class NormalizationRejection(ContractModel):
+    code: SafeCode
+    summary: SafeSummary
+
+
+class RecordApiAttempt(ContractModel):
+    refresh_run_id: UUID
+    attempt: SourceAttempt
+    completeness: CompletenessFinding
+    object_receipt: StoredLocalArtifact | None = None
+
+    @model_validator(mode="after")
+    def validate_attempt(self) -> "RecordApiAttempt":
+        if isinstance(self.attempt, FailedSourceAttempt):
+            if self.completeness.is_complete:
+                raise ValueError("a failed source attempt cannot be complete")
+            if self.object_receipt is not None:
+                raise ValueError(
+                    "a failed source attempt cannot have a payload receipt"
+                )
+            return self
+        if self.object_receipt is not None and (
+            self.object_receipt.sha256 != self.attempt.raw_sha256
+            or self.object_receipt.byte_length != self.attempt.byte_length
+        ):
+            raise ValueError("object receipt does not match the source payload")
+        return self
+
+
+class ApiRequest(ContractModel):
+    id: UUID
+    refresh_run_id: UUID
+    competition_season_id: UUID | None
+    endpoint_kind: EndpointKind
+    scope_key: ScopeKey
+    request_path: str
+    request_parameters: dict[str, RequestParameter]
+    week: int | None
+    bracket_kind: Literal["winners", "losers"] | None
+    requested_at: AwareDatetime
+    completed_at: AwareDatetime
+    latency_ms: int | None
+    status: RequestStatus
+    http_status: int | None
+    error: dict[str, JsonValue] | None
+    is_complete: StrictBool
+    completeness_reason: str | None
+    payload_id: UUID | None
+    response_sha256: Sha256 | None
+    normalization_status: NormalizationStatus
+    normalizer_version: str | None
+    normalized_at: AwareDatetime | None
+
+
+class SnapshotCandidateQuery(ContractModel):
+    competition_season_id: UUID
+    scope_keys: tuple[ScopeKey, ...]
+    through_week: int = Field(strict=True, ge=1, le=18)
+
+    @model_validator(mode="after")
+    def validate_scopes(self) -> "SnapshotCandidateQuery":
+        if not self.scope_keys:
+            raise ValueError("snapshot candidate query requires at least one scope")
+        if len(set(self.scope_keys)) != len(self.scope_keys):
+            raise ValueError("snapshot candidate scopes must be unique")
+        return self
+
+
+class ApiRequestCandidate(ContractModel):
+    request_id: UUID
+    competition_season_id: UUID | None
+    endpoint_kind: EndpointKind
+    scope_key: ScopeKey
+    week: int | None
+    bracket_kind: Literal["winners", "losers"] | None
+    requested_at: AwareDatetime
+    completed_at: AwareDatetime
+    payload_id: UUID
+    response_sha256: Sha256
+
+
+class InlineVerifiedPayload(ContractModel):
+    kind: Literal["inline_json"] = "inline_json"
+    request_id: UUID
+    scope_key: ScopeKey
+    sha256: Sha256
+    byte_length: int = Field(strict=True, ge=0)
+    media_type: Literal["application/json"]
+    payload: JsonValue
+
+
+class ObjectVerifiedPayload(ContractModel):
+    kind: Literal["object"] = "object"
+    request_id: UUID
+    scope_key: ScopeKey
+    sha256: Sha256
+    byte_length: int = Field(strict=True, ge=0)
+    media_type: Literal["application/json"]
+    storage_key: str
+
+    @model_validator(mode="after")
+    def validate_object_receipt(self) -> "ObjectVerifiedPayload":
+        StoredLocalArtifact(
+            storage_key=self.storage_key,
+            sha256=self.sha256,
+            byte_length=self.byte_length,
+        )
+        return self
+
+
+VerifiedPayload: TypeAlias = Annotated[
+    InlineVerifiedPayload | ObjectVerifiedPayload,
+    Field(discriminator="kind"),
+]

--- a/backend/tests/resources/sleeper_data/__init__.py
+++ b/backend/tests/resources/sleeper_data/__init__.py
@@ -1,0 +1,1 @@
+"""Sleeper data resource tests."""

--- a/backend/tests/resources/sleeper_data/conftest.py
+++ b/backend/tests/resources/sleeper_data/conftest.py
@@ -1,0 +1,254 @@
+"""Reusable PostgreSQL fixtures for Sleeper resource-manager tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import hashlib
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import (
+    Competition,
+    CompetitionSeason,
+    Franchise,
+    SeasonRoster,
+)
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.context import (
+    CompetitionScope,
+    ManagerContext,
+    SystemProcessActor,
+)
+from backend.resources.sleeper_data.refreshes import (
+    PlannedEndpointScope,
+    RefreshRun,
+    RefreshRunManager,
+    StartRefresh,
+)
+from backend.resources.sleeper_data.requests import (
+    ApiRequest,
+    ApiRequestManager,
+    RecordApiAttempt,
+)
+from backend.services.datalayer.canonical_json import JsonValue, canonical_json_bytes
+from backend.services.datalayer.contracts import RefreshTrigger, RequestStatus
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SanitizedSourceError,
+    SuccessfulSourceAttempt,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@pytest.fixture(autouse=True)
+def clean_sleeper_resources(request: pytest.FixtureRequest) -> None:
+    """Start every Sleeper resource test with no aggregate or domain rows."""
+
+    if "database_engine" not in request.fixturenames:
+        return
+    database_engine = request.getfixturevalue("database_engine")
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.text("TRUNCATE TABLE core.competitions, " "sleeper.api_payloads CASCADE")
+        )
+
+
+@dataclass(frozen=True)
+class Domain:
+    competition_id: UUID
+    season_id: UUID
+    sleeper_league_id: str
+    franchise_ids: tuple[UUID, UUID]
+    roster_ids: tuple[UUID, UUID]
+
+
+def seed_domain(database_engine: Engine, *, label: str = "Sleeper Resource") -> Domain:
+    """Seed the competition identities shared by audit, projection, and read tests."""
+
+    competition_id = uuid4()
+    season_id = uuid4()
+    franchise_ids = (uuid4(), uuid4())
+    roster_ids = (uuid4(), uuid4())
+    sleeper_league_id = f"league-{season_id}"
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": f"{label} League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": sleeper_league_id,
+            },
+        )
+        connection.execute(
+            sa.insert(Franchise),
+            [
+                {
+                    "id": franchise_ids[index],
+                    "competition_id": competition_id,
+                    "display_name": f"{label} Team {index + 1}",
+                }
+                for index in range(2)
+            ],
+        )
+        connection.execute(
+            sa.insert(SeasonRoster),
+            [
+                {
+                    "id": roster_ids[index],
+                    "competition_id": competition_id,
+                    "competition_season_id": season_id,
+                    "franchise_id": franchise_ids[index],
+                    "sleeper_roster_id": str(index + 1),
+                }
+                for index in range(2)
+            ],
+        )
+    return Domain(
+        competition_id=competition_id,
+        season_id=season_id,
+        sleeper_league_id=sleeper_league_id,
+        franchise_ids=franchise_ids,
+        roster_ids=roster_ids,
+    )
+
+
+def manager_context(domain: Domain) -> ManagerContext[CompetitionScope]:
+    return ManagerContext[CompetitionScope](
+        actor=SystemProcessActor(process_name="sleeper-resource-test"),
+        scope=CompetitionScope(competition_id=domain.competition_id),
+        correlation_id=uuid4(),
+    )
+
+
+def successful_attempt(
+    endpoint: EndpointRequest,
+    payload: JsonValue,
+    *,
+    requested_at: datetime | None = None,
+) -> SuccessfulSourceAttempt:
+    requested_at = requested_at or datetime.now(UTC)
+    content = canonical_json_bytes(payload)
+    return SuccessfulSourceAttempt(
+        endpoint=endpoint,
+        requested_at=requested_at,
+        completed_at=requested_at + timedelta(milliseconds=5),
+        latency_ms=5,
+        http_status=200,
+        payload=payload,
+        raw_sha256=hashlib.sha256(content).hexdigest(),
+        byte_length=len(content),
+    )
+
+
+def failed_attempt(
+    endpoint: EndpointRequest,
+    *,
+    requested_at: datetime | None = None,
+    status: RequestStatus = RequestStatus.TRANSPORT_ERROR,
+) -> FailedSourceAttempt:
+    requested_at = requested_at or datetime.now(UTC)
+    return FailedSourceAttempt(
+        endpoint=endpoint,
+        requested_at=requested_at,
+        completed_at=requested_at + timedelta(milliseconds=5),
+        latency_ms=5,
+        status=status,
+        http_status=500 if status is RequestStatus.HTTP_ERROR else None,
+        error=SanitizedSourceError(code="source_failed", summary="source failed"),
+    )
+
+
+def record_complete_attempt(
+    manager: ApiRequestManager,
+    refresh_id: UUID,
+    endpoint: EndpointRequest,
+    payload: JsonValue,
+    *,
+    requested_at: datetime | None = None,
+) -> ApiRequest:
+    """Record one complete successful observation for later projection tests."""
+
+    return manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh_id,
+            attempt=successful_attempt(
+                endpoint,
+                payload,
+                requested_at=requested_at,
+            ),
+            completeness=CompletenessFinding(is_complete=True),
+        )
+    )
+
+
+def start_refresh(
+    manager: RefreshRunManager,
+    domain: Domain,
+    *endpoints: EndpointRequest,
+    requested_through_week: int | None = None,
+    required: dict[str, bool] | None = None,
+) -> RefreshRun:
+    required = required or {}
+    return manager.start_refresh(
+        StartRefresh(
+            competition_season_id=domain.season_id,
+            requested_through_week=requested_through_week,
+            trigger=RefreshTrigger.MANUAL,
+            endpoint_scope=tuple(
+                PlannedEndpointScope(
+                    scope_key=endpoint.scope_key,
+                    endpoint_kind=endpoint.endpoint_kind,
+                    required=required.get(endpoint.scope_key.value, True),
+                )
+                for endpoint in endpoints
+            ),
+            code_version="test",
+            normalizer_version="test-normalizer",
+        )
+    )
+
+
+@pytest.fixture
+def domain(database_engine: Engine) -> Domain:
+    return seed_domain(database_engine)
+
+
+@pytest.fixture
+def session_factory(database_engine: Engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+@pytest.fixture
+def refresh_manager(
+    session_factory: SessionFactory,
+    domain: Domain,
+) -> RefreshRunManager:
+    return RefreshRunManager(session_factory, manager_context(domain))
+
+
+@pytest.fixture
+def request_manager(
+    session_factory: SessionFactory,
+    domain: Domain,
+) -> ApiRequestManager:
+    return ApiRequestManager(session_factory, manager_context(domain))
+
+
+@pytest.fixture
+def managers(
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> tuple[RefreshRunManager, ApiRequestManager]:
+    return refresh_manager, request_manager

--- a/backend/tests/resources/sleeper_data/test_api_request_manager.py
+++ b/backend/tests/resources/sleeper_data/test_api_request_manager.py
@@ -1,0 +1,282 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.sleeper import ApiPayload
+from backend.database.sessions import create_session_factory
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
+from backend.resources.sleeper_data.requests import (
+    ApiRequestManager,
+    NormalizationRejection,
+    RecordApiAttempt,
+    SnapshotCandidateQuery,
+)
+from backend.services.datalayer.contracts import (
+    NormalizationStatus,
+    RequestStatus,
+)
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+    InvalidDatalayerRequest,
+)
+from backend.services.datalayer.local_files import StoredLocalArtifact
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_matchups_request,
+    build_player_catalog_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    failed_attempt,
+    manager_context,
+    record_complete_attempt,
+    seed_domain,
+    start_refresh,
+    successful_attempt,
+)
+
+
+def test_record_attempt_initializes_statuses_and_rejects_only_pending_successes(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    complete = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"complete": True},
+        requested_at=now,
+    )
+    incomplete = request_manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh.id,
+            attempt=successful_attempt(
+                endpoint,
+                {"complete": False},
+                requested_at=now + timedelta(seconds=1),
+            ),
+            completeness=CompletenessFinding(
+                is_complete=False,
+                reason="catalog_incomplete",
+            ),
+        )
+    )
+    failed = request_manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh.id,
+            attempt=failed_attempt(
+                endpoint,
+                requested_at=now + timedelta(seconds=2),
+            ),
+            completeness=CompletenessFinding(
+                is_complete=False,
+                reason="source_attempt_failed",
+            ),
+        )
+    )
+
+    assert complete.normalization_status is NormalizationStatus.PENDING
+    assert incomplete.normalization_status is NormalizationStatus.REJECTED
+    assert failed.normalization_status is NormalizationStatus.NOT_APPLICABLE
+    assert failed.status is RequestStatus.TRANSPORT_ERROR
+    assert failed.error == {"code": "source_failed", "summary": "source failed"}
+
+    rejection = NormalizationRejection(
+        code="invalid_identity",
+        summary="Payload contains an invalid identity.",
+    )
+    rejected = request_manager.reject_normalization(complete.id, rejection)
+    assert rejected.normalization_status is NormalizationStatus.REJECTED
+    assert rejected.error == {
+        "stage": "normalization",
+        "code": "invalid_identity",
+        "summary": "Payload contains an invalid identity.",
+    }
+    for terminal in (incomplete, failed):
+        with pytest.raises(DatalayerScopeConflict, match="pending"):
+            request_manager.reject_normalization(terminal.id, rejection)
+    stored = request_manager.list_refresh_requests(refresh.id)
+    by_id = {request.id: request for request in stored.items}
+    assert by_id[incomplete.id].normalization_status is NormalizationStatus.REJECTED
+    assert by_id[failed.id].normalization_status is NormalizationStatus.NOT_APPLICABLE
+    assert by_id[failed.id].error == failed.error
+
+
+def test_payloads_are_deduplicated_while_request_observations_remain_distinct(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    payload = {"rating": Decimal("1.125")}
+
+    first = record_complete_attempt(
+        request_manager, refresh.id, endpoint, payload, requested_at=now
+    )
+    second = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        payload,
+        requested_at=now + timedelta(seconds=1),
+    )
+
+    assert first.id != second.id
+    assert first.payload_id == second.payload_id
+    with database_engine.connect() as connection:
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(ApiPayload)) == 1
+        )
+    resolved = request_manager.resolve_verified_payloads([second.id, first.id])
+    assert [item.request_id for item in resolved] == [second.id, first.id]
+    assert all(item.kind == "inline_json" for item in resolved)
+    assert resolved[0].payload == payload  # type: ignore[union-attr]
+
+
+def test_refresh_request_audit_is_ordered_paginated_and_competition_scoped(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> None:
+    endpoint = build_league_request(domain.season_id, domain.sleeper_league_id)
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    recorded = [
+        record_complete_attempt(
+            request_manager,
+            refresh.id,
+            endpoint,
+            {"order": order},
+            requested_at=now + timedelta(seconds=order),
+        )
+        for order in (2, 0, 1)
+    ]
+
+    page = request_manager.list_refresh_requests(refresh.id, limit=1, offset=1)
+    assert page.total == 3
+    assert page.items == (recorded[2],)
+    with pytest.raises(InvalidDatalayerRequest, match="page"):
+        request_manager.list_refresh_requests(refresh.id, limit=0)
+
+    other = seed_domain(database_engine, label="Other")
+    other_requests = ApiRequestManager(
+        create_session_factory(database_engine), manager_context(other)
+    )
+    with pytest.raises(DatalayerResourceNotFound):
+        other_requests.list_refresh_requests(refresh.id)
+    with pytest.raises(DatalayerResourceNotFound):
+        other_requests.resolve_verified_payloads([recorded[0].id])
+
+
+def test_object_payload_resolution_returns_immutable_receipt_without_file_io(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    attempt = successful_attempt(endpoint, {"large": True})
+    receipt = StoredLocalArtifact(
+        storage_key=(
+            f"payloads/sha256/{attempt.raw_sha256[:2]}/" f"{attempt.raw_sha256}.json"
+        ),
+        sha256=attempt.raw_sha256,
+        byte_length=attempt.byte_length,
+    )
+    request = request_manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh.id,
+            attempt=attempt,
+            completeness=CompletenessFinding(is_complete=True),
+            object_receipt=receipt,
+        )
+    )
+
+    payload = request_manager.resolve_verified_payloads([request.id])[0]
+    assert payload.kind == "object"
+    assert payload.storage_key == receipt.storage_key  # type: ignore[union-attr]
+    with pytest.raises(InvalidDatalayerRequest, match="unique"):
+        request_manager.resolve_verified_payloads([request.id, request.id])
+
+
+def test_snapshot_candidates_sort_newest_per_scope_and_exclude_future_weeks(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+) -> None:
+    player_catalog = build_player_catalog_request()
+    week_one = build_matchups_request(domain.season_id, domain.sleeper_league_id, 1)
+    week_three = build_matchups_request(domain.season_id, domain.sleeper_league_id, 3)
+    refresh = start_refresh(
+        refresh_manager,
+        domain,
+        player_catalog,
+        week_one,
+        week_three,
+        requested_through_week=3,
+    )
+    now = datetime.now(UTC)
+    older_player = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        player_catalog,
+        {"version": 1},
+        requested_at=now,
+    )
+    current_week = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        week_one,
+        [],
+        requested_at=now + timedelta(seconds=1),
+    )
+    newer_player = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        player_catalog,
+        {"version": 2},
+        requested_at=now + timedelta(seconds=2),
+    )
+    record_complete_attempt(
+        request_manager,
+        refresh.id,
+        week_three,
+        [],
+        requested_at=now + timedelta(seconds=3),
+    )
+
+    candidates = request_manager.list_snapshot_candidates(
+        SnapshotCandidateQuery(
+            competition_season_id=domain.season_id,
+            scope_keys=(
+                player_catalog.scope_key,
+                week_one.scope_key,
+                week_three.scope_key,
+            ),
+            through_week=2,
+        )
+    )
+
+    assert [item.scope_key.value for item in candidates] == sorted(
+        item.scope_key.value for item in candidates
+    )
+    assert [
+        item.request_id
+        for item in candidates
+        if item.scope_key == player_catalog.scope_key
+    ] == [newer_player.id, older_player.id]
+    assert current_week.id in {item.request_id for item in candidates}
+    assert all(item.week is None or item.week <= 2 for item in candidates)

--- a/backend/tests/resources/sleeper_data/test_audit_objects.py
+++ b/backend/tests/resources/sleeper_data/test_audit_objects.py
@@ -1,0 +1,116 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+import backend.resources.sleeper_data as sleeper_data
+from backend.resources.sleeper_data.refreshes import (
+    PlannedEndpointScope,
+    RefreshRunManager,
+    StartRefresh,
+)
+from backend.resources.sleeper_data.requests import (
+    ApiRequestManager,
+    RecordApiAttempt,
+    SnapshotCandidateQuery,
+)
+from backend.services.datalayer.contracts import RefreshTrigger
+from backend.services.datalayer.local_files import StoredLocalArtifact
+from backend.services.datalayer.sleeper.endpoints import build_player_catalog_request
+from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+from backend.tests.resources.sleeper_data.conftest import successful_attempt
+
+
+def test_only_audit_resource_managers_are_exported_and_own_their_modules() -> None:
+    exported_managers = {
+        name: getattr(sleeper_data, name)
+        for name in sleeper_data.__all__
+        if name.endswith("Manager")
+    }
+
+    assert exported_managers == {
+        "ApiRequestManager": ApiRequestManager,
+        "RefreshRunManager": RefreshRunManager,
+    }
+    assert RefreshRunManager.__module__.endswith(".refreshes.manager")
+    assert ApiRequestManager.__module__.endswith(".requests.manager")
+
+
+def test_refresh_plan_requires_ordered_unique_dependencies() -> None:
+    season_id = uuid4()
+    league = PlannedEndpointScope(
+        scope_key=ScopeKey.from_parts(EndpointKind.LEAGUE, season_id),
+        endpoint_kind=EndpointKind.LEAGUE,
+    )
+    rosters = PlannedEndpointScope(
+        scope_key=ScopeKey.from_parts(EndpointKind.LEAGUE_ROSTERS, season_id),
+        endpoint_kind=EndpointKind.LEAGUE_ROSTERS,
+        dependency_scope_keys=(league.scope_key,),
+    )
+
+    command = StartRefresh(
+        competition_season_id=season_id,
+        trigger=RefreshTrigger.MANUAL,
+        endpoint_scope=(league, rosters),
+        code_version="test",
+        normalizer_version="test",
+    )
+    assert command.endpoint_scope == (league, rosters)
+
+    with pytest.raises(ValidationError, match="precede"):
+        StartRefresh(
+            competition_season_id=season_id,
+            trigger=RefreshTrigger.MANUAL,
+            endpoint_scope=(rosters, league),
+            code_version="test",
+            normalizer_version="test",
+        )
+    with pytest.raises(ValidationError, match="unique"):
+        StartRefresh(
+            competition_season_id=season_id,
+            trigger=RefreshTrigger.MANUAL,
+            endpoint_scope=(league, league),
+            code_version="test",
+            normalizer_version="test",
+        )
+
+
+def test_object_payload_receipt_must_match_source_attempt() -> None:
+    attempt = successful_attempt(
+        build_player_catalog_request(),
+        {"fraction": Decimal("1.125")},
+        requested_at=datetime.now(UTC),
+    )
+    wrong_hash = "0" * 64
+
+    with pytest.raises(ValidationError, match="does not match"):
+        RecordApiAttempt(
+            refresh_run_id=uuid4(),
+            attempt=attempt,
+            completeness=CompletenessFinding(is_complete=True),
+            object_receipt=StoredLocalArtifact(
+                storage_key=f"payloads/sha256/00/{wrong_hash}.json",
+                sha256=wrong_hash,
+                byte_length=attempt.byte_length,
+            ),
+        )
+
+
+def test_snapshot_candidate_scopes_must_be_present_and_unique() -> None:
+    scope = ScopeKey.from_parts(EndpointKind.PLAYER_CATALOG, "nfl")
+
+    with pytest.raises(ValidationError, match="at least one"):
+        SnapshotCandidateQuery(
+            competition_season_id=uuid4(),
+            scope_keys=(),
+            through_week=1,
+        )
+    with pytest.raises(ValidationError, match="unique"):
+        SnapshotCandidateQuery(
+            competition_season_id=uuid4(),
+            scope_keys=(scope, scope),
+            through_week=1,
+        )

--- a/backend/tests/resources/sleeper_data/test_refresh_run_manager.py
+++ b/backend/tests/resources/sleeper_data/test_refresh_run_manager.py
@@ -1,0 +1,185 @@
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.sleeper import ApiRequest as StoredApiRequest
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
+from backend.resources.sleeper_data.requests import (
+    ApiRequest,
+    ApiRequestManager,
+    RecordApiAttempt,
+)
+from backend.services.datalayer.contracts import (
+    NormalizationStatus,
+    RefreshStatus,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_users_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.services.datalayer.sleeper.responses import EndpointRequest
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    failed_attempt,
+    manager_context,
+    seed_domain,
+    start_refresh,
+    successful_attempt,
+)
+
+
+def _record_success(
+    manager: ApiRequestManager,
+    refresh_id: UUID,
+    endpoint: EndpointRequest,
+    requested_at: datetime,
+) -> ApiRequest:
+    request = manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh_id,
+            attempt=successful_attempt(
+                endpoint,
+                {"observed_at": requested_at.isoformat()},
+                requested_at=requested_at,
+            ),
+            completeness=CompletenessFinding(is_complete=True),
+        )
+    )
+    return request
+
+
+def _record_failure(
+    manager: ApiRequestManager,
+    refresh_id: UUID,
+    endpoint: EndpointRequest,
+    requested_at: datetime,
+) -> None:
+    manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh_id,
+            attempt=failed_attempt(endpoint, requested_at=requested_at),
+            completeness=CompletenessFinding(
+                is_complete=False,
+                reason="source_attempt_failed",
+            ),
+        )
+    )
+
+
+def _mark_normalized(session_factory: SessionFactory, request_id: UUID) -> None:
+    with session_factory.begin() as session:
+        session.execute(
+            sa.update(StoredApiRequest)
+            .where(StoredApiRequest.id == request_id)
+            .values(
+                normalization_status=NormalizationStatus.SUCCEEDED.value,
+                normalizer_version="test-normalizer",
+                normalized_at=datetime.now(UTC),
+            )
+        )
+
+
+def _managers(
+    database_engine: Engine,
+    domain: Domain,
+) -> tuple[RefreshRunManager, ApiRequestManager, SessionFactory]:
+    session_factory = create_session_factory(database_engine)
+    context = manager_context(domain)
+    return (
+        RefreshRunManager(session_factory, context),
+        ApiRequestManager(session_factory, context),
+        session_factory,
+    )
+
+
+def test_refresh_run_is_competition_scoped(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+) -> None:
+    other = seed_domain(database_engine, label="Other")
+    other_refresh_manager, _, _ = _managers(database_engine, other)
+    endpoint = build_league_request(domain.season_id, domain.sleeper_league_id)
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+
+    assert refresh_manager.get_refresh(refresh.id) == refresh
+    with pytest.raises(DatalayerResourceNotFound):
+        other_refresh_manager.get_refresh(refresh.id)
+    with pytest.raises(DatalayerResourceNotFound):
+        start_refresh(other_refresh_manager, domain, endpoint)
+
+
+def test_finish_refresh_uses_latest_attempt_and_optional_failures_do_not_downgrade(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    session_factory: SessionFactory,
+) -> None:
+    league = build_league_request(domain.season_id, domain.sleeper_league_id)
+    users = build_league_users_request(domain.season_id, domain.sleeper_league_id)
+    now = datetime.now(UTC)
+    refresh = start_refresh(
+        refresh_manager,
+        domain,
+        league,
+        users,
+        required={users.scope_key.value: False},
+    )
+    league_request = _record_success(request_manager, refresh.id, league, now)
+    _mark_normalized(session_factory, league_request.id)
+    _record_failure(request_manager, refresh.id, users, now + timedelta(seconds=1))
+
+    finished = refresh_manager.finish_refresh(refresh.id)
+
+    assert finished.status is RefreshStatus.SUCCEEDED
+    assert (
+        finished.request_count,
+        finished.succeeded_request_count,
+        finished.failed_request_count,
+    ) == (2, 1, 1)
+    assert finished.error == {
+        "code": "refresh_scopes_failed",
+        "scope_keys": [users.scope_key.value],
+    }
+    assert refresh_manager.finish_refresh(refresh.id) == finished
+
+
+def test_finish_refresh_derives_partial_and_failed_required_plans(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    session_factory: SessionFactory,
+) -> None:
+    league = build_league_request(domain.season_id, domain.sleeper_league_id)
+    users = build_league_users_request(domain.season_id, domain.sleeper_league_id)
+    now = datetime.now(UTC)
+
+    partial = start_refresh(refresh_manager, domain, league, users)
+    good = _record_success(request_manager, partial.id, league, now)
+    _mark_normalized(session_factory, good.id)
+    _record_failure(request_manager, partial.id, users, now + timedelta(seconds=1))
+    assert refresh_manager.finish_refresh(partial.id).status is RefreshStatus.PARTIAL
+
+    failed = start_refresh(refresh_manager, domain, league)
+    first = _record_success(
+        request_manager,
+        failed.id,
+        league,
+        now + timedelta(seconds=2),
+    )
+    _mark_normalized(session_factory, first.id)
+    _record_failure(
+        request_manager,
+        failed.id,
+        league,
+        now + timedelta(seconds=3),
+    )
+    outcome = refresh_manager.finish_refresh(failed.id)
+    assert outcome.status is RefreshStatus.FAILED
+    assert (outcome.succeeded_request_count, outcome.failed_request_count) == (0, 1)


### PR DESCRIPTION
## Summary

Add the competition-scoped PostgreSQL audit resources for Sleeper refresh runs,
API request observations, and content-addressed payload receipts.

This is the first of three Layer 6 PRs. It intentionally excludes normalized
current-state projection and current-data read managers.

## Changes

- Add `RefreshRunManager` for refresh plans, terminal status/count derivation,
  and competition-scoped refresh reads.
- Add `ApiRequestManager` for attempt recording, audit pagination,
  normalization rejection, snapshot candidates, and verified payload
  resolution.
- Deduplicate payload content by SHA-256 while preserving every distinct
  request observation.
- Preserve canonical Decimal-safe inline JSON and immutable object receipts.
- Initialize failed, incomplete, and complete attempts as
  normalization-not-applicable, rejected, and pending respectively.
- Permit normalization rejection only for pending complete successes, so
  failed and incomplete audit records cannot be rewritten.
- Export frozen resource contracts only; ORM instances and sessions remain
  private.

`finish_refresh` lives with the refresh resource here. Successful completion
becomes publicly reachable in the next stacked PR, where scope application can
move pending observations to normalized success.

## Verification

- Audit resource tests: 12 passed.
- Focused resource plus inherited datalayer suite: 251 passed, 1 expected
  Windows symbolic-link capability skip.
- Package compilation, formatting, line-length audit, and `git diff --check`:
  passed.

## Stack

- Parent: #127
- Next: normalized-scope application and endpoint projections
