### PR TITLE
feat(datalayer): add refresh workflow

### DIFF
--- a/backend/composition.py
+++ b/backend/composition.py
@@ -6,7 +6,7 @@ from typing import Protocol
 from sqlalchemy import Engine
 from sqlalchemy.engine import make_url
 
-from backend.config import DatabaseSettings
+from backend.config import DatabaseSettings, DatalayerSettings
 from backend.database.engine import build_runtime_engine
 from backend.database.health import assert_database_ready, read_database_health
 from backend.database.sessions import SessionFactory, create_session_factory
@@ -18,6 +18,17 @@ from backend.resources.memory.revisions import RevisionManager
 from backend.resources.memory.search_documents import SearchDocumentManager
 from backend.resources.memory.storylines import StorylineManager
 from backend.resources.memory.triggers import TriggerManager
+from backend.resources.sleeper_data import (
+    ApiRequestManager,
+    LeagueSeasonManager,
+    NormalizedScopeManager,
+    RefreshRunManager,
+)
+from backend.services.datalayer import (
+    LocalDatalayerFileStore,
+    SleeperSourceClient,
+)
+from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 
 
@@ -76,6 +87,17 @@ class MemoryApiDependencies:
     mutations: MemoryMutationService
 
 
+@dataclass(frozen=True, slots=True)
+class DatalayerRefreshDependencies:
+    """One scoped refresh service and its owned source transport."""
+
+    refresh: DatalayerRefreshService
+    source: SleeperSourceClient
+
+    def close(self) -> None:
+        self.source.close()
+
+
 def build_memory_api_dependencies(
     session_factory: SessionFactory,
     context: ManagerContext[CompetitionScope],
@@ -105,6 +127,41 @@ def build_memory_api_dependencies(
             context_notes=context_notes,
         ),
         mutations=MemoryMutationService(revisions),
+    )
+
+
+def build_datalayer_refresh_dependencies(
+    session_factory: SessionFactory,
+    context: ManagerContext[CompetitionScope],
+    *,
+    settings: DatalayerSettings | None = None,
+) -> DatalayerRefreshDependencies:
+    """Compose one competition-scoped synchronous refresh capability."""
+
+    resolved = settings or DatalayerSettings.from_environment()
+    source = SleeperSourceClient(
+        base_url=resolved.sleeper_base_url,
+        timeout_seconds=resolved.sleeper_timeout_seconds,
+    )
+    refreshes = RefreshRunManager(session_factory, context)
+    attempts = ApiRequestManager(session_factory, context)
+    scopes = NormalizedScopeManager(session_factory, context)
+    identities = LeagueSeasonManager(session_factory, context)
+    files = LocalDatalayerFileStore(resolved.data_root)
+    return DatalayerRefreshDependencies(
+        refresh=DatalayerRefreshService(
+            source=source,
+            identities=identities,
+            refreshes=refreshes,
+            attempts=attempts,
+            scopes=scopes,
+            files=files,
+            code_version=resolved.code_version,
+            max_attempts=resolved.sleeper_max_attempts,
+            retry_backoff_seconds=resolved.sleeper_retry_backoff_seconds,
+            inline_payload_max_bytes=resolved.inline_payload_max_bytes,
+        ),
+        source=source,
     )
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,7 @@
 """Environment-backed product configuration."""
 
 from dataclasses import dataclass
+import math
 import os
 from pathlib import Path
 from typing import Literal
@@ -24,6 +25,14 @@ def _positive_int(name: str, default: int) -> int:
     raw_value = os.getenv(name)
     value = default if raw_value is None else int(raw_value)
     if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _positive_float(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    value = default if raw_value is None else float(raw_value)
+    if not math.isfinite(value) or value <= 0:
         raise ValueError(f"{name} must be positive")
     return value
 
@@ -92,6 +101,10 @@ class DatalayerSettings:
     data_root: Path
     sleeper_base_url: str
     sleeper_timeout_seconds: int
+    sleeper_max_attempts: int
+    sleeper_retry_backoff_seconds: float
+    inline_payload_max_bytes: int
+    code_version: str
 
     @classmethod
     def from_environment(cls) -> "DatalayerSettings":
@@ -103,10 +116,21 @@ class DatalayerSettings:
         ).strip().rstrip("/")
         if not base_url:
             raise ValueError("AIDAM_SLEEPER_BASE_URL must not be empty")
+        code_version = os.getenv("AIDAM_CODE_VERSION", "dev").strip()
+        if not code_version:
+            raise ValueError("AIDAM_CODE_VERSION must not be empty")
         return cls(
             data_root=Path(data_root).expanduser(),
             sleeper_base_url=base_url,
             sleeper_timeout_seconds=_positive_int(
                 "AIDAM_SLEEPER_TIMEOUT_SECONDS", 10
             ),
+            sleeper_max_attempts=_positive_int("AIDAM_SLEEPER_MAX_ATTEMPTS", 3),
+            sleeper_retry_backoff_seconds=_positive_float(
+                "AIDAM_SLEEPER_RETRY_BACKOFF_SECONDS", 1.0
+            ),
+            inline_payload_max_bytes=_positive_int(
+                "AIDAM_DATALAYER_INLINE_PAYLOAD_MAX_BYTES", 1024 * 1024
+            ),
+            code_version=code_version,
         )

--- a/backend/resources/sleeper_data/__init__.py
+++ b/backend/resources/sleeper_data/__init__.py
@@ -4,6 +4,7 @@ from backend.resources.sleeper_data.common import Page
 from backend.resources.sleeper_data.league_seasons import (
     LeagueSeasonManager,
     LeagueSeasonOverview,
+    RefreshSeasonIdentity,
     SnapshotPlanningContext,
 )
 from backend.resources.sleeper_data.matchups import (
@@ -68,6 +69,7 @@ __all__ = [
     "RecordApiAttempt",
     "RefreshRun",
     "RefreshRunManager",
+    "RefreshSeasonIdentity",
     "RosterManager",
     "RosterManagerAssignment",
     "RosterPlayer",

--- a/backend/resources/sleeper_data/league_seasons/__init__.py
+++ b/backend/resources/sleeper_data/league_seasons/__init__.py
@@ -1,11 +1,13 @@
 from backend.resources.sleeper_data.league_seasons.manager import LeagueSeasonManager
 from backend.resources.sleeper_data.league_seasons.objects import (
     LeagueSeasonOverview,
+    RefreshSeasonIdentity,
     SnapshotPlanningContext,
 )
 
 __all__ = [
     "LeagueSeasonManager",
     "LeagueSeasonOverview",
+    "RefreshSeasonIdentity",
     "SnapshotPlanningContext",
 ]

--- a/backend/resources/sleeper_data/league_seasons/manager.py
+++ b/backend/resources/sleeper_data/league_seasons/manager.py
@@ -15,6 +15,7 @@ from backend.resources.context import CompetitionScope, ManagerContext
 from backend.resources.sleeper_data.common.codec import parse_jsonb_text
 from backend.resources.sleeper_data.league_seasons.objects import (
     LeagueSeasonOverview,
+    RefreshSeasonIdentity,
     SnapshotPlanningContext,
 )
 from backend.services.datalayer.errors import DatalayerResourceNotFound
@@ -30,6 +31,29 @@ class LeagueSeasonManager:
     ) -> None:
         self._session_factory = session_factory
         self._competition_id = context.scope.competition_id
+
+    def get_refresh_identity(
+        self, competition_season_id: UUID
+    ) -> RefreshSeasonIdentity:
+        """Read bootstrap identity without requiring normalized Sleeper rows."""
+
+        with read_only_session(self._session_factory) as session:
+            season = session.scalar(
+                sa.select(CompetitionSeason).where(
+                    CompetitionSeason.id == competition_season_id,
+                    CompetitionSeason.competition_id == self._competition_id,
+                )
+            )
+            if season is None:
+                raise DatalayerResourceNotFound(
+                    "competition_season", str(competition_season_id)
+                )
+            return RefreshSeasonIdentity(
+                competition_id=self._competition_id,
+                competition_season_id=season.id,
+                sleeper_league_id=season.sleeper_league_id,
+                season_year=season.season_year,
+            )
 
     def get_snapshot_planning_context(
         self, competition_season_id: UUID

--- a/backend/resources/sleeper_data/league_seasons/objects.py
+++ b/backend/resources/sleeper_data/league_seasons/objects.py
@@ -10,6 +10,15 @@ from backend.resources._contracts import ContractModel
 from backend.services.datalayer.canonical_json import JsonValue
 
 
+class RefreshSeasonIdentity(ContractModel):
+    """Core season identity needed before Sleeper facts have been loaded."""
+
+    competition_id: UUID
+    competition_season_id: UUID
+    sleeper_league_id: str
+    season_year: int = Field(strict=True, ge=1900, le=9999)
+
+
 class SnapshotPlanningContext(ContractModel):
     competition_id: UUID
     competition_season_id: UUID

--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -1,5 +1,7 @@
 """Pure contracts shared by datalayer workflows and later adapters."""
 
+from typing import Any
+
 from backend.services.datalayer.contracts import (
     ApplyDisposition,
     CompletenessWarning,
@@ -111,6 +113,7 @@ __all__ = [
     "CompletenessFinding",
     "EndpointApplyMetadata",
     "DatalayerError",
+    "DatalayerRefreshService",
     "DatalayerResourceNotFound",
     "DatalayerScopeConflict",
     "EndpointKind",
@@ -138,6 +141,7 @@ __all__ = [
     "PlayerCatalogEndpointRecords",
     "PlayerPerformanceRecord",
     "PlayerRecord",
+    "PlannedRefresh",
     "RefreshOutcome",
     "RefreshRequest",
     "RefreshStatus",
@@ -172,6 +176,7 @@ __all__ = [
     "build_matchups_request",
     "build_nfl_state_request",
     "build_player_catalog_request",
+    "build_standard_refresh_plan",
     "build_traded_picks_request",
     "build_transactions_request",
     "build_winners_bracket_request",
@@ -198,3 +203,25 @@ __all__ = [
     "validate_transactions_completeness",
     "validate_winners_bracket_completeness",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose the resource-composing refresh service without a cycle."""
+
+    if name in {
+        "DatalayerRefreshService",
+        "PlannedRefresh",
+        "build_standard_refresh_plan",
+    }:
+        from backend.services.datalayer.refresh_service import (
+            DatalayerRefreshService,
+            PlannedRefresh,
+            build_standard_refresh_plan,
+        )
+
+        return {
+            "DatalayerRefreshService": DatalayerRefreshService,
+            "PlannedRefresh": PlannedRefresh,
+            "build_standard_refresh_plan": build_standard_refresh_plan,
+        }[name]
+    raise AttributeError(name)

--- a/backend/services/datalayer/refresh_service.py
+++ b/backend/services/datalayer/refresh_service.py
@@ -1,0 +1,617 @@
+"""Synchronous orchestration for one complete Sleeper refresh workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+import math
+from time import sleep
+from typing import Protocol, assert_never, cast
+from uuid import UUID
+
+from backend.resources.sleeper_data.league_seasons import RefreshSeasonIdentity
+from backend.resources.sleeper_data.normalized_scopes import ApplyResult
+from backend.resources.sleeper_data.refreshes import (
+    PlannedEndpointScope,
+    RefreshRun,
+    StartRefresh,
+)
+from backend.resources.sleeper_data.requests import (
+    ApiRequest,
+    NormalizationRejection,
+    RecordApiAttempt,
+)
+from backend.services.datalayer.canonical_json import JsonValue, canonical_json_bytes
+from backend.services.datalayer.contracts import (
+    NormalizationStatus,
+    RefreshOutcome,
+    RefreshRequest,
+    RequestStatus,
+    ScopeRefreshResult,
+)
+from backend.services.datalayer.errors import (
+    DatalayerScopeConflict,
+    EndpointPayloadRejected,
+)
+from backend.services.datalayer.local_files import (
+    LocalArtifactKind,
+    LocalArtifactVerificationError,
+    StoredLocalArtifact,
+)
+from backend.services.datalayer.sleeper.endpoints import (
+    CompletenessFinding,
+    EndpointRecords,
+    LeagueEndpointRecords,
+    NflStateEndpointRecords,
+    build_league_request,
+    build_league_rosters_request,
+    build_league_users_request,
+    build_losers_bracket_request,
+    build_matchups_request,
+    build_nfl_state_request,
+    build_player_catalog_request,
+    build_traded_picks_request,
+    build_transactions_request,
+    build_winners_bracket_request,
+    get_endpoint_apply_metadata,
+    missing_dependency_scope_keys,
+    normalize_league,
+    normalize_league_rosters,
+    normalize_league_users,
+    normalize_losers_bracket,
+    normalize_matchups,
+    normalize_nfl_state,
+    normalize_player_catalog,
+    normalize_traded_picks,
+    normalize_transactions,
+    normalize_winners_bracket,
+    validate_league_completeness,
+    validate_league_rosters_completeness,
+    validate_league_users_completeness,
+    validate_losers_bracket_completeness,
+    validate_matchups_completeness,
+    validate_nfl_state_completeness,
+    validate_player_catalog_completeness,
+    validate_traded_picks_completeness,
+    validate_transactions_completeness,
+    validate_winners_bracket_completeness,
+)
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SourceAttempt,
+    SuccessfulSourceAttempt,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+from backend.services.datalayer.versions import INGESTION_NORMALIZER_VERSION
+
+
+class SourceReader(Protocol):
+    def execute(self, request: EndpointRequest) -> SourceAttempt: ...
+
+
+class PayloadFileStore(Protocol):
+    def store_bytes(
+        self, kind: LocalArtifactKind, content: bytes
+    ) -> StoredLocalArtifact: ...
+
+
+class SeasonIdentityReader(Protocol):
+    def get_refresh_identity(
+        self, competition_season_id: UUID
+    ) -> RefreshSeasonIdentity: ...
+
+
+class RefreshWriter(Protocol):
+    def start_refresh(self, command: StartRefresh) -> RefreshRun: ...
+
+    def finish_refresh(self, refresh_id: UUID) -> RefreshRun: ...
+
+
+class AttemptWriter(Protocol):
+    def record_attempt(self, command: RecordApiAttempt) -> ApiRequest: ...
+
+    def reject_normalization(
+        self, request_id: UUID, rejection: NormalizationRejection
+    ) -> ApiRequest: ...
+
+
+class ScopeWriter(Protocol):
+    def apply_scope(
+        self, request_id: UUID, records: EndpointRecords
+    ) -> ApplyResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedRefresh:
+    requests: tuple[EndpointRequest, ...]
+    endpoint_scope: tuple[PlannedEndpointScope, ...]
+    through_week: int | None
+
+
+@dataclass(slots=True)
+class _AttemptState:
+    source: SourceAttempt
+    completeness: CompletenessFinding
+    stored: ApiRequest | None = None
+    warning_codes: tuple[str, ...] = ()
+    changed_current_view: bool = False
+
+
+class DatalayerRefreshService:
+    """Fetch, audit, normalize, apply, and finalize one Sleeper refresh."""
+
+    def __init__(
+        self,
+        *,
+        source: SourceReader,
+        identities: SeasonIdentityReader,
+        refreshes: RefreshWriter,
+        attempts: AttemptWriter,
+        scopes: ScopeWriter,
+        files: PayloadFileStore,
+        code_version: str,
+        max_attempts: int = 3,
+        retry_backoff_seconds: float = 1.0,
+        inline_payload_max_bytes: int = 1024 * 1024,
+        delay: Callable[[float], None] = sleep,
+    ) -> None:
+        if not code_version.strip():
+            raise ValueError("code_version must not be empty")
+        if (
+            isinstance(max_attempts, bool)
+            or not isinstance(max_attempts, int)
+            or max_attempts < 1
+        ):
+            raise ValueError("max_attempts must be positive")
+        if (
+            isinstance(retry_backoff_seconds, bool)
+            or not isinstance(retry_backoff_seconds, (int, float))
+            or not math.isfinite(retry_backoff_seconds)
+            or retry_backoff_seconds <= 0
+        ):
+            raise ValueError("retry_backoff_seconds must be positive")
+        if (
+            isinstance(inline_payload_max_bytes, bool)
+            or not isinstance(inline_payload_max_bytes, int)
+            or inline_payload_max_bytes < 1
+        ):
+            raise ValueError("inline_payload_max_bytes must be positive")
+        self._source = source
+        self._identities = identities
+        self._refreshes = refreshes
+        self._attempts = attempts
+        self._scopes = scopes
+        self._files = files
+        self._code_version = code_version.strip()
+        self._max_attempts = max_attempts
+        self._retry_backoff_seconds = retry_backoff_seconds
+        self._inline_payload_max_bytes = inline_payload_max_bytes
+        self._delay = delay
+
+    def refresh(self, request: RefreshRequest) -> RefreshOutcome:
+        identity = self._identities.get_refresh_identity(
+            request.competition_season_id
+        )
+        preflight_requests = (
+            build_league_request(
+                identity.competition_season_id, identity.sleeper_league_id
+            ),
+            build_nfl_state_request(),
+        )
+        buffered = {
+            endpoint.scope_key: self._execute_attempts(endpoint)
+            for endpoint in preflight_requests
+        }
+        league_records = _complete_league_records(
+            buffered[preflight_requests[0].scope_key]
+        )
+        nfl_records = _complete_nfl_records(buffered[preflight_requests[1].scope_key])
+        effective_week = request.through_week
+        if (
+            effective_week is None
+            and nfl_records is not None
+            and nfl_records.state.week > 0
+        ):
+            effective_week = min(nfl_records.state.week, 18)
+        plan = build_standard_refresh_plan(
+            identity,
+            through_week=effective_week,
+            league_records=league_records,
+        )
+        refresh = self._refreshes.start_refresh(
+            StartRefresh(
+                competition_season_id=identity.competition_season_id,
+                requested_through_week=request.through_week,
+                trigger=request.trigger,
+                endpoint_scope=plan.endpoint_scope,
+                code_version=self._code_version,
+                normalizer_version=INGESTION_NORMALIZER_VERSION,
+            )
+        )
+        states: dict[ScopeKey, list[_AttemptState]] = {}
+        try:
+            for endpoint in preflight_requests:
+                attempts = buffered[endpoint.scope_key]
+                states[endpoint.scope_key] = attempts
+                for state in attempts:
+                    self._record_attempt(refresh.id, state)
+            for endpoint in plan.requests:
+                if endpoint.scope_key in states:
+                    continue
+                attempts = self._execute_and_record(refresh.id, endpoint)
+                states[endpoint.scope_key] = attempts
+            self._apply_latest(plan, states)
+        except Exception:
+            self._refreshes.finish_refresh(refresh.id)
+            raise
+        terminal = self._refreshes.finish_refresh(refresh.id)
+        return _build_outcome(terminal, plan, states)
+
+    def _execute_attempts(self, endpoint: EndpointRequest) -> list[_AttemptState]:
+        results: list[_AttemptState] = []
+        for attempt_number in range(1, self._max_attempts + 1):
+            source = self._source.execute(endpoint)
+            completeness = _completeness(source)
+            results.append(_AttemptState(source=source, completeness=completeness))
+            if (
+                not _should_retry(source, completeness)
+                or attempt_number == self._max_attempts
+            ):
+                break
+            self._delay(
+                self._retry_backoff_seconds * (2 ** (attempt_number - 1))
+            )
+        return results
+
+    def _execute_and_record(
+        self,
+        refresh_id: UUID,
+        endpoint: EndpointRequest,
+    ) -> list[_AttemptState]:
+        results: list[_AttemptState] = []
+        for attempt_number in range(1, self._max_attempts + 1):
+            source = self._source.execute(endpoint)
+            completeness = _completeness(source)
+            state = _AttemptState(source=source, completeness=completeness)
+            self._record_attempt(refresh_id, state)
+            results.append(state)
+            if (
+                not _should_retry(source, completeness)
+                or attempt_number == self._max_attempts
+            ):
+                break
+            self._delay(
+                self._retry_backoff_seconds * (2 ** (attempt_number - 1))
+            )
+        return results
+
+    def _record_attempt(self, refresh_id: UUID, state: _AttemptState) -> None:
+        receipt: StoredLocalArtifact | None = None
+        warnings = list(state.warning_codes)
+        if isinstance(state.source, SuccessfulSourceAttempt):
+            payload_bytes = canonical_json_bytes(state.source.payload)
+        else:
+            payload_bytes = None
+        if (
+            payload_bytes is not None
+            and len(payload_bytes) > self._inline_payload_max_bytes
+        ):
+            try:
+                receipt = self._files.store_bytes(
+                    LocalArtifactKind.PAYLOAD,
+                    payload_bytes,
+                )
+            except (OSError, LocalArtifactVerificationError):
+                warnings.append("payload_storage_fallback")
+        state.stored = self._attempts.record_attempt(
+            RecordApiAttempt(
+                refresh_run_id=refresh_id,
+                attempt=state.source,
+                completeness=state.completeness,
+                object_receipt=receipt,
+            )
+        )
+        state.warning_codes = tuple(warnings)
+
+    def _apply_latest(
+        self,
+        plan: PlannedRefresh,
+        states: dict[ScopeKey, list[_AttemptState]],
+    ) -> None:
+        available: set[ScopeKey] = set()
+        for endpoint in plan.requests:
+            state = states[endpoint.scope_key][-1]
+            stored = cast(ApiRequest, state.stored)
+            if not (
+                isinstance(state.source, SuccessfulSourceAttempt)
+                and state.completeness.is_complete
+            ):
+                continue
+            metadata = get_endpoint_apply_metadata(endpoint)
+            missing = missing_dependency_scope_keys(metadata, available)
+            if missing:
+                state.stored = self._attempts.reject_normalization(
+                    stored.id,
+                    NormalizationRejection(
+                        code="normalization_dependency_unavailable",
+                        summary="A required refresh dependency was unavailable",
+                    ),
+                )
+                state.warning_codes += ("normalization_dependency_unavailable",)
+                continue
+            try:
+                records = _normalize(state.source, endpoint)
+                applied = self._scopes.apply_scope(stored.id, records)
+            except EndpointPayloadRejected as error:
+                state.stored = self._attempts.reject_normalization(
+                    stored.id,
+                    NormalizationRejection(code=error.code, summary=error.summary),
+                )
+                state.warning_codes += (error.code,)
+                continue
+            except DatalayerScopeConflict:
+                state.stored = self._attempts.reject_normalization(
+                    stored.id,
+                    NormalizationRejection(
+                        code="normalization_scope_conflict",
+                        summary=(
+                            "Normalized facts could not be mapped to the refresh scope"
+                        ),
+                    ),
+                )
+                state.warning_codes += ("normalization_scope_conflict",)
+                continue
+            state.stored = stored.model_copy(
+                update={"normalization_status": NormalizationStatus.SUCCEEDED}
+            )
+            state.changed_current_view = applied.changed_current_view
+            state.warning_codes += (
+                ("stale_observation",)
+                if applied.disposition.value == "stale_ignored"
+                else ()
+            )
+            available.add(endpoint.scope_key)
+
+
+def build_standard_refresh_plan(
+    identity: RefreshSeasonIdentity,
+    *,
+    through_week: int | None,
+    league_records: LeagueEndpointRecords | None,
+) -> PlannedRefresh:
+    """Build the one deterministic v1 product refresh plan."""
+
+    if through_week is not None and (
+        isinstance(through_week, bool)
+        or not isinstance(through_week, int)
+        or not 1 <= through_week <= 18
+    ):
+        raise ValueError("refresh plan through_week must be between 1 and 18")
+
+    requests: list[EndpointRequest] = [
+        build_league_request(
+            identity.competition_season_id, identity.sleeper_league_id
+        ),
+        build_league_users_request(
+            identity.competition_season_id, identity.sleeper_league_id
+        ),
+        build_nfl_state_request(),
+        build_player_catalog_request(),
+        build_league_rosters_request(
+            identity.competition_season_id, identity.sleeper_league_id
+        ),
+    ]
+    settings = (
+        league_records.league.provider_settings
+        if league_records is not None
+        else {}
+    )
+    raw_rounds = settings.get("draft_rounds")
+    if (
+        isinstance(raw_rounds, int)
+        and not isinstance(raw_rounds, bool)
+        and raw_rounds > 0
+    ):
+        requests.append(
+            build_traded_picks_request(
+                identity.competition_season_id, identity.sleeper_league_id
+            )
+        )
+    if through_week is not None:
+        for week in range(1, through_week + 1):
+            requests.extend(
+                (
+                    build_matchups_request(
+                        identity.competition_season_id,
+                        identity.sleeper_league_id,
+                        week,
+                    ),
+                    build_transactions_request(
+                        identity.competition_season_id,
+                        identity.sleeper_league_id,
+                        week,
+                    ),
+                )
+            )
+        playoff_start = (
+            league_records.league.playoff_start_week
+            if league_records is not None
+            else None
+        )
+        if league_records is not None and (
+            playoff_start is None or through_week >= playoff_start
+        ):
+            requests.extend(
+                (
+                    build_winners_bracket_request(
+                        identity.competition_season_id,
+                        identity.sleeper_league_id,
+                    ),
+                    build_losers_bracket_request(
+                        identity.competition_season_id,
+                        identity.sleeper_league_id,
+                    ),
+                )
+            )
+    endpoint_scope = tuple(
+        PlannedEndpointScope(
+            scope_key=endpoint.scope_key,
+            endpoint_kind=endpoint.endpoint_kind,
+            dependency_scope_keys=get_endpoint_apply_metadata(
+                endpoint
+            ).dependency_scope_keys,
+        )
+        for endpoint in requests
+    )
+    return PlannedRefresh(
+        requests=tuple(requests),
+        endpoint_scope=endpoint_scope,
+        through_week=through_week,
+    )
+
+
+def _completeness(source: SourceAttempt) -> CompletenessFinding:
+    if isinstance(source, FailedSourceAttempt):
+        return CompletenessFinding(
+            is_complete=False, reason="source_attempt_failed"
+        )
+    try:
+        return _validate(source.payload, source.endpoint)
+    except Exception:
+        return CompletenessFinding(
+            is_complete=False, reason="completeness_validation_failed"
+        )
+
+
+def _validate(payload: JsonValue, endpoint: EndpointRequest) -> CompletenessFinding:
+    match endpoint.endpoint_kind:
+        case EndpointKind.LEAGUE:
+            return validate_league_completeness(payload, endpoint)
+        case EndpointKind.LEAGUE_USERS:
+            return validate_league_users_completeness(payload, endpoint)
+        case EndpointKind.LEAGUE_ROSTERS:
+            return validate_league_rosters_completeness(payload, endpoint)
+        case EndpointKind.NFL_STATE:
+            return validate_nfl_state_completeness(payload, endpoint)
+        case EndpointKind.PLAYER_CATALOG:
+            return validate_player_catalog_completeness(payload, endpoint)
+        case EndpointKind.MATCHUPS:
+            return validate_matchups_completeness(payload, endpoint)
+        case EndpointKind.TRANSACTIONS:
+            return validate_transactions_completeness(payload, endpoint)
+        case EndpointKind.TRADED_PICKS:
+            return validate_traded_picks_completeness(payload, endpoint)
+        case EndpointKind.WINNERS_BRACKET:
+            return validate_winners_bracket_completeness(payload, endpoint)
+        case EndpointKind.LOSERS_BRACKET:
+            return validate_losers_bracket_completeness(payload, endpoint)
+    assert_never(endpoint.endpoint_kind)
+
+
+def _normalize(
+    source: SuccessfulSourceAttempt,
+    endpoint: EndpointRequest,
+) -> EndpointRecords:
+    match endpoint.endpoint_kind:
+        case EndpointKind.LEAGUE:
+            return normalize_league(source.payload, endpoint)
+        case EndpointKind.LEAGUE_USERS:
+            return normalize_league_users(source.payload, endpoint)
+        case EndpointKind.LEAGUE_ROSTERS:
+            return normalize_league_rosters(source.payload, endpoint)
+        case EndpointKind.NFL_STATE:
+            return normalize_nfl_state(source.payload, endpoint)
+        case EndpointKind.PLAYER_CATALOG:
+            return normalize_player_catalog(source.payload, endpoint)
+        case EndpointKind.MATCHUPS:
+            return normalize_matchups(source.payload, endpoint)
+        case EndpointKind.TRANSACTIONS:
+            return normalize_transactions(source.payload, endpoint)
+        case EndpointKind.TRADED_PICKS:
+            return normalize_traded_picks(source.payload, endpoint)
+        case EndpointKind.WINNERS_BRACKET:
+            return normalize_winners_bracket(source.payload, endpoint)
+        case EndpointKind.LOSERS_BRACKET:
+            return normalize_losers_bracket(source.payload, endpoint)
+    assert_never(endpoint.endpoint_kind)
+
+
+def _should_retry(
+    source: SourceAttempt,
+    completeness: CompletenessFinding,
+) -> bool:
+    if isinstance(source, SuccessfulSourceAttempt):
+        return not completeness.is_complete
+    if source.status in {
+        RequestStatus.TRANSPORT_ERROR,
+        RequestStatus.INVALID_PAYLOAD,
+    }:
+        return True
+    return source.status is RequestStatus.HTTP_ERROR and cast(
+        int, source.http_status
+    ) in {429, *range(500, 600)}
+
+
+def _complete_league_records(
+    states: Sequence[_AttemptState],
+) -> LeagueEndpointRecords | None:
+    state = states[-1]
+    if (
+        not isinstance(state.source, SuccessfulSourceAttempt)
+        or not state.completeness.is_complete
+    ):
+        return None
+    try:
+        return normalize_league(state.source.payload, state.source.endpoint)
+    except EndpointPayloadRejected:
+        return None
+
+
+def _complete_nfl_records(
+    states: Sequence[_AttemptState],
+) -> NflStateEndpointRecords | None:
+    state = states[-1]
+    if (
+        not isinstance(state.source, SuccessfulSourceAttempt)
+        or not state.completeness.is_complete
+    ):
+        return None
+    try:
+        return normalize_nfl_state(state.source.payload, state.source.endpoint)
+    except EndpointPayloadRejected:
+        return None
+
+
+def _build_outcome(
+    refresh: RefreshRun,
+    plan: PlannedRefresh,
+    states: dict[ScopeKey, list[_AttemptState]],
+) -> RefreshOutcome:
+    results: list[ScopeRefreshResult] = []
+    for endpoint in plan.requests:
+        state = states[endpoint.scope_key][-1]
+        stored = cast(ApiRequest, state.stored)
+        warning_codes = list(state.warning_codes)
+        if isinstance(state.source, FailedSourceAttempt):
+            warning_codes.append(state.source.error.code)
+        elif not state.completeness.is_complete:
+            warning_codes.append(cast(str, state.completeness.reason))
+        results.append(
+            ScopeRefreshResult(
+                scope_key=endpoint.scope_key,
+                api_request_id=stored.id,
+                fetch_status=stored.status,
+                normalization_status=stored.normalization_status,
+                changed_current_view=state.changed_current_view,
+                warning_codes=tuple(dict.fromkeys(warning_codes)),
+            )
+        )
+    return RefreshOutcome(
+        refresh_run_id=refresh.id,
+        status=refresh.status,
+        requested_scope_count=refresh.request_count,
+        succeeded_scope_count=refresh.succeeded_request_count,
+        failed_scope_count=refresh.failed_request_count,
+        scope_results=tuple(results),
+    )

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -1,12 +1,19 @@
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.engine import make_url
 
-from backend.composition import build_api_runtime, build_memory_api_dependencies
+from backend.composition import (
+    build_api_runtime,
+    build_datalayer_refresh_dependencies,
+    build_memory_api_dependencies,
+)
+from backend.config import DatalayerSettings
 from backend.database.sessions import create_session_factory
 from backend.resources.context import CompetitionScope, ManagerContext
+from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 
 
@@ -54,4 +61,35 @@ def test_memory_api_composition_is_scoped_without_opening_a_session() -> None:
         assert isinstance(runtime.retrieval, MemoryRetrievalService)
         assert isinstance(runtime.mutations, MemoryMutationService)
     finally:
+        engine.dispose()
+
+
+def test_datalayer_refresh_composition_is_scoped_without_opening_a_session(
+    tmp_path: Path,
+) -> None:
+    engine = create_engine("sqlite://")
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "system_process", "process_name": "test"},
+            "scope": {"kind": "competition", "competition_id": uuid4()},
+            "correlation_id": uuid4(),
+        }
+    )
+    dependencies = build_datalayer_refresh_dependencies(
+        create_session_factory(engine),
+        context,
+        settings=DatalayerSettings(
+            data_root=tmp_path,
+            sleeper_base_url="https://source.example/v1",
+            sleeper_timeout_seconds=5,
+            sleeper_max_attempts=3,
+            sleeper_retry_backoff_seconds=0.25,
+            inline_payload_max_bytes=1024,
+            code_version="test",
+        ),
+    )
+    try:
+        assert isinstance(dependencies.refresh, DatalayerRefreshService)
+    finally:
+        dependencies.close()
         engine.dispose()

--- a/backend/tests/resources/sleeper_data/test_league_season_manager.py
+++ b/backend/tests/resources/sleeper_data/test_league_season_manager.py
@@ -8,6 +8,7 @@ from backend.database.sessions import SessionFactory
 from backend.resources.sleeper_data.league_seasons import (
     LeagueSeasonManager,
     LeagueSeasonOverview,
+    RefreshSeasonIdentity,
     SnapshotPlanningContext,
 )
 from backend.services.datalayer.errors import DatalayerResourceNotFound
@@ -16,6 +17,27 @@ from backend.tests.resources.sleeper_data.conftest import (
     manager_context,
     seed_domain,
 )
+
+
+def test_refresh_identity_does_not_require_normalized_league(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+) -> None:
+    domain = seed_domain(database_engine, label="Bootstrap")
+    manager = LeagueSeasonManager(session_factory, manager_context(domain))
+
+    identity = manager.get_refresh_identity(domain.season_id)
+
+    assert isinstance(identity, RefreshSeasonIdentity)
+    assert identity.model_dump() == {
+        "competition_id": domain.competition_id,
+        "competition_season_id": domain.season_id,
+        "sleeper_league_id": domain.sleeper_league_id,
+        "season_year": 2026,
+    }
+
+    with pytest.raises(DatalayerResourceNotFound, match="competition_season"):
+        manager.get_refresh_identity(uuid4())
 
 
 def test_snapshot_planning_context_uses_latest_league_metadata(

--- a/backend/tests/services/datalayer/test_config.py
+++ b/backend/tests/services/datalayer/test_config.py
@@ -9,6 +9,10 @@ _ENVIRONMENT_NAMES = (
     "AIDAM_DATALAYER_ROOT",
     "AIDAM_SLEEPER_BASE_URL",
     "AIDAM_SLEEPER_TIMEOUT_SECONDS",
+    "AIDAM_SLEEPER_MAX_ATTEMPTS",
+    "AIDAM_SLEEPER_RETRY_BACKOFF_SECONDS",
+    "AIDAM_DATALAYER_INLINE_PAYLOAD_MAX_BYTES",
+    "AIDAM_CODE_VERSION",
 )
 
 
@@ -23,6 +27,10 @@ def test_datalayer_settings_have_local_source_defaults(
     assert settings.data_root == Path(".data/datalayer")
     assert settings.sleeper_base_url == "https://api.sleeper.app/v1"
     assert settings.sleeper_timeout_seconds == 10
+    assert settings.sleeper_max_attempts == 3
+    assert settings.sleeper_retry_backoff_seconds == 1.0
+    assert settings.inline_payload_max_bytes == 1024 * 1024
+    assert settings.code_version == "dev"
 
 
 def test_datalayer_settings_read_environment_and_normalize_base_url(
@@ -31,12 +39,20 @@ def test_datalayer_settings_read_environment_and_normalize_base_url(
     monkeypatch.setenv("AIDAM_DATALAYER_ROOT", "custom-data")
     monkeypatch.setenv("AIDAM_SLEEPER_BASE_URL", "https://source.example/v1///")
     monkeypatch.setenv("AIDAM_SLEEPER_TIMEOUT_SECONDS", "25")
+    monkeypatch.setenv("AIDAM_SLEEPER_MAX_ATTEMPTS", "4")
+    monkeypatch.setenv("AIDAM_SLEEPER_RETRY_BACKOFF_SECONDS", "0.25")
+    monkeypatch.setenv("AIDAM_DATALAYER_INLINE_PAYLOAD_MAX_BYTES", "2048")
+    monkeypatch.setenv("AIDAM_CODE_VERSION", "abc123")
 
     settings = DatalayerSettings.from_environment()
 
     assert settings.data_root == Path("custom-data")
     assert settings.sleeper_base_url == "https://source.example/v1"
     assert settings.sleeper_timeout_seconds == 25
+    assert settings.sleeper_max_attempts == 4
+    assert settings.sleeper_retry_backoff_seconds == 0.25
+    assert settings.inline_payload_max_bytes == 2048
+    assert settings.code_version == "abc123"
 
 
 @pytest.mark.parametrize("value", ["0", "-1"])

--- a/backend/tests/services/datalayer/test_refresh_service.py
+++ b/backend/tests/services/datalayer/test_refresh_service.py
@@ -1,0 +1,690 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from backend.resources.sleeper_data.league_seasons import RefreshSeasonIdentity
+from backend.resources.sleeper_data.normalized_scopes import ApplyResult
+from backend.resources.sleeper_data.refreshes import RefreshRun, StartRefresh
+from backend.resources.sleeper_data.requests import (
+    ApiRequest,
+    NormalizationRejection,
+    RecordApiAttempt,
+)
+from backend.services.datalayer import (
+    ApplyDisposition,
+    EndpointKind,
+    LocalDatalayerFileStore,
+    NormalizationStatus,
+    RefreshRequest,
+    RefreshStatus,
+    RefreshTrigger,
+    RequestStatus,
+    ScopeKey,
+    StoredLocalArtifact,
+    SuccessfulSourceAttempt,
+    build_league_request,
+    normalize_league,
+)
+from backend.services.datalayer.canonical_json import canonical_json_bytes
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.refresh_service import (
+    DatalayerRefreshService,
+    build_standard_refresh_plan,
+)
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SanitizedSourceError,
+    SourceAttempt,
+)
+
+
+NOW = datetime(2026, 8, 19, tzinfo=timezone.utc)
+COMPETITION_ID = UUID("10000000-0000-0000-0000-000000000001")
+SEASON_ID = UUID("20000000-0000-0000-0000-000000000002")
+REFRESH_ID = UUID("30000000-0000-0000-0000-000000000003")
+IDENTITY = RefreshSeasonIdentity(
+    competition_id=COMPETITION_ID,
+    competition_season_id=SEASON_ID,
+    sleeper_league_id="league-1",
+    season_year=2026,
+)
+
+
+def test_standard_plan_has_exact_dependency_order_and_conditionals() -> None:
+    league_request = build_league_request(SEASON_ID, "league-1")
+    league = normalize_league(
+        _league_payload(playoff_week=2, draft_rounds=2), league_request
+    )
+
+    plan = build_standard_refresh_plan(
+        IDENTITY,
+        through_week=2,
+        league_records=league,
+    )
+
+    assert [request.endpoint_kind for request in plan.requests] == [
+        EndpointKind.LEAGUE,
+        EndpointKind.LEAGUE_USERS,
+        EndpointKind.NFL_STATE,
+        EndpointKind.PLAYER_CATALOG,
+        EndpointKind.LEAGUE_ROSTERS,
+        EndpointKind.TRADED_PICKS,
+        EndpointKind.MATCHUPS,
+        EndpointKind.TRANSACTIONS,
+        EndpointKind.MATCHUPS,
+        EndpointKind.TRANSACTIONS,
+        EndpointKind.WINNERS_BRACKET,
+        EndpointKind.LOSERS_BRACKET,
+    ]
+    assert [request.week for request in plan.requests[6:10]] == [1, 1, 2, 2]
+    roster = plan.endpoint_scope[4]
+    assert roster.dependency_scope_keys == (
+        ScopeKey.from_parts(EndpointKind.LEAGUE, SEASON_ID),
+        ScopeKey.from_parts(EndpointKind.LEAGUE_USERS, SEASON_ID),
+        ScopeKey.from_parts(EndpointKind.PLAYER_CATALOG, "nfl"),
+    )
+
+
+def test_standard_plan_omits_unresolved_week_and_league_conditionals() -> None:
+    plan = build_standard_refresh_plan(
+        IDENTITY,
+        through_week=None,
+        league_records=None,
+    )
+
+    assert [request.endpoint_kind for request in plan.requests] == [
+        EndpointKind.LEAGUE,
+        EndpointKind.LEAGUE_USERS,
+        EndpointKind.NFL_STATE,
+        EndpointKind.PLAYER_CATALOG,
+        EndpointKind.LEAGUE_ROSTERS,
+    ]
+
+
+def test_refresh_without_week_does_not_guess_after_nfl_failure(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        permanent_failures={EndpointKind.NFL_STATE},
+        payloads=_payloads(nfl_week=8, playoff_week=9),
+    )
+
+    outcome = _service(tmp_path, source, backend).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=None,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.PARTIAL
+    assert outcome.requested_scope_count == 5
+    assert all(
+        not result.scope_key.value.startswith(("matchups:", "transactions:"))
+        for result in outcome.scope_results
+    )
+
+
+def test_refresh_derives_week_retries_and_records_before_backoff(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        failures={EndpointKind.PLAYER_CATALOG: 1},
+        payloads=_payloads(nfl_week=2, playoff_week=3),
+    )
+    delays: list[float] = []
+
+    def delay(seconds: float) -> None:
+        delays.append(seconds)
+        assert any(
+            item.endpoint_kind is EndpointKind.PLAYER_CATALOG
+            for item in backend.requests
+        )
+
+    outcome = _service(tmp_path, source, backend, delay=delay).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=None,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.SUCCEEDED
+    assert outcome.requested_scope_count == 9
+    assert outcome.failed_scope_count == 0
+    assert delays == [0.5]
+    assert [item.endpoint_kind for item in backend.requests].count(
+        EndpointKind.PLAYER_CATALOG
+    ) == 2
+    assert [
+        result.scope_key
+        for result in outcome.scope_results
+        if result.scope_key.value.startswith("matchups:")
+    ] == [
+        ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 1),
+        ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 2),
+    ]
+
+
+def test_incomplete_payload_retries_with_backoff_and_applies_latest_attempt(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        payloads=_payloads(nfl_week=1, playoff_week=3),
+        payload_sequences={
+            EndpointKind.PLAYER_CATALOG: [
+                {"p1": None},
+                {"p1": None},
+                {"p1": {"player_id": "p1"}},
+            ]
+        },
+    )
+    delays: list[float] = []
+
+    outcome = _service(
+        tmp_path, source, backend, delay=delays.append
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    player_attempts = [
+        item
+        for item in backend.requests
+        if item.endpoint_kind is EndpointKind.PLAYER_CATALOG
+    ]
+    player_result = next(
+        result
+        for result in outcome.scope_results
+        if result.scope_key
+        == ScopeKey.from_parts(EndpointKind.PLAYER_CATALOG, "nfl")
+    )
+    assert delays == [0.5, 1.0]
+    assert [item.is_complete for item in player_attempts] == [False, False, True]
+    assert player_result.api_request_id == player_attempts[-1].id
+    assert player_result.normalization_status is NormalizationStatus.SUCCEEDED
+
+
+def test_retryable_source_failures_retry_but_permanent_http_does_not(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        payloads=_payloads(nfl_week=1, playoff_week=3),
+        failure_scripts={
+            EndpointKind.LEAGUE_USERS: [
+                (RequestStatus.INVALID_PAYLOAD, 200)
+            ],
+            EndpointKind.PLAYER_CATALOG: [(RequestStatus.HTTP_ERROR, 429)],
+            EndpointKind.LEAGUE_ROSTERS: [(RequestStatus.HTTP_ERROR, 503)],
+            EndpointKind.NFL_STATE: [(RequestStatus.HTTP_ERROR, 404)],
+        },
+    )
+    delays: list[float] = []
+
+    outcome = _service(
+        tmp_path, source, backend, delay=delays.append
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.PARTIAL
+    assert delays == [0.5, 0.5, 0.5]
+    assert source.call_kinds.count(EndpointKind.NFL_STATE) == 1
+    assert source.call_kinds.count(EndpointKind.LEAGUE_USERS) == 2
+    assert source.call_kinds.count(EndpointKind.PLAYER_CATALOG) == 2
+    assert source.call_kinds.count(EndpointKind.LEAGUE_ROSTERS) == 2
+
+
+def test_explicit_week_wins_when_nfl_state_fails(tmp_path: Path) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        permanent_failures={EndpointKind.NFL_STATE},
+        payloads=_payloads(nfl_week=8, playoff_week=9),
+    )
+
+    outcome = _service(tmp_path, source, backend).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.BACKFILL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.PARTIAL
+    assert any(
+        result.scope_key == ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 1)
+        and result.normalization_status is NormalizationStatus.SUCCEEDED
+        for result in outcome.scope_results
+    )
+    nfl = next(
+        result
+        for result in outcome.scope_results
+        if result.scope_key == ScopeKey.from_parts(EndpointKind.NFL_STATE, "nfl")
+    )
+    assert nfl.fetch_status is RequestStatus.HTTP_ERROR
+    assert nfl.warning_codes == ("sleeper_http_error",)
+
+
+def test_missing_dependency_rejects_downstream_scopes(tmp_path: Path) -> None:
+    backend = FakeBackend()
+    source = FakeSource(
+        permanent_failures={EndpointKind.PLAYER_CATALOG},
+        payloads=_payloads(nfl_week=1, playoff_week=3),
+    )
+
+    outcome = _service(tmp_path, source, backend).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.SCHEDULED,
+        )
+    )
+
+    roster = next(
+        result
+        for result in outcome.scope_results
+        if result.scope_key
+        == ScopeKey.from_parts(EndpointKind.LEAGUE_ROSTERS, SEASON_ID)
+    )
+    matchup = next(
+        result
+        for result in outcome.scope_results
+        if result.scope_key == ScopeKey.from_parts(EndpointKind.MATCHUPS, SEASON_ID, 1)
+    )
+    assert outcome.status is RefreshStatus.PARTIAL
+    assert roster.normalization_status is NormalizationStatus.REJECTED
+    assert roster.warning_codes == ("normalization_dependency_unavailable",)
+    assert matchup.normalization_status is NormalizationStatus.REJECTED
+
+
+def test_scope_mapping_conflict_becomes_structured_rejection(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend(conflict_endpoint_kind=EndpointKind.TRANSACTIONS)
+    source = FakeSource(payloads=_payloads(nfl_week=1, playoff_week=3))
+
+    outcome = _service(tmp_path, source, backend).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    transaction = next(
+        result
+        for result in outcome.scope_results
+        if result.scope_key
+        == ScopeKey.from_parts(EndpointKind.TRANSACTIONS, SEASON_ID, 1)
+    )
+    assert outcome.status is RefreshStatus.PARTIAL
+    assert transaction.normalization_status is NormalizationStatus.REJECTED
+    assert transaction.warning_codes == ("normalization_scope_conflict",)
+
+
+def test_large_payload_storage_failure_falls_back_to_inline(tmp_path: Path) -> None:
+    backend = FakeBackend()
+    source = FakeSource(payloads=_payloads(nfl_week=1, playoff_week=3))
+
+    outcome = _service(
+        tmp_path,
+        source,
+        backend,
+        files=FailingFileStore(),
+        inline_payload_max_bytes=1,
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.GENERATION,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.SUCCEEDED
+    assert all(
+        "payload_storage_fallback" in result.warning_codes
+        for result in outcome.scope_results
+    )
+    assert all(command.object_receipt is None for command in backend.commands)
+
+
+def test_large_payloads_are_recorded_with_object_receipts(tmp_path: Path) -> None:
+    backend = FakeBackend()
+    source = FakeSource(payloads=_payloads(nfl_week=1, playoff_week=3))
+
+    outcome = _service(
+        tmp_path,
+        source,
+        backend,
+        inline_payload_max_bytes=1,
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.SUCCEEDED
+    assert all(command.object_receipt is not None for command in backend.commands)
+    assert all(
+        command.object_receipt.storage_key.startswith("payloads/sha256/")
+        for command in backend.commands
+        if command.object_receipt is not None
+    )
+
+
+class FailingFileStore:
+    def store_bytes(
+        self, kind: Any, content: bytes
+    ) -> StoredLocalArtifact:
+        del kind, content
+        raise OSError("object store unavailable")
+
+
+class FakeIdentityReader:
+    def get_refresh_identity(
+        self, competition_season_id: UUID
+    ) -> RefreshSeasonIdentity:
+        assert competition_season_id == SEASON_ID
+        return IDENTITY
+
+
+class FakeSource:
+    def __init__(
+        self,
+        *,
+        payloads: dict[EndpointKind, Any],
+        failures: dict[EndpointKind, int] | None = None,
+        permanent_failures: set[EndpointKind] | None = None,
+        payload_sequences: dict[EndpointKind, list[Any]] | None = None,
+        failure_scripts: dict[
+            EndpointKind, list[tuple[RequestStatus, int | None]]
+        ]
+        | None = None,
+    ) -> None:
+        self.payloads = payloads
+        self.failures = dict(failures or {})
+        self.permanent_failures = permanent_failures or set()
+        self.payload_sequences = {
+            key: list(values) for key, values in (payload_sequences or {}).items()
+        }
+        self.failure_scripts = {
+            key: list(values) for key, values in (failure_scripts or {}).items()
+        }
+        self.call_kinds: list[EndpointKind] = []
+
+    def execute(self, request: EndpointRequest) -> SourceAttempt:
+        self.call_kinds.append(request.endpoint_kind)
+        scripted_failures = self.failure_scripts.get(request.endpoint_kind, [])
+        if scripted_failures:
+            status, http_status = scripted_failures.pop(0)
+            return _failed(request, status=status, http_status=http_status)
+        remaining = self.failures.get(request.endpoint_kind, 0)
+        if remaining:
+            self.failures[request.endpoint_kind] = remaining - 1
+            return _failed(request, status=RequestStatus.TRANSPORT_ERROR)
+        if request.endpoint_kind in self.permanent_failures:
+            return _failed(
+                request,
+                status=RequestStatus.HTTP_ERROR,
+                http_status=404,
+            )
+        sequence = self.payload_sequences.get(request.endpoint_kind, [])
+        payload = sequence.pop(0) if sequence else self.payloads[request.endpoint_kind]
+        return _successful(request, payload)
+
+
+class FakeBackend:
+    def __init__(
+        self, *, conflict_endpoint_kind: EndpointKind | None = None
+    ) -> None:
+        self.command: StartRefresh | None = None
+        self.requests: list[ApiRequest] = []
+        self.commands: list[RecordApiAttempt] = []
+        self.conflict_endpoint_kind = conflict_endpoint_kind
+
+    def start_refresh(self, command: StartRefresh) -> RefreshRun:
+        self.command = command
+        return self._refresh(RefreshStatus.RUNNING, 0, 0)
+
+    def finish_refresh(self, refresh_id: UUID) -> RefreshRun:
+        assert refresh_id == REFRESH_ID
+        assert self.command is not None
+        latest = {item.scope_key: item for item in self.requests}
+        succeeded = sum(
+            latest[item.scope_key].normalization_status
+            is NormalizationStatus.SUCCEEDED
+            for item in self.command.endpoint_scope
+        )
+        failed = len(self.command.endpoint_scope) - succeeded
+        status = (
+            RefreshStatus.SUCCEEDED
+            if failed == 0
+            else RefreshStatus.PARTIAL
+            if succeeded
+            else RefreshStatus.FAILED
+        )
+        return self._refresh(status, succeeded, failed)
+
+    def record_attempt(self, command: RecordApiAttempt) -> ApiRequest:
+        self.commands.append(command)
+        source = command.attempt
+        successful = isinstance(source, SuccessfulSourceAttempt)
+        request = ApiRequest(
+            id=uuid4(),
+            refresh_run_id=REFRESH_ID,
+            competition_season_id=(
+                None
+                if source.endpoint.endpoint_kind
+                in {EndpointKind.NFL_STATE, EndpointKind.PLAYER_CATALOG}
+                else SEASON_ID
+            ),
+            endpoint_kind=source.endpoint.endpoint_kind,
+            scope_key=source.endpoint.scope_key,
+            request_path=source.endpoint.path,
+            request_parameters=dict(source.endpoint.parameters),
+            week=source.endpoint.week,
+            bracket_kind=source.endpoint.bracket_kind,
+            requested_at=source.requested_at,
+            completed_at=source.completed_at,
+            latency_ms=source.latency_ms,
+            status=RequestStatus.SUCCEEDED if successful else source.status,
+            http_status=source.http_status,
+            error=None if successful else source.error.model_dump(mode="json"),
+            is_complete=command.completeness.is_complete,
+            completeness_reason=command.completeness.reason,
+            payload_id=uuid4() if successful else None,
+            response_sha256=source.raw_sha256 if successful else None,
+            normalization_status=(
+                NormalizationStatus.PENDING
+                if successful and command.completeness.is_complete
+                else NormalizationStatus.REJECTED
+                if successful
+                else NormalizationStatus.NOT_APPLICABLE
+            ),
+            normalizer_version=None,
+            normalized_at=None,
+        )
+        self.requests.append(request)
+        return request
+
+    def reject_normalization(
+        self, request_id: UUID, rejection: NormalizationRejection
+    ) -> ApiRequest:
+        del rejection
+        request = self._request(request_id).model_copy(
+            update={"normalization_status": NormalizationStatus.REJECTED}
+        )
+        self._replace(request)
+        return request
+
+    def apply_scope(self, request_id: UUID, records: Any) -> ApplyResult:
+        del records
+        current = self._request(request_id)
+        if current.endpoint_kind is self.conflict_endpoint_kind:
+            raise DatalayerScopeConflict("test mapping conflict")
+        request = current.model_copy(
+            update={"normalization_status": NormalizationStatus.SUCCEEDED}
+        )
+        self._replace(request)
+        return ApplyResult(
+            request_id=request.id,
+            scope_key=request.scope_key,
+            disposition=ApplyDisposition.APPLIED,
+            head_request_id=request.id,
+            normalized_row_count=1,
+            changed_current_view=True,
+        )
+
+    def _request(self, request_id: UUID) -> ApiRequest:
+        return next(item for item in self.requests if item.id == request_id)
+
+    def _replace(self, replacement: ApiRequest) -> None:
+        self.requests = [
+            replacement if item.id == replacement.id else item
+            for item in self.requests
+        ]
+
+    def _refresh(
+        self,
+        status: RefreshStatus,
+        succeeded: int,
+        failed: int,
+    ) -> RefreshRun:
+        return RefreshRun(
+            id=REFRESH_ID,
+            competition_id=COMPETITION_ID,
+            competition_season_id=SEASON_ID,
+            requested_through_week=(
+                None if self.command is None else self.command.requested_through_week
+            ),
+            endpoint_scope=() if self.command is None else self.command.endpoint_scope,
+            trigger=(
+                RefreshTrigger.MANUAL if self.command is None else self.command.trigger
+            ),
+            status=status,
+            code_version="test",
+            normalizer_version="1",
+            started_at=NOW,
+            completed_at=None if status is RefreshStatus.RUNNING else NOW,
+            error=None,
+            request_count=(
+                0 if self.command is None else len(self.command.endpoint_scope)
+            ),
+            succeeded_request_count=succeeded,
+            failed_request_count=failed,
+        )
+
+
+def _service(
+    tmp_path: Path,
+    source: FakeSource,
+    backend: FakeBackend,
+    *,
+    delay: Any = lambda _: None,
+    files: Any | None = None,
+    inline_payload_max_bytes: int = 1024 * 1024,
+) -> DatalayerRefreshService:
+    return DatalayerRefreshService(
+        source=source,
+        identities=FakeIdentityReader(),
+        refreshes=backend,
+        attempts=backend,
+        scopes=backend,
+        files=files or LocalDatalayerFileStore(tmp_path),
+        code_version="test",
+        max_attempts=3,
+        retry_backoff_seconds=0.5,
+        inline_payload_max_bytes=inline_payload_max_bytes,
+        delay=delay,
+    )
+
+
+def _payloads(*, nfl_week: int, playoff_week: int) -> dict[EndpointKind, Any]:
+    return {
+        EndpointKind.LEAGUE: _league_payload(
+            playoff_week=playoff_week, draft_rounds=0
+        ),
+        EndpointKind.LEAGUE_USERS: [],
+        EndpointKind.NFL_STATE: {"season": "2026", "week": nfl_week},
+        EndpointKind.PLAYER_CATALOG: {"p1": {"player_id": "p1"}},
+        EndpointKind.LEAGUE_ROSTERS: [],
+        EndpointKind.TRADED_PICKS: [],
+        EndpointKind.MATCHUPS: [],
+        EndpointKind.TRANSACTIONS: [],
+        EndpointKind.WINNERS_BRACKET: [],
+        EndpointKind.LOSERS_BRACKET: [],
+    }
+
+
+def _league_payload(*, playoff_week: int, draft_rounds: int) -> dict[str, Any]:
+    return {
+        "league_id": "league-1",
+        "name": "Test League",
+        "season": "2026",
+        "sport": "nfl",
+        "settings": {
+            "playoff_week_start": playoff_week,
+            "draft_rounds": draft_rounds,
+        },
+        "scoring_settings": {},
+        "roster_positions": ["QB"],
+    }
+
+
+def _successful(request: EndpointRequest, payload: Any) -> SuccessfulSourceAttempt:
+    content = canonical_json_bytes(payload)
+    return SuccessfulSourceAttempt(
+        endpoint=request,
+        requested_at=NOW,
+        completed_at=NOW,
+        http_status=200,
+        latency_ms=1,
+        payload=payload,
+        raw_sha256=hashlib.sha256(content).hexdigest(),
+        byte_length=len(content),
+        media_type="application/json",
+    )
+
+
+def _failed(
+    request: EndpointRequest,
+    *,
+    status: RequestStatus,
+    http_status: int | None = None,
+) -> FailedSourceAttempt:
+    return FailedSourceAttempt(
+        endpoint=request,
+        requested_at=NOW,
+        completed_at=NOW,
+        status=status,
+        http_status=http_status,
+        latency_ms=1,
+        error=SanitizedSourceError(
+            code=(
+                "sleeper_http_error"
+                if status is RequestStatus.HTTP_ERROR
+                else "sleeper_invalid_json"
+                if status is RequestStatus.INVALID_PAYLOAD
+                else "sleeper_transport_error"
+            ),
+            summary="Source failed",
+        ),
+    )

--- a/backend/tests/services/datalayer/test_refresh_service_integration.py
+++ b/backend/tests/services/datalayer/test_refresh_service_integration.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.sleeper_data import (
+    ApiRequestManager,
+    LeagueSeasonManager,
+    MatchupManager,
+    NormalizedScopeManager,
+    PlayerManager,
+    PlayerSearch,
+    RefreshRunManager,
+    RosterManager,
+    TransactionManager,
+    TransactionQuery,
+)
+from backend.services.datalayer import (
+    EndpointKind,
+    LocalDatalayerFileStore,
+    RefreshRequest,
+    RefreshStatus,
+    RefreshTrigger,
+    RequestStatus,
+    SanitizedSourceError,
+    SuccessfulSourceAttempt,
+)
+from backend.services.datalayer.canonical_json import canonical_json_bytes
+from backend.services.datalayer.refresh_service import DatalayerRefreshService
+from backend.services.datalayer.sleeper.responses import (
+    EndpointRequest,
+    FailedSourceAttempt,
+    SourceAttempt,
+)
+from backend.tests.resources.sleeper_data.conftest import (
+    Domain,
+    manager_context,
+    seed_domain,
+)
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@pytest.fixture
+def session_factory(database_engine: Engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+def test_fixture_refresh_populates_current_postgresql_reads(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    tmp_path: Path,
+) -> None:
+    domain = seed_domain(database_engine, label="Refresh Workflow")
+    context = manager_context(domain)
+    service = DatalayerRefreshService(
+        source=FixtureSource(domain),
+        identities=LeagueSeasonManager(session_factory, context),
+        refreshes=RefreshRunManager(session_factory, context),
+        attempts=ApiRequestManager(session_factory, context),
+        scopes=NormalizedScopeManager(session_factory, context),
+        files=LocalDatalayerFileStore(tmp_path),
+        code_version="test",
+        delay=lambda _: None,
+    )
+
+    outcome = service.refresh(
+        RefreshRequest(
+            competition_season_id=domain.season_id,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.SUCCEEDED
+    assert outcome.requested_scope_count == 10
+    overview = LeagueSeasonManager(session_factory, context).get_season_overview(
+        domain.season_id
+    )
+    assert overview.league_name == "Refresh Workflow League"
+    roster = RosterManager(session_factory, context).get_roster(domain.roster_ids[0])
+    assert roster.competition_season_id == domain.season_id
+    assert PlayerManager(session_factory, context).search_players(
+        PlayerSearch()
+    ).total == 4
+    assert len(
+        MatchupManager(session_factory, context).list_matchups(
+            domain.season_id, 1
+        )
+    ) == 2
+    assert len(
+        TransactionManager(session_factory, context).list_transactions(
+            TransactionQuery(competition_season_id=domain.season_id, week=1)
+        )
+    ) == 1
+
+
+def test_partial_refresh_preserves_previous_good_scope_head(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    tmp_path: Path,
+) -> None:
+    domain = seed_domain(database_engine, label="Refresh Preservation")
+    context = manager_context(domain)
+
+    def service(source: FixtureSource) -> DatalayerRefreshService:
+        return DatalayerRefreshService(
+            source=source,
+            identities=LeagueSeasonManager(session_factory, context),
+            refreshes=RefreshRunManager(session_factory, context),
+            attempts=ApiRequestManager(session_factory, context),
+            scopes=NormalizedScopeManager(session_factory, context),
+            files=LocalDatalayerFileStore(tmp_path),
+            code_version="test",
+            max_attempts=1,
+            delay=lambda _: None,
+        )
+
+    first = service(FixtureSource(domain)).refresh(
+        RefreshRequest(
+            competition_season_id=domain.season_id,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+    before = MatchupManager(session_factory, context).list_matchups(
+        domain.season_id, 1
+    )
+
+    second = service(
+        FixtureSource(domain, failures={EndpointKind.MATCHUPS})
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=domain.season_id,
+            through_week=1,
+            trigger=RefreshTrigger.SCHEDULED,
+        )
+    )
+    after = MatchupManager(session_factory, context).list_matchups(
+        domain.season_id, 1
+    )
+
+    assert first.status is RefreshStatus.SUCCEEDED
+    assert second.status is RefreshStatus.PARTIAL
+    assert tuple(item.source_api_request_id for item in after) == tuple(
+        item.source_api_request_id for item in before
+    )
+
+
+class FixtureSource:
+    def __init__(
+        self,
+        domain: Domain,
+        *,
+        failures: set[EndpointKind] | None = None,
+    ) -> None:
+        self._domain = domain
+        self._failures = failures or set()
+
+    def execute(self, request: EndpointRequest) -> SourceAttempt:
+        if request.endpoint_kind in self._failures:
+            now = datetime.now(UTC)
+            return FailedSourceAttempt(
+                endpoint=request,
+                requested_at=now,
+                completed_at=now,
+                status=RequestStatus.HTTP_ERROR,
+                http_status=404,
+                latency_ms=0,
+                error=SanitizedSourceError(
+                    code="sleeper_http_error",
+                    summary="Sleeper returned HTTP 404",
+                ),
+            )
+        payload = self._payload(request.endpoint_kind)
+        content = canonical_json_bytes(payload)
+        now = datetime.now(UTC)
+        return SuccessfulSourceAttempt(
+            endpoint=request,
+            requested_at=now,
+            completed_at=now,
+            http_status=200,
+            latency_ms=0,
+            payload=payload,
+            raw_sha256=hashlib.sha256(content).hexdigest(),
+            byte_length=len(content),
+            media_type="application/json",
+        )
+
+    def _payload(self, kind: EndpointKind) -> Any:
+        if kind is EndpointKind.LEAGUE:
+            return {
+                "league_id": self._domain.sleeper_league_id,
+                "name": "Refresh Workflow League",
+                "season": "2026",
+                "sport": "nfl",
+                "settings": {"playoff_week_start": 1, "draft_rounds": 1},
+                "scoring_settings": {"rec": 1},
+                "roster_positions": ["QB", "RB"],
+            }
+        if kind is EndpointKind.LEAGUE_USERS:
+            return [
+                {"user_id": "u1", "display_name": "Alice"},
+                {"user_id": "u2", "display_name": "Bob"},
+            ]
+        if kind is EndpointKind.NFL_STATE:
+            return {"season": "2026", "week": 1}
+        if kind is EndpointKind.PLAYER_CATALOG:
+            return {
+                player_id: {"player_id": player_id, "full_name": player_id.upper()}
+                for player_id in ("p1", "p2", "p3", "p4")
+            }
+        if kind is EndpointKind.LEAGUE_ROSTERS:
+            return [
+                {
+                    "roster_id": 1,
+                    "owner_id": "u1",
+                    "settings": {"wins": 1, "losses": 0, "ties": 0},
+                    "metadata": {},
+                    "players": ["p1", "p2"],
+                    "starters": ["p1"],
+                },
+                {
+                    "roster_id": 2,
+                    "owner_id": "u2",
+                    "settings": {"wins": 0, "losses": 1, "ties": 0},
+                    "metadata": {},
+                    "players": ["p3", "p4"],
+                    "starters": ["p3"],
+                },
+            ]
+        if kind is EndpointKind.TRADED_PICKS:
+            return [
+                {"season": "2027", "round": 1, "roster_id": 1, "owner_id": 2}
+            ]
+        if kind is EndpointKind.MATCHUPS:
+            return [
+                {
+                    "matchup_id": 1,
+                    "roster_id": 1,
+                    "points": Decimal("100.5"),
+                    "starters": ["p1"],
+                    "players": ["p1", "p2"],
+                    "players_points": {"p1": Decimal("60.5"), "p2": 40},
+                },
+                {
+                    "matchup_id": 1,
+                    "roster_id": 2,
+                    "points": 90,
+                    "starters": ["p3"],
+                    "players": ["p3", "p4"],
+                    "players_points": {"p3": 55, "p4": 35},
+                },
+            ]
+        if kind is EndpointKind.TRANSACTIONS:
+            return [
+                {
+                    "transaction_id": "tx1",
+                    "type": "waiver",
+                    "status": "complete",
+                    "created": 1700000000,
+                    "settings": {"waiver_bid": 5},
+                    "metadata": {},
+                    "adds": {"p2": 1},
+                    "drops": {"p3": 2},
+                    "draft_picks": [],
+                }
+            ]
+        if kind in {EndpointKind.WINNERS_BRACKET, EndpointKind.LOSERS_BRACKET}:
+            return [
+                {"r": 1, "m": 1, "t1": 1, "t2": 2, "w": 1, "l": 2}
+            ]
+        raise AssertionError(f"unexpected endpoint kind: {kind}")

--- a/docs/datalayer/README.md
+++ b/docs/datalayer/README.md
@@ -58,7 +58,7 @@ generation snapshot when the reporter needs data.
 flowchart LR
     Caller["API, worker, or generation service"] --> Refresh["DatalayerRefreshService"]
     Refresh --> Sleeper["Sleeper source adapter"]
-    Refresh --> Data["SleeperDataManager"]
+    Refresh --> Data["Sleeper resource managers"]
     Data --> Current["Normalized PostgreSQL heads"]
     Caller --> Snapshot["DatalayerSnapshotService"]
     Snapshot --> Data
@@ -154,7 +154,8 @@ The baseline intentionally pays for only these deep boundaries:
 
 - refresh service for external fetch/retry/orchestration;
 - snapshot service for selection, atomic reuse/build, and artifact sealing;
-- `SleeperDataManager` for the complete ingestion persistence transaction;
+- resource-specific Sleeper managers, with `NormalizedScopeManager` owning the
+  complete ingestion persistence transaction;
 - `DataSnapshotManager` for canonical snapshot lifecycle;
 - SQLite projection plus `FrozenLeagueData` for cutoff-safe reporter execution;
 - local file storage for atomic, hash-verified artifacts.

--- a/docs/datalayer/application-contracts.md
+++ b/docs/datalayer/application-contracts.md
@@ -38,10 +38,12 @@ class RefreshRequest(BaseModel, frozen=True):
     trigger: RefreshTrigger
 ```
 
-The service derives `competition_id`, the standard endpoint set, player-catalog
-staleness, and bracket relevance. Ordinary callers cannot partially configure a
-refresh into an invalid data state. A future endpoint-specific maintenance
-command is separate from the product refresh contract.
+The service derives `competition_id`, the standard endpoint set, effective week,
+and bracket relevance. V1 always fetches the player catalog so the roster and
+weekly dependency graph is complete inside the same auditable refresh. Ordinary
+callers cannot partially configure a refresh into an invalid data state. A
+future endpoint-specific maintenance command is separate from the product
+refresh contract.
 
 ### Refresh outcome
 
@@ -146,11 +148,19 @@ identity correction is a maintenance command, not a second public service mode.
 The service accepts these constructor dependencies:
 
 - `SleeperSourceClient`;
-- `SleeperDataManager`;
+- resource-specific refresh, request, normalized-scope, and season managers;
 - read-only core identity lookup port;
-- a clock;
+- configured bounded retry policy and delay;
 - configured `LocalDatalayerFileStore` for raw payloads too large for inline
   PostgreSQL JSONB.
+
+League metadata and NFL state are fetched first because they resolve the
+effective week and settings-dependent scopes. Their attempt envelopes are held
+in memory only until the complete immutable refresh plan is created, then are
+recorded before normalization or current-view application. An explicit
+`through_week` takes precedence over NFL state. If neither it nor a complete NFL
+state supplies a positive week, the refresh records and applies only the
+resolvable season/global plan rather than guessing a week.
 
 Endpoint planning and endpoint-family dispatch are ordinary module functions,
 not injected registries or one-method strategy objects.
@@ -183,7 +193,7 @@ its exact membership.
 
 The service accepts:
 
-- `SleeperDataManager` for eligible request reads and payload resolution;
+- `ApiRequestManager` for eligible request reads and payload resolution;
 - `DataSnapshotManager` for atomic build-key ownership, lifecycle, and
   membership;
 - core identity lookup port;
@@ -224,33 +234,46 @@ All managers are constructed with a `ManagerContext`. Competition-scoped
 operations apply that context to every read and write. Signatures below omit
 ordinary pagination values for clarity.
 
-### `SleeperDataManager`
+### Sleeper resource managers
 
 ```python
-class SleeperDataManager:
+class RefreshRunManager:
     def start_refresh(self, command: StartRefresh) -> RefreshRun: ...
+    def finish_refresh(self, refresh_id: UUID) -> RefreshRun: ...
+    def get_refresh(self, refresh_id: UUID) -> RefreshRun: ...
+
+class ApiRequestManager:
     def record_attempt(self, command: RecordApiAttempt) -> ApiRequest: ...
+    def reject_normalization(self, request_id: UUID, rejection: Rejection) -> ApiRequest: ...
+    def list_refresh_requests(self, refresh_id: UUID) -> Page[ApiRequest]: ...
+    def list_snapshot_candidates(self, query: SnapshotCandidateQuery) -> tuple[ApiRequestCandidate, ...]: ...
+    def resolve_verified_payloads(self, request_ids: Collection[UUID]) -> tuple[VerifiedPayload, ...]: ...
+
+class NormalizedScopeManager:
     def apply_scope(
         self,
         request_id: UUID,
         records: EndpointRecords,
     ) -> ApplyResult: ...
-    def reject_normalization(self, request_id: UUID, rejection: Rejection) -> ApiRequest: ...
-    def finish_refresh(self, refresh_id: UUID) -> RefreshRun: ...
 
-    def get_refresh(self, refresh_id: UUID) -> RefreshRun: ...
-    def list_refresh_requests(self, refresh_id: UUID) -> Page[ApiRequest]: ...
+class LeagueSeasonManager:
+    def get_refresh_identity(self, competition_season_id: UUID) -> RefreshSeasonIdentity: ...
     def get_snapshot_planning_context(
         self,
         competition_season_id: UUID,
     ) -> SnapshotPlanningContext: ...
-    def list_snapshot_candidates(self, query: SnapshotCandidateQuery) -> tuple[ApiRequestCandidate, ...]: ...
-    def resolve_verified_payloads(self, request_ids: Collection[UUID]) -> tuple[VerifiedPayload, ...]: ...
-
     def get_season_overview(self, season_id: UUID) -> LeagueSeasonOverview: ...
+
+class RosterManager:
     def get_roster(self, season_roster_id: UUID) -> SeasonRosterState: ...
+
+class MatchupManager:
     def list_matchups(self, season_id: UUID, week: int) -> tuple[Matchup, ...]: ...
+
+class TransactionManager:
     def list_transactions(self, query: TransactionQuery) -> tuple[Transaction, ...]: ...
+
+class PlayerManager:
     def search_players(self, query: PlayerSearch) -> Page[Player]: ...
 ```
 
@@ -262,10 +285,11 @@ Large payload bytes are stored before this call; the manager verifies the
 supplied local-file receipt/hash rather than performing filesystem or network
 I/O.
 
-`apply_scope()` owns the compare-and-swap request/head/current-view transaction
-across the Sleeper persistence namespace. `finish_refresh()` derives status and
-counts from recorded request outcomes; the service does not calculate and pass
-the same summary back down.
+`NormalizedScopeManager.apply_scope()` owns the compare-and-swap
+request/head/current-view transaction across the Sleeper persistence namespace.
+`RefreshRunManager.finish_refresh()` derives status and counts from recorded
+request outcomes; the service does not calculate and pass the same summary back
+down.
 
 `get_snapshot_planning_context()` returns the current normalized structural
 settings for the requested season under v1's season-stability assumption.

--- a/docs/datalayer/architecture.md
+++ b/docs/datalayer/architecture.md
@@ -38,7 +38,7 @@ flowchart TB
     end
 
     subgraph Resources["backend/resources"]
-        DataManager["SleeperDataManager"]
+        DataManagers["Sleeper resource managers"]
         SnapshotManager["DataSnapshotManager"]
         CoreManagers["Competition and identity managers"]
     end
@@ -57,10 +57,10 @@ flowchart TB
     Refresh --> Source
     Source --> SleeperAPI
     Refresh --> Endpoints
-    Refresh --> DataManager
-    DataManager --> PG
+    Refresh --> DataManagers
+    DataManagers --> PG
     Snapshot --> Selector
-    Snapshot --> DataManager
+    Snapshot --> DataManagers
     Snapshot --> SnapshotManager
     Snapshot --> Endpoints
     Snapshot --> Projection
@@ -72,9 +72,10 @@ flowchart TB
     Refresh -. "resolved IDs" .-> CoreManagers
 ```
 
-`SleeperDataManager` owns the whole ingestion write aggregate, including the
-atomic “apply request and advance scope head” transaction. No manager reaches
-through another resource with session-bound write helpers.
+Resource-specific managers own their public objects and operations.
+`NormalizedScopeManager` owns the atomic “apply request and advance scope head”
+transaction and calls transaction-scoped endpoint projection writers; no ORM row
+or session leaves the resource package.
 
 ## Projection and Query Boundaries
 
@@ -165,8 +166,8 @@ Owns one refresh workflow from request planning through refresh completion. It:
   normalized facts;
 - delegates normalization of complete payloads to that same endpoint-family
   module;
-- asks `SleeperDataManager` to atomically apply eligible endpoint records;
-- asks the manager to derive and persist the final succeeded, partial, failed,
+- asks `NormalizedScopeManager` to atomically apply eligible endpoint records;
+- asks `RefreshRunManager` to derive and persist the final succeeded, partial, failed,
   or cancelled status from its recorded child requests.
 
 It does not open sessions or hold a transaction during HTTP work.
@@ -209,18 +210,20 @@ endpoint kinds.
 
 ### Resource Managers
 
-Two managers own deep persistence aggregates:
+Resource-specific managers own the Sleeper persistence boundaries:
 
 | Manager | Aggregate and responsibilities |
 | --- | --- |
-| `SleeperDataManager` | Refresh runs, API attempts/payloads, normalized scope heads, current normalized Sleeper tables, current product reads, snapshot candidates, and the atomic request/head/current-view transaction |
+| `RefreshRunManager` | Refresh plans, lifecycle, derived terminal status, and counts |
+| `ApiRequestManager` | API attempts, payload receipts, audit reads, snapshot candidates, and verified payload resolution |
+| `NormalizedScopeManager` | Atomic scope-head comparison and normalized current-view replacement |
+| Season, roster, matchup, transaction, and player managers | Scoped current product reads returning immutable resource objects |
 | `DataSnapshotManager` | Canonical build-key claim/reuse, snapshot lifecycle, exact request membership, immutable sealing, and failure state |
 
-There are no cross-resource `shared.py` write helpers. The Sleeper request,
-scope head, player catalog, and league current view form one ingestion write
-aggregate, so one manager owns that transaction. Its public read methods still
-apply explicit competition or global scope and return resource objects rather
-than ORM rows.
+There are no cross-resource `shared.py` write helpers. Endpoint projection
+writers run only inside the transaction owned by `NormalizedScopeManager`.
+Public read methods apply explicit competition or global scope and return
+resource objects rather than ORM rows.
 
 ### `DatalayerSnapshotService`
 
@@ -235,7 +238,7 @@ long-running snapshot workflow:
 - bounds waiting on an existing build, atomically fails an abandoned build,
   and retries the claim without exposing recovery policy to its caller;
 - reads season-stable planning settings, derives explicit required scopes, asks
-  `SleeperDataManager` for eligible request candidates, and selects exactly one
+  `ApiRequestManager` for eligible request candidates, and selects exactly one
   request for every requirement;
 - resolves and hash-verifies raw payloads;
 - runs the same normalizers used by ingestion;

--- a/docs/datalayer/ingestion.md
+++ b/docs/datalayer/ingestion.md
@@ -21,7 +21,7 @@ The ingestion design is governed by these rules:
 sequenceDiagram
     participant Caller
     participant Service as DatalayerRefreshService
-    participant Data as SleeperDataManager
+    participant Data as Sleeper resource managers
     participant Source as SleeperSourceClient
     participant Endpoint as Endpoint-family module
     participant DB as PostgreSQL
@@ -234,7 +234,7 @@ manager name.
 
 ## Atomic Scope Application
 
-`SleeperDataManager.apply_scope()` follows this transaction:
+`NormalizedScopeManager.apply_scope()` follows this transaction:
 
 1. load the recorded request and lock its `normalized_scopes` row;
 2. verify the source request is successful, complete, payload-hash verified,
@@ -314,7 +314,8 @@ only through the same eligibility transaction.
 
 ## Current-View Read Models
 
-`SleeperDataManager` returns resource objects designed for product display and
+The season, roster, matchup, transaction, and player managers return resource
+objects designed for product display and
 cross-season application workflows. They may join normalized Sleeper tables to
 core competition/franchise identities, but they do not expose source ORM rows.
 

--- a/docs/datalayer/snapshots-and-query-runtime.md
+++ b/docs/datalayer/snapshots-and-query-runtime.md
@@ -76,7 +76,7 @@ sequenceDiagram
     participant Caller
     participant Service as DatalayerSnapshotService
     participant Snap as DataSnapshotManager
-    participant Obs as SleeperDataManager
+    participant Obs as Sleeper resource managers
     participant Require as Pure requirement planning
     participant Select as Pure request selection
     participant Norm as Endpoint-family modules
@@ -143,7 +143,7 @@ rather than adding a reference-aware cleanup workflow.
 ## Required Request Set
 
 V1 assumes structural league settings remain stable within one competition
-season. `SleeperDataManager` returns a season-scoped `SnapshotPlanningContext`
+season. `LeagueSeasonManager` returns a season-scoped `SnapshotPlanningContext`
 from the current normalized league configuration; a pure planner expands that
 context and the `SnapshotRequest` into explicit `SnapshotRequirements` using
 the shared `EndpointKind` and `ScopeKey` vocabulary. These planning settings

--- a/docs/datalayer/transition.md
+++ b/docs/datalayer/transition.md
@@ -90,7 +90,7 @@ endpoint record.
 raw Sleeper payload
   -> endpoint-family validation/normalization
   -> EndpointRecords
-      -> SleeperDataManager current-view projection
+      -> NormalizedScopeManager current-view projection
       -> SQLite cutoff projection
 ```
 
@@ -101,7 +101,7 @@ Snapshot-only derivations remain in the snapshot projection.
 ### 3. Separate observations from facts
 
 The legacy cache can make a request disappear from runtime behavior. The new
-client always performs the planned call, and `SleeperDataManager` records
+client always performs the planned call, and `ApiRequestManager` records
 the attempt. Payload hashes deduplicate bytes without deduplicating observations.
 
 ### 4. Make historical reconstruction physical
@@ -136,7 +136,8 @@ constraints are proven before manager code depends on them.
 
 ### Slice 2: Deep persistence aggregates
 
-- Implement `SleeperDataManager` against the completed PostgreSQL models.
+- Implement resource-specific Sleeper managers against the completed PostgreSQL
+  models.
 - Implement content-addressed payload receipts and request recording.
 - Implement scope-head compare-and-swap and atomic apply behavior.
 - Make refresh finalization derive counts/status from child requests.


### PR DESCRIPTION
## Summary

Add the synchronous Layer 7 refresh workflow that turns a season identity and
refresh request into a fully audited, normalized PostgreSQL refresh outcome.

The workflow remains sequential in v1 for deterministic ordering and source
client safety. It adds no HTTP routes, scheduling, snapshots, reporter
integration, migrations, or legacy cutover.

## Changes

- Add bootstrap-safe refresh season identity reads without requiring an
  existing normalized league observation.
- Add deterministic standard planning for league metadata, users, NFL state,
  the full player catalog, rosters, weekly matchups/transactions, conditional
  traded picks, and conditional brackets.
- Prefetch league/NFL metadata, persist the complete resolvable plan and
  buffered attempts, and avoid guessing a week after state failure.
- Record every bounded retry attempt with injected exponential backoff for
  retryable transport, response, JSON, and completeness failures.
- Normalize only latest complete attempts in declared dependency order, while
  turning unavailable dependencies and mapping conflicts into structured
  rejections and continuing unrelated scopes.
- Store successful canonical payloads above the configured threshold in the
  local datalayer file store, with audited inline fallback warnings.
- Assemble ordered scope results from terminal attempts and delegate terminal
  status/count authority to `RefreshRunManager.finish_refresh()`.
- Add refresh settings and typed dependency composition without opening a
  database session during construction.
- Align architecture documentation with resource-specific managers and the
  deterministic full-catalog v1 plan.

## Verification

- Focused Layer 7 plus inherited datalayer service/resource suite: 247 passed.
- Complete repository suite against disposable PostgreSQL: 667 passed, 1
  expected Windows symbolic-link capability skip.
- Live integration proves public refresh populates current league, roster,
  player, matchup, transaction, pick, and bracket reads, and that a failed
  scope preserves its existing normalized head.
- Exact Alembic upgrade/head/downgrade/re-upgrade/metadata-drift lifecycle:
  passed at sole head `0007`, with no new upgrade operations.
- Package compilation, line-length audit, stale-facade scan, and diff checks:
  passed.

## Stack

- Parent: Layer 6 current reads (`174af3e`, PR #130)
- Local commit: `47c2cdb`
- Implements Layer 7
- GitHub stack: #123
