### PR TITLE
feat(datalayer): add sleeper normalized projections

### DIFF
--- a/backend/resources/sleeper_data/__init__.py
+++ b/backend/resources/sleeper_data/__init__.py
@@ -1,6 +1,10 @@
-"""Typed Sleeper refresh and request audit resources."""
+"""Typed Sleeper audit and normalized-scope resources."""
 
 from backend.resources.sleeper_data.common import Page
+from backend.resources.sleeper_data.normalized_scopes import (
+    ApplyResult,
+    NormalizedScopeManager,
+)
 from backend.resources.sleeper_data.refreshes import (
     PlannedEndpointScope,
     RefreshRun,
@@ -23,8 +27,10 @@ __all__ = [
     "ApiRequest",
     "ApiRequestCandidate",
     "ApiRequestManager",
+    "ApplyResult",
     "InlineVerifiedPayload",
     "NormalizationRejection",
+    "NormalizedScopeManager",
     "ObjectVerifiedPayload",
     "Page",
     "PlannedEndpointScope",

--- a/backend/resources/sleeper_data/normalized_scopes/__init__.py
+++ b/backend/resources/sleeper_data/normalized_scopes/__init__.py
@@ -1,0 +1,8 @@
+"""Normalized Sleeper scope resource."""
+
+from backend.resources.sleeper_data.normalized_scopes.manager import (
+    NormalizedScopeManager,
+)
+from backend.resources.sleeper_data.normalized_scopes.objects import ApplyResult
+
+__all__ = ["ApplyResult", "NormalizedScopeManager"]

--- a/backend/resources/sleeper_data/normalized_scopes/manager.py
+++ b/backend/resources/sleeper_data/normalized_scopes/manager.py
@@ -1,0 +1,219 @@
+"""Competition-scoped manager for atomic normalized scope transitions."""
+
+from datetime import datetime
+from typing import assert_never, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import (
+    ApiRequest,
+    NormalizedScope,
+    RefreshRun,
+)
+from backend.database.sessions import SessionFactory, transaction_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.normalized_scopes.objects import ApplyResult
+from backend.resources.sleeper_data.projections import write_endpoint_records
+from backend.services.datalayer.contracts import (
+    ApplyDisposition,
+    NormalizationStatus,
+    RequestStatus,
+)
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    EndpointRecords,
+    LeagueEndpointRecords,
+    LeagueRostersEndpointRecords,
+    LeagueUsersEndpointRecords,
+    LosersBracketEndpointRecords,
+    MatchupsEndpointRecords,
+    NflStateEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    TradedPicksEndpointRecords,
+    TransactionsEndpointRecords,
+    WinnersBracketEndpointRecords,
+)
+from backend.services.datalayer.sleeper.scope import ScopeKey
+
+
+class NormalizedScopeManager:
+    """Own atomic projection and provenance-head updates for endpoint scopes."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def apply_scope(
+        self,
+        request_id: UUID,
+        records: EndpointRecords,
+    ) -> ApplyResult:
+        """Apply one complete observation and advance its head atomically."""
+
+        with transaction_session(self._session_factory) as session:
+            request, refresh = self._load_request_with_refresh(
+                session, request_id, lock=True
+            )
+            _require_eligible_request(request)
+            if request.endpoint_kind != records.endpoint_kind.value:
+                raise DatalayerScopeConflict(
+                    "endpoint records do not match the recorded request"
+                )
+
+            _ = session.execute(
+                sa.select(
+                    sa.func.pg_advisory_xact_lock(
+                        sa.func.hashtextextended(request.scope_key, 0)
+                    )
+                )
+            ).scalar_one()
+            head = session.get(
+                NormalizedScope,
+                request.scope_key,
+                with_for_update=True,
+            )
+            row_count = endpoint_record_count(records)
+            if head is not None:
+                if head.source_api_request_id == request.id:
+                    return ApplyResult(
+                        request_id=request.id,
+                        scope_key=ScopeKey.parse(request.scope_key),
+                        disposition=ApplyDisposition.ALREADY_APPLIED,
+                        head_request_id=request.id,
+                        normalized_row_count=head.normalized_row_count,
+                        changed_current_view=False,
+                    )
+                previous = session.get(ApiRequest, head.source_api_request_id)
+                if previous is None:
+                    raise RuntimeError(
+                        "normalized scope head references a missing request"
+                    )
+                if request_order(request) < request_order(previous):
+                    _mark_normalized(request, refresh.normalizer_version)
+                    return ApplyResult(
+                        request_id=request.id,
+                        scope_key=ScopeKey.parse(request.scope_key),
+                        disposition=ApplyDisposition.STALE_IGNORED,
+                        head_request_id=head.source_api_request_id,
+                        normalized_row_count=head.normalized_row_count,
+                        changed_current_view=False,
+                    )
+                if request.response_sha256 == head.response_sha256:
+                    head.source_api_request_id = request.id
+                    head.normalized_row_count = row_count
+                    head.applied_at = sa.func.now()
+                    _mark_normalized(request, refresh.normalizer_version)
+                    return ApplyResult(
+                        request_id=request.id,
+                        scope_key=ScopeKey.parse(request.scope_key),
+                        disposition=ApplyDisposition.IDENTICAL_HEAD_ADVANCED,
+                        head_request_id=request.id,
+                        normalized_row_count=row_count,
+                        changed_current_view=False,
+                    )
+
+            write_endpoint_records(
+                session,
+                self._competition_id,
+                request,
+                records,
+            )
+            if head is None:
+                head = NormalizedScope(
+                    scope_key=request.scope_key,
+                    source_api_request_id=request.id,
+                    response_sha256=cast(str, request.response_sha256),
+                    normalized_row_count=row_count,
+                )
+                session.add(head)
+            else:
+                head.source_api_request_id = request.id
+                head.response_sha256 = cast(str, request.response_sha256)
+                head.normalized_row_count = row_count
+                head.applied_at = sa.func.now()
+            _mark_normalized(request, refresh.normalizer_version)
+            return ApplyResult(
+                request_id=request.id,
+                scope_key=ScopeKey.parse(request.scope_key),
+                disposition=ApplyDisposition.APPLIED,
+                head_request_id=request.id,
+                normalized_row_count=row_count,
+                changed_current_view=True,
+            )
+
+    def _load_request_with_refresh(
+        self,
+        session: Session,
+        request_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> tuple[ApiRequest, RefreshRun]:
+        statement = (
+            sa.select(ApiRequest, RefreshRun)
+            .join(RefreshRun, RefreshRun.id == ApiRequest.refresh_run_id)
+            .where(
+                ApiRequest.id == request_id,
+                RefreshRun.competition_id == self._competition_id,
+            )
+        )
+        if lock:
+            statement = statement.with_for_update(of=ApiRequest)
+        row = session.execute(statement).one_or_none()
+        if row is None:
+            raise DatalayerResourceNotFound("api_request", str(request_id))
+        return row[0], row[1]
+
+
+def endpoint_record_count(records: EndpointRecords) -> int:
+    """Count endpoint records, excluding auxiliary derived seed operations."""
+
+    if isinstance(records, LeagueEndpointRecords):
+        return 1
+    if isinstance(records, LeagueUsersEndpointRecords):
+        return len(records.users) + len(records.league_users)
+    if isinstance(records, NflStateEndpointRecords):
+        return 1
+    if isinstance(records, PlayerCatalogEndpointRecords):
+        return len(records.players)
+    if isinstance(records, LeagueRostersEndpointRecords):
+        return len(records.rosters) + len(records.managers) + len(records.players)
+    if isinstance(records, TradedPicksEndpointRecords):
+        return len(records.picks)
+    if isinstance(records, MatchupsEndpointRecords):
+        return len(records.matchups) + len(records.player_performances)
+    if isinstance(records, TransactionsEndpointRecords):
+        return len(records.transactions) + len(records.moves)
+    if isinstance(
+        records, (WinnersBracketEndpointRecords, LosersBracketEndpointRecords)
+    ):
+        return len(records.matchups)
+    assert_never(records)
+
+
+def request_order(request: ApiRequest) -> tuple[datetime, int]:
+    return request.requested_at, request.id.int
+
+
+def _require_eligible_request(request: ApiRequest) -> None:
+    if (
+        request.status != RequestStatus.SUCCEEDED.value
+        or not request.is_complete
+        or request.payload_id is None
+        or request.response_sha256 is None
+    ):
+        raise DatalayerScopeConflict("request is not eligible for normalization")
+
+
+def _mark_normalized(request: ApiRequest, version: str) -> None:
+    request.normalization_status = NormalizationStatus.SUCCEEDED.value
+    request.normalizer_version = version
+    request.normalized_at = sa.func.now()

--- a/backend/resources/sleeper_data/normalized_scopes/objects.py
+++ b/backend/resources/sleeper_data/normalized_scopes/objects.py
@@ -1,0 +1,20 @@
+"""Immutable contracts for normalized Sleeper scope heads."""
+
+from uuid import UUID
+
+from pydantic import Field, StrictBool
+
+from backend.resources._contracts import ContractModel
+from backend.services.datalayer.contracts import ApplyDisposition
+from backend.services.datalayer.sleeper.scope import ScopeKey
+
+
+class ApplyResult(ContractModel):
+    """Outcome of atomically applying one observed endpoint scope."""
+
+    request_id: UUID
+    scope_key: ScopeKey
+    disposition: ApplyDisposition
+    head_request_id: UUID
+    normalized_row_count: int = Field(strict=True, ge=0)
+    changed_current_view: StrictBool

--- a/backend/resources/sleeper_data/projections/__init__.py
+++ b/backend/resources/sleeper_data/projections/__init__.py
@@ -1,0 +1,5 @@
+"""Transaction-scoped normalized-current-state projection writers."""
+
+from backend.resources.sleeper_data.projections.dispatch import write_endpoint_records
+
+__all__ = ["write_endpoint_records"]

--- a/backend/resources/sleeper_data/projections/common.py
+++ b/backend/resources/sleeper_data/projections/common.py
@@ -1,0 +1,110 @@
+"""Shared transaction-scoped lookup helpers for normalized projections."""
+
+from collections.abc import Iterable
+from datetime import datetime
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason, SeasonRoster
+from backend.database.models.sleeper import (
+    ApiRequest,
+    Player,
+    User,
+)
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+)
+
+
+def request_order(request: ApiRequest) -> tuple[datetime, int]:
+    return request.requested_at, request.id.int
+
+
+def require_season(
+    session: Session,
+    competition_id: UUID,
+    season_id: UUID,
+) -> CompetitionSeason:
+    season = session.scalar(
+        sa.select(CompetitionSeason).where(
+            CompetitionSeason.id == season_id,
+            CompetitionSeason.competition_id == competition_id,
+        )
+    )
+    if season is None:
+        raise DatalayerResourceNotFound("competition_season", str(season_id))
+    return season
+
+
+def request_season(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+) -> CompetitionSeason:
+    if request.competition_season_id is None:
+        raise DatalayerScopeConflict("endpoint requires a competition season")
+    return require_season(session, competition_id, request.competition_season_id)
+
+
+def season_roster_identities(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+) -> tuple[CompetitionSeason, dict[str, SeasonRoster]]:
+    season = request_season(session, competition_id, request)
+    rows = session.scalars(
+        sa.select(SeasonRoster).where(
+            SeasonRoster.competition_season_id == season.id,
+            SeasonRoster.competition_id == competition_id,
+        )
+    ).all()
+    return season, {row.sleeper_roster_id: row for row in rows}
+
+
+def request_week(request: ApiRequest) -> int:
+    if request.week is None:
+        raise DatalayerScopeConflict("weekly endpoint is missing its week")
+    return request.week
+
+
+def require_users(session: Session, user_ids: Iterable[str]) -> None:
+    required = set(user_ids)
+    if not required:
+        return
+    found = set(
+        session.scalars(
+            sa.select(User.sleeper_user_id).where(User.sleeper_user_id.in_(required))
+        )
+    )
+    if found != required:
+        raise DatalayerScopeConflict("normalized scope references unknown users")
+
+
+def require_players(session: Session, player_ids: Iterable[str]) -> None:
+    required = set(player_ids)
+    if not required:
+        return
+    found = set(
+        session.scalars(
+            sa.select(Player.sleeper_player_id).where(
+                Player.sleeper_player_id.in_(required)
+            )
+        )
+    )
+    if found != required:
+        raise DatalayerScopeConflict("normalized scope references unknown players")
+
+
+def optional_identity(
+    identities: dict[str, SeasonRoster],
+    sleeper_roster_id: str | None,
+) -> SeasonRoster | None:
+    if sleeper_roster_id is None:
+        return None
+    identity = identities.get(sleeper_roster_id)
+    if identity is None:
+        raise DatalayerScopeConflict("normalized scope references an unmapped roster")
+    return identity

--- a/backend/resources/sleeper_data/projections/dispatch.py
+++ b/backend/resources/sleeper_data/projections/dispatch.py
@@ -1,0 +1,69 @@
+"""Explicit endpoint-kind dispatch for transaction-scoped projections."""
+
+from typing import assert_never
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import ApiRequest
+from backend.resources.sleeper_data.projections.draft_picks import (
+    write_traded_picks,
+)
+from backend.resources.sleeper_data.projections.leagues import (
+    write_league,
+    write_league_users,
+)
+from backend.resources.sleeper_data.projections.matchups import write_matchups
+from backend.resources.sleeper_data.projections.players import write_players
+from backend.resources.sleeper_data.projections.playoff_matchups import (
+    write_playoff_matchups,
+)
+from backend.resources.sleeper_data.projections.rosters import write_rosters
+from backend.resources.sleeper_data.projections.transactions import (
+    write_transactions,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    EndpointRecords,
+    LeagueEndpointRecords,
+    LeagueRostersEndpointRecords,
+    LeagueUsersEndpointRecords,
+    LosersBracketEndpointRecords,
+    MatchupsEndpointRecords,
+    NflStateEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    TradedPicksEndpointRecords,
+    TransactionsEndpointRecords,
+    WinnersBracketEndpointRecords,
+)
+
+
+def write_endpoint_records(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: EndpointRecords,
+) -> None:
+    """Project endpoint records using only the caller-owned transaction."""
+
+    if isinstance(records, LeagueEndpointRecords):
+        write_league(session, competition_id, request, records)
+    elif isinstance(records, LeagueUsersEndpointRecords):
+        write_league_users(session, competition_id, request, records)
+    elif isinstance(records, NflStateEndpointRecords):
+        return
+    elif isinstance(records, PlayerCatalogEndpointRecords):
+        write_players(session, competition_id, request, records)
+    elif isinstance(records, LeagueRostersEndpointRecords):
+        write_rosters(session, competition_id, request, records)
+    elif isinstance(records, TradedPicksEndpointRecords):
+        write_traded_picks(session, competition_id, request, records)
+    elif isinstance(records, MatchupsEndpointRecords):
+        write_matchups(session, competition_id, request, records)
+    elif isinstance(records, TransactionsEndpointRecords):
+        write_transactions(session, competition_id, request, records)
+    elif isinstance(
+        records, (WinnersBracketEndpointRecords, LosersBracketEndpointRecords)
+    ):
+        write_playoff_matchups(session, competition_id, request, records)
+    else:
+        assert_never(records)

--- a/backend/resources/sleeper_data/projections/draft_picks.py
+++ b/backend/resources/sleeper_data/projections/draft_picks.py
@@ -1,0 +1,64 @@
+"""Transaction-scoped writer for the complete traded-pick ownership view."""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import ApiRequest, DraftPick
+from backend.resources.sleeper_data.projections.common import (
+    season_roster_identities,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    TradedPicksEndpointRecords,
+)
+
+
+def write_traded_picks(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: TradedPicksEndpointRecords,
+) -> None:
+    """Reset and reapply the complete ownership view in the caller transaction."""
+
+    season, identities = season_roster_identities(session, competition_id, request)
+    years = range(season.season_year + 1, season.season_year + 4)
+    session.execute(
+        sa.update(DraftPick)
+        .where(
+            DraftPick.competition_id == competition_id,
+            DraftPick.draft_season_year.in_(years),
+            DraftPick.source == "traded_pick",
+        )
+        .values(
+            current_franchise_id=DraftPick.original_franchise_id,
+            sleeper_pick_id=None,
+            source="seeded",
+            source_api_request_id=request.id,
+            source_api_request_competition_season_id=season.id,
+        )
+    )
+    for record in records.picks:
+        original = identities.get(record.original_sleeper_roster_id)
+        current = identities.get(record.current_owner_sleeper_roster_id)
+        if original is None or current is None:
+            raise DatalayerScopeConflict("traded pick references an unmapped roster")
+        stored = session.scalar(
+            sa.select(DraftPick).where(
+                DraftPick.competition_id == competition_id,
+                DraftPick.draft_season_year == record.draft_season_year,
+                DraftPick.round == record.draft_round,
+                DraftPick.original_franchise_id == original.franchise_id,
+            )
+        )
+        if stored is None:
+            raise DatalayerScopeConflict(
+                "traded pick is outside the seeded pick coordinates"
+            )
+        stored.current_franchise_id = current.franchise_id
+        stored.sleeper_pick_id = record.sleeper_pick_id
+        stored.source = "traded_pick"
+        stored.source_api_request_id = request.id
+        stored.source_api_request_competition_season_id = season.id

--- a/backend/resources/sleeper_data/projections/leagues.py
+++ b/backend/resources/sleeper_data/projections/leagues.py
@@ -1,0 +1,136 @@
+"""Transaction-scoped writers for league metadata and membership."""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import (
+    ApiRequest,
+    League,
+    LeagueUser,
+    User,
+)
+from backend.resources.sleeper_data.common.codec import jsonb_expression
+from backend.resources.sleeper_data.projections.common import (
+    request_order,
+    request_season,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    LeagueEndpointRecords,
+    LeagueUsersEndpointRecords,
+)
+
+
+def write_league(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: LeagueEndpointRecords,
+) -> None:
+    """Upsert the competition season's league metadata in the caller transaction."""
+
+    season = request_season(session, competition_id, request)
+    record = records.league
+    if record.sleeper_league_id != season.sleeper_league_id or record.season != str(
+        season.season_year
+    ):
+        raise DatalayerScopeConflict(
+            "league record does not match core season identity"
+        )
+    values = {
+        "competition_season_id": season.id,
+        "source_api_request_id": request.id,
+        "name": record.name,
+        "status": record.status,
+        "season": record.season,
+        "previous_sleeper_league_id": record.previous_sleeper_league_id,
+        "sleeper_draft_id": record.sleeper_draft_id,
+        "sport": record.sport,
+        "scoring_settings": jsonb_expression(record.scoring_settings),
+        "roster_positions": jsonb_expression(list(record.roster_positions)),
+        "provider_settings": jsonb_expression(record.provider_settings),
+        "playoff_start_week": record.playoff_start_week,
+        "playoff_team_count": record.playoff_team_count,
+        "league_average_match": record.league_average_match,
+        "updated_at": sa.func.now(),
+    }
+    session.execute(
+        pg_insert(League.__table__)
+        .values(**values)
+        .on_conflict_do_update(
+            index_elements=[League.competition_season_id],
+            set_={
+                key: value
+                for key, value in values.items()
+                if key != "competition_season_id"
+            },
+        )
+    )
+
+
+def write_league_users(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: LeagueUsersEndpointRecords,
+) -> None:
+    """Replace season membership and upsert globally ordered user profiles."""
+
+    season = request_season(session, competition_id, request)
+    sleeper_user_ids = [row.sleeper_user_id for row in records.users]
+    existing_users = {
+        row[0].sleeper_user_id: (row[0], row[1])
+        for row in session.execute(
+            sa.select(User, ApiRequest)
+            .join(ApiRequest, ApiRequest.id == User.source_api_request_id)
+            .where(User.sleeper_user_id.in_(sleeper_user_ids))
+        )
+    }
+    for record in records.users:
+        existing = existing_users.get(record.sleeper_user_id)
+        existing_order = None if existing is None else request_order(existing[1])
+        if existing_order is not None and request_order(request) < existing_order:
+            continue
+        values = {
+            "sleeper_user_id": record.sleeper_user_id,
+            "display_name": record.display_name,
+            "username": record.username,
+            "avatar": record.avatar,
+            "metadata": jsonb_expression(record.metadata),
+            "source_api_request_id": request.id,
+            "updated_at": sa.func.now(),
+        }
+        session.execute(
+            pg_insert(User.__table__)
+            .values(**values)
+            .on_conflict_do_update(
+                index_elements=[User.sleeper_user_id],
+                set_={
+                    key: value
+                    for key, value in values.items()
+                    if key != "sleeper_user_id"
+                },
+            )
+        )
+
+    user_ids = {row.sleeper_user_id for row in records.users}
+    if any(row.sleeper_user_id not in user_ids for row in records.league_users):
+        raise DatalayerScopeConflict("league-local user is missing its global profile")
+    session.execute(
+        sa.delete(LeagueUser).where(LeagueUser.competition_season_id == season.id)
+    )
+    for record in records.league_users:
+        session.execute(
+            sa.insert(LeagueUser.__table__).values(
+                competition_season_id=season.id,
+                sleeper_user_id=record.sleeper_user_id,
+                team_name=record.team_name,
+                nickname=record.nickname,
+                is_commissioner=record.is_commissioner,
+                metadata=jsonb_expression(record.metadata),
+                source_api_request_id=request.id,
+            )
+        )

--- a/backend/resources/sleeper_data/projections/matchups.py
+++ b/backend/resources/sleeper_data/projections/matchups.py
@@ -1,0 +1,82 @@
+"""Transaction-scoped writer for matchup current state."""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import (
+    ApiRequest,
+    Matchup,
+    PlayerPerformance,
+)
+from backend.resources.sleeper_data.projections.common import (
+    request_week,
+    require_players,
+    season_roster_identities,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    MatchupsEndpointRecords,
+)
+
+
+def write_matchups(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: MatchupsEndpointRecords,
+) -> None:
+    """Replace one exact season/week of matchups and performances."""
+
+    season, identities = season_roster_identities(session, competition_id, request)
+    week = request_week(request)
+    if any(
+        row.week != week for row in (*records.matchups, *records.player_performances)
+    ):
+        raise DatalayerScopeConflict("matchup records do not match the request week")
+    for roster_id in {
+        row.sleeper_roster_id
+        for row in (*records.matchups, *records.player_performances)
+    }:
+        if roster_id not in identities:
+            raise DatalayerScopeConflict("matchup references an unmapped roster")
+    require_players(
+        session, [row.sleeper_player_id for row in records.player_performances]
+    )
+    session.execute(
+        sa.delete(PlayerPerformance).where(
+            PlayerPerformance.competition_season_id == season.id,
+            PlayerPerformance.week == week,
+        )
+    )
+    session.execute(
+        sa.delete(Matchup).where(
+            Matchup.competition_season_id == season.id,
+            Matchup.week == week,
+        )
+    )
+    for record in records.matchups:
+        session.add(
+            Matchup(
+                competition_season_id=season.id,
+                week=week,
+                season_roster_id=identities[record.sleeper_roster_id].id,
+                sleeper_matchup_id=record.sleeper_matchup_id,
+                points=record.points,
+                source_api_request_id=request.id,
+            )
+        )
+    for record in records.player_performances:
+        session.add(
+            PlayerPerformance(
+                competition_season_id=season.id,
+                week=week,
+                season_roster_id=identities[record.sleeper_roster_id].id,
+                sleeper_matchup_id=record.sleeper_matchup_id,
+                sleeper_player_id=record.sleeper_player_id,
+                points=record.points,
+                role=record.role,
+                source_api_request_id=request.id,
+            )
+        )

--- a/backend/resources/sleeper_data/projections/players.py
+++ b/backend/resources/sleeper_data/projections/players.py
@@ -1,0 +1,54 @@
+"""Transaction-scoped writer for the global Sleeper player catalog."""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import ApiRequest, Player
+from backend.resources.sleeper_data.common.codec import jsonb_expression
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    PlayerCatalogEndpointRecords,
+)
+
+
+def write_players(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: PlayerCatalogEndpointRecords,
+) -> None:
+    """Upsert observed players without deleting omitted catalog entries."""
+
+    del competition_id
+    if request.competition_season_id is not None:
+        raise DatalayerScopeConflict("player catalog request must be global")
+    for record in records.players:
+        values = {
+            "sleeper_player_id": record.sleeper_player_id,
+            "full_name": record.full_name,
+            "position": record.position,
+            "nfl_team": record.nfl_team,
+            "active": record.active,
+            "status": record.status,
+            "injury_status": record.injury_status,
+            "age": record.age,
+            "years_experience": record.years_experience,
+            "metadata": jsonb_expression(record.metadata),
+            "source_api_request_id": request.id,
+            "updated_at": sa.func.now(),
+        }
+        session.execute(
+            pg_insert(Player.__table__)
+            .values(**values)
+            .on_conflict_do_update(
+                index_elements=[Player.sleeper_player_id],
+                set_={
+                    key: value
+                    for key, value in values.items()
+                    if key != "sleeper_player_id"
+                },
+            )
+        )

--- a/backend/resources/sleeper_data/projections/playoff_matchups.py
+++ b/backend/resources/sleeper_data/projections/playoff_matchups.py
@@ -1,0 +1,65 @@
+"""Transaction-scoped writer for playoff bracket nodes."""
+
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import ApiRequest, PlayoffMatchup
+from backend.resources.sleeper_data.projections.common import (
+    optional_identity,
+    season_roster_identities,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    LosersBracketEndpointRecords,
+    WinnersBracketEndpointRecords,
+)
+
+
+def write_playoff_matchups(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: WinnersBracketEndpointRecords | LosersBracketEndpointRecords,
+) -> None:
+    """Replace one exact season/bracket-kind of playoff nodes."""
+
+    season, identities = season_roster_identities(session, competition_id, request)
+    bracket_kind = (
+        "winners" if isinstance(records, WinnersBracketEndpointRecords) else "losers"
+    )
+    if request.bracket_kind != bracket_kind:
+        raise DatalayerScopeConflict("bracket records do not match the request kind")
+    session.execute(
+        sa.delete(PlayoffMatchup).where(
+            PlayoffMatchup.competition_season_id == season.id,
+            PlayoffMatchup.bracket_kind == bracket_kind,
+        )
+    )
+    for record in records.matchups:
+        roster_fields = (
+            record.t1_sleeper_roster_id,
+            record.t2_sleeper_roster_id,
+            record.winner_sleeper_roster_id,
+            record.loser_sleeper_roster_id,
+        )
+        mapped = [optional_identity(identities, value) for value in roster_fields]
+        session.add(
+            PlayoffMatchup(
+                competition_season_id=season.id,
+                bracket_kind=bracket_kind,
+                node_key=record.node_key,
+                round=record.round,
+                t1_season_roster_id=None if mapped[0] is None else mapped[0].id,
+                t2_season_roster_id=None if mapped[1] is None else mapped[1].id,
+                t1_from_node_key=record.t1_from_node_key,
+                t1_from_outcome=record.t1_from_outcome,
+                t2_from_node_key=record.t2_from_node_key,
+                t2_from_outcome=record.t2_from_outcome,
+                winner_season_roster_id=(None if mapped[2] is None else mapped[2].id),
+                loser_season_roster_id=(None if mapped[3] is None else mapped[3].id),
+                placement=record.placement,
+                source_api_request_id=request.id,
+            )
+        )

--- a/backend/resources/sleeper_data/projections/rosters.py
+++ b/backend/resources/sleeper_data/projections/rosters.py
@@ -1,0 +1,158 @@
+"""Transaction-scoped writers for rosters and draft-pick seed coordinates."""
+
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason, SeasonRoster
+from backend.database.models.sleeper import (
+    ApiRequest,
+    DraftPick,
+    League,
+    Roster,
+    RosterManager,
+    RosterPlayer,
+)
+from backend.resources.sleeper_data.common.codec import jsonb_expression
+from backend.resources.sleeper_data.projections.common import (
+    require_players,
+    require_users,
+    season_roster_identities,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    LeagueRostersEndpointRecords,
+)
+
+
+def write_rosters(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: LeagueRostersEndpointRecords,
+) -> None:
+    """Replace roster current state and seed its draft-pick coordinates."""
+
+    season, identities = season_roster_identities(session, competition_id, request)
+    roster_ids = {row.sleeper_roster_id for row in records.rosters}
+    if any(roster_id not in identities for roster_id in roster_ids):
+        raise DatalayerScopeConflict(
+            "roster response contains an unmapped Sleeper roster"
+        )
+    if any(row.sleeper_roster_id not in roster_ids for row in records.managers):
+        raise DatalayerScopeConflict("roster manager references an unknown roster")
+    if any(row.sleeper_roster_id not in roster_ids for row in records.players):
+        raise DatalayerScopeConflict("roster player references an unknown roster")
+    require_users(session, [row.sleeper_user_id for row in records.managers])
+    require_players(session, [row.sleeper_player_id for row in records.players])
+
+    session.execute(
+        sa.delete(RosterPlayer).where(RosterPlayer.competition_season_id == season.id)
+    )
+    delete_managers = sa.delete(RosterManager).where(
+        RosterManager.competition_season_id == season.id
+    )
+    session.execute(delete_managers)
+    session.execute(sa.delete(Roster).where(Roster.competition_season_id == season.id))
+    for record in records.rosters:
+        identity = identities[record.sleeper_roster_id]
+        session.execute(
+            sa.insert(Roster.__table__).values(
+                season_roster_id=identity.id,
+                competition_season_id=season.id,
+                source_api_request_id=request.id,
+                settings=jsonb_expression(record.settings),
+                metadata=jsonb_expression(record.metadata),
+                record_string=record.record_string,
+                wins=record.wins,
+                losses=record.losses,
+                ties=record.ties,
+                points_for=record.points_for,
+                points_against=record.points_against,
+            )
+        )
+    for record in records.managers:
+        session.add(
+            RosterManager(
+                season_roster_id=identities[record.sleeper_roster_id].id,
+                competition_season_id=season.id,
+                sleeper_user_id=record.sleeper_user_id,
+                role=record.role,
+                source_order=record.source_order,
+                source_api_request_id=request.id,
+            )
+        )
+    for record in records.players:
+        session.add(
+            RosterPlayer(
+                season_roster_id=identities[record.sleeper_roster_id].id,
+                competition_season_id=season.id,
+                sleeper_player_id=record.sleeper_player_id,
+                role=record.role,
+                source_api_request_id=request.id,
+            )
+        )
+    _seed_draft_picks(
+        session,
+        competition_id,
+        request,
+        season,
+        records,
+        identities,
+    )
+
+
+def _seed_draft_picks(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    season: CompetitionSeason,
+    records: LeagueRostersEndpointRecords,
+    identities: dict[str, SeasonRoster],
+) -> None:
+    league = session.get(League, season.id)
+    if league is None:
+        raise DatalayerScopeConflict("roster normalization requires league metadata")
+    raw_rounds = league.provider_settings.get("draft_rounds")
+    if isinstance(raw_rounds, bool) or not isinstance(raw_rounds, int):
+        draft_rounds = 0
+    else:
+        draft_rounds = max(raw_rounds, 0)
+    for offset in range(1, 4):
+        draft_year = season.season_year + offset
+        for roster in records.rosters:
+            identity = identities[roster.sleeper_roster_id]
+            for round_number in range(1, draft_rounds + 1):
+                values = {
+                    "id": uuid4(),
+                    "competition_id": competition_id,
+                    "draft_season_year": draft_year,
+                    "round": round_number,
+                    "original_franchise_id": identity.franchise_id,
+                    "current_franchise_id": identity.franchise_id,
+                    "sleeper_pick_id": None,
+                    "source": "seeded",
+                    "source_api_request_id": request.id,
+                    "source_api_request_competition_season_id": season.id,
+                }
+                session.execute(
+                    pg_insert(DraftPick.__table__)
+                    .values(**values)
+                    .on_conflict_do_update(
+                        constraint="uq_draft_picks_natural",
+                        set_={
+                            key: value
+                            for key, value in values.items()
+                            if key
+                            not in {
+                                "id",
+                                "competition_id",
+                                "draft_season_year",
+                                "round",
+                                "original_franchise_id",
+                            }
+                        },
+                    )
+                )

--- a/backend/resources/sleeper_data/projections/transactions.py
+++ b/backend/resources/sleeper_data/projections/transactions.py
@@ -1,0 +1,118 @@
+"""Transaction-scoped writer for transaction current state."""
+
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import (
+    ApiRequest,
+    DraftPick,
+    Transaction,
+    TransactionMove,
+)
+from backend.resources.sleeper_data.common.codec import jsonb_expression
+from backend.resources.sleeper_data.projections.common import (
+    optional_identity,
+    request_week,
+    require_players,
+    season_roster_identities,
+)
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    TransactionsEndpointRecords,
+)
+
+
+def write_transactions(
+    session: Session,
+    competition_id: UUID,
+    request: ApiRequest,
+    records: TransactionsEndpointRecords,
+) -> None:
+    """Replace one exact season/week of transactions and moves."""
+
+    season, identities = season_roster_identities(session, competition_id, request)
+    week = request_week(request)
+    if any(row.week != week for row in records.transactions):
+        raise DatalayerScopeConflict(
+            "transaction records do not match the request week"
+        )
+    transaction_ids = session.scalars(
+        sa.select(Transaction.id).where(
+            Transaction.competition_season_id == season.id,
+            Transaction.week == week,
+        )
+    ).all()
+    if transaction_ids:
+        session.execute(
+            sa.delete(TransactionMove).where(
+                TransactionMove.transaction_id.in_(transaction_ids)
+            )
+        )
+        session.execute(
+            sa.delete(Transaction).where(Transaction.id.in_(transaction_ids))
+        )
+    ids = {row.sleeper_transaction_id: uuid4() for row in records.transactions}
+    if any(row.sleeper_transaction_id not in ids for row in records.moves):
+        raise DatalayerScopeConflict(
+            "transaction move references an unknown transaction"
+        )
+    require_players(
+        session,
+        [
+            row.sleeper_player_id
+            for row in records.moves
+            if row.sleeper_player_id is not None
+        ],
+    )
+    for record in records.transactions:
+        session.execute(
+            sa.insert(Transaction.__table__).values(
+                id=ids[record.sleeper_transaction_id],
+                competition_season_id=season.id,
+                sleeper_transaction_id=record.sleeper_transaction_id,
+                week=week,
+                transaction_type=record.transaction_type,
+                status=record.status,
+                provider_created_at_ms=record.provider_created_at_ms,
+                settings=jsonb_expression(record.settings),
+                metadata=jsonb_expression(record.metadata),
+                source_api_request_id=request.id,
+            )
+        )
+    for record in records.moves:
+        from_roster = optional_identity(identities, record.from_sleeper_roster_id)
+        to_roster = optional_identity(identities, record.to_sleeper_roster_id)
+        draft_pick: DraftPick | None = None
+        if record.move_kind == "pick":
+            original = optional_identity(identities, record.original_sleeper_roster_id)
+            if original is None:
+                raise DatalayerScopeConflict("pick move has no original roster")
+            draft_pick = session.scalar(
+                sa.select(DraftPick).where(
+                    DraftPick.competition_id == competition_id,
+                    DraftPick.draft_season_year == record.draft_season_year,
+                    DraftPick.round == record.draft_round,
+                    DraftPick.original_franchise_id == original.franchise_id,
+                )
+            )
+            if draft_pick is None:
+                raise DatalayerScopeConflict(
+                    "transaction pick is outside seeded coordinates"
+                )
+        from_roster_id = None if from_roster is None else from_roster.id
+        session.add(
+            TransactionMove(
+                transaction_id=ids[record.sleeper_transaction_id],
+                competition_season_id=season.id,
+                competition_id=competition_id,
+                move_index=record.move_index,
+                move_kind=record.move_kind,
+                from_season_roster_id=from_roster_id,
+                to_season_roster_id=None if to_roster is None else to_roster.id,
+                sleeper_player_id=record.sleeper_player_id,
+                draft_pick_id=None if draft_pick is None else draft_pick.id,
+                budget_amount=record.budget_amount,
+            )
+        )

--- a/backend/tests/resources/sleeper_data/conftest.py
+++ b/backend/tests/resources/sleeper_data/conftest.py
@@ -29,6 +29,7 @@ from backend.resources.sleeper_data.refreshes import (
     RefreshRunManager,
     StartRefresh,
 )
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
 from backend.resources.sleeper_data.requests import (
     ApiRequest,
     ApiRequestManager,
@@ -54,9 +55,10 @@ def clean_sleeper_resources(request: pytest.FixtureRequest) -> None:
         return
     database_engine = request.getfixturevalue("database_engine")
     with database_engine.begin() as connection:
-        connection.execute(
-            sa.text("TRUNCATE TABLE core.competitions, " "sleeper.api_payloads CASCADE")
-        )
+        connection.execute(sa.text("""
+                TRUNCATE TABLE core.competitions,
+                    sleeper.api_payloads CASCADE
+                """))
 
 
 @dataclass(frozen=True)
@@ -244,6 +246,14 @@ def request_manager(
     domain: Domain,
 ) -> ApiRequestManager:
     return ApiRequestManager(session_factory, manager_context(domain))
+
+
+@pytest.fixture
+def normalized_scope_manager(
+    session_factory: SessionFactory,
+    domain: Domain,
+) -> NormalizedScopeManager:
+    return NormalizedScopeManager(session_factory, manager_context(domain))
 
 
 @pytest.fixture

--- a/backend/tests/resources/sleeper_data/test_audit_objects.py
+++ b/backend/tests/resources/sleeper_data/test_audit_objects.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 import backend.resources.sleeper_data as sleeper_data
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
 from backend.resources.sleeper_data.refreshes import (
     PlannedEndpointScope,
     RefreshRunManager,
@@ -24,19 +25,19 @@ from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
 from backend.tests.resources.sleeper_data.conftest import successful_attempt
 
 
-def test_only_audit_resource_managers_are_exported_and_own_their_modules() -> None:
+def test_audit_resource_managers_are_exported_and_own_their_modules() -> None:
     exported_managers = {
         name: getattr(sleeper_data, name)
         for name in sleeper_data.__all__
         if name.endswith("Manager")
     }
 
-    assert exported_managers == {
-        "ApiRequestManager": ApiRequestManager,
-        "RefreshRunManager": RefreshRunManager,
-    }
+    assert exported_managers["ApiRequestManager"] is ApiRequestManager
+    assert exported_managers["NormalizedScopeManager"] is NormalizedScopeManager
+    assert exported_managers["RefreshRunManager"] is RefreshRunManager
     assert RefreshRunManager.__module__.endswith(".refreshes.manager")
     assert ApiRequestManager.__module__.endswith(".requests.manager")
+    assert NormalizedScopeManager.__module__.endswith(".normalized_scopes.manager")
 
 
 def test_refresh_plan_requires_ordered_unique_dependencies() -> None:

--- a/backend/tests/resources/sleeper_data/test_identity_projections.py
+++ b/backend/tests/resources/sleeper_data/test_identity_projections.py
@@ -1,0 +1,261 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.sleeper import (
+    ApiRequest as StoredApiRequest,
+    League,
+    LeagueUser,
+    NormalizedScope,
+    Player,
+    User,
+)
+from backend.database.sessions import SessionFactory
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
+from backend.resources.sleeper_data.requests import ApiRequestManager
+from backend.services.datalayer.contracts import NormalizationStatus
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_users_request,
+    build_player_catalog_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    LeagueEndpointRecords,
+    LeagueRecord,
+    LeagueUserRecord,
+    LeagueUsersEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    PlayerRecord,
+    UserRecord,
+)
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    manager_context,
+    record_complete_attempt,
+    seed_domain,
+    start_refresh,
+)
+
+
+def test_league_projection_upserts_matching_season_and_rejects_identity_drift(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    endpoint = build_league_request(domain.season_id, domain.sleeper_league_id)
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    good = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"version": 1}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        good.id,
+        LeagueEndpointRecords(
+            league=LeagueRecord(
+                sleeper_league_id=domain.sleeper_league_id,
+                name="Projection League",
+                season="2026",
+                sport="nfl",
+                scoring_settings={"bonus": 1.125},
+                roster_positions=("QB", "RB"),
+                provider_settings={"draft_rounds": 2},
+            )
+        ),
+    )
+    bad = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"version": 2},
+        requested_at=now + timedelta(seconds=1),
+    )
+    with pytest.raises(DatalayerScopeConflict, match="core season identity"):
+        normalized_scope_manager.apply_scope(
+            bad.id,
+            LeagueEndpointRecords(
+                league=LeagueRecord(
+                    sleeper_league_id="wrong-league",
+                    name="Bad League",
+                    season="2026",
+                    sport="nfl",
+                    scoring_settings={},
+                    roster_positions=(),
+                    provider_settings={},
+                )
+            ),
+        )
+
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                League.name,
+                League.roster_positions,
+                League.provider_settings,
+                League.source_api_request_id,
+            ).where(League.competition_season_id == domain.season_id)
+        ).one() == (
+            "Projection League",
+            ["QB", "RB"],
+            {"draft_rounds": 2},
+            good.id,
+        )
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.source_api_request_id).where(
+                    NormalizedScope.scope_key == endpoint.scope_key.value
+                )
+            )
+            == good.id
+        )
+        assert (
+            connection.scalar(
+                sa.select(StoredApiRequest.normalization_status).where(
+                    StoredApiRequest.id == bad.id
+                )
+            )
+            == NormalizationStatus.PENDING.value
+        )
+
+
+def test_league_users_replace_membership_but_order_global_profiles_across_competitions(
+    database_engine: Engine,
+    domain: Domain,
+    session_factory: SessionFactory,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    other = seed_domain(database_engine, label="Other")
+    other_context = manager_context(other)
+    other_refresh_manager = RefreshRunManager(session_factory, other_context)
+    other_request_manager = ApiRequestManager(session_factory, other_context)
+    other_scope_manager = NormalizedScopeManager(session_factory, other_context)
+    endpoint = build_league_users_request(domain.season_id, domain.sleeper_league_id)
+    other_endpoint = build_league_users_request(
+        other.season_id, other.sleeper_league_id
+    )
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    other_refresh = start_refresh(other_refresh_manager, other, other_endpoint)
+    now = datetime.now(UTC)
+    newer = record_complete_attempt(
+        other_request_manager,
+        other_refresh.id,
+        other_endpoint,
+        {"name": "new"},
+        requested_at=now + timedelta(seconds=2),
+    )
+    other_scope_manager.apply_scope(
+        newer.id,
+        LeagueUsersEndpointRecords(
+            users=(
+                UserRecord(sleeper_user_id="shared", display_name="New", metadata={}),
+            ),
+            league_users=(
+                LeagueUserRecord(sleeper_user_id="shared", team_name="B", metadata={}),
+            ),
+        ),
+    )
+    older = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"name": "old"}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        older.id,
+        LeagueUsersEndpointRecords(
+            users=(
+                UserRecord(sleeper_user_id="shared", display_name="Old", metadata={}),
+            ),
+            league_users=(
+                LeagueUserRecord(sleeper_user_id="shared", team_name="A", metadata={}),
+            ),
+        ),
+    )
+    empty = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        [],
+        requested_at=now + timedelta(seconds=3),
+    )
+    normalized_scope_manager.apply_scope(
+        empty.id, LeagueUsersEndpointRecords(users=(), league_users=())
+    )
+
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(User.display_name, User.source_api_request_id).where(
+                User.sleeper_user_id == "shared"
+            )
+        ).one() == ("New", newer.id)
+        assert connection.execute(
+            sa.select(
+                LeagueUser.competition_season_id,
+                LeagueUser.team_name,
+                LeagueUser.source_api_request_id,
+            )
+        ).all() == [(other.season_id, "B", newer.id)]
+
+
+def test_player_catalog_upserts_observed_players_without_deleting_omissions(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    first = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"version": 1}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        first.id,
+        PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="Before", metadata={}),
+                PlayerRecord(sleeper_player_id="p2", full_name="Omitted", metadata={}),
+            )
+        ),
+    )
+    second = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"version": 2},
+        requested_at=now + timedelta(seconds=1),
+    )
+    result = normalized_scope_manager.apply_scope(
+        second.id,
+        PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="After", metadata={}),
+            )
+        ),
+    )
+
+    assert result.normalized_row_count == 1
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                Player.sleeper_player_id,
+                Player.full_name,
+                Player.source_api_request_id,
+            ).order_by(Player.sleeper_player_id)
+        ).all() == [
+            ("p1", "After", second.id),
+            ("p2", "Omitted", first.id),
+        ]
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.normalized_row_count).where(
+                    NormalizedScope.scope_key == endpoint.scope_key.value
+                )
+            )
+            == 1
+        )

--- a/backend/tests/resources/sleeper_data/test_normalized_scope_manager.py
+++ b/backend/tests/resources/sleeper_data/test_normalized_scope_manager.py
@@ -1,0 +1,278 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.sleeper import (
+    ApiRequest as StoredApiRequest,
+    NormalizedScope,
+    Player,
+)
+from backend.database.sessions import SessionFactory
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
+from backend.resources.sleeper_data.requests import (
+    ApiRequestManager,
+    RecordApiAttempt,
+)
+from backend.services.datalayer.contracts import (
+    ApplyDisposition,
+    NormalizationStatus,
+)
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    DatalayerScopeConflict,
+)
+from backend.services.datalayer.sleeper.endpoints import (
+    build_nfl_state_request,
+    build_player_catalog_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    CompletenessFinding,
+    LeagueEndpointRecords,
+    LeagueRecord,
+    NflStateEndpointRecords,
+    NflStateRecord,
+    PlayerCatalogEndpointRecords,
+    PlayerRecord,
+)
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    manager_context,
+    record_complete_attempt,
+    seed_domain,
+    start_refresh,
+    successful_attempt,
+)
+
+
+def test_apply_scope_tracks_applied_identical_stale_and_replayed_observations(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    records = PlayerCatalogEndpointRecords(
+        players=(PlayerRecord(sleeper_player_id="p1", full_name="First", metadata={}),)
+    )
+    first = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"same": 1}, requested_at=now
+    )
+    identical = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"same": 1},
+        requested_at=now + timedelta(seconds=2),
+    )
+    stale = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"older": True},
+        requested_at=now + timedelta(seconds=1),
+    )
+
+    applied = normalized_scope_manager.apply_scope(first.id, records)
+    advanced = normalized_scope_manager.apply_scope(identical.id, records)
+    ignored = normalized_scope_manager.apply_scope(stale.id, records)
+    replayed = normalized_scope_manager.apply_scope(identical.id, records)
+
+    assert applied.disposition is ApplyDisposition.APPLIED
+    assert advanced.disposition is ApplyDisposition.IDENTICAL_HEAD_ADVANCED
+    assert ignored.disposition is ApplyDisposition.STALE_IGNORED
+    assert replayed.disposition is ApplyDisposition.ALREADY_APPLIED
+    assert not advanced.changed_current_view
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                NormalizedScope.source_api_request_id,
+                NormalizedScope.response_sha256,
+                NormalizedScope.normalized_row_count,
+            ).where(NormalizedScope.scope_key == endpoint.scope_key.value)
+        ).one() == (identical.id, identical.response_sha256, 1)
+        assert connection.execute(
+            sa.select(Player.full_name, Player.source_api_request_id).where(
+                Player.sleeper_player_id == "p1"
+            )
+        ).one() == ("First", first.id)
+        attempts = connection.execute(
+            sa.select(
+                StoredApiRequest.normalization_status,
+                StoredApiRequest.normalizer_version,
+            )
+            .where(StoredApiRequest.id.in_((first.id, identical.id, stale.id)))
+            .order_by(StoredApiRequest.requested_at)
+        ).all()
+        assert attempts == [
+            (NormalizationStatus.SUCCEEDED.value, "test-normalizer"),
+            (NormalizationStatus.SUCCEEDED.value, "test-normalizer"),
+            (NormalizationStatus.SUCCEEDED.value, "test-normalizer"),
+        ]
+
+
+def test_apply_scope_rejects_incomplete_mismatched_and_foreign_requests(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+    session_factory: SessionFactory,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    incomplete = request_manager.record_attempt(
+        RecordApiAttempt(
+            refresh_run_id=refresh.id,
+            attempt=successful_attempt(endpoint, {"partial": True}),
+            completeness=CompletenessFinding(
+                is_complete=False, reason="catalog_incomplete"
+            ),
+        )
+    )
+    with pytest.raises(DatalayerScopeConflict, match="eligible"):
+        normalized_scope_manager.apply_scope(
+            incomplete.id, PlayerCatalogEndpointRecords(players=())
+        )
+
+    complete = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"complete": True}
+    )
+    with pytest.raises(DatalayerScopeConflict, match="do not match"):
+        normalized_scope_manager.apply_scope(
+            complete.id,
+            LeagueEndpointRecords(
+                league=LeagueRecord(
+                    sleeper_league_id=domain.sleeper_league_id,
+                    name="Wrong endpoint",
+                    season="2026",
+                    sport="nfl",
+                    scoring_settings={},
+                    roster_positions=(),
+                    provider_settings={},
+                )
+            ),
+        )
+
+    other = seed_domain(database_engine, label="Other")
+    foreign_manager = NormalizedScopeManager(session_factory, manager_context(other))
+    with pytest.raises(DatalayerResourceNotFound):
+        foreign_manager.apply_scope(
+            complete.id, PlayerCatalogEndpointRecords(players=())
+        )
+
+    with database_engine.connect() as connection:
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(NormalizedScope))
+            == 0
+        )
+
+
+def test_concurrent_scope_claim_keeps_the_newest_observation(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    endpoint = build_player_catalog_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    now = datetime.now(UTC)
+    older = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"version": 1}, requested_at=now
+    )
+    newer = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoint,
+        {"version": 2},
+        requested_at=now + timedelta(seconds=1),
+    )
+    records = {
+        older.id: PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="Older", metadata={}),
+            )
+        ),
+        newer.id: PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="Newer", metadata={}),
+            )
+        ),
+    }
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(
+            executor.map(
+                lambda request_id: normalized_scope_manager.apply_scope(
+                    request_id, records[request_id]
+                ),
+                (newer.id, older.id),
+            )
+        )
+
+    assert all(
+        result.disposition in {ApplyDisposition.APPLIED, ApplyDisposition.STALE_IGNORED}
+        for result in outcomes
+    )
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(Player.full_name, Player.source_api_request_id).where(
+                Player.sleeper_player_id == "p1"
+            )
+        ).one() == ("Newer", newer.id)
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.source_api_request_id).where(
+                    NormalizedScope.scope_key == endpoint.scope_key.value
+                )
+            )
+            == newer.id
+        )
+
+
+def test_nfl_state_advances_only_observation_provenance(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    endpoint = build_nfl_state_request()
+    refresh = start_refresh(refresh_manager, domain, endpoint)
+    request = record_complete_attempt(
+        request_manager, refresh.id, endpoint, {"week": 4, "season": "2026"}
+    )
+    result = normalized_scope_manager.apply_scope(
+        request.id,
+        NflStateEndpointRecords(
+            state=NflStateRecord(
+                week=4,
+                season="2026",
+                provider_state={"display_week": 4},
+            )
+        ),
+    )
+
+    assert result.disposition is ApplyDisposition.APPLIED
+    assert result.normalized_row_count == 1
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                NormalizedScope.source_api_request_id,
+                NormalizedScope.normalized_row_count,
+            ).where(NormalizedScope.scope_key == endpoint.scope_key.value)
+        ).one() == (request.id, 1)
+        assert (
+            connection.scalar(
+                sa.select(StoredApiRequest.normalization_status).where(
+                    StoredApiRequest.id == request.id
+                )
+            )
+            == NormalizationStatus.SUCCEEDED.value
+        )

--- a/backend/tests/resources/sleeper_data/test_roster_pick_projections.py
+++ b/backend/tests/resources/sleeper_data/test_roster_pick_projections.py
@@ -1,0 +1,390 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from backend.database.models.sleeper import (
+    ApiRequest as StoredApiRequest,
+    DraftPick,
+    NormalizedScope,
+    Roster,
+    RosterManager,
+    RosterPlayer,
+)
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
+from backend.resources.sleeper_data.refreshes import RefreshRun, RefreshRunManager
+from backend.resources.sleeper_data.requests import ApiRequestManager
+from backend.services.datalayer.contracts import NormalizationStatus
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_rosters_request,
+    build_league_users_request,
+    build_player_catalog_request,
+    build_traded_picks_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    LeagueEndpointRecords,
+    LeagueRecord,
+    LeagueRostersEndpointRecords,
+    LeagueUserRecord,
+    LeagueUsersEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    PlayerRecord,
+    RosterManagerRecord,
+    RosterPlayerRecord,
+    RosterRecord,
+    TradedPickRecord,
+    TradedPicksEndpointRecords,
+    UserRecord,
+)
+from backend.services.datalayer.sleeper.responses import EndpointRequest
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    record_complete_attempt,
+    start_refresh,
+)
+
+
+def _roster_record(roster_id: str) -> RosterRecord:
+    return RosterRecord(
+        sleeper_roster_id=roster_id,
+        settings={},
+        metadata={},
+        wins=0,
+        losses=0,
+        ties=0,
+        points_for=Decimal(0),
+        points_against=Decimal(0),
+    )
+
+
+def _start_roster_refresh(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    *,
+    include_traded_picks: bool = False,
+) -> tuple[RefreshRun, tuple[EndpointRequest, ...]]:
+    endpoints = (
+        build_league_request(domain.season_id, domain.sleeper_league_id),
+        build_league_users_request(domain.season_id, domain.sleeper_league_id),
+        build_player_catalog_request(),
+        build_league_rosters_request(domain.season_id, domain.sleeper_league_id),
+    )
+    if include_traded_picks:
+        endpoints += (
+            build_traded_picks_request(domain.season_id, domain.sleeper_league_id),
+        )
+    return start_refresh(refresh_manager, domain, *endpoints), endpoints
+
+
+def _apply_roster_prerequisites(
+    domain: Domain,
+    request_manager: ApiRequestManager,
+    scope_manager: NormalizedScopeManager,
+    refresh: RefreshRun,
+    endpoints: tuple[EndpointRequest, ...],
+    now: datetime,
+) -> None:
+    league = record_complete_attempt(
+        request_manager, refresh.id, endpoints[0], {"league": 1}, requested_at=now
+    )
+    scope_manager.apply_scope(
+        league.id,
+        LeagueEndpointRecords(
+            league=LeagueRecord(
+                sleeper_league_id=domain.sleeper_league_id,
+                name="Roster League",
+                season="2026",
+                sport="nfl",
+                scoring_settings={},
+                roster_positions=("QB",),
+                provider_settings={"draft_rounds": 2},
+            )
+        ),
+    )
+    users = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[1],
+        {"users": 1},
+        requested_at=now + timedelta(milliseconds=1),
+    )
+    scope_manager.apply_scope(
+        users.id,
+        LeagueUsersEndpointRecords(
+            users=(
+                UserRecord(sleeper_user_id="u1", display_name="One", metadata={}),
+                UserRecord(sleeper_user_id="u2", display_name="Two", metadata={}),
+            ),
+            league_users=(
+                LeagueUserRecord(sleeper_user_id="u1", metadata={}),
+                LeagueUserRecord(sleeper_user_id="u2", metadata={}),
+            ),
+        ),
+    )
+    players = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[2],
+        {"players": 1},
+        requested_at=now + timedelta(milliseconds=2),
+    )
+    scope_manager.apply_scope(
+        players.id,
+        PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="One", metadata={}),
+            )
+        ),
+    )
+
+
+def test_rosters_replace_children_and_seed_three_year_pick_coordinates(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    refresh, endpoints = _start_roster_refresh(domain, refresh_manager)
+    now = datetime.now(UTC)
+    _apply_roster_prerequisites(
+        domain, request_manager, normalized_scope_manager, refresh, endpoints, now
+    )
+    first = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[3],
+        {"rosters": 1},
+        requested_at=now + timedelta(seconds=1),
+    )
+    first_result = normalized_scope_manager.apply_scope(
+        first.id,
+        LeagueRostersEndpointRecords(
+            rosters=(_roster_record("1"), _roster_record("2")),
+            managers=(
+                RosterManagerRecord(
+                    sleeper_roster_id="1",
+                    sleeper_user_id="u1",
+                    role="owner",
+                    source_order=0,
+                ),
+                RosterManagerRecord(
+                    sleeper_roster_id="2",
+                    sleeper_user_id="u2",
+                    role="owner",
+                    source_order=0,
+                ),
+            ),
+            players=(
+                RosterPlayerRecord(
+                    sleeper_roster_id="1", sleeper_player_id="p1", role="starter"
+                ),
+            ),
+        ),
+    )
+    second = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[3],
+        [],
+        requested_at=now + timedelta(seconds=2),
+    )
+    second_result = normalized_scope_manager.apply_scope(
+        second.id,
+        LeagueRostersEndpointRecords(
+            rosters=(_roster_record("2"),), managers=(), players=()
+        ),
+    )
+
+    assert (first_result.normalized_row_count, second_result.normalized_row_count) == (
+        5,
+        1,
+    )
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(Roster.season_roster_id, Roster.source_api_request_id)
+        ).all() == [(domain.roster_ids[1], second.id)]
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(RosterManager))
+            == 0
+        )
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(RosterPlayer)) == 0
+        )
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(DraftPick)) == 12
+        )
+
+
+def test_traded_picks_reset_and_reapply_complete_ownership_view(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    refresh, endpoints = _start_roster_refresh(
+        domain, refresh_manager, include_traded_picks=True
+    )
+    now = datetime.now(UTC)
+    _apply_roster_prerequisites(
+        domain, request_manager, normalized_scope_manager, refresh, endpoints, now
+    )
+    rosters = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[3],
+        {"rosters": 1},
+        requested_at=now + timedelta(seconds=1),
+    )
+    normalized_scope_manager.apply_scope(
+        rosters.id,
+        LeagueRostersEndpointRecords(
+            rosters=(_roster_record("1"), _roster_record("2")),
+            managers=(),
+            players=(),
+        ),
+    )
+    traded = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[4],
+        {"traded": 1},
+        requested_at=now + timedelta(seconds=2),
+    )
+    normalized_scope_manager.apply_scope(
+        traded.id,
+        TradedPicksEndpointRecords(
+            picks=(
+                TradedPickRecord(
+                    draft_season_year=2027,
+                    draft_round=1,
+                    original_sleeper_roster_id="1",
+                    current_owner_sleeper_roster_id="2",
+                ),
+            )
+        ),
+    )
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(DraftPick.current_franchise_id, DraftPick.source).where(
+                DraftPick.competition_id == domain.competition_id,
+                DraftPick.draft_season_year == 2027,
+                DraftPick.round == 1,
+                DraftPick.original_franchise_id == domain.franchise_ids[0],
+            )
+        ).one() == (domain.franchise_ids[1], "traded_pick")
+
+    empty = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[4],
+        [],
+        requested_at=now + timedelta(seconds=3),
+    )
+    normalized_scope_manager.apply_scope(empty.id, TradedPicksEndpointRecords(picks=()))
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                DraftPick.current_franchise_id,
+                DraftPick.source,
+                DraftPick.source_api_request_id,
+            ).where(
+                DraftPick.competition_id == domain.competition_id,
+                DraftPick.draft_season_year == 2027,
+                DraftPick.round == 1,
+                DraftPick.original_franchise_id == domain.franchise_ids[0],
+            )
+        ).one() == (domain.franchise_ids[0], "seeded", empty.id)
+
+
+def test_roster_constraint_failure_rolls_back_replacement_and_head(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    refresh, endpoints = _start_roster_refresh(domain, refresh_manager)
+    now = datetime.now(UTC)
+    _apply_roster_prerequisites(
+        domain, request_manager, normalized_scope_manager, refresh, endpoints, now
+    )
+    good = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[3],
+        {"version": 1},
+        requested_at=now + timedelta(seconds=1),
+    )
+    normalized_scope_manager.apply_scope(
+        good.id,
+        LeagueRostersEndpointRecords(
+            rosters=(_roster_record("1"),),
+            managers=(
+                RosterManagerRecord(
+                    sleeper_roster_id="1",
+                    sleeper_user_id="u1",
+                    role="owner",
+                    source_order=0,
+                ),
+            ),
+            players=(),
+        ),
+    )
+    bad = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        endpoints[3],
+        {"version": 2},
+        requested_at=now + timedelta(seconds=2),
+    )
+    with pytest.raises(IntegrityError):
+        normalized_scope_manager.apply_scope(
+            bad.id,
+            LeagueRostersEndpointRecords(
+                rosters=(_roster_record("1"),),
+                managers=(
+                    RosterManagerRecord(
+                        sleeper_roster_id="1",
+                        sleeper_user_id="u1",
+                        role="owner",
+                        source_order=0,
+                    ),
+                    RosterManagerRecord(
+                        sleeper_roster_id="1",
+                        sleeper_user_id="u2",
+                        role="owner",
+                        source_order=1,
+                    ),
+                ),
+                players=(),
+            ),
+        )
+
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(Roster.source_api_request_id, RosterManager.sleeper_user_id).join(
+                RosterManager, RosterManager.season_roster_id == Roster.season_roster_id
+            )
+        ).one() == (good.id, "u1")
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.source_api_request_id).where(
+                    NormalizedScope.scope_key == endpoints[3].scope_key.value
+                )
+            )
+            == good.id
+        )
+        assert (
+            connection.scalar(
+                sa.select(StoredApiRequest.normalization_status).where(
+                    StoredApiRequest.id == bad.id
+                )
+            )
+            == NormalizationStatus.PENDING.value
+        )

--- a/backend/tests/resources/sleeper_data/test_weekly_and_bracket_projections.py
+++ b/backend/tests/resources/sleeper_data/test_weekly_and_bracket_projections.py
@@ -1,0 +1,398 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.sleeper import (
+    ApiRequest as StoredApiRequest,
+    Matchup,
+    NormalizedScope,
+    PlayerPerformance,
+    PlayoffMatchup,
+    Transaction,
+    TransactionMove,
+)
+from backend.resources.sleeper_data.normalized_scopes import NormalizedScopeManager
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
+from backend.resources.sleeper_data.requests import ApiRequestManager
+from backend.services.datalayer.contracts import NormalizationStatus
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_rosters_request,
+    build_losers_bracket_request,
+    build_matchups_request,
+    build_player_catalog_request,
+    build_transactions_request,
+    build_winners_bracket_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    BracketMatchupRecord,
+    LeagueEndpointRecords,
+    LeagueRecord,
+    LeagueRostersEndpointRecords,
+    LosersBracketEndpointRecords,
+    MatchupRecord,
+    MatchupsEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    PlayerPerformanceRecord,
+    PlayerRecord,
+    RosterRecord,
+    TransactionMoveRecord,
+    TransactionRecord,
+    TransactionsEndpointRecords,
+    WinnersBracketEndpointRecords,
+)
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    record_complete_attempt,
+    start_refresh,
+)
+
+
+def _roster_record(roster_id: str) -> RosterRecord:
+    return RosterRecord(
+        sleeper_roster_id=roster_id,
+        settings={},
+        metadata={},
+        wins=0,
+        losses=0,
+        ties=0,
+        points_for=Decimal(0),
+        points_against=Decimal(0),
+    )
+
+
+def test_matchups_replace_exact_week_child_first_and_accept_complete_empty(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    catalog = build_player_catalog_request()
+    week_one = build_matchups_request(domain.season_id, domain.sleeper_league_id, 1)
+    week_two = build_matchups_request(domain.season_id, domain.sleeper_league_id, 2)
+    refresh = start_refresh(
+        refresh_manager, domain, catalog, week_one, week_two, requested_through_week=2
+    )
+    now = datetime.now(UTC)
+    player_request = record_complete_attempt(
+        request_manager, refresh.id, catalog, {"players": 1}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        player_request.id,
+        PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(sleeper_player_id="p1", full_name="One", metadata={}),
+            )
+        ),
+    )
+    week_requests = []
+    for week, endpoint in ((1, week_one), (2, week_two)):
+        request = record_complete_attempt(
+            request_manager,
+            refresh.id,
+            endpoint,
+            {"week": week},
+            requested_at=now + timedelta(seconds=week),
+        )
+        normalized_scope_manager.apply_scope(
+            request.id,
+            MatchupsEndpointRecords(
+                matchups=(
+                    MatchupRecord(
+                        week=week,
+                        sleeper_roster_id="1",
+                        sleeper_matchup_id=week,
+                        points=Decimal(10 + week),
+                    ),
+                ),
+                player_performances=(
+                    PlayerPerformanceRecord(
+                        week=week,
+                        sleeper_roster_id="1",
+                        sleeper_matchup_id=week,
+                        sleeper_player_id="p1",
+                        points=Decimal(week),
+                        role="starter",
+                    ),
+                ),
+            ),
+        )
+        week_requests.append(request)
+    empty = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        week_one,
+        [],
+        requested_at=now + timedelta(seconds=3),
+    )
+    result = normalized_scope_manager.apply_scope(
+        empty.id, MatchupsEndpointRecords(matchups=(), player_performances=())
+    )
+
+    assert result.normalized_row_count == 0
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(Matchup.week, Matchup.source_api_request_id)
+        ).all() == [(2, week_requests[1].id)]
+        assert connection.execute(
+            sa.select(PlayerPerformance.week, PlayerPerformance.source_api_request_id)
+        ).all() == [(2, week_requests[1].id)]
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.normalized_row_count).where(
+                    NormalizedScope.scope_key == week_one.scope_key.value
+                )
+            )
+            == 0
+        )
+
+
+def test_transactions_replace_exact_week_and_roll_back_invalid_pick_move(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    league = build_league_request(domain.season_id, domain.sleeper_league_id)
+    rosters = build_league_rosters_request(domain.season_id, domain.sleeper_league_id)
+    week_one = build_transactions_request(domain.season_id, domain.sleeper_league_id, 1)
+    week_two = build_transactions_request(domain.season_id, domain.sleeper_league_id, 2)
+    refresh = start_refresh(
+        refresh_manager,
+        domain,
+        league,
+        rosters,
+        week_one,
+        week_two,
+        requested_through_week=2,
+    )
+    now = datetime.now(UTC)
+    league_request = record_complete_attempt(
+        request_manager, refresh.id, league, {"league": 1}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        league_request.id,
+        LeagueEndpointRecords(
+            league=LeagueRecord(
+                sleeper_league_id=domain.sleeper_league_id,
+                name="Transaction League",
+                season="2026",
+                sport="nfl",
+                scoring_settings={},
+                roster_positions=(),
+                provider_settings={"draft_rounds": 1},
+            )
+        ),
+    )
+    roster_request = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        rosters,
+        {"rosters": 1},
+        requested_at=now + timedelta(milliseconds=1),
+    )
+    normalized_scope_manager.apply_scope(
+        roster_request.id,
+        LeagueRostersEndpointRecords(
+            rosters=(_roster_record("1"), _roster_record("2")),
+            managers=(),
+            players=(),
+        ),
+    )
+    good_requests = []
+    for week, endpoint in ((1, week_one), (2, week_two)):
+        request = record_complete_attempt(
+            request_manager,
+            refresh.id,
+            endpoint,
+            {"week": week},
+            requested_at=now + timedelta(seconds=week),
+        )
+        normalized_scope_manager.apply_scope(
+            request.id,
+            TransactionsEndpointRecords(
+                transactions=(
+                    TransactionRecord(
+                        week=week,
+                        sleeper_transaction_id=f"tx{week}",
+                        transaction_type="trade",
+                        settings={},
+                        metadata={},
+                    ),
+                ),
+                moves=(
+                    TransactionMoveRecord(
+                        sleeper_transaction_id=f"tx{week}",
+                        move_index=0,
+                        move_kind="pick",
+                        from_sleeper_roster_id="1",
+                        to_sleeper_roster_id="2",
+                        draft_season_year=2027,
+                        draft_round=1,
+                        original_sleeper_roster_id="1",
+                    ),
+                ),
+            ),
+        )
+        good_requests.append(request)
+    bad = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        week_one,
+        {"week": 1, "bad": True},
+        requested_at=now + timedelta(seconds=3),
+    )
+    with pytest.raises(DatalayerScopeConflict, match="seeded coordinates"):
+        normalized_scope_manager.apply_scope(
+            bad.id,
+            TransactionsEndpointRecords(
+                transactions=(
+                    TransactionRecord(
+                        week=1,
+                        sleeper_transaction_id="bad",
+                        transaction_type="trade",
+                        settings={},
+                        metadata={},
+                    ),
+                ),
+                moves=(
+                    TransactionMoveRecord(
+                        sleeper_transaction_id="bad",
+                        move_index=0,
+                        move_kind="pick",
+                        draft_season_year=2099,
+                        draft_round=1,
+                        original_sleeper_roster_id="1",
+                    ),
+                ),
+            ),
+        )
+
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                Transaction.week,
+                Transaction.sleeper_transaction_id,
+                Transaction.source_api_request_id,
+            ).order_by(Transaction.week)
+        ).all() == [
+            (1, "tx1", good_requests[0].id),
+            (2, "tx2", good_requests[1].id),
+        ]
+        assert (
+            connection.scalar(sa.select(sa.func.count()).select_from(TransactionMove))
+            == 2
+        )
+        assert (
+            connection.scalar(
+                sa.select(NormalizedScope.source_api_request_id).where(
+                    NormalizedScope.scope_key == week_one.scope_key.value
+                )
+            )
+            == good_requests[0].id
+        )
+        assert (
+            connection.scalar(
+                sa.select(StoredApiRequest.normalization_status).where(
+                    StoredApiRequest.id == bad.id
+                )
+            )
+            == NormalizationStatus.PENDING.value
+        )
+
+
+def test_playoff_brackets_replace_exact_kind(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> None:
+    winners = build_winners_bracket_request(domain.season_id, domain.sleeper_league_id)
+    losers = build_losers_bracket_request(domain.season_id, domain.sleeper_league_id)
+    refresh = start_refresh(refresh_manager, domain, winners, losers)
+    now = datetime.now(UTC)
+    winner_request = record_complete_attempt(
+        request_manager, refresh.id, winners, {"winners": 1}, requested_at=now
+    )
+    normalized_scope_manager.apply_scope(
+        winner_request.id,
+        WinnersBracketEndpointRecords(
+            matchups=(
+                BracketMatchupRecord(
+                    bracket_kind="winners",
+                    node_key="w1",
+                    round=1,
+                    t1_sleeper_roster_id="1",
+                    t2_sleeper_roster_id="2",
+                    winner_sleeper_roster_id="1",
+                    loser_sleeper_roster_id="2",
+                ),
+            )
+        ),
+    )
+    loser_request = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        losers,
+        {"losers": 1},
+        requested_at=now + timedelta(seconds=1),
+    )
+    normalized_scope_manager.apply_scope(
+        loser_request.id,
+        LosersBracketEndpointRecords(
+            matchups=(
+                BracketMatchupRecord(
+                    bracket_kind="losers",
+                    node_key="l1",
+                    round=1,
+                    t1_sleeper_roster_id="1",
+                    t2_sleeper_roster_id="2",
+                    winner_sleeper_roster_id="2",
+                    loser_sleeper_roster_id="1",
+                ),
+            )
+        ),
+    )
+    empty = record_complete_attempt(
+        request_manager,
+        refresh.id,
+        winners,
+        [],
+        requested_at=now + timedelta(seconds=2),
+    )
+    normalized_scope_manager.apply_scope(
+        empty.id, WinnersBracketEndpointRecords(matchups=())
+    )
+
+    with database_engine.connect() as connection:
+        assert connection.execute(
+            sa.select(
+                PlayoffMatchup.bracket_kind,
+                PlayoffMatchup.node_key,
+                PlayoffMatchup.winner_season_roster_id,
+                PlayoffMatchup.source_api_request_id,
+            )
+        ).all() == [("losers", "l1", domain.roster_ids[1], loser_request.id)]
+        assert connection.execute(
+            sa.select(
+                NormalizedScope.scope_key,
+                NormalizedScope.source_api_request_id,
+                NormalizedScope.normalized_row_count,
+            )
+            .where(
+                NormalizedScope.scope_key.in_(
+                    (winners.scope_key.value, losers.scope_key.value)
+                )
+            )
+            .order_by(NormalizedScope.scope_key)
+        ).all() == [
+            (losers.scope_key.value, loser_request.id, 1),
+            (winners.scope_key.value, empty.id, 0),
+        ]


### PR DESCRIPTION
## Summary

Add atomic normalized-scope application and explicit endpoint projection
writers on top of the Sleeper audit resources.

This is the second of three Layer 6 PRs. It owns normalized writes and
provenance heads, but intentionally excludes the current-data read managers.

## Changes

- Add `NormalizedScopeManager.apply_scope` as the sole projection transaction
  owner.
- Claim scope heads with PostgreSQL advisory locks and row locks.
- Protect newer heads from stale completion and advance identical newer
  provenance without rewriting current rows.
- Apply league, user, NFL-state, player, roster, draft-pick, matchup,
  transaction, and bracket endpoint records through session-scoped writers.
- Preserve endpoint-specific replacement/upsert behavior, global user ordering,
  draft-pick seeding, exact-week replacement, and complete-empty semantics.
- Roll back normalized rows, request metadata, and head movement together on
  identity, dependency, constraint, or projection failure.
- Define normalized row counts from endpoint records only, excluding auxiliary
  derived seed operations.

## Verification

- Projection tests: 13 added, 25 cumulative Sleeper resource tests passed.
- Every endpoint dispatch kind is covered using direct stored-row assertions;
  no future current-read manager is imported.
- Focused resource plus inherited datalayer suite: 264 passed, 1 expected
  Windows symbolic-link capability skip.
- Concurrency, stale/identical heads, exact empty replacement, cross-scope user
  ordering, draft-pick ownership, and rollback atomicity pass on PostgreSQL.
- Package compilation, formatting, line-length audit, and `git diff --check`:
  passed.

## Stack

- Parent: Sleeper refresh and request audits
- Next: latest current-data read managers
