### PR TITLE
feat(datalayer): add sleeper current reads

### DIFF
--- a/backend/resources/sleeper_data/__init__.py
+++ b/backend/resources/sleeper_data/__init__.py
@@ -1,10 +1,21 @@
-"""Typed Sleeper audit and normalized-scope resources."""
+"""Typed Sleeper resources, grouped by resource kind."""
 
 from backend.resources.sleeper_data.common import Page
+from backend.resources.sleeper_data.league_seasons import (
+    LeagueSeasonManager,
+    LeagueSeasonOverview,
+    SnapshotPlanningContext,
+)
+from backend.resources.sleeper_data.matchups import (
+    Matchup,
+    MatchupManager,
+    PlayerPerformance,
+)
 from backend.resources.sleeper_data.normalized_scopes import (
     ApplyResult,
     NormalizedScopeManager,
 )
+from backend.resources.sleeper_data.players import Player, PlayerManager, PlayerSearch
 from backend.resources.sleeper_data.refreshes import (
     PlannedEndpointScope,
     RefreshRun,
@@ -22,6 +33,18 @@ from backend.resources.sleeper_data.requests import (
     SnapshotCandidateQuery,
     VerifiedPayload,
 )
+from backend.resources.sleeper_data.rosters import (
+    RosterManager,
+    RosterManagerAssignment,
+    RosterPlayer,
+    SeasonRosterState,
+)
+from backend.resources.sleeper_data.transactions import (
+    Transaction,
+    TransactionManager,
+    TransactionMove,
+    TransactionQuery,
+)
 
 __all__ = [
     "ApiRequest",
@@ -29,15 +52,32 @@ __all__ = [
     "ApiRequestManager",
     "ApplyResult",
     "InlineVerifiedPayload",
+    "LeagueSeasonManager",
+    "LeagueSeasonOverview",
+    "Matchup",
+    "MatchupManager",
     "NormalizationRejection",
     "NormalizedScopeManager",
     "ObjectVerifiedPayload",
     "Page",
     "PlannedEndpointScope",
+    "Player",
+    "PlayerManager",
+    "PlayerPerformance",
+    "PlayerSearch",
     "RecordApiAttempt",
     "RefreshRun",
     "RefreshRunManager",
+    "RosterManager",
+    "RosterManagerAssignment",
+    "RosterPlayer",
+    "SeasonRosterState",
     "SnapshotCandidateQuery",
+    "SnapshotPlanningContext",
     "StartRefresh",
+    "Transaction",
+    "TransactionManager",
+    "TransactionMove",
+    "TransactionQuery",
     "VerifiedPayload",
 ]

--- a/backend/resources/sleeper_data/league_seasons/__init__.py
+++ b/backend/resources/sleeper_data/league_seasons/__init__.py
@@ -1,0 +1,11 @@
+from backend.resources.sleeper_data.league_seasons.manager import LeagueSeasonManager
+from backend.resources.sleeper_data.league_seasons.objects import (
+    LeagueSeasonOverview,
+    SnapshotPlanningContext,
+)
+
+__all__ = [
+    "LeagueSeasonManager",
+    "LeagueSeasonOverview",
+    "SnapshotPlanningContext",
+]

--- a/backend/resources/sleeper_data/league_seasons/manager.py
+++ b/backend/resources/sleeper_data/league_seasons/manager.py
@@ -1,0 +1,139 @@
+"""Competition-scoped Sleeper league-season reads."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.sleeper import League as StoredLeague
+from backend.database.models.sleeper import Roster as StoredRoster
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.common.codec import parse_jsonb_text
+from backend.resources.sleeper_data.league_seasons.objects import (
+    LeagueSeasonOverview,
+    SnapshotPlanningContext,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+
+
+class LeagueSeasonManager:
+    """Read latest league metadata for one competition's seasons."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def get_snapshot_planning_context(
+        self, competition_season_id: UUID
+    ) -> SnapshotPlanningContext:
+        with read_only_session(self._session_factory) as session:
+            season = session.scalar(
+                sa.select(CompetitionSeason).where(
+                    CompetitionSeason.id == competition_season_id,
+                    CompetitionSeason.competition_id == self._competition_id,
+                )
+            )
+            if season is None:
+                raise DatalayerResourceNotFound(
+                    "competition_season", str(competition_season_id)
+                )
+            league = session.get(StoredLeague, season.id)
+            if league is None:
+                raise DatalayerResourceNotFound(
+                    "league_season_overview", str(season.id)
+                )
+            raw_rounds = league.provider_settings.get("draft_rounds")
+            draft_rounds = (
+                raw_rounds
+                if isinstance(raw_rounds, int)
+                and not isinstance(raw_rounds, bool)
+                and raw_rounds >= 0
+                else 0
+            )
+            return SnapshotPlanningContext(
+                competition_id=self._competition_id,
+                competition_season_id=season.id,
+                sleeper_league_id=season.sleeper_league_id,
+                season_year=season.season_year,
+                playoff_start_week=league.playoff_start_week,
+                playoff_team_count=league.playoff_team_count,
+                draft_rounds=draft_rounds,
+                league_average_match=league.league_average_match,
+            )
+
+    def get_season_overview(self, season_id: UUID) -> LeagueSeasonOverview:
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(
+                sa.select(
+                    Competition,
+                    CompetitionSeason,
+                    StoredLeague,
+                    sa.cast(StoredLeague.scoring_settings, sa.Text).label(
+                        "scoring_text"
+                    ),
+                    sa.cast(StoredLeague.roster_positions, sa.Text).label(
+                        "positions_text"
+                    ),
+                    sa.cast(StoredLeague.provider_settings, sa.Text).label(
+                        "provider_text"
+                    ),
+                    sa.func.count(StoredRoster.season_roster_id),
+                )
+                .join(
+                    CompetitionSeason,
+                    CompetitionSeason.competition_id == Competition.id,
+                )
+                .join(
+                    StoredLeague,
+                    StoredLeague.competition_season_id == CompetitionSeason.id,
+                )
+                .outerjoin(
+                    StoredRoster,
+                    StoredRoster.competition_season_id == CompetitionSeason.id,
+                )
+                .where(
+                    Competition.id == self._competition_id,
+                    CompetitionSeason.id == season_id,
+                )
+                .group_by(
+                    Competition.id,
+                    CompetitionSeason.id,
+                    StoredLeague.competition_season_id,
+                )
+            ).one_or_none()
+            if row is None:
+                raise DatalayerResourceNotFound(
+                    "league_season_overview", str(season_id)
+                )
+            competition, season, league, scoring, positions, provider, roster_count = (
+                row
+            )
+            parsed_positions = parse_jsonb_text(positions)
+            if not isinstance(parsed_positions, list):
+                raise ValueError("stored roster positions are not a list")
+            return LeagueSeasonOverview(
+                competition_id=competition.id,
+                competition_season_id=season.id,
+                competition_name=competition.display_name,
+                sleeper_league_id=season.sleeper_league_id,
+                season_year=season.season_year,
+                sequence_number=season.sequence_number,
+                league_name=league.name,
+                status=league.status,
+                scoring_settings=cast(dict[str, Any], parse_jsonb_text(scoring)),
+                roster_positions=tuple(cast(list[str], parsed_positions)),
+                provider_settings=cast(dict[str, Any], parse_jsonb_text(provider)),
+                playoff_start_week=league.playoff_start_week,
+                playoff_team_count=league.playoff_team_count,
+                league_average_match=league.league_average_match,
+                roster_count=roster_count,
+                source_api_request_id=league.source_api_request_id,
+            )

--- a/backend/resources/sleeper_data/league_seasons/objects.py
+++ b/backend/resources/sleeper_data/league_seasons/objects.py
@@ -1,0 +1,40 @@
+"""Immutable Sleeper league-season read contracts."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel
+from backend.services.datalayer.canonical_json import JsonValue
+
+
+class SnapshotPlanningContext(ContractModel):
+    competition_id: UUID
+    competition_season_id: UUID
+    sleeper_league_id: str
+    season_year: int = Field(strict=True, ge=1900, le=9999)
+    playoff_start_week: int | None
+    playoff_team_count: int | None
+    draft_rounds: int = Field(strict=True, ge=0)
+    league_average_match: int | None
+
+
+class LeagueSeasonOverview(ContractModel):
+    competition_id: UUID
+    competition_season_id: UUID
+    competition_name: str
+    sleeper_league_id: str
+    season_year: int
+    sequence_number: int
+    league_name: str
+    status: str | None
+    scoring_settings: dict[str, JsonValue]
+    roster_positions: tuple[str, ...]
+    provider_settings: dict[str, JsonValue]
+    playoff_start_week: int | None
+    playoff_team_count: int | None
+    league_average_match: int | None
+    roster_count: int = Field(strict=True, ge=0)
+    source_api_request_id: UUID

--- a/backend/resources/sleeper_data/matchups/__init__.py
+++ b/backend/resources/sleeper_data/matchups/__init__.py
@@ -1,0 +1,4 @@
+from backend.resources.sleeper_data.matchups.manager import MatchupManager
+from backend.resources.sleeper_data.matchups.objects import Matchup, PlayerPerformance
+
+__all__ = ["Matchup", "MatchupManager", "PlayerPerformance"]

--- a/backend/resources/sleeper_data/matchups/manager.py
+++ b/backend/resources/sleeper_data/matchups/manager.py
@@ -1,0 +1,102 @@
+"""Competition-scoped current matchup reads."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.core import CompetitionSeason, Franchise, SeasonRoster
+from backend.database.models.sleeper import Matchup as StoredMatchup
+from backend.database.models.sleeper import Player as StoredPlayer
+from backend.database.models.sleeper import (
+    PlayerPerformance as StoredPlayerPerformance,
+)
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.matchups.objects import Matchup, PlayerPerformance
+from backend.services.datalayer.errors import (
+    DatalayerResourceNotFound,
+    InvalidDatalayerRequest,
+)
+
+
+class MatchupManager:
+    """Read latest matchup observations within one competition."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def list_matchups(self, season_id: UUID, week: int) -> tuple[Matchup, ...]:
+        if not 1 <= week <= 18:
+            raise InvalidDatalayerRequest("week must be between 1 and 18")
+        with read_only_session(self._session_factory) as session:
+            season_exists = session.scalar(
+                sa.select(sa.literal(True)).where(
+                    sa.exists().where(
+                        CompetitionSeason.id == season_id,
+                        CompetitionSeason.competition_id == self._competition_id,
+                    )
+                )
+            )
+            if not season_exists:
+                raise DatalayerResourceNotFound("competition_season", str(season_id))
+            matchup_rows = session.execute(
+                sa.select(StoredMatchup, SeasonRoster, Franchise)
+                .join(SeasonRoster, SeasonRoster.id == StoredMatchup.season_roster_id)
+                .join(Franchise, Franchise.id == SeasonRoster.franchise_id)
+                .where(
+                    StoredMatchup.competition_season_id == season_id,
+                    StoredMatchup.week == week,
+                )
+                .order_by(
+                    StoredMatchup.sleeper_matchup_id, SeasonRoster.sleeper_roster_id
+                )
+            ).all()
+            performance_rows = session.execute(
+                sa.select(StoredPlayerPerformance, StoredPlayer)
+                .join(
+                    StoredPlayer,
+                    StoredPlayer.sleeper_player_id
+                    == StoredPlayerPerformance.sleeper_player_id,
+                )
+                .where(
+                    StoredPlayerPerformance.competition_season_id == season_id,
+                    StoredPlayerPerformance.week == week,
+                )
+                .order_by(
+                    StoredPlayerPerformance.season_roster_id,
+                    StoredPlayerPerformance.sleeper_player_id,
+                )
+            ).all()
+            by_roster: dict[UUID, list[PlayerPerformance]] = defaultdict(list)
+            for performance, player in performance_rows:
+                by_roster[performance.season_roster_id].append(
+                    PlayerPerformance(
+                        sleeper_player_id=performance.sleeper_player_id,
+                        full_name=player.full_name,
+                        points=performance.points,
+                        role=cast(Any, performance.role),
+                    )
+                )
+            return tuple(
+                Matchup(
+                    season_roster_id=identity.id,
+                    sleeper_roster_id=identity.sleeper_roster_id,
+                    franchise_id=identity.franchise_id,
+                    franchise_name=franchise.display_name,
+                    week=stored.week,
+                    sleeper_matchup_id=stored.sleeper_matchup_id,
+                    points=stored.points,
+                    player_performances=tuple(by_roster[identity.id]),
+                    source_api_request_id=stored.source_api_request_id,
+                )
+                for stored, identity, franchise in matchup_rows
+            )

--- a/backend/resources/sleeper_data/matchups/objects.py
+++ b/backend/resources/sleeper_data/matchups/objects.py
@@ -1,0 +1,28 @@
+"""Immutable current matchup resource contracts."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from backend.resources._contracts import ContractModel
+
+
+class PlayerPerformance(ContractModel):
+    sleeper_player_id: str
+    full_name: str | None
+    points: Decimal
+    role: Literal["starter", "bench"]
+
+
+class Matchup(ContractModel):
+    season_roster_id: UUID
+    sleeper_roster_id: str
+    franchise_id: UUID
+    franchise_name: str
+    week: int
+    sleeper_matchup_id: int | None
+    points: Decimal
+    player_performances: tuple[PlayerPerformance, ...]
+    source_api_request_id: UUID

--- a/backend/resources/sleeper_data/players/__init__.py
+++ b/backend/resources/sleeper_data/players/__init__.py
@@ -1,0 +1,5 @@
+from backend.resources.sleeper_data.common.objects import Page
+from backend.resources.sleeper_data.players.manager import PlayerManager
+from backend.resources.sleeper_data.players.objects import Player, PlayerSearch
+
+__all__ = ["Page", "Player", "PlayerManager", "PlayerSearch"]

--- a/backend/resources/sleeper_data/players/codec.py
+++ b/backend/resources/sleeper_data/players/codec.py
@@ -1,0 +1,25 @@
+"""Player ORM-to-resource decoding."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from backend.database.models.sleeper import Player as StoredPlayer
+from backend.resources.sleeper_data.common.codec import parse_jsonb_text
+from backend.resources.sleeper_data.players.objects import Player
+
+
+def decode_player(stored: StoredPlayer, metadata_text: str) -> Player:
+    return Player(
+        sleeper_player_id=stored.sleeper_player_id,
+        full_name=stored.full_name,
+        position=stored.position,
+        nfl_team=stored.nfl_team,
+        active=stored.active,
+        status=stored.status,
+        injury_status=stored.injury_status,
+        age=stored.age,
+        years_experience=stored.years_experience,
+        metadata=cast(dict[str, Any], parse_jsonb_text(metadata_text)),
+        source_api_request_id=stored.source_api_request_id,
+    )

--- a/backend/resources/sleeper_data/players/manager.py
+++ b/backend/resources/sleeper_data/players/manager.py
@@ -1,0 +1,74 @@
+"""Global Sleeper player catalog reads."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import sqlalchemy as sa
+
+from backend.database.models.sleeper import Player as StoredPlayer
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.players.codec import decode_player
+from backend.resources.sleeper_data.players.objects import Page, Player, PlayerSearch
+
+
+class PlayerManager:
+    """Read the latest observed global player catalog."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        # Player catalog rows are global, but construction remains competition scoped
+        # so all resource managers share the same boundary contract.
+        self._competition_id = context.scope.competition_id
+
+    def search_players(self, query: PlayerSearch) -> Page[Player]:
+        with read_only_session(self._session_factory) as session:
+            predicates: list[Any] = []
+            if query.text is not None:
+                pattern = f"%{query.text.strip().casefold()}%"
+                predicates.append(sa.func.lower(StoredPlayer.full_name).like(pattern))
+            if query.position is not None:
+                predicates.append(
+                    sa.func.lower(StoredPlayer.position)
+                    == query.position.strip().casefold()
+                )
+            if query.nfl_team is not None:
+                predicates.append(
+                    sa.func.lower(StoredPlayer.nfl_team)
+                    == query.nfl_team.strip().casefold()
+                )
+            if query.active is not None:
+                predicates.append(StoredPlayer.active.is_(query.active))
+            where = sa.and_(*predicates) if predicates else sa.true()
+            total = session.scalar(
+                sa.select(sa.func.count()).select_from(StoredPlayer).where(where)
+            )
+            metadata_text = sa.cast(StoredPlayer.metadata_json, sa.Text).label(
+                "metadata_text"
+            )
+            rows = session.execute(
+                sa.select(
+                    StoredPlayer,
+                    metadata_text,
+                )
+                .where(where)
+                .order_by(
+                    sa.func.lower(StoredPlayer.full_name).nulls_last(),
+                    StoredPlayer.sleeper_player_id,
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return Page[Player](
+                items=tuple(
+                    decode_player(player, metadata) for player, metadata in rows
+                ),
+                total=cast(int, total),
+                limit=query.limit,
+                offset=query.offset,
+            )

--- a/backend/resources/sleeper_data/players/objects.py
+++ b/backend/resources/sleeper_data/players/objects.py
@@ -1,0 +1,42 @@
+"""Immutable player catalog resource contracts."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field, StrictBool, model_validator
+
+from backend.resources._contracts import ContractModel
+from backend.resources.sleeper_data.common.objects import Page
+from backend.services.datalayer.canonical_json import JsonValue
+
+
+class Player(ContractModel):
+    sleeper_player_id: str
+    full_name: str | None
+    position: str | None
+    nfl_team: str | None
+    active: bool | None
+    status: str | None
+    injury_status: str | None
+    age: int | None
+    years_experience: int | None
+    metadata: dict[str, JsonValue]
+    source_api_request_id: UUID
+
+
+class PlayerSearch(ContractModel):
+    text: str | None = None
+    position: str | None = None
+    nfl_team: str | None = None
+    active: StrictBool | None = None
+    limit: int = Field(default=50, strict=True, ge=1, le=200)
+    offset: int = Field(default=0, strict=True, ge=0)
+
+    @model_validator(mode="after")
+    def normalize_search(self) -> "PlayerSearch":
+        for name in ("text", "position", "nfl_team"):
+            value = getattr(self, name)
+            if value is not None and not value.strip():
+                raise ValueError(f"player search {name} must not be blank")
+        return self

--- a/backend/resources/sleeper_data/rosters/__init__.py
+++ b/backend/resources/sleeper_data/rosters/__init__.py
@@ -1,0 +1,13 @@
+from backend.resources.sleeper_data.rosters.manager import RosterManager
+from backend.resources.sleeper_data.rosters.objects import (
+    RosterManagerAssignment,
+    RosterPlayer,
+    SeasonRosterState,
+)
+
+__all__ = [
+    "RosterManager",
+    "RosterManagerAssignment",
+    "RosterPlayer",
+    "SeasonRosterState",
+]

--- a/backend/resources/sleeper_data/rosters/manager.py
+++ b/backend/resources/sleeper_data/rosters/manager.py
@@ -1,0 +1,128 @@
+"""Competition-scoped current roster reads."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.core import Franchise, SeasonRoster
+from backend.database.models.sleeper import Player as StoredPlayer
+from backend.database.models.sleeper import Roster as StoredRoster
+from backend.database.models.sleeper import RosterManager as StoredRosterManager
+from backend.database.models.sleeper import RosterPlayer as StoredRosterPlayer
+from backend.database.models.sleeper import User as StoredUser
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.common.codec import parse_jsonb_text
+from backend.resources.sleeper_data.players.codec import decode_player
+from backend.resources.sleeper_data.rosters.objects import (
+    RosterManagerAssignment,
+    RosterPlayer,
+    SeasonRosterState,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+
+
+class RosterManager:
+    """Read latest roster state within one competition."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def get_roster(self, season_roster_id: UUID) -> SeasonRosterState:
+        with read_only_session(self._session_factory) as session:
+            settings_text = sa.cast(StoredRoster.settings_json, sa.Text).label(
+                "settings_text"
+            )
+            metadata_text = sa.cast(StoredRoster.metadata_json, sa.Text).label(
+                "metadata_text"
+            )
+            row = session.execute(
+                sa.select(
+                    SeasonRoster,
+                    Franchise,
+                    StoredRoster,
+                    settings_text,
+                    metadata_text,
+                )
+                .join(Franchise, Franchise.id == SeasonRoster.franchise_id)
+                .join(StoredRoster, StoredRoster.season_roster_id == SeasonRoster.id)
+                .where(
+                    SeasonRoster.id == season_roster_id,
+                    SeasonRoster.competition_id == self._competition_id,
+                )
+            ).one_or_none()
+            if row is None:
+                raise DatalayerResourceNotFound("season_roster", str(season_roster_id))
+            identity, franchise, stored, settings, metadata = row
+            manager_rows = session.execute(
+                sa.select(StoredRosterManager, StoredUser)
+                .join(
+                    StoredUser,
+                    StoredUser.sleeper_user_id == StoredRosterManager.sleeper_user_id,
+                )
+                .where(StoredRosterManager.season_roster_id == identity.id)
+                .order_by(
+                    StoredRosterManager.source_order,
+                    StoredRosterManager.sleeper_user_id,
+                )
+            ).all()
+            player_order = (
+                StoredRosterPlayer.role,
+                StoredRosterPlayer.sleeper_player_id,
+            )
+            player_rows = session.execute(
+                sa.select(
+                    StoredRosterPlayer,
+                    StoredPlayer,
+                    sa.cast(StoredPlayer.metadata_json, sa.Text).label(
+                        "player_metadata_text"
+                    ),
+                )
+                .join(
+                    StoredPlayer,
+                    StoredPlayer.sleeper_player_id
+                    == StoredRosterPlayer.sleeper_player_id,
+                )
+                .where(StoredRosterPlayer.season_roster_id == identity.id)
+                .order_by(*player_order)
+            ).all()
+            return SeasonRosterState(
+                season_roster_id=identity.id,
+                competition_season_id=identity.competition_season_id,
+                franchise_id=identity.franchise_id,
+                sleeper_roster_id=identity.sleeper_roster_id,
+                franchise_name=franchise.display_name,
+                settings=cast(dict[str, Any], parse_jsonb_text(settings)),
+                metadata=cast(dict[str, Any], parse_jsonb_text(metadata)),
+                record_string=stored.record_string,
+                wins=stored.wins,
+                losses=stored.losses,
+                ties=stored.ties,
+                points_for=stored.points_for,
+                points_against=stored.points_against,
+                managers=tuple(
+                    RosterManagerAssignment(
+                        sleeper_user_id=manager.sleeper_user_id,
+                        display_name=user.display_name,
+                        role=cast(Any, manager.role),
+                        source_order=manager.source_order,
+                    )
+                    for manager, user in manager_rows
+                ),
+                players=tuple(
+                    RosterPlayer(
+                        player=decode_player(player, player_metadata),
+                        role=cast(Any, membership.role),
+                    )
+                    for membership, player, player_metadata in player_rows
+                ),
+                source_api_request_id=stored.source_api_request_id,
+            )

--- a/backend/resources/sleeper_data/rosters/objects.py
+++ b/backend/resources/sleeper_data/rosters/objects.py
@@ -1,0 +1,44 @@
+"""Immutable current roster resource contracts."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel
+from backend.resources.sleeper_data.players.objects import Player
+from backend.services.datalayer.canonical_json import JsonValue
+
+
+class RosterManagerAssignment(ContractModel):
+    sleeper_user_id: str
+    display_name: str
+    role: Literal["owner", "co_owner"]
+    source_order: int = Field(strict=True, ge=0)
+
+
+class RosterPlayer(ContractModel):
+    player: Player
+    role: Literal["starter", "bench", "taxi", "reserve", "ir", "unknown"]
+
+
+class SeasonRosterState(ContractModel):
+    season_roster_id: UUID
+    competition_season_id: UUID
+    franchise_id: UUID
+    sleeper_roster_id: str
+    franchise_name: str
+    settings: dict[str, JsonValue]
+    metadata: dict[str, JsonValue]
+    record_string: str | None
+    wins: int
+    losses: int
+    ties: int
+    points_for: Decimal | None
+    points_against: Decimal | None
+    managers: tuple[RosterManagerAssignment, ...]
+    players: tuple[RosterPlayer, ...]
+    source_api_request_id: UUID

--- a/backend/resources/sleeper_data/transactions/__init__.py
+++ b/backend/resources/sleeper_data/transactions/__init__.py
@@ -1,0 +1,13 @@
+from backend.resources.sleeper_data.transactions.manager import TransactionManager
+from backend.resources.sleeper_data.transactions.objects import (
+    Transaction,
+    TransactionMove,
+    TransactionQuery,
+)
+
+__all__ = [
+    "Transaction",
+    "TransactionManager",
+    "TransactionMove",
+    "TransactionQuery",
+]

--- a/backend/resources/sleeper_data/transactions/manager.py
+++ b/backend/resources/sleeper_data/transactions/manager.py
@@ -1,0 +1,130 @@
+"""Competition-scoped current transaction reads."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from backend.database.models.core import CompetitionSeason
+from backend.database.models.sleeper import DraftPick as StoredDraftPick
+from backend.database.models.sleeper import Transaction as StoredTransaction
+from backend.database.models.sleeper import TransactionMove as StoredTransactionMove
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.sleeper_data.common.codec import parse_jsonb_text
+from backend.resources.sleeper_data.transactions.objects import (
+    Transaction,
+    TransactionMove,
+    TransactionQuery,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+
+
+class TransactionManager:
+    """Read latest transaction observations within one competition."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def list_transactions(self, query: TransactionQuery) -> tuple[Transaction, ...]:
+        with read_only_session(self._session_factory) as session:
+            season_exists = session.scalar(
+                sa.select(sa.literal(True)).where(
+                    sa.exists().where(
+                        CompetitionSeason.id == query.competition_season_id,
+                        CompetitionSeason.competition_id == self._competition_id,
+                    )
+                )
+            )
+            if not season_exists:
+                raise DatalayerResourceNotFound(
+                    "competition_season", str(query.competition_season_id)
+                )
+            statement = sa.select(StoredTransaction).where(
+                StoredTransaction.competition_season_id == query.competition_season_id
+            )
+            if query.week is not None:
+                statement = statement.where(StoredTransaction.week == query.week)
+            if query.transaction_type is not None:
+                statement = statement.where(
+                    StoredTransaction.transaction_type == query.transaction_type
+                )
+            if query.status is not None:
+                statement = statement.where(StoredTransaction.status == query.status)
+            stored_transactions = session.scalars(
+                statement.order_by(
+                    StoredTransaction.week.desc(),
+                    StoredTransaction.sleeper_transaction_id,
+                )
+            ).all()
+            if not stored_transactions:
+                return ()
+            transaction_ids = [row.id for row in stored_transactions]
+            move_rows = session.execute(
+                sa.select(StoredTransactionMove, StoredDraftPick)
+                .outerjoin(
+                    StoredDraftPick,
+                    StoredDraftPick.id == StoredTransactionMove.draft_pick_id,
+                )
+                .where(StoredTransactionMove.transaction_id.in_(transaction_ids))
+                .order_by(
+                    StoredTransactionMove.transaction_id,
+                    StoredTransactionMove.move_index,
+                )
+            ).all()
+            by_transaction: dict[UUID, list[TransactionMove]] = defaultdict(list)
+            for move, pick in move_rows:
+                by_transaction[move.transaction_id].append(
+                    TransactionMove(
+                        move_index=move.move_index,
+                        move_kind=cast(Any, move.move_kind),
+                        from_season_roster_id=move.from_season_roster_id,
+                        to_season_roster_id=move.to_season_roster_id,
+                        sleeper_player_id=move.sleeper_player_id,
+                        draft_season_year=(
+                            None if pick is None else pick.draft_season_year
+                        ),
+                        draft_round=None if pick is None else pick.round,
+                        original_franchise_id=(
+                            None if pick is None else pick.original_franchise_id
+                        ),
+                        sleeper_pick_id=None if pick is None else pick.sleeper_pick_id,
+                        budget_amount=move.budget_amount,
+                    )
+                )
+            result: list[Transaction] = []
+            for stored in stored_transactions:
+                settings, metadata = session.execute(
+                    sa.select(
+                        sa.cast(StoredTransaction.settings_json, sa.Text).label(
+                            "settings_text"
+                        ),
+                        sa.cast(StoredTransaction.metadata_json, sa.Text).label(
+                            "metadata_text"
+                        ),
+                    ).where(StoredTransaction.id == stored.id)
+                ).one()
+                result.append(
+                    Transaction(
+                        id=stored.id,
+                        sleeper_transaction_id=stored.sleeper_transaction_id,
+                        competition_season_id=stored.competition_season_id,
+                        week=stored.week,
+                        transaction_type=stored.transaction_type,
+                        status=stored.status,
+                        provider_created_at_ms=stored.provider_created_at_ms,
+                        settings=cast(dict[str, Any], parse_jsonb_text(settings)),
+                        metadata=cast(dict[str, Any], parse_jsonb_text(metadata)),
+                        moves=tuple(by_transaction[stored.id]),
+                        source_api_request_id=stored.source_api_request_id,
+                    )
+                )
+            return tuple(result)

--- a/backend/resources/sleeper_data/transactions/objects.py
+++ b/backend/resources/sleeper_data/transactions/objects.py
@@ -1,0 +1,45 @@
+"""Immutable current transaction resource contracts."""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import Field
+
+from backend.resources._contracts import ContractModel
+from backend.services.datalayer.canonical_json import JsonValue
+
+
+class TransactionMove(ContractModel):
+    move_index: int
+    move_kind: Literal["player", "pick"]
+    from_season_roster_id: UUID | None
+    to_season_roster_id: UUID | None
+    sleeper_player_id: str | None
+    draft_season_year: int | None
+    draft_round: int | None
+    original_franchise_id: UUID | None
+    sleeper_pick_id: str | None
+    budget_amount: int | None
+
+
+class Transaction(ContractModel):
+    id: UUID
+    sleeper_transaction_id: str
+    competition_season_id: UUID
+    week: int
+    transaction_type: str
+    status: str | None
+    provider_created_at_ms: int | None
+    settings: dict[str, JsonValue]
+    metadata: dict[str, JsonValue]
+    moves: tuple[TransactionMove, ...]
+    source_api_request_id: UUID
+
+
+class TransactionQuery(ContractModel):
+    competition_season_id: UUID
+    week: int | None = Field(default=None, strict=True, ge=1, le=18)
+    transaction_type: str | None = None
+    status: str | None = None

--- a/backend/tests/resources/sleeper_data/conftest.py
+++ b/backend/tests/resources/sleeper_data/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 import hashlib
 from uuid import UUID, uuid4
 
@@ -43,7 +44,34 @@ from backend.services.datalayer.sleeper.responses import (
     SanitizedSourceError,
     SuccessfulSourceAttempt,
 )
-from backend.services.datalayer.sleeper.endpoints.contracts import CompletenessFinding
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_rosters_request,
+    build_league_users_request,
+    build_matchups_request,
+    build_player_catalog_request,
+    build_transactions_request,
+)
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    CompletenessFinding,
+    LeagueEndpointRecords,
+    LeagueRecord,
+    LeagueRostersEndpointRecords,
+    LeagueUserRecord,
+    LeagueUsersEndpointRecords,
+    MatchupRecord,
+    MatchupsEndpointRecords,
+    PlayerCatalogEndpointRecords,
+    PlayerPerformanceRecord,
+    PlayerRecord,
+    RosterManagerRecord,
+    RosterPlayerRecord,
+    RosterRecord,
+    TransactionMoveRecord,
+    TransactionRecord,
+    TransactionsEndpointRecords,
+    UserRecord,
+)
 from backend.tests.database.conftest import database_engine, migrated_database
 
 
@@ -68,6 +96,24 @@ class Domain:
     sleeper_league_id: str
     franchise_ids: tuple[UUID, UUID]
     roster_ids: tuple[UUID, UUID]
+
+
+@dataclass(frozen=True)
+class ProjectedSeason:
+    """Representative current state shared by resource read-manager tests."""
+
+    domain: Domain
+    refresh_run_id: UUID
+    league_request_id: UUID
+    users_request_id: UUID
+    player_request_id: UUID
+    roster_request_id: UUID
+    matchup_request_id: UUID
+    transaction_request_id: UUID
+    week: int
+    user_ids: tuple[str, str]
+    player_ids: tuple[str, str, str, str]
+    sleeper_transaction_id: str
 
 
 def seed_domain(database_engine: Engine, *, label: str = "Sleeper Resource") -> Domain:
@@ -254,6 +300,260 @@ def normalized_scope_manager(
     domain: Domain,
 ) -> NormalizedScopeManager:
     return NormalizedScopeManager(session_factory, manager_context(domain))
+
+
+@pytest.fixture
+def projected_season(
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    normalized_scope_manager: NormalizedScopeManager,
+) -> ProjectedSeason:
+    """Apply a small, complete league graph through the public write boundary."""
+
+    week = 1
+    endpoints = (
+        build_league_request(domain.season_id, domain.sleeper_league_id),
+        build_league_users_request(domain.season_id, domain.sleeper_league_id),
+        build_player_catalog_request(),
+        build_league_rosters_request(domain.season_id, domain.sleeper_league_id),
+        build_matchups_request(domain.season_id, domain.sleeper_league_id, week),
+        build_transactions_request(domain.season_id, domain.sleeper_league_id, week),
+    )
+    refresh = start_refresh(
+        refresh_manager,
+        domain,
+        *endpoints,
+        requested_through_week=week,
+    )
+    now = datetime.now(UTC)
+    requests = tuple(
+        record_complete_attempt(
+            request_manager,
+            refresh.id,
+            endpoint,
+            {"fixture_scope": index},
+            requested_at=now + timedelta(milliseconds=index),
+        )
+        for index, endpoint in enumerate(endpoints)
+    )
+    normalized_scope_manager.apply_scope(
+        requests[0].id,
+        LeagueEndpointRecords(
+            league=LeagueRecord(
+                sleeper_league_id=domain.sleeper_league_id,
+                name="Projected League",
+                status="in_season",
+                season="2026",
+                sport="nfl",
+                scoring_settings={"passing_bonus": Decimal("1.125")},
+                roster_positions=("QB", "RB"),
+                provider_settings={"draft_rounds": 2},
+                playoff_start_week=15,
+                playoff_team_count=2,
+                league_average_match=1,
+            )
+        ),
+    )
+    normalized_scope_manager.apply_scope(
+        requests[1].id,
+        LeagueUsersEndpointRecords(
+            users=(
+                UserRecord(
+                    sleeper_user_id="u1",
+                    display_name="Manager One",
+                    metadata={"rank": 1},
+                ),
+                UserRecord(
+                    sleeper_user_id="u2",
+                    display_name="Manager Two",
+                    metadata={"rank": 2},
+                ),
+            ),
+            league_users=(
+                LeagueUserRecord(
+                    sleeper_user_id="u1",
+                    team_name="Alpha Team",
+                    is_commissioner=True,
+                    metadata={},
+                ),
+                LeagueUserRecord(
+                    sleeper_user_id="u2",
+                    team_name="Beta Team",
+                    metadata={},
+                ),
+            ),
+        ),
+    )
+    normalized_scope_manager.apply_scope(
+        requests[2].id,
+        PlayerCatalogEndpointRecords(
+            players=(
+                PlayerRecord(
+                    sleeper_player_id="p1",
+                    full_name="Alpha Quarterback",
+                    position="QB",
+                    nfl_team="SEA",
+                    active=True,
+                    status="Active",
+                    age=25,
+                    years_experience=3,
+                    metadata={"rating": Decimal("9.75")},
+                ),
+                PlayerRecord(
+                    sleeper_player_id="p2",
+                    full_name="Beta Runner",
+                    position="RB",
+                    nfl_team="SF",
+                    active=True,
+                    status="Active",
+                    metadata={"rating": Decimal("8.5")},
+                ),
+                PlayerRecord(
+                    sleeper_player_id="p3",
+                    full_name="Beta Runner",
+                    position="RB",
+                    nfl_team="SEA",
+                    active=False,
+                    status="Inactive",
+                    metadata={},
+                ),
+                PlayerRecord(
+                    sleeper_player_id="p4",
+                    full_name=None,
+                    position="QB",
+                    nfl_team="SEA",
+                    active=True,
+                    metadata={},
+                ),
+            )
+        ),
+    )
+    normalized_scope_manager.apply_scope(
+        requests[3].id,
+        LeagueRostersEndpointRecords(
+            rosters=(
+                RosterRecord(
+                    sleeper_roster_id="1",
+                    settings={"waiver_position": 1},
+                    metadata={"streak": "W2"},
+                    record_string="2-0",
+                    wins=2,
+                    losses=0,
+                    ties=0,
+                    points_for=Decimal("200.75"),
+                    points_against=Decimal("180.5"),
+                ),
+                RosterRecord(
+                    sleeper_roster_id="2",
+                    settings={"waiver_position": 2},
+                    metadata={"streak": "L2"},
+                    record_string="0-2",
+                    wins=0,
+                    losses=2,
+                    ties=0,
+                    points_for=Decimal("150.5"),
+                    points_against=Decimal("190.25"),
+                ),
+            ),
+            managers=(
+                RosterManagerRecord(
+                    sleeper_roster_id="1",
+                    sleeper_user_id="u1",
+                    role="owner",
+                    source_order=0,
+                ),
+                RosterManagerRecord(
+                    sleeper_roster_id="2",
+                    sleeper_user_id="u2",
+                    role="owner",
+                    source_order=0,
+                ),
+            ),
+            players=(
+                RosterPlayerRecord(
+                    sleeper_roster_id="1",
+                    sleeper_player_id="p1",
+                    role="starter",
+                ),
+                RosterPlayerRecord(
+                    sleeper_roster_id="2",
+                    sleeper_player_id="p2",
+                    role="starter",
+                ),
+            ),
+        ),
+    )
+    normalized_scope_manager.apply_scope(
+        requests[4].id,
+        MatchupsEndpointRecords(
+            matchups=(
+                MatchupRecord(
+                    week=week,
+                    sleeper_roster_id="1",
+                    sleeper_matchup_id=1,
+                    points=Decimal("101.5"),
+                ),
+                MatchupRecord(
+                    week=week,
+                    sleeper_roster_id="2",
+                    sleeper_matchup_id=1,
+                    points=Decimal("87.25"),
+                ),
+            ),
+            player_performances=(
+                PlayerPerformanceRecord(
+                    week=week,
+                    sleeper_roster_id="1",
+                    sleeper_matchup_id=1,
+                    sleeper_player_id="p1",
+                    points=Decimal("25.125"),
+                    role="starter",
+                ),
+            ),
+        ),
+    )
+    normalized_scope_manager.apply_scope(
+        requests[5].id,
+        TransactionsEndpointRecords(
+            transactions=(
+                TransactionRecord(
+                    week=week,
+                    sleeper_transaction_id="tx1",
+                    transaction_type="trade",
+                    status="complete",
+                    provider_created_at_ms=123456,
+                    settings={"waiver_bid": Decimal("3.5")},
+                    metadata={"note": "fixture"},
+                ),
+            ),
+            moves=(
+                TransactionMoveRecord(
+                    sleeper_transaction_id="tx1",
+                    move_index=0,
+                    move_kind="player",
+                    from_sleeper_roster_id="1",
+                    to_sleeper_roster_id="2",
+                    sleeper_player_id="p2",
+                ),
+            ),
+        ),
+    )
+    refresh_manager.finish_refresh(refresh.id)
+    return ProjectedSeason(
+        domain=domain,
+        refresh_run_id=refresh.id,
+        league_request_id=requests[0].id,
+        users_request_id=requests[1].id,
+        player_request_id=requests[2].id,
+        roster_request_id=requests[3].id,
+        matchup_request_id=requests[4].id,
+        transaction_request_id=requests[5].id,
+        week=week,
+        user_ids=("u1", "u2"),
+        player_ids=("p1", "p2", "p3", "p4"),
+        sleeper_transaction_id="tx1",
+    )
 
 
 @pytest.fixture

--- a/backend/tests/resources/sleeper_data/test_current_objects.py
+++ b/backend/tests/resources/sleeper_data/test_current_objects.py
@@ -1,0 +1,54 @@
+import pytest
+from pydantic import ValidationError
+
+import backend.resources.sleeper_data as sleeper_data
+from backend.resources.sleeper_data import (
+    ApiRequestManager,
+    LeagueSeasonManager,
+    MatchupManager,
+    NormalizedScopeManager,
+    PlayerManager,
+    PlayerSearch,
+    RefreshRunManager,
+    RosterManager,
+    TransactionManager,
+)
+
+
+def test_all_resource_managers_are_exported_from_distinct_owning_modules() -> None:
+    managers = (
+        RefreshRunManager,
+        ApiRequestManager,
+        NormalizedScopeManager,
+        LeagueSeasonManager,
+        RosterManager,
+        MatchupManager,
+        TransactionManager,
+        PlayerManager,
+    )
+    exported_managers = {
+        name: getattr(sleeper_data, name)
+        for name in sleeper_data.__all__
+        if name.endswith("Manager")
+    }
+
+    assert set(exported_managers.values()) == set(managers)
+    assert len({manager.__module__ for manager in managers}) == len(managers)
+    assert all(manager.__module__.endswith(".manager") for manager in managers)
+    assert "SleeperDataManager" not in sleeper_data.__all__
+    assert not hasattr(sleeper_data, "SleeperDataManager")
+
+
+@pytest.mark.parametrize("field", ("text", "position", "nfl_team"))
+def test_player_search_rejects_blank_filters(field: str) -> None:
+    with pytest.raises(ValidationError, match="must not be blank"):
+        PlayerSearch(**{field: " "})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("limit", 0), ("limit", 201), ("offset", -1)),
+)
+def test_player_search_rejects_unsafe_pagination(field: str, value: int) -> None:
+    with pytest.raises(ValidationError):
+        PlayerSearch(**{field: value})

--- a/backend/tests/resources/sleeper_data/test_league_season_manager.py
+++ b/backend/tests/resources/sleeper_data/test_league_season_manager.py
@@ -1,0 +1,82 @@
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory
+from backend.resources.sleeper_data.league_seasons import (
+    LeagueSeasonManager,
+    LeagueSeasonOverview,
+    SnapshotPlanningContext,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+from backend.tests.resources.sleeper_data.conftest import (
+    ProjectedSeason,
+    manager_context,
+    seed_domain,
+)
+
+
+def test_snapshot_planning_context_uses_latest_league_metadata(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    domain = projected_season.domain
+    manager = LeagueSeasonManager(session_factory, manager_context(domain))
+
+    context = manager.get_snapshot_planning_context(domain.season_id)
+
+    assert isinstance(context, SnapshotPlanningContext)
+    assert context.model_dump() == {
+        "competition_id": domain.competition_id,
+        "competition_season_id": domain.season_id,
+        "sleeper_league_id": domain.sleeper_league_id,
+        "season_year": 2026,
+        "playoff_start_week": 15,
+        "playoff_team_count": 2,
+        "draft_rounds": 2,
+        "league_average_match": 1,
+    }
+
+
+def test_season_overview_preserves_decimal_json_and_counts_current_rosters(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    domain = projected_season.domain
+    manager = LeagueSeasonManager(session_factory, manager_context(domain))
+
+    overview = manager.get_season_overview(domain.season_id)
+
+    assert isinstance(overview, LeagueSeasonOverview)
+    assert overview.competition_id == domain.competition_id
+    assert overview.competition_season_id == domain.season_id
+    assert overview.competition_name == "Sleeper Resource League"
+    assert overview.league_name == "Projected League"
+    assert overview.status == "in_season"
+    assert overview.scoring_settings == {"passing_bonus": Decimal("1.125")}
+    assert overview.roster_positions == ("QB", "RB")
+    assert overview.provider_settings == {"draft_rounds": 2}
+    assert overview.roster_count == 2
+    assert overview.source_api_request_id == projected_season.league_request_id
+
+
+def test_league_season_reads_enforce_competition_scope_and_not_found(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    other = seed_domain(database_engine, label="Other")
+    other_manager = LeagueSeasonManager(session_factory, manager_context(other))
+
+    with pytest.raises(DatalayerResourceNotFound, match="competition_season"):
+        other_manager.get_snapshot_planning_context(projected_season.domain.season_id)
+    with pytest.raises(DatalayerResourceNotFound, match="league_season_overview"):
+        other_manager.get_snapshot_planning_context(other.season_id)
+    with pytest.raises(DatalayerResourceNotFound, match="league_season_overview"):
+        other_manager.get_season_overview(other.season_id)
+    with pytest.raises(DatalayerResourceNotFound, match="league_season_overview"):
+        LeagueSeasonManager(
+            session_factory, manager_context(projected_season.domain)
+        ).get_season_overview(uuid4())

--- a/backend/tests/resources/sleeper_data/test_matchup_manager.py
+++ b/backend/tests/resources/sleeper_data/test_matchup_manager.py
@@ -1,0 +1,94 @@
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.sleeper_data.matchups import (
+    Matchup,
+    MatchupManager,
+    PlayerPerformance,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+from backend.tests.resources.sleeper_data.conftest import (
+    ProjectedSeason,
+    manager_context,
+    seed_domain,
+)
+
+
+def test_matchup_read_returns_exact_week_with_typed_player_performances(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = MatchupManager(
+        session_factory,
+        manager_context(projected_season.domain),
+    )
+
+    matchups = manager.list_matchups(
+        projected_season.domain.season_id,
+        projected_season.week,
+    )
+
+    assert len(matchups) == 2
+    assert all(isinstance(matchup, Matchup) for matchup in matchups)
+    by_roster = {matchup.sleeper_roster_id: matchup for matchup in matchups}
+    first = by_roster["1"]
+    second = by_roster["2"]
+    assert first.season_roster_id == projected_season.domain.roster_ids[0]
+    assert first.franchise_id == projected_season.domain.franchise_ids[0]
+    assert first.franchise_name == "Sleeper Resource Team 1"
+    assert first.week == projected_season.week
+    assert first.sleeper_matchup_id == 1
+    assert first.points == Decimal("101.5000")
+    assert first.source_api_request_id == projected_season.matchup_request_id
+    assert first.player_performances == (
+        PlayerPerformance(
+            sleeper_player_id=projected_season.player_ids[0],
+            full_name="Alpha Quarterback",
+            points=Decimal("25.1250"),
+            role="starter",
+        ),
+    )
+    assert second.season_roster_id == projected_season.domain.roster_ids[1]
+    assert second.franchise_id == projected_season.domain.franchise_ids[1]
+    assert second.points == Decimal("87.2500")
+    assert second.player_performances == ()
+    assert second.source_api_request_id == projected_season.matchup_request_id
+
+    assert (
+        manager.list_matchups(
+            projected_season.domain.season_id,
+            projected_season.week + 1,
+        )
+        == ()
+    )
+    with pytest.raises(ValidationError, match="frozen"):
+        setattr(first, "points", Decimal("0"))
+
+
+def test_matchup_read_reports_not_found_and_enforces_competition_scope(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = MatchupManager(
+        session_factory,
+        manager_context(projected_season.domain),
+    )
+    other_domain = seed_domain(database_engine, label="Other")
+    other_manager = MatchupManager(
+        create_session_factory(database_engine),
+        manager_context(other_domain),
+    )
+
+    with pytest.raises(DatalayerResourceNotFound, match="competition_season"):
+        manager.list_matchups(uuid4(), projected_season.week)
+    with pytest.raises(DatalayerResourceNotFound, match="competition_season"):
+        other_manager.list_matchups(
+            projected_season.domain.season_id,
+            projected_season.week,
+        )

--- a/backend/tests/resources/sleeper_data/test_player_manager.py
+++ b/backend/tests/resources/sleeper_data/test_player_manager.py
@@ -1,0 +1,80 @@
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory
+from backend.resources.sleeper_data.players import Player, PlayerManager, PlayerSearch
+from backend.tests.resources.sleeper_data.conftest import (
+    ProjectedSeason,
+    manager_context,
+    seed_domain,
+)
+
+
+def test_player_search_applies_case_insensitive_filters_and_preserves_decimal_json(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = PlayerManager(session_factory, manager_context(projected_season.domain))
+
+    by_name = manager.search_players(PlayerSearch(text=" QUARTER "))
+    filtered = manager.search_players(
+        PlayerSearch(position=" rb ", nfl_team=" sea ", active=False)
+    )
+
+    assert by_name.total == 1
+    assert isinstance(by_name.items[0], Player)
+    assert by_name.items[0].sleeper_player_id == "p1"
+    assert by_name.items[0].metadata == {"rating": Decimal("9.75")}
+    assert by_name.items[0].source_api_request_id == projected_season.player_request_id
+    assert [player.sleeper_player_id for player in filtered.items] == ["p3"]
+
+
+def test_player_search_orders_and_paginates_global_catalog(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = PlayerManager(session_factory, manager_context(projected_season.domain))
+
+    page = manager.search_players(PlayerSearch(limit=2, offset=1))
+
+    assert (page.total, page.limit, page.offset) == (4, 2, 1)
+    assert [player.sleeper_player_id for player in page.items] == ["p2", "p3"]
+    assert [player.full_name for player in page.items] == [
+        "Beta Runner",
+        "Beta Runner",
+    ]
+
+    other = seed_domain(database_engine, label="Other")
+    global_page = PlayerManager(session_factory, manager_context(other)).search_players(
+        PlayerSearch(limit=200)
+    )
+    assert global_page.total == 4
+    assert [player.sleeper_player_id for player in global_page.items] == [
+        "p1",
+        "p2",
+        "p3",
+        "p4",
+    ]
+
+
+@pytest.mark.parametrize(
+    "values",
+    (
+        {"text": " "},
+        {"position": "\t"},
+        {"nfl_team": ""},
+        {"limit": 0},
+        {"limit": 201},
+        {"offset": -1},
+        {"active": 1},
+    ),
+)
+def test_player_search_rejects_invalid_filters_and_pagination(
+    values: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        PlayerSearch.model_validate(values)

--- a/backend/tests/resources/sleeper_data/test_roster_manager.py
+++ b/backend/tests/resources/sleeper_data/test_roster_manager.py
@@ -1,0 +1,100 @@
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.sleeper_data.players.objects import Player
+from backend.resources.sleeper_data.rosters import (
+    RosterManager,
+    RosterManagerAssignment,
+    RosterPlayer,
+    SeasonRosterState,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+from backend.tests.resources.sleeper_data.conftest import (
+    ProjectedSeason,
+    manager_context,
+    seed_domain,
+)
+
+
+def test_roster_read_hydrates_frozen_nested_resources_and_decimal_json(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = RosterManager(
+        session_factory,
+        manager_context(projected_season.domain),
+    )
+
+    roster = manager.get_roster(projected_season.domain.roster_ids[0])
+
+    assert isinstance(roster, SeasonRosterState)
+    assert roster.season_roster_id == projected_season.domain.roster_ids[0]
+    assert roster.competition_season_id == projected_season.domain.season_id
+    assert roster.franchise_id == projected_season.domain.franchise_ids[0]
+    assert roster.sleeper_roster_id == "1"
+    assert roster.franchise_name == "Sleeper Resource Team 1"
+    assert roster.settings == {"waiver_position": 1}
+    assert roster.metadata == {"streak": "W2"}
+    assert (roster.record_string, roster.wins, roster.losses, roster.ties) == (
+        "2-0",
+        2,
+        0,
+        0,
+    )
+    assert roster.points_for == Decimal("200.7500")
+    assert roster.points_against == Decimal("180.5000")
+    assert roster.source_api_request_id == projected_season.roster_request_id
+
+    assert roster.managers == (
+        RosterManagerAssignment(
+            sleeper_user_id=projected_season.user_ids[0],
+            display_name="Manager One",
+            role="owner",
+            source_order=0,
+        ),
+    )
+    assert len(roster.players) == 1
+    membership = roster.players[0]
+    assert isinstance(membership, RosterPlayer)
+    assert membership.role == "starter"
+    assert isinstance(membership.player, Player)
+    assert membership.player.sleeper_player_id == projected_season.player_ids[0]
+    assert membership.player.full_name == "Alpha Quarterback"
+    assert membership.player.position == "QB"
+    assert membership.player.nfl_team == "SEA"
+    assert membership.player.active is True
+    assert membership.player.age == 25
+    assert membership.player.years_experience == 3
+    assert membership.player.metadata == {"rating": Decimal("9.75")}
+    assert membership.player.source_api_request_id == projected_season.player_request_id
+
+    with pytest.raises(ValidationError, match="frozen"):
+        setattr(roster, "wins", 99)
+    with pytest.raises(ValidationError, match="frozen"):
+        setattr(membership.player, "full_name", "Changed")
+
+
+def test_roster_read_reports_not_found_and_enforces_competition_scope(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    manager = RosterManager(
+        session_factory,
+        manager_context(projected_season.domain),
+    )
+    other_domain = seed_domain(database_engine, label="Other")
+    other_manager = RosterManager(
+        create_session_factory(database_engine),
+        manager_context(other_domain),
+    )
+
+    with pytest.raises(DatalayerResourceNotFound, match="season_roster"):
+        manager.get_roster(uuid4())
+    with pytest.raises(DatalayerResourceNotFound, match="season_roster"):
+        other_manager.get_roster(projected_season.domain.roster_ids[0])

--- a/backend/tests/resources/sleeper_data/test_transaction_manager.py
+++ b/backend/tests/resources/sleeper_data/test_transaction_manager.py
@@ -1,0 +1,113 @@
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory
+from backend.resources.sleeper_data.transactions import (
+    TransactionManager,
+    TransactionQuery,
+)
+from backend.services.datalayer.errors import DatalayerResourceNotFound
+from backend.tests.resources.sleeper_data.conftest import (
+    ProjectedSeason,
+    manager_context,
+    seed_domain,
+)
+
+
+def _manager(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> TransactionManager:
+    return TransactionManager(
+        session_factory,
+        manager_context(projected_season.domain),
+    )
+
+
+def test_transaction_reads_include_ordered_moves_and_decimal_safe_json(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    transactions = _manager(session_factory, projected_season).list_transactions(
+        TransactionQuery(competition_season_id=projected_season.domain.season_id)
+    )
+
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert transaction.sleeper_transaction_id == projected_season.sleeper_transaction_id
+    assert transaction.competition_season_id == projected_season.domain.season_id
+    assert transaction.week == projected_season.week
+    assert transaction.transaction_type == "trade"
+    assert transaction.status == "complete"
+    assert transaction.provider_created_at_ms == 123456
+    assert transaction.settings == {"waiver_bid": Decimal("3.5")}
+    assert isinstance(transaction.settings["waiver_bid"], Decimal)
+    assert transaction.metadata == {"note": "fixture"}
+    assert transaction.source_api_request_id == projected_season.transaction_request_id
+    assert len(transaction.moves) == 1
+    move = transaction.moves[0]
+    assert move.move_index == 0
+    assert move.move_kind == "player"
+    assert move.from_season_roster_id == projected_season.domain.roster_ids[0]
+    assert move.to_season_roster_id == projected_season.domain.roster_ids[1]
+    assert move.sleeper_player_id == projected_season.player_ids[1]
+    assert move.draft_season_year is None
+    assert move.draft_round is None
+    assert move.original_franchise_id is None
+    assert move.sleeper_pick_id is None
+
+
+@pytest.mark.parametrize(
+    "query_values",
+    (
+        {"week": 2},
+        {"transaction_type": "waiver"},
+        {"status": "pending"},
+    ),
+)
+def test_transaction_query_filters_exact_current_rows(
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+    query_values: dict[str, object],
+) -> None:
+    manager = _manager(session_factory, projected_season)
+    matching = manager.list_transactions(
+        TransactionQuery(
+            competition_season_id=projected_season.domain.season_id,
+            week=projected_season.week,
+            transaction_type="trade",
+            status="complete",
+        )
+    )
+    missing = manager.list_transactions(
+        TransactionQuery(
+            competition_season_id=projected_season.domain.season_id,
+            **query_values,
+        )
+    )
+
+    assert [item.sleeper_transaction_id for item in matching] == [
+        projected_season.sleeper_transaction_id
+    ]
+    assert missing == ()
+
+
+def test_transaction_reads_reject_a_season_from_another_competition(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    other_domain = seed_domain(database_engine, label="Other")
+    other_manager = TransactionManager(
+        session_factory,
+        manager_context(other_domain),
+    )
+
+    with pytest.raises(DatalayerResourceNotFound):
+        other_manager.list_transactions(
+            TransactionQuery(
+                competition_season_id=projected_season.domain.season_id,
+            )
+        )


### PR DESCRIPTION
## Summary

Add resource-specific latest-observation read managers for Sleeper league
seasons, rosters, matchups, transactions, and the global player catalog.

This is the final Layer 6 PR. It adds no historical cutoff behavior; frozen
historical reads remain snapshot-owned.

## Changes

- Add `LeagueSeasonManager` for snapshot planning context and season overview.
- Add `RosterManager` for current roster, manager, and player hydration.
- Add `MatchupManager` for exact-week matchups and player performances.
- Add `TransactionManager` for filtered transactions and ordered moves.
- Add `PlayerManager` for global catalog search, filtering, ordering, and
  pagination.
- Return frozen validated resource objects with Decimal-safe provider JSON and
  source request provenance.
- Keep every manager in its owning resource package; there is no aggregate
  `SleeperDataManager` facade.
- Replace the former monolithic manager test with a shared projected-season
  fixture and one focused test module per current-data manager.

## Verification

- Current-read tests: 28 added, 53 cumulative Sleeper resource tests passed.
- Focused resource plus inherited datalayer suite: 292 passed, 1 expected
  Windows symbolic-link capability skip.
- Complete repository suite against disposable PostgreSQL: 652 passed, 1
  expected symbolic-link capability skip.
- Exact Alembic upgrade/head/downgrade/re-upgrade/metadata-drift lifecycle:
  passed at sole head `0007`, with no new upgrade operations.
- Inherited PostgreSQL snapshot/constraint gate: 18 passed.
- Package compilation, formatting, line-length audit, and `git diff --check`:
  passed.

## Stack

- Parent: Sleeper normalized projections
- Completes Layer 6
