### PR TITLE
feat(datalayer): materialize deterministic SQLite snapshots

### DIFF
--- a/backend/composition.py
+++ b/backend/composition.py
@@ -20,12 +20,15 @@ from backend.resources.memory.storylines import StorylineManager
 from backend.resources.memory.triggers import TriggerManager
 from backend.resources.sleeper_data import (
     ApiRequestManager,
+    DataSnapshotManager,
     LeagueSeasonManager,
     NormalizedScopeManager,
     RefreshRunManager,
 )
 from backend.services.datalayer import (
+    DatalayerSnapshotService,
     LocalDatalayerFileStore,
+    SQLiteSnapshotMaterializer,
     SleeperSourceClient,
 )
 from backend.services.datalayer.refresh_service import DatalayerRefreshService
@@ -98,6 +101,13 @@ class DatalayerRefreshDependencies:
         self.source.close()
 
 
+@dataclass(frozen=True, slots=True)
+class DatalayerSnapshotDependencies:
+    """One competition-scoped immutable snapshot capability."""
+
+    snapshot: DatalayerSnapshotService
+
+
 def build_memory_api_dependencies(
     session_factory: SessionFactory,
     context: ManagerContext[CompetitionScope],
@@ -162,6 +172,30 @@ def build_datalayer_refresh_dependencies(
             inline_payload_max_bytes=resolved.inline_payload_max_bytes,
         ),
         source=source,
+    )
+
+
+def build_datalayer_snapshot_dependencies(
+    session_factory: SessionFactory,
+    context: ManagerContext[CompetitionScope],
+    *,
+    settings: DatalayerSettings | None = None,
+) -> DatalayerSnapshotDependencies:
+    """Compose one competition-scoped snapshot service."""
+
+    resolved = settings or DatalayerSettings.from_environment()
+    files = LocalDatalayerFileStore(resolved.data_root)
+    return DatalayerSnapshotDependencies(
+        snapshot=DatalayerSnapshotService(
+            planning=LeagueSeasonManager(session_factory, context),
+            requests=ApiRequestManager(session_factory, context),
+            snapshots=DataSnapshotManager(session_factory, context),
+            materializer=SQLiteSnapshotMaterializer(
+                files.root / ".staging" / "snapshots"
+            ),
+            files=files,
+            code_version=resolved.code_version,
+        )
     )
 
 

--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -159,6 +159,7 @@ __all__ = [
     "SNAPSHOT_PROJECTION_VERSION",
     "ScopeKey",
     "ScopeRefreshResult",
+    "SQLiteSnapshotMaterializer",
     "SelectedRequestManifest",
     "SelectedRequestManifestEntry",
     "SnapshotRequirement",
@@ -240,7 +241,14 @@ def __getattr__(name: str) -> Any:
         "canonical_snapshot_build_key",
         "plan_snapshot_requirements",
         "select_snapshot_requests",
+        "SQLiteSnapshotMaterializer",
     }:
+        if name == "SQLiteSnapshotMaterializer":
+            from backend.services.datalayer.snapshot_sqlite import (
+                SQLiteSnapshotMaterializer,
+            )
+
+            return SQLiteSnapshotMaterializer
         if name in {
             "DatalayerSnapshotService",
             "MaterializedSnapshot",

--- a/backend/services/datalayer/snapshot_service.py
+++ b/backend/services/datalayer/snapshot_service.py
@@ -260,6 +260,7 @@ class DatalayerSnapshotService:
         request: SnapshotRequest,
         claimed: DataSnapshot,
     ) -> ReadyDataSnapshot | None:
+        materialized: MaterializedSnapshot | None = None
         try:
             context = self._planning.get_snapshot_planning_context(
                 request.competition_season_id
@@ -321,6 +322,12 @@ class DatalayerSnapshotService:
             if public_error is error:
                 raise
             raise public_error from error
+        finally:
+            if materialized is not None:
+                try:
+                    materialized.path.unlink(missing_ok=True)
+                except OSError:
+                    pass
         return self._reuse_ready(sealed)
 
     def _replay(

--- a/backend/services/datalayer/snapshot_sqlite/__init__.py
+++ b/backend/services/datalayer/snapshot_sqlite/__init__.py
@@ -12,12 +12,20 @@ from backend.services.datalayer.snapshot_sqlite.projection import (
 from backend.services.datalayer.snapshot_sqlite.derivations import (
     derive_snapshot_rows,
 )
+from backend.services.datalayer.snapshot_sqlite.materializer import (
+    SQLiteSnapshotMaterializer,
+    SnapshotArtifactInvalid,
+    verify_snapshot_file,
+)
 
 __all__ = [
     "SnapshotProjection",
+    "SQLiteSnapshotMaterializer",
+    "SnapshotArtifactInvalid",
     "SnapshotSchema",
     "SourceRowProvenance",
     "derive_snapshot_rows",
     "get_snapshot_schema",
     "project_source_records",
+    "verify_snapshot_file",
 ]

--- a/backend/services/datalayer/snapshot_sqlite/materializer.py
+++ b/backend/services/datalayer/snapshot_sqlite/materializer.py
@@ -1,0 +1,278 @@
+"""Deterministic construction and verification of frozen SQLite artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import sqlite3
+import tempfile
+from typing import Any
+
+from sqlalchemy import create_engine
+
+from backend.services.datalayer.canonical_json import canonical_json_bytes
+from backend.services.datalayer.snapshot_service import (
+    MaterializedSnapshot,
+    SnapshotMaterializationInput,
+)
+from backend.services.datalayer.snapshot_sqlite.derivations import (
+    derive_snapshot_rows,
+)
+from backend.services.datalayer.snapshot_sqlite.projection import (
+    SnapshotProjection,
+    project_source_records,
+)
+from backend.services.datalayer.snapshot_sqlite.schema import get_snapshot_schema
+
+
+SQLITE_APPLICATION_ID = 0x41494441
+_WEEK_TABLES = (
+    "matchups",
+    "player_performances",
+    "games",
+    "standings",
+    "transactions",
+)
+_DERIVED_TABLES = {
+    "games",
+    "standings",
+    "team_profiles",
+    "draft_picks",
+    "season_context",
+}
+
+
+class SnapshotArtifactInvalid(RuntimeError):
+    """A staged SQLite artifact does not satisfy its immutable manifest."""
+
+
+class SQLiteSnapshotMaterializer:
+    """Build verified snapshot SQLite files under a private staging root."""
+
+    def __init__(self, staging_root: Path) -> None:
+        self._staging_root = staging_root.expanduser().resolve()
+        self._staging_root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def staging_root(self) -> Path:
+        return self._staging_root
+
+    def materialize(
+        self,
+        materialization: SnapshotMaterializationInput,
+    ) -> MaterializedSnapshot:
+        schema = get_snapshot_schema(materialization.snapshot_projection_version)
+        descriptor, name = tempfile.mkstemp(
+            suffix=".sqlite",
+            dir=self._staging_root,
+        )
+        path = Path(name).resolve()
+        try:
+            _close_descriptor(descriptor)
+            Path(name).unlink()
+            source = project_source_records(materialization)
+            projection = derive_snapshot_rows(materialization, source)
+            _validate_projection(materialization, source, projection)
+            metadata_row = _metadata_row(materialization, projection)
+            engine = create_engine(f"sqlite:///{path.as_posix()}")
+            try:
+                with engine.begin() as connection:
+                    connection.exec_driver_sql("PRAGMA page_size = 4096")
+                    connection.exec_driver_sql("PRAGMA encoding = 'UTF-8'")
+                    connection.exec_driver_sql("PRAGMA auto_vacuum = NONE")
+                    connection.exec_driver_sql("PRAGMA journal_mode = DELETE")
+                    connection.exec_driver_sql("PRAGMA foreign_keys = ON")
+                    connection.exec_driver_sql(
+                        f"PRAGMA application_id = {SQLITE_APPLICATION_ID}"
+                    )
+                    connection.exec_driver_sql("PRAGMA user_version = 1")
+                    schema.metadata.create_all(connection)
+                    for table_name in schema.table_order:
+                        table = schema.tables[table_name]
+                        values = (
+                            (metadata_row,)
+                            if table_name == "snapshot_metadata"
+                            else projection.rows_for(table_name)
+                        )
+                        if values:
+                            connection.execute(
+                                table.insert(),
+                                [dict(row) for row in values],
+                            )
+                with engine.connect() as connection:
+                    connection.exec_driver_sql("VACUUM")
+            finally:
+                engine.dispose()
+            verify_snapshot_file(path, materialization, projection)
+            sha256, byte_length = _hash_file(path)
+            return MaterializedSnapshot(
+                path=path,
+                sha256=sha256,
+                byte_length=byte_length,
+                completeness_warnings=projection.warnings,
+            )
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+
+
+def verify_snapshot_file(
+    path: Path,
+    materialization: SnapshotMaterializationInput,
+    projection: SnapshotProjection,
+) -> None:
+    """Reopen a staged artifact immutably and verify its complete contract."""
+
+    expected_schema = get_snapshot_schema(
+        materialization.snapshot_projection_version
+    )
+    uri = f"file:{path.as_posix()}?mode=ro&immutable=1"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as error:
+        raise SnapshotArtifactInvalid("snapshot SQLite file is unavailable") from error
+    connection.row_factory = sqlite3.Row
+    try:
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        if integrity is None or integrity[0] != "ok":
+            raise SnapshotArtifactInvalid("snapshot SQLite integrity check failed")
+        application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+        user_version = connection.execute("PRAGMA user_version").fetchone()[0]
+        if application_id != SQLITE_APPLICATION_ID or user_version != 1:
+            raise SnapshotArtifactInvalid("snapshot SQLite version markers differ")
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        if tables != set(expected_schema.tables):
+            raise SnapshotArtifactInvalid("snapshot SQLite table set is incomplete")
+        metadata_rows = connection.execute("SELECT * FROM snapshot_metadata").fetchall()
+        if len(metadata_rows) != 1 or dict(metadata_rows[0]) != _metadata_row(
+            materialization,
+            projection,
+        ):
+            raise SnapshotArtifactInvalid("snapshot metadata differs from build input")
+        cutoff = materialization.request.through_week
+        for table_name in _WEEK_TABLES:
+            leaked = connection.execute(
+                f'SELECT 1 FROM "{table_name}" WHERE week > ? LIMIT 1',
+                (cutoff,),
+            ).fetchone()
+            if leaked is not None:
+                raise SnapshotArtifactInvalid("snapshot contains post-cutoff facts")
+        playoff_start = materialization.planning_context.playoff_start_week
+        if playoff_start is None:
+            bracket_count = connection.execute(
+                "SELECT COUNT(*) FROM playoff_matchups"
+            ).fetchone()[0]
+            if bracket_count:
+                raise SnapshotArtifactInvalid("snapshot bracket cutoff is unknown")
+        else:
+            leaked = connection.execute(
+                "SELECT 1 FROM playoff_matchups "
+                "WHERE (? + round - 1) > ? LIMIT 1",
+                (playoff_start, cutoff),
+            ).fetchone()
+            if leaked is not None:
+                raise SnapshotArtifactInvalid(
+                    "snapshot contains post-cutoff bracket facts"
+                )
+    except sqlite3.Error as error:
+        raise SnapshotArtifactInvalid("snapshot SQLite verification failed") from error
+    finally:
+        connection.close()
+
+
+def _validate_projection(
+    materialization: SnapshotMaterializationInput,
+    source: SnapshotProjection,
+    projection: SnapshotProjection,
+) -> None:
+    selected_scopes = {entry.scope_key for entry in materialization.manifest.entries}
+    source_count = sum(
+        len(rows)
+        for table, rows in source.rows.items()
+        if table not in _DERIVED_TABLES
+    )
+    if len(source.provenance) != source_count:
+        raise SnapshotArtifactInvalid("source row provenance is incomplete")
+    if any(entry.scope_key not in selected_scopes for entry in source.provenance):
+        raise SnapshotArtifactInvalid("source row provenance is outside the manifest")
+    context = materialization.planning_context
+    league_ids = {
+        row["league_id"]
+        for table, rows in projection.rows.items()
+        if table not in {"users", "players", "transaction_moves"}
+        for row in rows
+        if "league_id" in row
+    }
+    if league_ids - {context.sleeper_league_id}:
+        raise SnapshotArtifactInvalid("snapshot combines multiple leagues")
+    seasons = {
+        row["season"]
+        for table, rows in projection.rows.items()
+        if table != "draft_picks"
+        for row in rows
+        if "season" in row and row["season"] is not None
+        and row.get("league_id") == context.sleeper_league_id
+    }
+    if seasons - {str(context.season_year)}:
+        raise SnapshotArtifactInvalid("snapshot combines multiple competition seasons")
+    roster_ids = {row["roster_id"] for row in projection.rows_for("rosters")}
+    roster_tables = (
+        "matchups",
+        "player_performances",
+        "roster_players",
+        "standings",
+    )
+    for table_name in roster_tables:
+        if any(
+            row["roster_id"] not in roster_ids
+            for row in projection.rows_for(table_name)
+        ):
+            raise SnapshotArtifactInvalid(
+                "snapshot contains an unknown roster reference"
+            )
+
+
+def _metadata_row(
+    materialization: SnapshotMaterializationInput,
+    projection: SnapshotProjection,
+) -> dict[str, Any]:
+    manifest = [
+        entry.model_dump(mode="json") for entry in materialization.manifest.entries
+    ]
+    warnings = [warning.model_dump(mode="json") for warning in projection.warnings]
+    context = materialization.planning_context
+    request = materialization.request
+    return {
+        "singleton_id": 1,
+        "build_key": materialization.build_key,
+        "competition_id": str(context.competition_id),
+        "primary_competition_season_id": str(context.competition_season_id),
+        "sleeper_league_id": context.sleeper_league_id,
+        "season_year": context.season_year,
+        "through_week": request.through_week,
+        "as_of_date": request.as_of_date.isoformat(),
+        "snapshot_projection_version": materialization.snapshot_projection_version,
+        "selected_requests_json": canonical_json_bytes(manifest).decode("utf-8"),
+        "completeness_warnings_json": canonical_json_bytes(warnings).decode("utf-8"),
+    }
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    length = 0
+    with path.open("rb") as content:
+        while chunk := content.read(1024 * 1024):
+            digest.update(chunk)
+            length += len(chunk)
+    return digest.hexdigest(), length
+
+
+def _close_descriptor(descriptor: int) -> None:
+    import os
+
+    os.close(descriptor)

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -8,12 +8,14 @@ from sqlalchemy.engine import make_url
 from backend.composition import (
     build_api_runtime,
     build_datalayer_refresh_dependencies,
+    build_datalayer_snapshot_dependencies,
     build_memory_api_dependencies,
 )
 from backend.config import DatalayerSettings
 from backend.database.sessions import create_session_factory
 from backend.resources.context import CompetitionScope, ManagerContext
 from backend.services.datalayer.refresh_service import DatalayerRefreshService
+from backend.services.datalayer.snapshot_service import DatalayerSnapshotService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 
 
@@ -92,4 +94,34 @@ def test_datalayer_refresh_composition_is_scoped_without_opening_a_session(
         assert isinstance(dependencies.refresh, DatalayerRefreshService)
     finally:
         dependencies.close()
+        engine.dispose()
+
+
+def test_datalayer_snapshot_composition_is_scoped_without_opening_a_session(
+    tmp_path: Path,
+) -> None:
+    engine = create_engine("sqlite://")
+    context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "system_process", "process_name": "test"},
+            "scope": {"kind": "competition", "competition_id": uuid4()},
+            "correlation_id": uuid4(),
+        }
+    )
+    dependencies = build_datalayer_snapshot_dependencies(
+        create_session_factory(engine),
+        context,
+        settings=DatalayerSettings(
+            data_root=tmp_path,
+            sleeper_base_url="https://source.example/v1",
+            sleeper_timeout_seconds=5,
+            sleeper_max_attempts=3,
+            sleeper_retry_backoff_seconds=0.25,
+            inline_payload_max_bytes=1024,
+            code_version="test",
+        ),
+    )
+    try:
+        assert isinstance(dependencies.snapshot, DatalayerSnapshotService)
+    finally:
         engine.dispose()

--- a/backend/tests/services/datalayer/test_snapshot_materializer_integration.py
+++ b/backend/tests/services/datalayer/test_snapshot_materializer_integration.py
@@ -1,0 +1,84 @@
+from datetime import date
+from pathlib import Path
+
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import create_session_factory
+from backend.resources.sleeper_data import (
+    ApiRequestManager,
+    DataSnapshotManager,
+    LeagueSeasonManager,
+    NormalizedScopeManager,
+    RefreshRunManager,
+)
+from backend.services.datalayer import (
+    DatalayerSnapshotService,
+    LocalDatalayerFileStore,
+    RefreshRequest,
+    RefreshTrigger,
+    SQLiteSnapshotMaterializer,
+    SnapshotRequest,
+)
+from backend.services.datalayer.refresh_service import DatalayerRefreshService
+from backend.tests.database.conftest import database_engine, migrated_database
+from backend.tests.resources.sleeper_data.conftest import (
+    manager_context,
+    seed_domain,
+)
+from backend.tests.services.datalayer.test_refresh_service_integration import (
+    FixtureSource,
+)
+
+
+def test_refresh_to_materialization_and_atomic_seal(
+    database_engine: Engine,
+    tmp_path: Path,
+) -> None:
+    domain = seed_domain(database_engine, label="Snapshot Materializer")
+    context = manager_context(domain)
+    sessions = create_session_factory(database_engine)
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    requests = ApiRequestManager(sessions, context)
+    planning = LeagueSeasonManager(sessions, context)
+    snapshots = DataSnapshotManager(sessions, context)
+    refresh = DatalayerRefreshService(
+        source=FixtureSource(domain),
+        identities=planning,
+        refreshes=RefreshRunManager(sessions, context),
+        attempts=requests,
+        scopes=NormalizedScopeManager(sessions, context),
+        files=files,
+        code_version="test",
+        delay=lambda _: None,
+    )
+    refresh.refresh(
+        RefreshRequest(
+            competition_season_id=domain.season_id,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+    service = DatalayerSnapshotService(
+        planning=planning,
+        requests=requests,
+        snapshots=snapshots,
+        materializer=SQLiteSnapshotMaterializer(tmp_path / "staging"),
+        files=files,
+        code_version="test",
+    )
+
+    ready = service.get_or_create(
+        SnapshotRequest(
+            competition_season_id=domain.season_id,
+            through_week=1,
+            as_of_date=date(2026, 9, 8),
+        )
+    )
+
+    memberships = snapshots.list_requests(ready.id)
+    assert ready.artifact.path.exists()
+    assert ready.artifact.path.read_bytes().startswith(b"SQLite format 3")
+    assert len(memberships) == 10
+    assert len({item.scope_key for item in memberships}) == 10
+    assert all(len(item.response_sha256) == 64 for item in memberships)
+    assert list((tmp_path / "staging").glob("*.sqlite")) == []

--- a/backend/tests/services/datalayer/test_snapshot_sqlite_materializer.py
+++ b/backend/tests/services/datalayer/test_snapshot_sqlite_materializer.py
@@ -1,0 +1,146 @@
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from backend.services.datalayer.snapshot_sqlite import (
+    SQLiteSnapshotMaterializer,
+    SnapshotArtifactInvalid,
+    derive_snapshot_rows,
+    project_source_records,
+    verify_snapshot_file,
+)
+from backend.services.datalayer import (
+    DatalayerSnapshotService,
+    LocalDatalayerFileStore,
+)
+from backend.tests.services.datalayer.test_snapshot_service import (
+    FakePlanning,
+    FakeRequests,
+    FakeSnapshots,
+    _request,
+)
+from backend.tests.services.datalayer.test_snapshot_source_projection import (
+    _fixture_input,
+)
+
+
+def test_identical_inputs_produce_identical_sqlite_bytes(tmp_path: Path) -> None:
+    materialization = _fixture_input()
+    materializer = SQLiteSnapshotMaterializer(tmp_path / "staging")
+
+    first = materializer.materialize(materialization)
+    second = materializer.materialize(materialization)
+    try:
+        assert first.sha256 == second.sha256
+        assert first.byte_length == second.byte_length
+        assert first.path.read_bytes() == second.path.read_bytes()
+    finally:
+        first.path.unlink(missing_ok=True)
+        second.path.unlink(missing_ok=True)
+
+
+def test_artifact_contains_manifest_warnings_and_no_volatile_state(
+    tmp_path: Path,
+) -> None:
+    materialization = _fixture_input()
+    artifact = SQLiteSnapshotMaterializer(tmp_path / "staging").materialize(
+        materialization
+    )
+    try:
+        connection = sqlite3.connect(artifact.path)
+        connection.row_factory = sqlite3.Row
+        metadata = dict(
+            connection.execute("SELECT * FROM snapshot_metadata").fetchone()
+        )
+        player = dict(connection.execute("SELECT * FROM players LIMIT 1").fetchone())
+        context = dict(connection.execute("SELECT * FROM season_context").fetchone())
+        connection.close()
+
+        assert metadata["build_key"] == materialization.build_key
+        assert metadata["through_week"] == 2
+        assert "week_matchups" in metadata["selected_requests_json"]
+        assert "snapshot.player_state_omitted" in metadata[
+            "completeness_warnings_json"
+        ]
+        assert player["nfl_team"] is None
+        assert player["status"] is None
+        assert context == {
+            "league_id": "123",
+            "computed_week": 2,
+            "override_week": 2,
+            "effective_week": 2,
+            "generated_at": None,
+        }
+    finally:
+        artifact.path.unlink(missing_ok=True)
+
+
+def test_wrong_expected_build_metadata_fails_closed(tmp_path: Path) -> None:
+    materialization = _fixture_input()
+    artifact = SQLiteSnapshotMaterializer(tmp_path / "staging").materialize(
+        materialization
+    )
+    source = project_source_records(materialization)
+    projection = derive_snapshot_rows(materialization, source)
+    wrong = materialization.model_copy(update={"build_key": "b" * 64})
+    try:
+        with pytest.raises(SnapshotArtifactInvalid, match="metadata"):
+            verify_snapshot_file(artifact.path, wrong, projection)
+    finally:
+        artifact.path.unlink(missing_ok=True)
+
+
+def test_corrupt_or_incomplete_sqlite_fails_closed(tmp_path: Path) -> None:
+    materialization = _fixture_input()
+    source = project_source_records(materialization)
+    projection = derive_snapshot_rows(materialization, source)
+    incomplete = tmp_path / "incomplete.sqlite"
+    sqlite3.connect(incomplete).close()
+
+    with pytest.raises(SnapshotArtifactInvalid, match="version markers|table set"):
+        verify_snapshot_file(incomplete, materialization, projection)
+
+
+def test_unsupported_projection_version_removes_staged_file(tmp_path: Path) -> None:
+    materialization = _fixture_input().model_copy(
+        update={"snapshot_projection_version": "2"}
+    )
+    staging = tmp_path / "staging"
+    materializer = SQLiteSnapshotMaterializer(staging)
+
+    with pytest.raises(ValueError, match="unsupported"):
+        materializer.materialize(materialization)
+
+    assert list(staging.iterdir()) == []
+
+
+def test_real_materializer_runs_through_storage_and_sealing(tmp_path: Path) -> None:
+    class FixturePlanning(FakePlanning):
+        def get_snapshot_planning_context(self, competition_season_id):
+            context = super().get_snapshot_planning_context(competition_season_id)
+            return context.model_copy(update={"season_year": 2024})
+
+    files = LocalDatalayerFileStore(tmp_path / "data")
+    requests = FakeRequests(files=files)
+    snapshots = FakeSnapshots()
+    staging = tmp_path / "materializer-staging"
+    service = DatalayerSnapshotService(
+        planning=FixturePlanning(),
+        requests=requests,
+        snapshots=snapshots,
+        materializer=SQLiteSnapshotMaterializer(staging),
+        files=files,
+        code_version="test",
+    )
+
+    ready = service.get_or_create(_request())
+
+    assert ready.artifact.path.exists()
+    assert ready.artifact.sha256 == snapshots.sealed.artifact.sha256
+    assert snapshots.sealed is not None
+    assert len(snapshots.sealed.requests) == 7
+    assert list(staging.glob("*.sqlite")) == []
+    connection = sqlite3.connect(ready.artifact.path)
+    assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    connection.close()


### PR DESCRIPTION
## Summary

Complete Layer 9 with deterministic SQLite construction, immutable artifact
verification, staged-file ownership, real snapshot composition, and the full
refresh-to-seal workflow.

Frozen query methods, reporter tools, routes, generation policy, and legacy
removal remain deferred to their assigned layers.

## Changes

- Build fresh SQLite files with fixed format pragmas and stable insert order.
- Embed canonical manifest/warning metadata without volatile instance fields.
- Verify schema, metadata, integrity, cutoff leakage, season isolation,
  provenance, and roster references through immutable read-only reopen.
- Hash and size the verified temporary file before content-addressed storage.
- Delete staged files after storage attempts while retaining only benign
  content-addressed orphans when later sealing fails.
- Compose the real materializer, local store, request/planning managers, and
  snapshot lifecycle manager behind `DatalayerSnapshotService`.

## Verification

- Cumulative non-live datalayer suite: 287 passed, 3 expected environment
  skips.
- Focused live PostgreSQL snapshot/constraint gate: 16 passed, including real
  refresh, selection, payload replay, SQLite build, storage, and atomic seal.
- Complete repository suite against disposable PostgreSQL: 712 passed, 1
  expected Windows symbolic-link capability skip.
- Exact Alembic lifecycle and metadata drift check: passed at sole head `0007`.
- Byte determinism, corrupt/incomplete rejection, metadata mismatch, strict
  cutoff content, composition, cleanup, compilation, and diff checks: passed.

## Stack

- Parent: Layer 9c derived projections (`c85f234`)
- Local commit: `cb77f1e`
- Implements Layer 9d and completes Layer 9
- GitHub stack: #123
