### PR TITLE
feat(datalayer): add snapshot selection

### DIFF
--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -12,7 +12,10 @@ from backend.services.datalayer.contracts import (
     RefreshTrigger,
     RequestStatus,
     ScopeRefreshResult,
+    SnapshotSelectionRole,
+    SnapshotStatus,
     SnapshotRequest,
+    ReadyDataSnapshot,
     WarningCode,
 )
 from backend.services.datalayer.errors import (
@@ -154,8 +157,15 @@ __all__ = [
     "SNAPSHOT_PROJECTION_VERSION",
     "ScopeKey",
     "ScopeRefreshResult",
+    "SelectedRequestManifest",
+    "SelectedRequestManifestEntry",
+    "SnapshotRequirement",
+    "SnapshotRequirements",
     "SnapshotRequest",
+    "SnapshotSelectionRole",
+    "SnapshotStatus",
     "SnapshotUnavailable",
+    "ReadyDataSnapshot",
     "SleeperSourceClient",
     "SourceAttempt",
     "StoredLocalArtifact",
@@ -177,11 +187,13 @@ __all__ = [
     "build_nfl_state_request",
     "build_player_catalog_request",
     "build_standard_refresh_plan",
+    "canonical_snapshot_build_key",
     "build_traded_picks_request",
     "build_transactions_request",
     "build_winners_bracket_request",
     "get_endpoint_apply_metadata",
     "missing_dependency_scope_keys",
+    "plan_snapshot_requirements",
     "normalize_league",
     "normalize_league_rosters",
     "normalize_league_users",
@@ -202,17 +214,53 @@ __all__ = [
     "validate_traded_picks_completeness",
     "validate_transactions_completeness",
     "validate_winners_bracket_completeness",
+    "select_snapshot_requests",
 ]
 
 
 def __getattr__(name: str) -> Any:
-    """Lazily expose the resource-composing refresh service without a cycle."""
+    """Lazily expose resource-composing workflows without import cycles."""
 
     if name in {
         "DatalayerRefreshService",
         "PlannedRefresh",
         "build_standard_refresh_plan",
+        "SelectedRequestManifest",
+        "SelectedRequestManifestEntry",
+        "SnapshotRequirement",
+        "SnapshotRequirements",
+        "canonical_snapshot_build_key",
+        "plan_snapshot_requirements",
+        "select_snapshot_requests",
     }:
+        if name in {
+            "SelectedRequestManifest",
+            "SelectedRequestManifestEntry",
+            "SnapshotRequirement",
+            "SnapshotRequirements",
+            "canonical_snapshot_build_key",
+            "plan_snapshot_requirements",
+            "select_snapshot_requests",
+        }:
+            from backend.services.datalayer.snapshot_selection import (
+                SelectedRequestManifest,
+                SelectedRequestManifestEntry,
+                SnapshotRequirement,
+                SnapshotRequirements,
+                canonical_snapshot_build_key,
+                plan_snapshot_requirements,
+                select_snapshot_requests,
+            )
+
+            return {
+                "SelectedRequestManifest": SelectedRequestManifest,
+                "SelectedRequestManifestEntry": SelectedRequestManifestEntry,
+                "SnapshotRequirement": SnapshotRequirement,
+                "SnapshotRequirements": SnapshotRequirements,
+                "canonical_snapshot_build_key": canonical_snapshot_build_key,
+                "plan_snapshot_requirements": plan_snapshot_requirements,
+                "select_snapshot_requests": select_snapshot_requests,
+            }[name]
         from backend.services.datalayer.refresh_service import (
             DatalayerRefreshService,
             PlannedRefresh,

--- a/backend/services/datalayer/contracts.py
+++ b/backend/services/datalayer/contracts.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
+from backend.services.datalayer.local_files import VerifiedLocalArtifact
 from backend.services.datalayer.sleeper.scope import ScopeKey
 
 
@@ -60,6 +61,26 @@ class NormalizationStatus(StrEnum):
     NOT_APPLICABLE = "not_applicable"
 
 
+class SnapshotStatus(StrEnum):
+    BUILDING = "building"
+    READY = "ready"
+    FAILED = "failed"
+    EXPIRED = "expired"
+
+
+class SnapshotSelectionRole(StrEnum):
+    LEAGUE = "league"
+    LEAGUE_USERS = "league_users"
+    NFL_STATE = "nfl_state"
+    PLAYER_CATALOG = "player_catalog"
+    LEAGUE_ROSTERS = "league_rosters"
+    TRADED_PICKS = "traded_picks"
+    WEEK_MATCHUPS = "week_matchups"
+    WEEK_TRANSACTIONS = "week_transactions"
+    WINNERS_BRACKET = "winners_bracket"
+    LOSERS_BRACKET = "losers_bracket"
+
+
 class ApplyDisposition(StrEnum):
     APPLIED = "applied"
     STALE_IGNORED = "stale_ignored"
@@ -103,3 +124,15 @@ class CompletenessWarning(_WorkflowValue):
     code: WarningCode
     summary: WarningSummary
     scope_key: ScopeKey | None = None
+
+
+class ReadyDataSnapshot(_WorkflowValue):
+    id: UUID
+    competition_id: UUID
+    primary_competition_season_id: UUID
+    through_week: int = Field(ge=1, le=18, strict=True)
+    as_of_date: date
+    build_key: str
+    snapshot_projection_version: str
+    artifact: VerifiedLocalArtifact
+    completeness_warnings: tuple[CompletenessWarning, ...] = ()

--- a/backend/services/datalayer/snapshot_selection.py
+++ b/backend/services/datalayer/snapshot_selection.py
@@ -1,0 +1,256 @@
+"""Pure daily identity, requirement planning, and request selection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import Field, StringConstraints, model_validator
+
+from backend.resources._contracts import ContractModel
+from backend.resources.sleeper_data.league_seasons import SnapshotPlanningContext
+from backend.resources.sleeper_data.requests import ApiRequestCandidate
+from backend.services.datalayer.canonical_json import canonical_json_sha256
+from backend.services.datalayer.contracts import (
+    SnapshotRequest,
+    SnapshotSelectionRole,
+)
+from backend.services.datalayer.errors import (
+    DatalayerScopeConflict,
+    SnapshotUnavailable,
+)
+from backend.services.datalayer.sleeper.endpoints import (
+    build_league_request,
+    build_league_rosters_request,
+    build_league_users_request,
+    build_losers_bracket_request,
+    build_matchups_request,
+    build_nfl_state_request,
+    build_player_catalog_request,
+    build_traded_picks_request,
+    build_transactions_request,
+    build_winners_bracket_request,
+)
+from backend.services.datalayer.sleeper.responses import EndpointRequest
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+
+
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{64}$")]
+_GLOBAL_ENDPOINTS = {EndpointKind.NFL_STATE, EndpointKind.PLAYER_CATALOG}
+
+
+class SnapshotRequirement(ContractModel):
+    request: EndpointRequest
+    selection_role: SnapshotSelectionRole
+
+
+class SnapshotRequirements(ContractModel):
+    entries: tuple[SnapshotRequirement, ...]
+
+    @model_validator(mode="after")
+    def validate_entries(self) -> "SnapshotRequirements":
+        if not self.entries:
+            raise ValueError("snapshot requirements must not be empty")
+        scopes = [entry.request.scope_key for entry in self.entries]
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("snapshot requirement scopes must be unique")
+        return self
+
+    @property
+    def scope_keys(self) -> tuple[ScopeKey, ...]:
+        return tuple(entry.request.scope_key for entry in self.entries)
+
+
+class SelectedRequestManifestEntry(ContractModel):
+    request_id: UUID
+    endpoint_kind: EndpointKind
+    scope_key: ScopeKey
+    selection_role: SnapshotSelectionRole
+    response_sha256: Sha256
+
+
+class SelectedRequestManifest(ContractModel):
+    entries: tuple[SelectedRequestManifestEntry, ...]
+
+    @model_validator(mode="after")
+    def validate_entries(self) -> "SelectedRequestManifest":
+        if not self.entries:
+            raise ValueError("selected request manifest must not be empty")
+        request_ids = [entry.request_id for entry in self.entries]
+        scopes = [entry.scope_key for entry in self.entries]
+        if len(request_ids) != len(set(request_ids)):
+            raise ValueError("selected request IDs must be unique")
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("selected request scopes must be unique")
+        return self
+
+
+def canonical_snapshot_build_key(
+    request: SnapshotRequest,
+    snapshot_projection_version: str,
+) -> str:
+    """Return the stable daily identity before any candidate reads."""
+
+    version = snapshot_projection_version
+    if not version or version != version.strip():
+        raise ValueError("snapshot projection version must not be empty")
+    return canonical_json_sha256(
+        {
+            "as_of_date": request.as_of_date.isoformat(),
+            "competition_season_id": str(request.competition_season_id),
+            "snapshot_projection_version": version,
+            "through_week": request.through_week,
+        }
+    )
+
+
+def plan_snapshot_requirements(
+    request: SnapshotRequest,
+    context: SnapshotPlanningContext,
+) -> SnapshotRequirements:
+    """Expand stable season settings into the exact required request scopes."""
+
+    if context.competition_season_id != request.competition_season_id:
+        raise DatalayerScopeConflict("snapshot planning context is for another season")
+
+    season_id = request.competition_season_id
+    league_id = context.sleeper_league_id
+    entries = [
+        SnapshotRequirement(
+            request=build_league_request(season_id, league_id),
+            selection_role=SnapshotSelectionRole.LEAGUE,
+        ),
+        SnapshotRequirement(
+            request=build_league_users_request(season_id, league_id),
+            selection_role=SnapshotSelectionRole.LEAGUE_USERS,
+        ),
+        SnapshotRequirement(
+            request=build_nfl_state_request(),
+            selection_role=SnapshotSelectionRole.NFL_STATE,
+        ),
+        SnapshotRequirement(
+            request=build_player_catalog_request(),
+            selection_role=SnapshotSelectionRole.PLAYER_CATALOG,
+        ),
+        SnapshotRequirement(
+            request=build_league_rosters_request(season_id, league_id),
+            selection_role=SnapshotSelectionRole.LEAGUE_ROSTERS,
+        ),
+    ]
+    if context.draft_rounds > 0:
+        entries.append(
+            SnapshotRequirement(
+                request=build_traded_picks_request(season_id, league_id),
+                selection_role=SnapshotSelectionRole.TRADED_PICKS,
+            )
+        )
+    for week in range(1, request.through_week + 1):
+        entries.extend(
+            (
+                SnapshotRequirement(
+                    request=build_matchups_request(season_id, league_id, week),
+                    selection_role=SnapshotSelectionRole.WEEK_MATCHUPS,
+                ),
+                SnapshotRequirement(
+                    request=build_transactions_request(season_id, league_id, week),
+                    selection_role=SnapshotSelectionRole.WEEK_TRANSACTIONS,
+                ),
+            )
+        )
+    if (
+        context.playoff_start_week is None
+        or request.through_week >= context.playoff_start_week
+    ):
+        entries.extend(
+            (
+                SnapshotRequirement(
+                    request=build_winners_bracket_request(season_id, league_id),
+                    selection_role=SnapshotSelectionRole.WINNERS_BRACKET,
+                ),
+                SnapshotRequirement(
+                    request=build_losers_bracket_request(season_id, league_id),
+                    selection_role=SnapshotSelectionRole.LOSERS_BRACKET,
+                ),
+            )
+        )
+    return SnapshotRequirements(entries=tuple(entries))
+
+
+def select_snapshot_requests(
+    request: SnapshotRequest,
+    requirements: SnapshotRequirements,
+    candidates: Iterable[ApiRequestCandidate],
+) -> SelectedRequestManifest:
+    """Select the latest structurally valid observation for every requirement."""
+
+    by_scope: dict[ScopeKey, list[ApiRequestCandidate]] = {
+        scope: [] for scope in requirements.scope_keys
+    }
+    for candidate in candidates:
+        matching = by_scope.get(candidate.scope_key)
+        if matching is not None:
+            matching.append(candidate)
+
+    selected: list[SelectedRequestManifestEntry] = []
+    missing: list[ScopeKey] = []
+    for requirement in requirements.entries:
+        eligible = [
+            candidate
+            for candidate in by_scope[requirement.request.scope_key]
+            if _candidate_is_eligible(request, requirement, candidate)
+        ]
+        if not eligible:
+            missing.append(requirement.request.scope_key)
+            continue
+        candidate = max(
+            eligible,
+            key=lambda item: (item.requested_at, item.request_id.int),
+        )
+        selected.append(
+            SelectedRequestManifestEntry(
+                request_id=candidate.request_id,
+                endpoint_kind=candidate.endpoint_kind,
+                scope_key=candidate.scope_key,
+                selection_role=requirement.selection_role,
+                response_sha256=candidate.response_sha256,
+            )
+        )
+    if missing:
+        raise SnapshotUnavailable(
+            "required snapshot inputs are unavailable",
+            missing_scopes=missing,
+        )
+    return SelectedRequestManifest(entries=tuple(selected))
+
+
+def _candidate_is_eligible(
+    snapshot_request: SnapshotRequest,
+    requirement: SnapshotRequirement,
+    candidate: ApiRequestCandidate,
+) -> bool:
+    expected = requirement.request
+    if candidate.endpoint_kind is not expected.endpoint_kind:
+        raise DatalayerScopeConflict(
+            "snapshot candidate endpoint does not match its required scope"
+        )
+    if candidate.endpoint_kind in _GLOBAL_ENDPOINTS:
+        if candidate.competition_season_id is not None:
+            raise DatalayerScopeConflict(
+                "global snapshot candidate unexpectedly belongs to a season"
+            )
+    elif (
+        candidate.competition_season_id
+        != snapshot_request.competition_season_id
+    ):
+        raise DatalayerScopeConflict(
+            "snapshot candidate belongs to another competition season"
+        )
+    if (
+        candidate.week != expected.week
+        or candidate.bracket_kind != expected.bracket_kind
+    ):
+        raise DatalayerScopeConflict(
+            "snapshot candidate metadata does not match its required scope"
+        )
+    return candidate.week is None or candidate.week <= snapshot_request.through_week

--- a/backend/tests/services/datalayer/test_snapshot_selection.py
+++ b/backend/tests/services/datalayer/test_snapshot_selection.py
@@ -1,0 +1,195 @@
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+import pytest
+
+from backend.resources.sleeper_data import (
+    ApiRequestCandidate,
+    SnapshotPlanningContext,
+)
+from backend.services.datalayer import (
+    DatalayerScopeConflict,
+    EndpointKind,
+    SnapshotRequest,
+    SnapshotSelectionRole,
+    SnapshotUnavailable,
+    canonical_snapshot_build_key,
+    plan_snapshot_requirements,
+    select_snapshot_requests,
+)
+
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+COMPETITION_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+def _snapshot(through_week: int = 2) -> SnapshotRequest:
+    return SnapshotRequest(
+        competition_season_id=SEASON_ID,
+        through_week=through_week,
+        as_of_date=date(2026, 10, 27),
+    )
+
+
+def _context(
+    *, draft_rounds: int = 3, playoff_start_week: int | None = 2
+) -> SnapshotPlanningContext:
+    return SnapshotPlanningContext(
+        competition_id=COMPETITION_ID,
+        competition_season_id=SEASON_ID,
+        sleeper_league_id="12345",
+        season_year=2026,
+        playoff_start_week=playoff_start_week,
+        playoff_team_count=4,
+        draft_rounds=draft_rounds,
+        league_average_match=1,
+    )
+
+
+def _candidate(
+    requirement,
+    *,
+    request_id: int,
+    requested_hour: int = 1,
+    completed_hour: int = 2,
+    season_id: UUID | None | object = ...,
+) -> ApiRequestCandidate:
+    endpoint = requirement.request
+    resolved_season = (
+        None
+        if endpoint.endpoint_kind
+        in {EndpointKind.NFL_STATE, EndpointKind.PLAYER_CATALOG}
+        else SEASON_ID
+    )
+    if season_id is not ...:
+        resolved_season = season_id
+    return ApiRequestCandidate(
+        request_id=UUID(int=request_id),
+        competition_season_id=resolved_season,
+        endpoint_kind=endpoint.endpoint_kind,
+        scope_key=endpoint.scope_key,
+        week=endpoint.week,
+        bracket_kind=endpoint.bracket_kind,
+        requested_at=datetime(2026, 11, 1, requested_hour, tzinfo=timezone.utc),
+        completed_at=datetime(2026, 11, 1, completed_hour, tzinfo=timezone.utc),
+        payload_id=UUID(int=10_000 + request_id),
+        response_sha256=f"{request_id:064x}",
+    )
+
+
+def test_build_key_has_a_stable_daily_golden_vector() -> None:
+    assert canonical_snapshot_build_key(_snapshot(8), "1") == (
+        "ba41c48a9ed2cb6d463dd13ced35326b65a31c4c0afc4dbbd19c6f5c905dd624"
+    )
+    assert canonical_snapshot_build_key(_snapshot(8), "2") != (
+        canonical_snapshot_build_key(_snapshot(8), "1")
+    )
+
+
+def test_requirement_planning_is_explicit_and_stably_ordered() -> None:
+    requirements = plan_snapshot_requirements(_snapshot(), _context())
+
+    assert [entry.selection_role for entry in requirements.entries] == [
+        SnapshotSelectionRole.LEAGUE,
+        SnapshotSelectionRole.LEAGUE_USERS,
+        SnapshotSelectionRole.NFL_STATE,
+        SnapshotSelectionRole.PLAYER_CATALOG,
+        SnapshotSelectionRole.LEAGUE_ROSTERS,
+        SnapshotSelectionRole.TRADED_PICKS,
+        SnapshotSelectionRole.WEEK_MATCHUPS,
+        SnapshotSelectionRole.WEEK_TRANSACTIONS,
+        SnapshotSelectionRole.WEEK_MATCHUPS,
+        SnapshotSelectionRole.WEEK_TRANSACTIONS,
+        SnapshotSelectionRole.WINNERS_BRACKET,
+        SnapshotSelectionRole.LOSERS_BRACKET,
+    ]
+    assert [
+        entry.request.week
+        for entry in requirements.entries
+        if entry.request.endpoint_kind
+        in {EndpointKind.MATCHUPS, EndpointKind.TRANSACTIONS}
+    ] == [1, 1, 2, 2]
+
+
+def test_requirement_planning_omits_inapplicable_conditional_scopes() -> None:
+    requirements = plan_snapshot_requirements(
+        _snapshot(1),
+        _context(draft_rounds=0, playoff_start_week=14),
+    )
+
+    assert EndpointKind.TRADED_PICKS not in {
+        entry.request.endpoint_kind for entry in requirements.entries
+    }
+    assert EndpointKind.WINNERS_BRACKET not in {
+        entry.request.endpoint_kind for entry in requirements.entries
+    }
+
+
+def test_selection_uses_request_start_time_and_ignores_daily_label() -> None:
+    request = _snapshot(1)
+    requirements = plan_snapshot_requirements(
+        request,
+        _context(draft_rounds=0, playoff_start_week=14),
+    )
+    candidates = []
+    for index, requirement in enumerate(requirements.entries, start=1):
+        candidates.append(_candidate(requirement, request_id=index))
+    target = requirements.entries[-1]
+    candidates.extend(
+        (
+            _candidate(
+                target,
+                request_id=100,
+                requested_hour=3,
+                completed_hour=5,
+            ),
+            _candidate(
+                target,
+                request_id=101,
+                requested_hour=4,
+                completed_hour=4,
+            ),
+        )
+    )
+
+    manifest = select_snapshot_requests(request, requirements, candidates)
+
+    assert manifest.entries[-1].request_id == UUID(int=101)
+    assert manifest.entries[-1].scope_key == target.request.scope_key
+
+
+def test_selection_reports_ordered_missing_scopes() -> None:
+    request = _snapshot(1)
+    requirements = plan_snapshot_requirements(
+        request,
+        _context(draft_rounds=0, playoff_start_week=14),
+    )
+    candidates = [
+        _candidate(requirement, request_id=index)
+        for index, requirement in enumerate(requirements.entries[:-2], start=1)
+    ]
+
+    with pytest.raises(SnapshotUnavailable) as captured:
+        select_snapshot_requests(request, requirements, candidates)
+
+    assert captured.value.missing_scopes == requirements.scope_keys[-2:]
+
+
+def test_selection_rejects_a_season_mismatch_for_an_exact_scope() -> None:
+    request = _snapshot(1)
+    requirements = plan_snapshot_requirements(
+        request,
+        _context(draft_rounds=0, playoff_start_week=14),
+    )
+    candidates = [
+        _candidate(requirement, request_id=index)
+        for index, requirement in enumerate(requirements.entries, start=1)
+    ]
+    candidates[0] = _candidate(
+        requirements.entries[0],
+        request_id=99,
+        season_id=UUID("33333333-3333-3333-3333-333333333333"),
+    )
+
+    with pytest.raises(DatalayerScopeConflict):
+        select_snapshot_requests(request, requirements, candidates)


### PR DESCRIPTION
## Summary

Add Layer 8's pure snapshot vocabulary, canonical daily identity, explicit
requirement planning, and deterministic source-request selection.

This PR performs no database writes, file I/O, waiting, materialization, or
snapshot orchestration. Those boundaries remain in the two stacked children.

## Changes

- Add immutable snapshot statuses, stable selection roles, ready-snapshot
  output, requirements, and selected-request manifest contracts.
- Hash canonical JSON over season, through-week, ISO date, and projection
  version before any candidate read.
- Expand season-stable settings into required league, global, roster, weekly,
  pick, and bracket scopes using the existing endpoint builders.
- Select the latest structurally valid candidate per scope by request start
  time and request ID without applying an observation-date cutoff.
- Return deterministic manifest ordering and safe ordered missing-scope
  metadata; never infer optionality from absent candidates.

## Verification

- Focused selection/contract tests plus inherited datalayer service and legacy
  datalayer suites: 258 passed, 1 expected Windows symbolic-link skip.
- Golden build-key vectors, conditional plans, later corrections, tie-breaking,
  global/season validation, and missing-scope behavior: passed.
- Package compilation, line-length audit, import checks, and diff checks:
  passed.

## Stack

- Parent: Layer 7 refresh workflow (`47c2cdb`, PR #131)
- Local commit: `f0c8c0f`
- Implements Layer 8a
- GitHub stack: #123
