### PR TITLE
feat(datalayer): add snapshot workflow

### DIFF
--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -117,6 +117,7 @@ __all__ = [
     "EndpointApplyMetadata",
     "DatalayerError",
     "DatalayerRefreshService",
+    "DatalayerSnapshotService",
     "DatalayerResourceNotFound",
     "DatalayerScopeConflict",
     "EndpointKind",
@@ -130,6 +131,7 @@ __all__ = [
     "LocalArtifactKind",
     "LocalArtifactVerificationError",
     "LocalDatalayerFileStore",
+    "MaterializedSnapshot",
     "LeagueEndpointRecords",
     "LeagueRecord",
     "LeagueRostersEndpointRecords",
@@ -162,6 +164,8 @@ __all__ = [
     "SnapshotRequirement",
     "SnapshotRequirements",
     "SnapshotRequest",
+    "SnapshotEndpointRecords",
+    "SnapshotMaterializationInput",
     "SnapshotSelectionRole",
     "SnapshotStatus",
     "SnapshotUnavailable",
@@ -225,6 +229,10 @@ def __getattr__(name: str) -> Any:
         "DatalayerRefreshService",
         "PlannedRefresh",
         "build_standard_refresh_plan",
+        "DatalayerSnapshotService",
+        "MaterializedSnapshot",
+        "SnapshotEndpointRecords",
+        "SnapshotMaterializationInput",
         "SelectedRequestManifest",
         "SelectedRequestManifestEntry",
         "SnapshotRequirement",
@@ -233,6 +241,25 @@ def __getattr__(name: str) -> Any:
         "plan_snapshot_requirements",
         "select_snapshot_requests",
     }:
+        if name in {
+            "DatalayerSnapshotService",
+            "MaterializedSnapshot",
+            "SnapshotEndpointRecords",
+            "SnapshotMaterializationInput",
+        }:
+            from backend.services.datalayer.snapshot_service import (
+                DatalayerSnapshotService,
+                MaterializedSnapshot,
+                SnapshotEndpointRecords,
+                SnapshotMaterializationInput,
+            )
+
+            return {
+                "DatalayerSnapshotService": DatalayerSnapshotService,
+                "MaterializedSnapshot": MaterializedSnapshot,
+                "SnapshotEndpointRecords": SnapshotEndpointRecords,
+                "SnapshotMaterializationInput": SnapshotMaterializationInput,
+            }[name]
         if name in {
             "SelectedRequestManifest",
             "SelectedRequestManifestEntry",

--- a/backend/services/datalayer/snapshot_service.py
+++ b/backend/services/datalayer/snapshot_service.py
@@ -1,0 +1,494 @@
+"""Daily snapshot claim, selection, replay, and sealing workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection
+from datetime import datetime, timedelta, timezone
+import math
+from pathlib import Path
+from time import monotonic, sleep
+from typing import Annotated, Protocol, assert_never
+from uuid import UUID
+
+from pydantic import Field, StringConstraints, model_validator
+
+from backend.resources._contracts import ContractModel
+from backend.resources.sleeper_data.league_seasons import SnapshotPlanningContext
+from backend.resources.sleeper_data.requests import (
+    ApiRequestCandidate,
+    InlineVerifiedPayload,
+    ObjectVerifiedPayload,
+    SnapshotCandidateQuery,
+    VerifiedPayload,
+)
+from backend.resources.sleeper_data.snapshots import (
+    ArtifactFailure,
+    BeginSnapshotBuild,
+    ClaimedSnapshotBuild,
+    DataSnapshot,
+    ExistingBuildingSnapshot,
+    ExistingReadySnapshot,
+    SealSnapshot,
+    SnapshotBuildState,
+    SnapshotFailure,
+    SnapshotRequestMembership,
+)
+from backend.services.datalayer.canonical_json import JsonValue, parse_json_bytes
+from backend.services.datalayer.contracts import (
+    CompletenessWarning,
+    ReadyDataSnapshot,
+    SnapshotRequest,
+    SnapshotStatus,
+)
+from backend.services.datalayer.errors import (
+    DatalayerError,
+    DatalayerScopeConflict,
+    InternalDatalayerFailure,
+    SnapshotUnavailable,
+)
+from backend.services.datalayer.local_files import (
+    LocalArtifactKind,
+    LocalArtifactVerificationError,
+    StoredLocalArtifact,
+    VerifiedLocalArtifact,
+)
+from backend.services.datalayer.snapshot_selection import (
+    SelectedRequestManifest,
+    SelectedRequestManifestEntry,
+    SnapshotRequirement,
+    SnapshotRequirements,
+    canonical_snapshot_build_key,
+    plan_snapshot_requirements,
+    select_snapshot_requests,
+)
+from backend.services.datalayer.sleeper.endpoints import (
+    EndpointRecords,
+    normalize_league,
+    normalize_league_rosters,
+    normalize_league_users,
+    normalize_losers_bracket,
+    normalize_matchups,
+    normalize_nfl_state,
+    normalize_player_catalog,
+    normalize_traded_picks,
+    normalize_transactions,
+    normalize_winners_bracket,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind, ScopeKey
+from backend.services.datalayer.versions import SNAPSHOT_PROJECTION_VERSION
+
+
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{64}$")]
+WallClock = Callable[[], datetime]
+MonotonicClock = Callable[[], float]
+
+
+class SnapshotPlanningReader(Protocol):
+    def get_snapshot_planning_context(
+        self, competition_season_id: UUID
+    ) -> SnapshotPlanningContext: ...
+
+
+class SnapshotRequestReader(Protocol):
+    def list_snapshot_candidates(
+        self,
+        query: SnapshotCandidateQuery,
+    ) -> tuple[ApiRequestCandidate, ...]: ...
+
+    def resolve_verified_payloads(
+        self,
+        request_ids: Collection[UUID],
+    ) -> tuple[VerifiedPayload, ...]: ...
+
+
+class SnapshotLifecycle(Protocol):
+    def begin_or_get(self, command: BeginSnapshotBuild) -> SnapshotBuildState: ...
+
+    def seal_ready(self, snapshot_id: UUID, command: SealSnapshot) -> DataSnapshot: ...
+
+    def mark_failed(
+        self, snapshot_id: UUID, failure: SnapshotFailure
+    ) -> DataSnapshot: ...
+
+    def fail_stale_build(self, build_key: str, stale_before: datetime) -> bool: ...
+
+    def expire_unusable(
+        self, snapshot_id: UUID, failure: ArtifactFailure
+    ) -> DataSnapshot: ...
+
+    def get(self, snapshot_id: UUID) -> DataSnapshot: ...
+
+
+class SnapshotFileStore(Protocol):
+    def store_file(
+        self, kind: LocalArtifactKind, source: Path
+    ) -> StoredLocalArtifact: ...
+
+    def open_verified(
+        self,
+        storage_key: str,
+        *,
+        expected_sha256: str,
+        expected_byte_length: int,
+    ) -> VerifiedLocalArtifact: ...
+
+
+class SnapshotEndpointRecords(ContractModel):
+    manifest_entry: SelectedRequestManifestEntry
+    records: EndpointRecords
+
+    @model_validator(mode="after")
+    def validate_endpoint(self) -> "SnapshotEndpointRecords":
+        if self.records.endpoint_kind is not self.manifest_entry.endpoint_kind:
+            raise ValueError("snapshot records do not match their manifest endpoint")
+        return self
+
+
+class SnapshotMaterializationInput(ContractModel):
+    request: SnapshotRequest
+    planning_context: SnapshotPlanningContext
+    build_key: Sha256
+    snapshot_projection_version: str
+    manifest: SelectedRequestManifest
+    endpoint_records: tuple[SnapshotEndpointRecords, ...]
+
+    @model_validator(mode="after")
+    def validate_records(self) -> "SnapshotMaterializationInput":
+        manifest_ids = [entry.request_id for entry in self.manifest.entries]
+        record_ids = [
+            entry.manifest_entry.request_id for entry in self.endpoint_records
+        ]
+        if record_ids != manifest_ids:
+            raise ValueError("snapshot endpoint records must follow manifest order")
+        return self
+
+
+class MaterializedSnapshot(ContractModel):
+    path: Path
+    sha256: Sha256
+    byte_length: int = Field(strict=True, ge=0)
+    completeness_warnings: tuple[CompletenessWarning, ...] = ()
+
+    @model_validator(mode="after")
+    def validate_path(self) -> "MaterializedSnapshot":
+        if not self.path.is_absolute():
+            raise ValueError("materialized snapshot path must be absolute")
+        return self
+
+
+class SnapshotMaterializer(Protocol):
+    def materialize(
+        self,
+        materialization: SnapshotMaterializationInput,
+    ) -> MaterializedSnapshot: ...
+
+
+class DatalayerSnapshotService:
+    """Resolve one healthy ready snapshot for a daily factual identity."""
+
+    def __init__(
+        self,
+        *,
+        planning: SnapshotPlanningReader,
+        requests: SnapshotRequestReader,
+        snapshots: SnapshotLifecycle,
+        materializer: SnapshotMaterializer,
+        files: SnapshotFileStore,
+        code_version: str,
+        snapshot_projection_version: str = SNAPSHOT_PROJECTION_VERSION,
+        wait_timeout_seconds: float = 30.0,
+        stale_after_seconds: float = 300.0,
+        poll_interval_seconds: float = 0.1,
+        clock: WallClock | None = None,
+        monotonic_clock: MonotonicClock = monotonic,
+        delay: Callable[[float], None] = sleep,
+    ) -> None:
+        self._code_version = _nonblank(code_version, "code_version")
+        self._projection_version = _nonblank(
+            snapshot_projection_version,
+            "snapshot_projection_version",
+        )
+        self._wait_timeout = _positive_number(
+            wait_timeout_seconds, "wait_timeout_seconds"
+        )
+        self._stale_after = _positive_number(
+            stale_after_seconds, "stale_after_seconds"
+        )
+        self._poll_interval = _positive_number(
+            poll_interval_seconds, "poll_interval_seconds"
+        )
+        self._planning = planning
+        self._requests = requests
+        self._snapshots = snapshots
+        self._materializer = materializer
+        self._files = files
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._monotonic = monotonic_clock
+        self._delay = delay
+
+    def get_or_create(self, request: SnapshotRequest) -> ReadyDataSnapshot:
+        build_key = canonical_snapshot_build_key(request, self._projection_version)
+        command = BeginSnapshotBuild(
+            competition_season_id=request.competition_season_id,
+            through_week=request.through_week,
+            as_of_date=request.as_of_date,
+            build_key=build_key,
+            snapshot_projection_version=self._projection_version,
+            code_version=self._code_version,
+        )
+        while True:
+            state = self._snapshots.begin_or_get(command)
+            if isinstance(state, ClaimedSnapshotBuild):
+                ready = self._build_claimed(request, state.snapshot)
+                if ready is not None:
+                    return ready
+                continue
+            if isinstance(state, ExistingReadySnapshot):
+                ready = self._reuse_ready(state.snapshot)
+                if ready is not None:
+                    return ready
+                continue
+            if isinstance(state, ExistingBuildingSnapshot):
+                ready = self._wait_for_existing(state.snapshot)
+                if ready is not None:
+                    return ready
+                continue
+            assert_never(state)
+
+    def _build_claimed(
+        self,
+        request: SnapshotRequest,
+        claimed: DataSnapshot,
+    ) -> ReadyDataSnapshot | None:
+        try:
+            context = self._planning.get_snapshot_planning_context(
+                request.competition_season_id
+            )
+            requirements = plan_snapshot_requirements(request, context)
+            candidates = self._requests.list_snapshot_candidates(
+                SnapshotCandidateQuery(
+                    competition_season_id=request.competition_season_id,
+                    scope_keys=requirements.scope_keys,
+                    through_week=request.through_week,
+                )
+            )
+            manifest = select_snapshot_requests(request, requirements, candidates)
+            payloads = self._requests.resolve_verified_payloads(
+                [entry.request_id for entry in manifest.entries]
+            )
+            records = self._replay(requirements, manifest, payloads)
+            materialized = self._materializer.materialize(
+                SnapshotMaterializationInput(
+                    request=request,
+                    planning_context=context,
+                    build_key=claimed.build_key,
+                    snapshot_projection_version=self._projection_version,
+                    manifest=manifest,
+                    endpoint_records=records,
+                )
+            )
+            receipt = self._files.store_file(
+                LocalArtifactKind.SNAPSHOT,
+                materialized.path,
+            )
+            if (
+                receipt.sha256 != materialized.sha256
+                or receipt.byte_length != materialized.byte_length
+            ):
+                raise DatalayerScopeConflict(
+                    "stored snapshot artifact differs from materializer output"
+                )
+            sealed = self._snapshots.seal_ready(
+                claimed.id,
+                SealSnapshot(
+                    requests=tuple(
+                        SnapshotRequestMembership(
+                            request_id=entry.request_id,
+                            endpoint_kind=entry.endpoint_kind,
+                            scope_key=entry.scope_key,
+                            response_sha256=entry.response_sha256,
+                            selection_role=entry.selection_role,
+                        )
+                        for entry in manifest.entries
+                    ),
+                    artifact=receipt,
+                    completeness_warnings=materialized.completeness_warnings,
+                ),
+            )
+        except Exception as error:
+            self._fail_claimed(claimed.id, error)
+            public_error = self._public_failure(claimed.id, error)
+            if public_error is error:
+                raise
+            raise public_error from error
+        return self._reuse_ready(sealed)
+
+    def _replay(
+        self,
+        requirements: SnapshotRequirements,
+        manifest: SelectedRequestManifest,
+        payloads: tuple[VerifiedPayload, ...],
+    ) -> tuple[SnapshotEndpointRecords, ...]:
+        if len(payloads) != len(manifest.entries):
+            raise DatalayerScopeConflict(
+                "resolved snapshot payload count does not match the manifest"
+            )
+        requirements_by_scope = {
+            entry.request.scope_key: entry for entry in requirements.entries
+        }
+        replayed: list[SnapshotEndpointRecords] = []
+        for manifest_entry, payload in zip(manifest.entries, payloads, strict=True):
+            if (
+                payload.request_id != manifest_entry.request_id
+                or payload.scope_key != manifest_entry.scope_key
+                or payload.sha256 != manifest_entry.response_sha256
+            ):
+                raise DatalayerScopeConflict(
+                    "resolved snapshot payload does not match the manifest"
+                )
+            requirement = requirements_by_scope[manifest_entry.scope_key]
+            replayed.append(
+                SnapshotEndpointRecords(
+                    manifest_entry=manifest_entry,
+                    records=_normalize_payload(
+                        self._payload_value(payload),
+                        requirement,
+                    ),
+                )
+            )
+        return tuple(replayed)
+
+    def _payload_value(self, payload: VerifiedPayload) -> JsonValue:
+        if isinstance(payload, InlineVerifiedPayload):
+            return payload.payload
+        if isinstance(payload, ObjectVerifiedPayload):
+            artifact = self._files.open_verified(
+                payload.storage_key,
+                expected_sha256=payload.sha256,
+                expected_byte_length=payload.byte_length,
+            )
+            return parse_json_bytes(artifact.path.read_bytes())
+        assert_never(payload)
+
+    def _wait_for_existing(
+        self,
+        building: DataSnapshot,
+    ) -> ReadyDataSnapshot | None:
+        deadline = self._monotonic() + self._wait_timeout
+        while True:
+            stale_before = self._clock() - timedelta(seconds=self._stale_after)
+            if self._snapshots.fail_stale_build(building.build_key, stale_before):
+                return None
+            current = self._snapshots.get(building.id)
+            if current.status is SnapshotStatus.READY:
+                return self._reuse_ready(current)
+            if current.status in {SnapshotStatus.FAILED, SnapshotStatus.EXPIRED}:
+                return None
+            if self._monotonic() >= deadline:
+                raise SnapshotUnavailable(
+                    "snapshot build did not finish within the wait budget"
+                )
+            self._delay(self._poll_interval)
+
+    def _reuse_ready(self, snapshot: DataSnapshot) -> ReadyDataSnapshot | None:
+        if snapshot.status is not SnapshotStatus.READY or snapshot.artifact is None:
+            raise DatalayerScopeConflict("snapshot is not a sealed ready artifact")
+        try:
+            artifact = self._files.open_verified(
+                snapshot.artifact.storage_key,
+                expected_sha256=snapshot.artifact.sha256,
+                expected_byte_length=snapshot.artifact.byte_length,
+            )
+        except LocalArtifactVerificationError:
+            self._snapshots.expire_unusable(
+                snapshot.id,
+                ArtifactFailure(
+                    code="snapshot_artifact_unusable",
+                    summary="Snapshot artifact is missing or corrupt",
+                ),
+            )
+            return None
+        return ReadyDataSnapshot(
+            id=snapshot.id,
+            competition_id=snapshot.competition_id,
+            primary_competition_season_id=snapshot.primary_competition_season_id,
+            through_week=snapshot.through_week,
+            as_of_date=snapshot.as_of_date,
+            build_key=snapshot.build_key,
+            snapshot_projection_version=snapshot.snapshot_projection_version,
+            artifact=artifact,
+            completeness_warnings=snapshot.completeness_warnings,
+        )
+
+    def _fail_claimed(self, snapshot_id: UUID, error: Exception) -> None:
+        if isinstance(error, SnapshotUnavailable):
+            code = "snapshot_inputs_unavailable"
+            summary = error.message
+        elif isinstance(error, DatalayerError):
+            code = "snapshot_build_rejected"
+            summary = str(error)
+        elif isinstance(error, LocalArtifactVerificationError):
+            code = "snapshot_artifact_invalid"
+            summary = "Snapshot artifact verification failed"
+        else:
+            code = "snapshot_build_failed"
+            summary = "Snapshot build failed unexpectedly"
+        self._snapshots.mark_failed(
+            snapshot_id,
+            SnapshotFailure(code=code, summary=summary[:500]),
+        )
+
+    @staticmethod
+    def _public_failure(snapshot_id: UUID, error: Exception) -> Exception:
+        if isinstance(error, DatalayerError):
+            return error
+        if isinstance(error, LocalArtifactVerificationError):
+            return SnapshotUnavailable("selected snapshot payload is unavailable")
+        return InternalDatalayerFailure(str(snapshot_id))
+
+
+def _normalize_payload(
+    payload: JsonValue,
+    requirement: SnapshotRequirement,
+) -> EndpointRecords:
+    endpoint = requirement.request
+    match endpoint.endpoint_kind:
+        case EndpointKind.LEAGUE:
+            return normalize_league(payload, endpoint)
+        case EndpointKind.LEAGUE_USERS:
+            return normalize_league_users(payload, endpoint)
+        case EndpointKind.LEAGUE_ROSTERS:
+            return normalize_league_rosters(payload, endpoint)
+        case EndpointKind.NFL_STATE:
+            return normalize_nfl_state(payload, endpoint)
+        case EndpointKind.PLAYER_CATALOG:
+            return normalize_player_catalog(payload, endpoint)
+        case EndpointKind.MATCHUPS:
+            return normalize_matchups(payload, endpoint)
+        case EndpointKind.TRANSACTIONS:
+            return normalize_transactions(payload, endpoint)
+        case EndpointKind.TRADED_PICKS:
+            return normalize_traded_picks(payload, endpoint)
+        case EndpointKind.WINNERS_BRACKET:
+            return normalize_winners_bracket(payload, endpoint)
+        case EndpointKind.LOSERS_BRACKET:
+            return normalize_losers_bracket(payload, endpoint)
+    assert_never(endpoint.endpoint_kind)
+
+
+def _nonblank(value: str, name: str) -> str:
+    normalized = value.strip()
+    if not normalized or normalized != value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _positive_number(value: float, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError(f"{name} must be positive")
+    return float(value)

--- a/backend/tests/services/datalayer/test_snapshot_service.py
+++ b/backend/tests/services/datalayer/test_snapshot_service.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, date, datetime
+import hashlib
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.resources.sleeper_data import (
+    ApiRequestCandidate,
+    ArtifactFailure,
+    BeginSnapshotBuild,
+    ClaimedSnapshotBuild,
+    DataSnapshot,
+    ExistingBuildingSnapshot,
+    ExistingReadySnapshot,
+    InlineVerifiedPayload,
+    ObjectVerifiedPayload,
+    SealSnapshot,
+    SnapshotBuildState,
+    SnapshotCandidateQuery,
+    SnapshotFailure,
+    SnapshotPlanningContext,
+)
+from backend.services.datalayer import (
+    DatalayerSnapshotService,
+    EndpointKind,
+    InternalDatalayerFailure,
+    LocalArtifactKind,
+    LocalDatalayerFileStore,
+    MaterializedSnapshot,
+    SnapshotRequest,
+    SnapshotStatus,
+    SnapshotUnavailable,
+)
+from backend.services.datalayer.canonical_json import (
+    JsonValue,
+    canonical_json_bytes,
+    parse_json_bytes,
+)
+from backend.services.datalayer.local_files import StoredLocalArtifact
+from backend.services.datalayer.snapshot_service import SnapshotMaterializationInput
+
+
+SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
+COMPETITION_ID = UUID("22222222-2222-2222-2222-222222222222")
+FIXTURES = Path(__file__).parents[4] / "datalayer" / "tests" / "fixtures" / "sleeper"
+PAYLOAD_FILES = {
+    EndpointKind.LEAGUE: "league.json",
+    EndpointKind.LEAGUE_USERS: "users.json",
+    EndpointKind.NFL_STATE: "state.json",
+    EndpointKind.PLAYER_CATALOG: "players.json",
+    EndpointKind.LEAGUE_ROSTERS: "rosters.json",
+    EndpointKind.MATCHUPS: "matchups_week1.json",
+    EndpointKind.TRANSACTIONS: "transactions_week1.json",
+}
+
+
+class FakePlanning:
+    def get_snapshot_planning_context(self, competition_season_id: UUID):
+        assert competition_season_id == SEASON_ID
+        return SnapshotPlanningContext(
+            competition_id=COMPETITION_ID,
+            competition_season_id=SEASON_ID,
+            sleeper_league_id="123",
+            season_year=2026,
+            playoff_start_week=14,
+            playoff_team_count=4,
+            draft_rounds=0,
+            league_average_match=0,
+        )
+
+
+class FakeRequests:
+    def __init__(
+        self,
+        *,
+        files: LocalDatalayerFileStore,
+        missing_last: bool = False,
+        object_kind: EndpointKind | None = None,
+    ) -> None:
+        self.files = files
+        self.missing_last = missing_last
+        self.object_kind = object_kind
+        self.payloads: dict[UUID, tuple[ApiRequestCandidate, JsonValue]] = {}
+
+    def list_snapshot_candidates(self, query: SnapshotCandidateQuery):
+        from backend.services.datalayer.snapshot_selection import (
+            plan_snapshot_requirements,
+        )
+
+        request = SnapshotRequest(
+            competition_season_id=query.competition_season_id,
+            through_week=query.through_week,
+            as_of_date=date(2026, 10, 27),
+        )
+        context = FakePlanning().get_snapshot_planning_context(SEASON_ID)
+        requirements = plan_snapshot_requirements(request, context)
+        self.payloads.clear()
+        for index, requirement in enumerate(requirements.entries, start=1):
+            endpoint = requirement.request
+            fixture = FIXTURES / PAYLOAD_FILES[endpoint.endpoint_kind]
+            payload = parse_json_bytes(fixture.read_bytes())
+            content = canonical_json_bytes(payload)
+            candidate = ApiRequestCandidate(
+                request_id=UUID(int=index),
+                competition_season_id=(
+                    None
+                    if endpoint.endpoint_kind
+                    in {EndpointKind.NFL_STATE, EndpointKind.PLAYER_CATALOG}
+                    else SEASON_ID
+                ),
+                endpoint_kind=endpoint.endpoint_kind,
+                scope_key=endpoint.scope_key,
+                week=endpoint.week,
+                bracket_kind=endpoint.bracket_kind,
+                requested_at=datetime(2026, 11, 1, index, tzinfo=UTC),
+                completed_at=datetime(2026, 11, 1, index, 1, tzinfo=UTC),
+                payload_id=UUID(int=1_000 + index),
+                response_sha256=hashlib.sha256(content).hexdigest(),
+            )
+            self.payloads[candidate.request_id] = (candidate, payload)
+        candidates = tuple(candidate for candidate, _ in self.payloads.values())
+        return candidates[:-1] if self.missing_last else candidates
+
+    def resolve_verified_payloads(self, request_ids):
+        resolved = []
+        for request_id in request_ids:
+            candidate, payload = self.payloads[request_id]
+            content = canonical_json_bytes(payload)
+            common = {
+                "request_id": request_id,
+                "scope_key": candidate.scope_key,
+                "sha256": candidate.response_sha256,
+                "byte_length": len(content),
+                "media_type": "application/json",
+            }
+            if candidate.endpoint_kind is self.object_kind:
+                receipt = self.files.store_bytes(LocalArtifactKind.PAYLOAD, content)
+                resolved.append(
+                    ObjectVerifiedPayload(storage_key=receipt.storage_key, **common)
+                )
+            else:
+                resolved.append(InlineVerifiedPayload(payload=payload, **common))
+        return tuple(resolved)
+
+
+class FakeSnapshots:
+    def __init__(
+        self,
+        states: tuple[SnapshotBuildState, ...] = (),
+        observed: tuple[DataSnapshot, ...] = (),
+    ) -> None:
+        self.states = deque(states)
+        self.observed = deque(observed)
+        self.current: DataSnapshot | None = None
+        self.sealed: SealSnapshot | None = None
+        self.failed: list[SnapshotFailure] = []
+        self.expired: list[ArtifactFailure] = []
+        self.stale = False
+
+    def begin_or_get(self, command: BeginSnapshotBuild):
+        if self.states:
+            state = self.states.popleft()
+            self.current = state.snapshot
+            return state
+        self.current = _snapshot_from_command(command)
+        return ClaimedSnapshotBuild(snapshot=self.current)
+
+    def seal_ready(self, snapshot_id: UUID, command: SealSnapshot):
+        assert self.current is not None and snapshot_id == self.current.id
+        self.sealed = command
+        self.current = self.current.model_copy(
+            update={
+                "status": SnapshotStatus.READY,
+                "artifact": command.artifact,
+                "completeness_warnings": command.completeness_warnings,
+                "completed_at": datetime.now(UTC),
+            }
+        )
+        return self.current
+
+    def mark_failed(self, snapshot_id: UUID, failure: SnapshotFailure):
+        assert self.current is not None and snapshot_id == self.current.id
+        self.failed.append(failure)
+        self.current = self.current.model_copy(
+            update={"status": SnapshotStatus.FAILED, "failure": failure}
+        )
+        return self.current
+
+    def fail_stale_build(self, build_key: str, stale_before: datetime):
+        del build_key, stale_before
+        return self.stale
+
+    def expire_unusable(self, snapshot_id: UUID, failure: ArtifactFailure):
+        assert self.current is not None and snapshot_id == self.current.id
+        self.expired.append(failure)
+        self.current = self.current.model_copy(
+            update={"status": SnapshotStatus.EXPIRED}
+        )
+        return self.current
+
+    def get(self, snapshot_id: UUID):
+        assert self.current is not None and snapshot_id == self.current.id
+        if self.observed:
+            self.current = self.observed.popleft()
+        return self.current
+
+
+class FakeMaterializer:
+    def __init__(self, output: Path) -> None:
+        self.output = output.resolve()
+        self.calls: list[SnapshotMaterializationInput] = []
+        self.failure: Exception | None = None
+
+    def materialize(self, materialization: SnapshotMaterializationInput):
+        self.calls.append(materialization)
+        if self.failure is not None:
+            raise self.failure
+        content = b"synthetic snapshot sqlite"
+        self.output.write_bytes(content)
+        return MaterializedSnapshot(
+            path=self.output,
+            sha256=hashlib.sha256(content).hexdigest(),
+            byte_length=len(content),
+        )
+
+
+def _request() -> SnapshotRequest:
+    return SnapshotRequest(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+    )
+
+
+def _snapshot_from_command(
+    command: BeginSnapshotBuild,
+    *,
+    status: SnapshotStatus = SnapshotStatus.BUILDING,
+    artifact=None,
+) -> DataSnapshot:
+    return DataSnapshot(
+        id=uuid4(),
+        competition_id=COMPETITION_ID,
+        primary_competition_season_id=command.competition_season_id,
+        build_key=command.build_key,
+        through_week=command.through_week,
+        as_of_date=command.as_of_date,
+        status=status,
+        snapshot_projection_version=command.snapshot_projection_version,
+        code_version=command.code_version,
+        completeness_warnings=(),
+        failure=None,
+        artifact=artifact,
+        created_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC) if status is SnapshotStatus.READY else None,
+    )
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    snapshots: FakeSnapshots | None = None,
+    requests: FakeRequests | None = None,
+    monotonic_clock=lambda: 0.0,
+    delay=lambda _: None,
+) -> tuple[
+    DatalayerSnapshotService,
+    FakeSnapshots,
+    FakeMaterializer,
+    LocalDatalayerFileStore,
+]:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    lifecycle = snapshots or FakeSnapshots()
+    reader = requests or FakeRequests(files=files)
+    materializer = FakeMaterializer(tmp_path / "synthetic.sqlite")
+    return (
+        DatalayerSnapshotService(
+            planning=FakePlanning(),
+            requests=reader,
+            snapshots=lifecycle,
+            materializer=materializer,
+            files=files,
+            code_version="test",
+            wait_timeout_seconds=1,
+            stale_after_seconds=300,
+            poll_interval_seconds=0.1,
+            monotonic_clock=monotonic_clock,
+            delay=delay,
+        ),
+        lifecycle,
+        materializer,
+        files,
+    )
+
+
+def test_claimed_build_replays_inline_and_object_payloads_then_seals(
+    tmp_path: Path,
+) -> None:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    requests = FakeRequests(files=files, object_kind=EndpointKind.PLAYER_CATALOG)
+    service, snapshots, materializer, _ = _service(tmp_path, requests=requests)
+
+    ready = service.get_or_create(_request())
+
+    assert ready.artifact.path.exists()
+    assert snapshots.sealed is not None
+    assert len(snapshots.sealed.requests) == 7
+    assert len(materializer.calls) == 1
+    endpoint_kinds = [
+        entry.records.endpoint_kind
+        for entry in materializer.calls[0].endpoint_records
+    ]
+    assert endpoint_kinds == [
+        EndpointKind.LEAGUE,
+        EndpointKind.LEAGUE_USERS,
+        EndpointKind.NFL_STATE,
+        EndpointKind.PLAYER_CATALOG,
+        EndpointKind.LEAGUE_ROSTERS,
+        EndpointKind.MATCHUPS,
+        EndpointKind.TRANSACTIONS,
+    ]
+
+
+def test_healthy_ready_snapshot_is_verified_without_rebuilding(tmp_path: Path) -> None:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    receipt = files.store_bytes(LocalArtifactKind.SNAPSHOT, b"ready")
+    command = BeginSnapshotBuild(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+        build_key="a" * 64,
+        snapshot_projection_version="1",
+        code_version="test",
+    )
+    stored = _snapshot_from_command(
+        command,
+        status=SnapshotStatus.READY,
+        artifact=receipt,
+    )
+    snapshots = FakeSnapshots((ExistingReadySnapshot(snapshot=stored),))
+    service, _, materializer, _ = _service(tmp_path, snapshots=snapshots)
+
+    ready = service.get_or_create(_request())
+
+    assert ready.id == stored.id
+    assert materializer.calls == []
+
+
+def test_corrupt_ready_snapshot_is_expired_before_replacement(tmp_path: Path) -> None:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    missing_sha = "b" * 64
+    missing = StoredLocalArtifact(
+        storage_key=f"snapshots/sha256/bb/{missing_sha}.sqlite",
+        sha256=missing_sha,
+        byte_length=10,
+    )
+    command = BeginSnapshotBuild(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+        build_key="a" * 64,
+        snapshot_projection_version="1",
+        code_version="test",
+    )
+    stored = _snapshot_from_command(
+        command,
+        status=SnapshotStatus.READY,
+        artifact=missing,
+    )
+    snapshots = FakeSnapshots((ExistingReadySnapshot(snapshot=stored),))
+    service, lifecycle, materializer, _ = _service(tmp_path, snapshots=snapshots)
+
+    ready = service.get_or_create(_request())
+
+    assert lifecycle.expired[0].code == "snapshot_artifact_unusable"
+    assert ready.id != stored.id
+    assert len(materializer.calls) == 1
+
+
+def test_missing_required_scope_marks_claim_failed(tmp_path: Path) -> None:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    reader = FakeRequests(files=files, missing_last=True)
+    service, snapshots, materializer, _ = _service(tmp_path, requests=reader)
+
+    with pytest.raises(SnapshotUnavailable) as captured:
+        service.get_or_create(_request())
+
+    assert captured.value.missing_scopes
+    assert snapshots.failed[0].code == "snapshot_inputs_unavailable"
+    assert snapshots.sealed is None
+    assert materializer.calls == []
+
+
+def test_materializer_failure_marks_claim_failed_without_membership(
+    tmp_path: Path,
+) -> None:
+    service, snapshots, materializer, _ = _service(tmp_path)
+    materializer.failure = RuntimeError("private implementation detail")
+
+    with pytest.raises(InternalDatalayerFailure):
+        service.get_or_create(_request())
+
+    assert snapshots.failed[0].code == "snapshot_build_failed"
+    assert snapshots.failed[0].summary == "Snapshot build failed unexpectedly"
+    assert snapshots.sealed is None
+
+
+def test_existing_build_times_out_without_stealing_a_healthy_claim(
+    tmp_path: Path,
+) -> None:
+    command = BeginSnapshotBuild(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+        build_key="a" * 64,
+        snapshot_projection_version="1",
+        code_version="test",
+    )
+    building = _snapshot_from_command(command)
+    snapshots = FakeSnapshots((ExistingBuildingSnapshot(snapshot=building),))
+    ticks = iter((0.0, 0.0, 1.0))
+    service, _, _, _ = _service(
+        tmp_path,
+        snapshots=snapshots,
+        monotonic_clock=lambda: next(ticks),
+    )
+
+    with pytest.raises(SnapshotUnavailable, match="wait budget"):
+        service.get_or_create(_request())
+
+
+def test_existing_build_waits_for_and_reuses_ready_result(tmp_path: Path) -> None:
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    receipt = files.store_bytes(LocalArtifactKind.SNAPSHOT, b"ready")
+    command = BeginSnapshotBuild(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+        build_key="a" * 64,
+        snapshot_projection_version="1",
+        code_version="test",
+    )
+    building = _snapshot_from_command(command)
+    ready_state = building.model_copy(
+        update={
+            "status": SnapshotStatus.READY,
+            "artifact": receipt,
+            "completed_at": datetime.now(UTC),
+        }
+    )
+    snapshots = FakeSnapshots(
+        (ExistingBuildingSnapshot(snapshot=building),),
+        observed=(ready_state,),
+    )
+    service, _, materializer, _ = _service(tmp_path, snapshots=snapshots)
+
+    ready = service.get_or_create(_request())
+
+    assert ready.id == building.id
+    assert materializer.calls == []
+
+
+def test_stale_existing_build_is_failed_before_reclaim(tmp_path: Path) -> None:
+    command = BeginSnapshotBuild(
+        competition_season_id=SEASON_ID,
+        through_week=1,
+        as_of_date=date(2026, 10, 27),
+        build_key="a" * 64,
+        snapshot_projection_version="1",
+        code_version="test",
+    )
+    building = _snapshot_from_command(command)
+    snapshots = FakeSnapshots((ExistingBuildingSnapshot(snapshot=building),))
+    snapshots.stale = True
+    service, lifecycle, materializer, _ = _service(
+        tmp_path,
+        snapshots=snapshots,
+    )
+
+    ready = service.get_or_create(_request())
+
+    assert ready.id != building.id
+    assert lifecycle.sealed is not None
+    assert len(materializer.calls) == 1


### PR DESCRIPTION
## Summary

Add the Layer 8 snapshot workflow that composes daily identity, candidate
selection, verified payload replay, lifecycle recovery, and atomic sealing
through an injected materializer boundary.

The concrete SQLite schema and materializer remain entirely deferred to Layer
9; this PR adds no reporter queries, routes, generation policy, or migrations.

## Changes

- Claim or reuse the daily identity before planning or reading candidates.
- Verify ready artifacts, expire unusable rows, bound waiting, fail stale
  builders atomically, and retry released identities.
- Plan and select exact requests, resolve inline and file-backed payloads, and
  replay the existing endpoint-family normalizers in manifest order.
- Define immutable materialization input/output and a narrow injected protocol,
  then store, verify, and atomically seal the returned synthetic artifact.
- Mark post-claim failures with sanitized metadata, preserve typed datalayer
  errors, and correlate unexpected failures by snapshot ID.

## Verification

- Cumulative Layer 8 plus inherited datalayer service/resource suite against
  disposable PostgreSQL: 326 passed, 1 expected Windows symbolic-link skip.
- Complete repository suite: 687 passed, 1 expected Windows symbolic-link
  capability skip.
- Exact Alembic upgrade/head/downgrade/re-upgrade/metadata-drift lifecycle:
  passed at sole head `0007`, with no new upgrade operations.
- Service tests cover healthy reuse, corrupt-artifact recovery, bounded wait,
  stale reclaim, missing inputs, sanitized downstream failure, inline/object
  replay, synthetic storage, verification, and sealing.
- Package compilation, line-length audit, lazy import check, and diff checks:
  passed.

## Stack

- Parent: Layer 8b snapshot lifecycle resource (`8e5247e`)
- Local commit: `4fb7cd0`
- Implements Layer 8c and completes Layer 8
- GitHub stack: #123
