### PR TITLE
feat(datalayer): add frozen query runtime

### DIFF
--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -125,6 +125,8 @@ __all__ = [
     "EndpointRequest",
     "EndpointPayloadRejected",
     "FailedSourceAttempt",
+    "FrozenLeagueData",
+    "FrozenSnapshotInvalid",
     "INGESTION_NORMALIZER_VERSION",
     "InternalDatalayerFailure",
     "InvalidDatalayerRequest",
@@ -242,7 +244,19 @@ def __getattr__(name: str) -> Any:
         "plan_snapshot_requirements",
         "select_snapshot_requests",
         "SQLiteSnapshotMaterializer",
+        "FrozenLeagueData",
+        "FrozenSnapshotInvalid",
     }:
+        if name in {"FrozenLeagueData", "FrozenSnapshotInvalid"}:
+            from backend.services.datalayer.query import (
+                FrozenLeagueData,
+                FrozenSnapshotInvalid,
+            )
+
+            return {
+                "FrozenLeagueData": FrozenLeagueData,
+                "FrozenSnapshotInvalid": FrozenSnapshotInvalid,
+            }[name]
         if name == "SQLiteSnapshotMaterializer":
             from backend.services.datalayer.snapshot_sqlite import (
                 SQLiteSnapshotMaterializer,

--- a/backend/services/datalayer/query/__init__.py
+++ b/backend/services/datalayer/query/__init__.py
@@ -1,0 +1,8 @@
+"""Frozen SQLite reporter query runtime."""
+
+from backend.services.datalayer.query.runtime import (
+    FrozenLeagueData,
+    FrozenSnapshotInvalid,
+)
+
+__all__ = ["FrozenLeagueData", "FrozenSnapshotInvalid"]

--- a/backend/services/datalayer/query/curated/__init__.py
+++ b/backend/services/datalayer/query/curated/__init__.py
@@ -1,0 +1,53 @@
+"""Curated factual queries over one frozen league snapshot."""
+
+from backend.services.datalayer.query.curated.league import (
+    get_bench_analysis,
+    get_league_snapshot,
+    get_season_leaders,
+    get_standings,
+    get_team_game,
+    get_team_game_with_players,
+    get_week_games,
+    get_week_games_with_players,
+    get_week_player_leaderboard,
+)
+from backend.services.datalayer.query.curated.player import (
+    get_player_summary,
+    get_player_weekly_log,
+)
+from backend.services.datalayer.query.curated.playoffs import (
+    get_playoff_bracket,
+    get_team_playoff_path,
+)
+from backend.services.datalayer.query.curated.team import (
+    get_roster_at_cutoff,
+    get_roster_snapshot,
+    get_team_dossier,
+    get_team_schedule,
+)
+from backend.services.datalayer.query.curated.transactions import (
+    get_team_transactions,
+    get_transactions,
+)
+
+__all__ = [
+    "get_bench_analysis",
+    "get_league_snapshot",
+    "get_player_summary",
+    "get_player_weekly_log",
+    "get_playoff_bracket",
+    "get_roster_at_cutoff",
+    "get_roster_snapshot",
+    "get_season_leaders",
+    "get_standings",
+    "get_team_dossier",
+    "get_team_game",
+    "get_team_game_with_players",
+    "get_team_playoff_path",
+    "get_team_schedule",
+    "get_team_transactions",
+    "get_transactions",
+    "get_week_games",
+    "get_week_games_with_players",
+    "get_week_player_leaderboard",
+]

--- a/backend/services/datalayer/query/curated/_helpers.py
+++ b/backend/services/datalayer/query/curated/_helpers.py
@@ -1,0 +1,123 @@
+"""Shared utility functions for query modules."""
+
+from __future__ import annotations
+
+from sqlite3 import Connection
+from typing import Any, Iterable, Mapping
+
+# Position order for sorting (standard fantasy football order)
+POSITION_ORDER = {"QB": 0, "RB": 1, "WR": 2, "TE": 3, "K": 4, "DEF": 5}
+POSITIONS = ["qb", "rb", "wr", "te", "k", "def"]
+
+# Fields to exclude from team profile responses (internal/UI-only)
+_TEAM_PROFILE_EXCLUDE = {"avatar_url"}
+
+
+def fetch_all(
+    conn: Connection, sql: str, params: Mapping[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    """Execute SQL and return all rows as list of dicts."""
+    result = conn.execute(sql, params or {})
+    return [dict(row) for row in result.fetchall()]
+
+
+def fetch_one(
+    conn: Connection, sql: str, params: Mapping[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Execute SQL and return first row as dict, or None."""
+    result = conn.execute(sql, params or {})
+    row = result.fetchone()
+    return dict(row) if row else None
+
+
+def normalize_lookup_key(value: Any) -> str:
+    """Normalize a lookup key to a stripped string."""
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _strip_id_fields_recursive(value: Any) -> Any:
+    """Recursively remove fields ending with '_id' from dicts."""
+    if isinstance(value, dict):
+        return {
+            key: _strip_id_fields_recursive(val)
+            for key, val in value.items()
+            if not key.endswith("_id")
+        }
+    if isinstance(value, list):
+        return [_strip_id_fields_recursive(item) for item in value]
+    return value
+
+
+def strip_id_fields(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Remove all '_id' fields from a dict."""
+    if payload is None:
+        return None
+    return _strip_id_fields_recursive(payload)
+
+
+def strip_id_fields_list(items: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove all '_id' fields from a list of dicts."""
+    return [_strip_id_fields_recursive(item) for item in items]
+
+
+def clean_team_profile(profile: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Remove ID fields and UI-only fields (like avatar_url) from team profile."""
+    if profile is None:
+        return None
+    return {
+        key: value
+        for key, value in profile.items()
+        if not key.endswith("_id") and key not in _TEAM_PROFILE_EXCLUDE
+    }
+
+
+def format_record(wins: int | None, losses: int | None, ties: int | None) -> str | None:
+    """Format W-L-T record as string (e.g., '7-3' or '7-3-1')."""
+    if wins is None or losses is None:
+        return None
+    ties = ties or 0
+    if ties:
+        return f"{wins}-{losses}-{ties}"
+    return f"{wins}-{losses}"
+
+
+def organize_players_by_role_and_position(
+    players: list[dict[str, Any]],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Organize players into a structured dict by role and position.
+
+    Returns:
+        {
+            "starters": {"qb": [...], "rb": [...], ...},
+            "bench": {"qb": [...], "rb": [...], ...}
+        }
+    """
+    result: dict[str, dict[str, list[dict[str, Any]]]] = {
+        "starters": {pos: [] for pos in POSITIONS},
+        "bench": {pos: [] for pos in POSITIONS},
+    }
+
+    for player in players:
+        role = player.get("role", "bench")
+        position = (player.get("position") or "").upper()
+        pos_key = position.lower() if position in POSITION_ORDER else "def"
+
+        if role == "starter":
+            bucket = "starters"
+        else:
+            bucket = "bench"
+
+        result[bucket][pos_key].append(player)
+
+    # Sort each position group by points descending (if available), then by name
+    def sort_key(p: dict[str, Any]) -> tuple[float, str]:
+        points = p.get("points")
+        return (-(points if points is not None else 0), p.get("player_name") or "")
+
+    for role_bucket in result.values():
+        for pos_list in role_bucket.values():
+            pos_list.sort(key=sort_key)
+
+    return result

--- a/backend/services/datalayer/query/curated/_resolvers.py
+++ b/backend/services/datalayer/query/curated/_resolvers.py
@@ -1,0 +1,129 @@
+"""Name/ID resolution functions for flexible lookups."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import fetch_all, fetch_one, normalize_lookup_key
+
+
+def resolve_player_id(conn, player_key: Any) -> dict[str, Any]:
+    """Resolve a player name or ID to a player_id.
+
+    Args:
+        conn: SQLite database connection.
+        player_key: Player name (str) or player_id.
+
+    Returns:
+        On success: {"found": True, "player_id": str, "player_name": str, ...}
+        On failure: {"found": False, "player_key": ...}
+        On ambiguous: {"found": False, "player_key": ..., "matches": [...]}
+    """
+    key = normalize_lookup_key(player_key)
+    if not key:
+        return {"found": False, "player_key": player_key}
+
+    by_id = fetch_one(
+        conn,
+        """
+        SELECT player_id, full_name, position, age, nfl_team
+        FROM players
+        WHERE player_id = :player_id
+        """,
+        {"player_id": key},
+    )
+    if by_id:
+        return {
+            "found": True,
+            "player_id": by_id["player_id"],
+            "player_name": by_id["full_name"],
+            "position": by_id.get("position"),
+            "age": by_id.get("age"),
+            "nfl_team": by_id.get("nfl_team"),
+        }
+
+    matches = fetch_all(
+        conn,
+        """
+        SELECT player_id, full_name AS player_name, position, age, nfl_team
+        FROM players
+        WHERE full_name IS NOT NULL AND lower(full_name) = lower(:full_name)
+        ORDER BY full_name ASC
+        """,
+        {"full_name": key},
+    )
+    if not matches:
+        return {"found": False, "player_key": player_key}
+    if len(matches) > 1:
+        return {"found": False, "player_key": player_key, "matches": matches}
+    return {
+        "found": True,
+        "player_id": matches[0]["player_id"],
+        "player_name": matches[0]["player_name"],
+    }
+
+
+def resolve_roster_id(conn, league_id: str, roster_key: Any) -> dict[str, Any]:
+    """Resolve a team name, manager name, or roster_id to a roster_id.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name (str), or roster_id (int).
+
+    Returns:
+        On success: {"found": True, "roster_id": int, "team_name": str | None}
+        On failure: {"found": False, "roster_key": ...}
+        On ambiguous: {"found": False, "roster_key": ..., "matches": [...]}
+    """
+    key = normalize_lookup_key(roster_key)
+    if not key:
+        return {"found": False, "roster_key": roster_key}
+
+    if key.isdigit():
+        roster_id = int(key)
+        roster = fetch_one(
+            conn,
+            """
+            SELECT league_id, roster_id
+            FROM rosters
+            WHERE league_id = :league_id AND roster_id = :roster_id
+            """,
+            {"league_id": league_id, "roster_id": roster_id},
+        )
+        if not roster:
+            return {"found": False, "roster_key": roster_key}
+        profile = fetch_one(
+            conn,
+            """
+            SELECT team_name
+            FROM team_profiles
+            WHERE league_id = :league_id AND roster_id = :roster_id
+            """,
+            {"league_id": league_id, "roster_id": roster_id},
+        )
+        return {
+            "found": True,
+            "roster_id": roster_id,
+            "team_name": profile.get("team_name") if profile else None,
+        }
+
+    matches = fetch_all(
+        conn,
+        """
+        SELECT roster_id, team_name
+        FROM team_profiles
+        WHERE league_id = :league_id
+          AND (
+            (team_name IS NOT NULL AND lower(team_name) = lower(:key))
+            OR (manager_name IS NOT NULL AND lower(manager_name) = lower(:key))
+          )
+        ORDER BY team_name ASC, manager_name ASC
+        """,
+        {"league_id": league_id, "key": key},
+    )
+    if not matches:
+        return {"found": False, "roster_key": roster_key}
+    if len(matches) > 1:
+        return {"found": False, "roster_key": roster_key, "matches": matches}
+    return {"found": True, **matches[0]}

--- a/backend/services/datalayer/query/curated/league.py
+++ b/backend/services/datalayer/query/curated/league.py
@@ -1,0 +1,830 @@
+"""League-wide query functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import (
+    POSITIONS,
+    fetch_all,
+    fetch_one,
+    format_record,
+    organize_players_by_role_and_position,
+    strip_id_fields,
+    strip_id_fields_list,
+)
+from ._resolvers import resolve_roster_id
+
+
+def _build_matchup_player_lookup(
+    conn, league_id: str, season: str, week: int, matchup_ids: list[int]
+) -> dict[tuple[int, int], dict[str, dict[str, list[dict[str, Any]]]]]:
+    """Build a lookup of player performances by (matchup_id, roster_id)."""
+    if not matchup_ids:
+        return {}
+    placeholders = ", ".join([f":m{i}" for i in range(len(matchup_ids))])
+    params: dict[str, Any] = {
+        "league_id": league_id,
+        "season": season,
+        "week": week,
+    }
+    params.update({f"m{i}": mid for i, mid in enumerate(matchup_ids)})
+    rows = fetch_all(
+        conn,
+        f"""
+        SELECT
+            pp.matchup_id,
+            pp.roster_id,
+            pp.player_id,
+            pp.points,
+            pp.role,
+            p.full_name,
+            p.position,
+            p.nfl_team
+        FROM player_performances pp
+        LEFT JOIN players p
+            ON p.player_id = pp.player_id
+        WHERE pp.league_id = :league_id
+          AND pp.season = :season
+          AND pp.week = :week
+          AND pp.matchup_id IN ({placeholders});
+        """,
+        params,
+    )
+    # Group rows by (matchup_id, roster_id)
+    grouped: dict[tuple[int, int], list[dict[str, Any]]] = {}
+    for row in rows:
+        key = (int(row["matchup_id"]), int(row["roster_id"]))
+        grouped.setdefault(key, []).append(
+            {
+                "player_name": row.get("full_name"),
+                "position": row.get("position"),
+                "nfl_team": row.get("nfl_team"),
+                "points": row.get("points"),
+                "role": row.get("role"),
+            }
+        )
+    # Organize each group by role and position
+    return {
+        key: organize_players_by_role_and_position(players)
+        for key, players in grouped.items()
+    }
+
+
+def _build_team_players(
+    matchup_lookup: dict[tuple[int, int], dict[str, dict[str, list[dict[str, Any]]]]],
+    matchup_id: Any,
+    roster_id: Any,
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Get player breakdown for a team in a matchup from the lookup."""
+    empty_result: dict[str, dict[str, list[dict[str, Any]]]] = {
+        "starters": {pos: [] for pos in POSITIONS},
+        "bench": {pos: [] for pos in POSITIONS},
+    }
+    if matchup_id is None or roster_id is None:
+        return empty_result
+    return matchup_lookup.get((int(matchup_id), int(roster_id)), empty_result)
+
+
+def get_league_snapshot(
+    conn, league_id: str, season: str, week: int
+) -> dict[str, Any]:
+    """Get a comprehensive snapshot of the league for a specific week.
+
+    Provides standings, all matchup results, and transactions for the week.
+    This is the primary entry point for getting a high-level view of league state.
+
+    Args:
+        conn: SQLite database connection.
+        week: Week number to query. Defaults to the current effective week.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "league": {
+                "name": str,
+                "season": str,
+                "sport": str,
+                "playoff_week_start": int | None
+            },
+            "standings": [
+                {
+                    "team_name": str,
+                    "wins": int,
+                    "losses": int,
+                    "ties": int,
+                    "points_for": float,
+                    "points_against": float,
+                    "rank": int
+                },
+                ...
+            ],
+            "games": [...],  # See get_week_games for structure
+            "transactions": [...]  # See transactions.get_transactions for structure
+        }
+    """
+    # Import here to avoid circular dependency
+    from .transactions import get_transactions
+
+    league = fetch_one(
+        conn,
+        """
+        SELECT league_id, season, name, sport, playoff_week_start
+        FROM leagues
+        WHERE league_id = :league_id AND season = :season
+        """,
+        {"league_id": league_id, "season": season},
+    )
+    if not league:
+        return {"found": False}
+
+    effective_week = week
+
+    standings = []
+    if effective_week is not None:
+        standings = fetch_all(
+            conn,
+            """
+            SELECT s.roster_id, s.wins, s.losses, s.ties, s.points_for, s.points_against, s.rank,
+                   tp.team_name
+            FROM standings s
+            LEFT JOIN team_profiles tp
+                ON tp.league_id = s.league_id AND tp.roster_id = s.roster_id
+            WHERE s.league_id = :league_id
+              AND s.season = :season
+              AND s.week = :week
+            ORDER BY s.rank ASC;
+            """,
+            {"league_id": league_id, "season": season, "week": effective_week},
+        )
+
+    games = (
+        get_week_games(conn, league_id, season, effective_week)
+        if effective_week is not None
+        else []
+    )
+    transactions = (
+        get_transactions(conn, league_id, season, effective_week, effective_week)
+        if effective_week is not None
+        else []
+    )
+
+    return {
+        "found": True,
+        "as_of_week": effective_week,
+        "league": strip_id_fields(league),
+        "standings": strip_id_fields_list(standings),
+        "games": strip_id_fields_list(games),
+        "transactions": strip_id_fields_list(transactions),
+    }
+
+
+def _fetch_games_rows(
+    conn,
+    league_id: str,
+    season: str,
+    week: int,
+    roster_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch raw game rows from the database."""
+    params: dict[str, Any] = {
+        "week": week,
+        "league_id": league_id,
+        "season": season,
+    }
+    roster_filter = ""
+    if roster_id is not None:
+        params["roster_id"] = roster_id
+        roster_filter = "AND (g.roster_id_a = :roster_id OR g.roster_id_b = :roster_id)"
+
+    return fetch_all(
+        conn,
+        f"""
+        SELECT
+            g.week,
+            g.matchup_id,
+            g.roster_id_a,
+            g.roster_id_b,
+            g.points_a,
+            g.points_b,
+            tpa.team_name AS team_a,
+            tpb.team_name AS team_b,
+            CASE
+                WHEN g.winner_roster_id = g.roster_id_a THEN tpa.team_name
+                WHEN g.winner_roster_id = g.roster_id_b THEN tpb.team_name
+                ELSE NULL
+            END AS winner
+        FROM games g
+        LEFT JOIN team_profiles tpa
+            ON tpa.league_id = g.league_id AND tpa.roster_id = g.roster_id_a
+        LEFT JOIN team_profiles tpb
+            ON tpb.league_id = g.league_id AND tpb.roster_id = g.roster_id_b
+        WHERE g.league_id = :league_id
+          AND g.season = :season
+          AND g.week = :week
+        {roster_filter}
+        ORDER BY g.matchup_id;
+        """,
+        params,
+    )
+
+
+def _attach_players_to_games(
+    conn, league_id: str, season: str, week: int, rows: list[dict[str, Any]]
+) -> None:
+    """Attach player breakdowns to game rows in-place."""
+    matchup_ids = [
+        row["matchup_id"] for row in rows if row.get("matchup_id") is not None
+    ]
+    matchup_lookup = _build_matchup_player_lookup(
+        conn, league_id, season, week, matchup_ids
+    )
+    for row in rows:
+        row["team_a_players"] = _build_team_players(
+            matchup_lookup,
+            row.get("matchup_id"),
+            row.get("roster_id_a"),
+        )
+        row["team_b_players"] = _build_team_players(
+            matchup_lookup,
+            row.get("matchup_id"),
+            row.get("roster_id_b"),
+        )
+
+
+def get_week_games(
+    conn, league_id: str, season: str, week: int
+) -> list[dict[str, Any]]:
+    """Get all matchup games for a specific week.
+
+    Returns head-to-head matchups with scores and winner.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+
+    Returns:
+        [
+            {
+                "week": int,
+                "team_a": str,
+                "team_b": str,
+                "points_a": float,
+                "points_b": float,
+                "winner": str | None
+            },
+            ...
+        ]
+    """
+    rows = _fetch_games_rows(conn, league_id, season, week)
+    return strip_id_fields_list(rows)
+
+
+def get_week_games_with_players(
+    conn, league_id: str, season: str, week: int
+) -> list[dict[str, Any]]:
+    """Get all matchup games for a specific week with player breakdowns.
+
+    Returns head-to-head matchups with scores, winner, and full player-by-player
+    breakdowns for detailed game analysis.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+
+    Returns:
+        [
+            {
+                "week": int,
+                "team_a": str,
+                "team_b": str,
+                "points_a": float,
+                "points_b": float,
+                "winner": str | None,
+                "team_a_players": {
+                    "starters": {"qb": [...], "rb": [...], ...},
+                    "bench": {"qb": [...], ...}
+                },
+                "team_b_players": {...}
+            },
+            ...
+        ]
+    """
+    rows = _fetch_games_rows(conn, league_id, season, week)
+    if rows:
+        _attach_players_to_games(conn, league_id, season, week, rows)
+    return strip_id_fields_list(rows)
+
+
+def get_team_game(
+    conn, league_id: str, season: str, week: int, roster_key: Any
+) -> dict[str, Any]:
+    """Get a specific team's game for a week.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+        roster_key: Team name, manager name, or roster_id.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "game": {
+                "week": int,
+                "team_a": str,
+                "team_b": str,
+                "points_a": float,
+                "points_b": float,
+                "winner": str | None
+            }
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {"found": False, "roster_key": roster_key, "as_of_week": week}
+
+    rows = _fetch_games_rows(
+        conn, league_id, season, week, roster_id=resolved["roster_id"]
+    )
+    if not rows:
+        return {"found": False, "roster_key": roster_key, "as_of_week": week}
+
+    games = strip_id_fields_list(rows)
+    return {"found": True, "as_of_week": week, "game": games[0]}
+
+
+def get_team_game_with_players(
+    conn, league_id: str, season: str, week: int, roster_key: Any
+) -> dict[str, Any]:
+    """Get a specific team's game for a week with player breakdowns.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+        roster_key: Team name, manager name, or roster_id.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "game": {
+                "week": int,
+                "team_a": str,
+                "team_b": str,
+                "points_a": float,
+                "points_b": float,
+                "winner": str | None,
+                "team_a_players": {
+                    "starters": {"qb": [...], "rb": [...], ...},
+                    "bench": {"qb": [...], ...}
+                },
+                "team_b_players": {...}
+            }
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {"found": False, "roster_key": roster_key, "as_of_week": week}
+
+    rows = _fetch_games_rows(
+        conn, league_id, season, week, roster_id=resolved["roster_id"]
+    )
+    if not rows:
+        return {"found": False, "roster_key": roster_key, "as_of_week": week}
+
+    _attach_players_to_games(conn, league_id, season, week, rows)
+    games = strip_id_fields_list(rows)
+    return {"found": True, "as_of_week": week, "game": games[0]}
+
+
+def get_week_player_leaderboard(
+    conn, league_id: str, season: str, week: int, *, limit: int = 10
+) -> list[dict[str, Any]]:
+    """Get the top-scoring players for a specific week.
+
+    Returns players ranked by fantasy points scored, useful for identifying
+    standout performances and weekly MVPs.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+        limit: Maximum number of players to return. Defaults to 10.
+
+    Returns:
+        [
+            {
+                "rank": int,  # 1-indexed position in leaderboard
+                "player_name": str,
+                "position": str,
+                "nfl_team": str,
+                "team_name": str,  # Fantasy team that rostered this player
+                "points": float,
+                "role": str  # "starter" or "bench"
+            },
+            ...
+        ]
+    """
+    rows = fetch_all(
+        conn,
+        """
+        SELECT
+            pp.player_id,
+            pp.points,
+            pp.role,
+            pp.roster_id,
+            p.full_name AS player_name,
+            p.position,
+            p.nfl_team,
+            tp.team_name
+        FROM player_performances pp
+        LEFT JOIN players p
+            ON p.player_id = pp.player_id
+        LEFT JOIN team_profiles tp
+            ON tp.league_id = pp.league_id AND tp.roster_id = pp.roster_id
+        WHERE pp.league_id = :league_id
+          AND pp.season = :season
+          AND pp.week = :week
+        ORDER BY pp.points DESC, p.full_name ASC
+        LIMIT :limit
+        """,
+        {"league_id": league_id, "season": season, "week": week, "limit": limit},
+    )
+    result = strip_id_fields_list(rows)
+    # Add rank field
+    for i, row in enumerate(result, start=1):
+        row["rank"] = i
+    return result
+
+
+def get_season_leaders(
+    conn,
+    league_id: str,
+    season: str,
+    *,
+    week_from: int | None = None,
+    week_to: int | None = None,
+    position: str | None = None,
+    roster_key: Any = None,
+    role: str | None = None,
+    sort_by: str = "total",
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Get top players for the season ranked by total or average fantasy points.
+
+    Aggregates player_performances across weeks. All filter parameters are
+    optional — omit everything for an overall season leaderboard.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week_from: Starting week (inclusive). Omit for full season.
+        week_to: Ending week (inclusive). Omit for full season.
+        position: Filter to a single position (e.g., "QB", "RB").
+        roster_key: Filter to one team's players (team name, manager, or roster_id).
+        role: Filter by role — "starter" to exclude bench performances.
+        sort_by: "total" (default) to rank by total points, "avg" for average.
+        limit: Maximum results (default 10, hard cap 30).
+
+    Returns:
+        [
+            {
+                "rank": int,
+                "player_name": str,
+                "position": str,
+                "nfl_team": str,
+                "team_name": str,  # Most recent fantasy team
+                "total_points": float,
+                "avg_points": float,
+                "weeks_played": int,
+                "best_week": float,
+                "worst_week": float
+            },
+            ...
+        ]
+    """
+    capped_limit = min(max(limit, 1), 30)
+
+    filters = ["pp.league_id = :league_id", "pp.season = :season"]
+    params: dict[str, Any] = {
+        "league_id": league_id,
+        "season": season,
+        "limit": capped_limit,
+    }
+
+    if week_from is not None:
+        filters.append("pp.week >= :week_from")
+        params["week_from"] = week_from
+    if week_to is not None:
+        filters.append("pp.week <= :week_to")
+        params["week_to"] = week_to
+    if position is not None:
+        filters.append("UPPER(p.position) = UPPER(:position)")
+        params["position"] = position
+    if role is not None:
+        filters.append("pp.role = :role")
+        params["role"] = role
+
+    roster_filter = ""
+    if roster_key is not None:
+        resolved = resolve_roster_id(conn, league_id, roster_key)
+        if not resolved.get("found"):
+            return []
+        filters.append("pp.roster_id = :filter_roster_id")
+        params["filter_roster_id"] = resolved["roster_id"]
+
+    order_col = "avg_points" if sort_by == "avg" else "total_points"
+    where_clause = " AND ".join(filters)
+
+    rows = fetch_all(
+        conn,
+        f"""
+        SELECT
+            pp.player_id,
+            p.full_name AS player_name,
+            p.position,
+            p.nfl_team,
+            ROUND(SUM(pp.points), 2)  AS total_points,
+            ROUND(AVG(pp.points), 2)  AS avg_points,
+            COUNT(*)                   AS weeks_played,
+            ROUND(MAX(pp.points), 2)  AS best_week,
+            ROUND(MIN(pp.points), 2)  AS worst_week,
+            (
+                SELECT tp2.team_name
+                FROM player_performances pp2
+                LEFT JOIN team_profiles tp2
+                    ON tp2.league_id = pp2.league_id AND tp2.roster_id = pp2.roster_id
+                WHERE pp2.league_id = pp.league_id
+                  AND pp2.season = pp.season
+                  AND pp2.player_id = pp.player_id
+                ORDER BY pp2.week DESC
+                LIMIT 1
+            ) AS team_name
+        FROM player_performances pp
+        LEFT JOIN players p ON p.player_id = pp.player_id
+        WHERE {where_clause}
+        GROUP BY pp.player_id
+        ORDER BY {order_col} DESC, player_name ASC
+        LIMIT :limit
+        """,
+        params,
+    )
+
+    result = strip_id_fields_list(rows)
+    for i, row in enumerate(result, start=1):
+        row["rank"] = i
+    return result
+
+
+def get_bench_analysis(
+    conn, league_id: str, season: str, week: int, roster_key: Any = None
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Get starter vs bench scoring breakdown for a week.
+
+    League-wide mode (no roster_key): Returns every team's starter/bench point
+    totals, sorted by bench points descending.
+
+    Team-specific mode (with roster_key): Same breakdown for one team, plus
+    individual bench player details.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: The week number to query.
+        roster_key: Optional team name, manager name, or roster_id. If provided,
+            returns team-specific breakdown with bench player details.
+
+    Returns:
+        League-wide: list of dicts with team_name, starter_points, bench_points,
+            total_points.
+        Team-specific: dict with found, as_of_week, team_name, starter_points,
+            bench_points, total_points, bench_players.
+    """
+    if roster_key is not None:
+        resolved = resolve_roster_id(conn, league_id, roster_key)
+        if not resolved.get("found"):
+            return {"found": False, "roster_key": roster_key, "as_of_week": week}
+        roster_id = resolved["roster_id"]
+
+        # Get starter/bench totals for this team
+        totals = fetch_one(
+            conn,
+            """
+            SELECT
+                ROUND(SUM(
+                    CASE WHEN pp.role = 'starter' THEN pp.points ELSE 0 END
+                ), 2) AS starter_points,
+                ROUND(SUM(
+                    CASE WHEN pp.role = 'bench' THEN pp.points ELSE 0 END
+                ), 2) AS bench_points
+            FROM player_performances pp
+            WHERE pp.league_id = :league_id AND pp.season = :season
+              AND pp.week = :week AND pp.roster_id = :roster_id
+            """,
+            {
+                "league_id": league_id,
+                "season": season,
+                "week": week,
+                "roster_id": roster_id,
+            },
+        )
+        starter_pts = (totals or {}).get("starter_points") or 0.0
+        bench_pts = (totals or {}).get("bench_points") or 0.0
+
+        # Get individual bench players
+        bench_rows = fetch_all(
+            conn,
+            """
+            SELECT
+                pp.points,
+                p.full_name AS player_name,
+                p.position,
+                p.nfl_team
+            FROM player_performances pp
+            LEFT JOIN players p ON p.player_id = pp.player_id
+            WHERE pp.league_id = :league_id AND pp.season = :season
+              AND pp.week = :week
+              AND pp.roster_id = :roster_id AND pp.role = 'bench'
+            ORDER BY pp.points DESC
+            """,
+            {
+                "league_id": league_id,
+                "season": season,
+                "week": week,
+                "roster_id": roster_id,
+            },
+        )
+
+        return {
+            "found": True,
+            "as_of_week": week,
+            "team_name": resolved.get("team_name"),
+            "starter_points": starter_pts,
+            "bench_points": bench_pts,
+            "total_points": round(starter_pts + bench_pts, 2),
+            "bench_players": strip_id_fields_list(bench_rows),
+        }
+
+    # League-wide mode
+    rows = fetch_all(
+        conn,
+        """
+        SELECT pp.roster_id, tp.team_name,
+               ROUND(SUM(
+                   CASE WHEN pp.role = 'starter' THEN pp.points ELSE 0 END
+               ), 2) AS starter_points,
+               ROUND(SUM(
+                   CASE WHEN pp.role = 'bench' THEN pp.points ELSE 0 END
+               ), 2) AS bench_points
+        FROM player_performances pp
+        LEFT JOIN team_profiles tp
+            ON tp.league_id = pp.league_id AND tp.roster_id = pp.roster_id
+        WHERE pp.league_id = :league_id AND pp.season = :season
+          AND pp.week = :week
+        GROUP BY pp.roster_id
+        ORDER BY bench_points DESC
+        """,
+        {"league_id": league_id, "season": season, "week": week},
+    )
+    result = strip_id_fields_list(rows)
+    for row in result:
+        starter = row.get("starter_points") or 0.0
+        bench = row.get("bench_points") or 0.0
+        row["total_points"] = round(starter + bench, 2)
+    return result
+
+
+def get_standings(
+    conn, league_id: str, season: str, week: int
+) -> dict[str, Any]:
+    """Get league standings for a specific week.
+
+    Queries the standings table and enriches with league_average_match info,
+    formatted records, and backfilled points/ranks when derived from
+    record_string.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week: Week number. Defaults to the current effective week.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "league_average_match": bool,
+            "standings": [
+                {
+                    "team_name": str,
+                    "wins": int,
+                    "losses": int,
+                    "ties": int,
+                    "record": str,
+                    "points_for": float,
+                    "points_against": float,
+                    "rank": int,
+                    "streak_type": str | None,
+                    "streak_len": int | None
+                },
+                ...
+            ]
+        }
+    """
+    effective_week = week
+
+    league_row = fetch_one(
+        conn,
+        """
+        SELECT league_average_match FROM leagues
+        WHERE league_id = :league_id AND season = :season
+        """,
+        {"league_id": league_id, "season": season},
+    )
+    league_average_match = bool(
+        (league_row or {}).get("league_average_match")
+    )
+
+    rows = fetch_all(
+        conn,
+        """
+        SELECT s.roster_id, s.wins, s.losses, s.ties, s.points_for, s.points_against,
+               s.rank, s.streak_type, s.streak_len, tp.team_name
+        FROM standings s
+        LEFT JOIN team_profiles tp
+            ON tp.league_id = s.league_id AND tp.roster_id = s.roster_id
+        WHERE s.league_id = :league_id AND s.season = :season
+          AND s.week = :week
+        ORDER BY s.rank ASC NULLS LAST, s.wins DESC, s.points_for DESC
+        """,
+        {"league_id": league_id, "season": season, "week": effective_week},
+    )
+
+    if not rows:
+        return {"found": False, "as_of_week": effective_week}
+
+    # Check if points_for needs backfilling (record_string-derived rows have 0)
+    needs_backfill = any(
+        (row.get("points_for") or 0) == 0 and row.get("rank") is None
+        for row in rows
+    )
+
+    points_lookup: dict[int, float] = {}
+    if needs_backfill:
+        points_rows = fetch_all(
+            conn,
+            """
+            SELECT roster_id, ROUND(SUM(points), 2) AS total_points
+            FROM matchups
+            WHERE league_id = :league_id AND season = :season AND week <= :week
+            GROUP BY roster_id
+            """,
+            {"league_id": league_id, "season": season, "week": effective_week},
+        )
+        points_lookup = {
+            int(r["roster_id"]): r["total_points"] or 0.0 for r in points_rows
+        }
+
+    standings = []
+    for row in rows:
+        roster_id = row.get("roster_id")
+        points_for = row.get("points_for") or 0.0
+        if needs_backfill and points_for == 0 and roster_id is not None:
+            points_for = points_lookup.get(int(roster_id), 0.0)
+
+        standings.append({
+            "team_name": row.get("team_name"),
+            "wins": row.get("wins") or 0,
+            "losses": row.get("losses") or 0,
+            "ties": row.get("ties") or 0,
+            "record": format_record(
+                row.get("wins"), row.get("losses"), row.get("ties")
+            ),
+            "points_for": points_for,
+            "points_against": row.get("points_against") or 0.0,
+            "rank": row.get("rank"),
+            "streak_type": row.get("streak_type"),
+            "streak_len": row.get("streak_len"),
+        })
+
+    # Compute rank dynamically if any are None
+    if any(s["rank"] is None for s in standings):
+        standings.sort(key=lambda s: (-s["wins"], -s["points_for"]))
+        for i, s in enumerate(standings, start=1):
+            s["rank"] = i
+
+    return {
+        "found": True,
+        "as_of_week": effective_week,
+        "league_average_match": league_average_match,
+        "standings": standings,
+    }

--- a/backend/services/datalayer/query/curated/player.py
+++ b/backend/services/datalayer/query/curated/player.py
@@ -1,0 +1,181 @@
+"""Player-specific query functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import fetch_all, fetch_one, strip_id_fields, strip_id_fields_list
+from ._resolvers import resolve_player_id
+
+
+def get_player_summary(conn, player_key: Any) -> dict[str, Any]:
+    """Get basic metadata about an NFL player.
+
+    Returns player identity, position, team, and injury status. Useful for
+    looking up player details before querying their performance log.
+
+    Args:
+        conn: SQLite database connection.
+        player_key: Player name or player_id.
+
+    Returns:
+        {
+            "found": True,
+            "player": {
+                "player_name": str,
+                "position": str,
+                "nfl_team": str,
+                "status": str,  # "Active", "Inactive", etc.
+                "injury_status": str | None  # "Questionable", "Out", etc.
+            }
+        }
+
+        Returns {"found": False, "player_key": ...} if player not found.
+        If multiple players match the name, returns {"found": False, "matches": [...]}.
+    """
+    resolved = resolve_player_id(conn, player_key)
+    if not resolved.get("found"):
+        return {**resolved}
+
+    player = fetch_one(
+        conn,
+        """
+        SELECT player_id, full_name, position, nfl_team, status, injury_status
+        FROM players
+        WHERE player_id = :player_id
+        """,
+        {"player_id": resolved["player_id"]},
+    )
+    if not player:
+        return {"found": False, "player_key": player_key}
+
+    player["player_name"] = player.get("full_name")
+    del player["full_name"]
+    return {"found": True, "player": strip_id_fields(player)}
+
+
+def _fetch_player_performances(
+    conn,
+    league_id: str,
+    season: str,
+    player_id: str,
+    week_from: int | None = None,
+    week_to: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch player performance rows from the database."""
+    params: dict[str, Any] = {
+        "league_id": league_id,
+        "season": season,
+        "player_id": player_id,
+    }
+    filters = [
+        "pp.league_id = :league_id",
+        "pp.season = :season",
+        "pp.player_id = :player_id",
+    ]
+    if week_from is not None:
+        params["week_from"] = week_from
+        filters.append("pp.week >= :week_from")
+    if week_to is not None:
+        params["week_to"] = week_to
+        filters.append("pp.week <= :week_to")
+
+    return fetch_all(
+        conn,
+        f"""
+        SELECT
+            pp.week,
+            pp.points,
+            pp.role,
+            pp.roster_id,
+            tp.team_name
+        FROM player_performances pp
+        LEFT JOIN team_profiles tp
+            ON tp.league_id = pp.league_id AND tp.roster_id = pp.roster_id
+        WHERE {" AND ".join(filters)}
+        ORDER BY pp.week ASC
+        """,
+        params,
+    )
+
+
+def _build_player_log_response(
+    player_name: str, rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Build the standard player log response structure."""
+    performances = strip_id_fields_list(rows)
+    weeks_played = len(performances)
+    total_points = sum(p.get("points") or 0 for p in performances)
+    avg_points = round(total_points / weeks_played, 2) if weeks_played > 0 else 0.0
+
+    return {
+        "found": True,
+        "player_name": player_name,
+        "weeks_played": weeks_played,
+        "total_points": round(total_points, 2),
+        "avg_points": avg_points,
+        "performances": performances,
+    }
+
+
+def get_player_weekly_log(
+    conn,
+    league_id: str,
+    season: str,
+    player_key: Any,
+    week_from: int | None = None,
+    week_to: int | None = None,
+) -> dict[str, Any]:
+    """Get a player's fantasy performance log, optionally filtered to a week range.
+
+    Returns each week's points, the fantasy team they were on, and whether
+    they were started or benched. Includes summary stats for the period.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        player_key: Player name or player_id.
+        week_from: Starting week (inclusive). Omit for full season.
+        week_to: Ending week (inclusive). Omit for full season.
+
+    Returns:
+        {
+            "found": True,
+            "player_name": str,
+            "weeks_played": int,
+            "total_points": float,
+            "avg_points": float,
+            "performances": [
+                {
+                    "week": int,
+                    "points": float,
+                    "role": str,  # "starter" or "bench"
+                    "team_name": str  # Fantasy team that rostered them
+                },
+                ...
+            ]
+        }
+
+        When week_from or week_to is provided, the response also includes
+        "week_from" and/or "week_to" keys reflecting the requested range.
+
+        Returns {"found": False, "player_key": ...} if player not found.
+    """
+    resolved = resolve_player_id(conn, player_key)
+    if not resolved.get("found"):
+        return {**resolved}
+
+    rows = _fetch_player_performances(
+        conn,
+        league_id,
+        season,
+        resolved["player_id"],
+        week_from=week_from,
+        week_to=week_to,
+    )
+    result = _build_player_log_response(resolved.get("player_name", ""), rows)
+    if week_from is not None:
+        result["week_from"] = week_from
+    if week_to is not None:
+        result["week_to"] = week_to
+    return result

--- a/backend/services/datalayer/query/curated/playoffs.py
+++ b/backend/services/datalayer/query/curated/playoffs.py
@@ -1,0 +1,276 @@
+"""Playoff bracket query functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import fetch_all, fetch_one
+from ._resolvers import resolve_roster_id
+
+
+def get_playoff_bracket(
+    conn, league_id: str, season: str, bracket_type: str | None = None
+) -> dict[str, Any]:
+    """Get the playoff bracket structure with team names and results.
+
+    Fetches all playoff matchups, resolves team names via LEFT JOINs, and
+    organizes by bracket_type and round. Each matchup includes status
+    (complete/pending), team names (or progression labels like "Winner of
+    Match 1"), and placements.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        bracket_type: "winners" or "losers". If None, returns both brackets.
+
+    Returns:
+        {
+            "found": True,
+            "brackets": {
+                "winners": {
+                    "rounds": {
+                        1: [{"matchup_id": int, "round": int, ...}, ...],
+                        2: [...]
+                    },
+                    "champion": str | None,
+                    "placements": [{"placement": int, "team_name": str}, ...]
+                },
+                "losers": { ... }
+            }
+        }
+
+        Returns {"found": False} if no bracket data exists.
+    """
+    params: dict[str, Any] = {"league_id": league_id, "season": season}
+    type_filter = ""
+    if bracket_type is not None:
+        type_filter = "AND pm.bracket_type = :bracket_type"
+        params["bracket_type"] = bracket_type
+
+    rows = fetch_all(
+        conn,
+        f"""
+        SELECT
+            pm.bracket_type,
+            pm.round,
+            pm.matchup_id,
+            pm.t1_roster_id,
+            pm.t2_roster_id,
+            pm.t1_from_matchup_id,
+            pm.t1_from_outcome,
+            pm.t2_from_matchup_id,
+            pm.t2_from_outcome,
+            pm.winner_roster_id,
+            pm.loser_roster_id,
+            pm.placement,
+            tp1.team_name AS t1_team_name,
+            tp2.team_name AS t2_team_name,
+            tpw.team_name AS winner_team_name,
+            tpl.team_name AS loser_team_name
+        FROM playoff_matchups pm
+        LEFT JOIN team_profiles tp1
+            ON tp1.league_id = pm.league_id AND tp1.roster_id = pm.t1_roster_id
+        LEFT JOIN team_profiles tp2
+            ON tp2.league_id = pm.league_id AND tp2.roster_id = pm.t2_roster_id
+        LEFT JOIN team_profiles tpw
+            ON tpw.league_id = pm.league_id AND tpw.roster_id = pm.winner_roster_id
+        LEFT JOIN team_profiles tpl
+            ON tpl.league_id = pm.league_id AND tpl.roster_id = pm.loser_roster_id
+        WHERE pm.league_id = :league_id AND pm.season = :season {type_filter}
+        ORDER BY pm.bracket_type, pm.round, pm.matchup_id
+        """,
+        params,
+    )
+
+    if not rows:
+        return {"found": False}
+
+    brackets: dict[str, dict[str, Any]] = {}
+
+    for row in rows:
+        bt = row["bracket_type"]
+        if bt not in brackets:
+            brackets[bt] = {"rounds": {}, "champion": None, "placements": []}
+
+        rd = row["round"]
+        if rd not in brackets[bt]["rounds"]:
+            brackets[bt]["rounds"][rd] = []
+
+        def _team_label(roster_id, team_name, from_matchup_id, from_outcome):
+            if team_name is not None:
+                return team_name
+            if roster_id is not None:
+                return f"Roster {roster_id}"
+            if from_matchup_id is not None:
+                label = "Winner" if from_outcome == "w" else "Loser"
+                return f"{label} of Match {from_matchup_id}"
+            return None
+
+        team_1 = _team_label(
+            row["t1_roster_id"],
+            row["t1_team_name"],
+            row["t1_from_matchup_id"],
+            row["t1_from_outcome"],
+        )
+        team_2 = _team_label(
+            row["t2_roster_id"],
+            row["t2_team_name"],
+            row["t2_from_matchup_id"],
+            row["t2_from_outcome"],
+        )
+
+        status = "complete" if row["winner_roster_id"] is not None else "pending"
+
+        matchup: dict[str, Any] = {
+            "matchup_id": row["matchup_id"],
+            "round": rd,
+            "team_1": team_1,
+            "team_2": team_2,
+            "winner": row["winner_team_name"],
+            "loser": row["loser_team_name"],
+            "status": status,
+        }
+        if row["placement"] is not None:
+            matchup["placement"] = row["placement"]
+
+        brackets[bt]["rounds"][rd].append(matchup)
+
+        if row["placement"] is not None and row["winner_team_name"] is not None:
+            brackets[bt]["placements"].append(
+                {
+                    "placement": row["placement"],
+                    "team_name": row["winner_team_name"],
+                }
+            )
+            if row["placement"] == 1:
+                brackets[bt]["champion"] = row["winner_team_name"]
+
+    # Sort placements by placement number
+    for bt_data in brackets.values():
+        bt_data["placements"].sort(key=lambda x: x["placement"])
+
+    return {"found": True, "brackets": brackets}
+
+
+def get_team_playoff_path(
+    conn, league_id: str, season: str, roster_key: Any
+) -> dict[str, Any]:
+    """Get a specific team's playoff bracket journey.
+
+    Resolves the team via roster_key, then fetches all bracket matchups where
+    the team appears as a participant (t1, t2) or result (winner, loser).
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name, or roster_id.
+
+    Returns:
+        {
+            "found": True,
+            "team_name": str,
+            "bracket_type": str,  # "winners" or "losers" (first bracket they appear in)
+            "matchups": [
+                {
+                    "round": int,
+                    "matchup_id": int,
+                    "opponent": str | None,
+                    "result": "win" | "loss" | "pending",
+                    "placement": int | None
+                },
+                ...
+            ],
+            "final_placement": int | None,
+            "is_eliminated": bool,
+            "is_champion": bool
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found or not in playoffs.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {**resolved}
+    roster_id = resolved["roster_id"]
+    team_name = resolved.get("team_name")
+
+    rows = fetch_all(
+        conn,
+        """
+        SELECT
+            pm.bracket_type,
+            pm.round,
+            pm.matchup_id,
+            pm.t1_roster_id,
+            pm.t2_roster_id,
+            pm.winner_roster_id,
+            pm.loser_roster_id,
+            pm.placement,
+            tp1.team_name AS t1_team_name,
+            tp2.team_name AS t2_team_name
+        FROM playoff_matchups pm
+        LEFT JOIN team_profiles tp1
+            ON tp1.league_id = pm.league_id AND tp1.roster_id = pm.t1_roster_id
+        LEFT JOIN team_profiles tp2
+            ON tp2.league_id = pm.league_id AND tp2.roster_id = pm.t2_roster_id
+        WHERE pm.league_id = :league_id
+          AND pm.season = :season
+          AND (
+            pm.t1_roster_id = :roster_id
+            OR pm.t2_roster_id = :roster_id
+            OR pm.winner_roster_id = :roster_id
+            OR pm.loser_roster_id = :roster_id
+          )
+        ORDER BY pm.bracket_type, pm.round, pm.matchup_id
+        """,
+        {"league_id": league_id, "season": season, "roster_id": roster_id},
+    )
+
+    if not rows:
+        return {"found": False, "roster_key": roster_key}
+
+    matchups: list[dict[str, Any]] = []
+    final_placement: int | None = None
+    is_eliminated = False
+    is_champion = False
+    bracket_type: str | None = None
+
+    for row in rows:
+        if bracket_type is None:
+            bracket_type = row["bracket_type"]
+
+        is_t1 = row["t1_roster_id"] == roster_id
+        opponent_name = row["t2_team_name"] if is_t1 else row["t1_team_name"]
+
+        if row["winner_roster_id"] == roster_id:
+            result = "win"
+        elif row["loser_roster_id"] == roster_id:
+            result = "loss"
+            is_eliminated = True
+        else:
+            result = "pending"
+
+        entry: dict[str, Any] = {
+            "round": row["round"],
+            "matchup_id": row["matchup_id"],
+            "opponent": opponent_name,
+            "result": result,
+        }
+
+        if row["placement"] is not None:
+            entry["placement"] = row["placement"]
+            if row["winner_roster_id"] == roster_id:
+                final_placement = row["placement"]
+                if row["placement"] == 1:
+                    is_champion = True
+
+        matchups.append(entry)
+
+    return {
+        "found": True,
+        "team_name": team_name,
+        "bracket_type": bracket_type,
+        "matchups": matchups,
+        "final_placement": final_placement,
+        "is_eliminated": is_eliminated,
+        "is_champion": is_champion,
+    }

--- a/backend/services/datalayer/query/curated/team.py
+++ b/backend/services/datalayer/query/curated/team.py
@@ -1,0 +1,519 @@
+"""Team-specific query functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import (
+    clean_team_profile,
+    fetch_all,
+    fetch_one,
+    format_record,
+    organize_players_by_role_and_position,
+    strip_id_fields,
+    strip_id_fields_list,
+)
+from ._resolvers import resolve_roster_id
+
+
+def get_team_dossier(
+    conn, league_id: str, season: str, roster_key: Any, week: int
+) -> dict[str, Any]:
+    """Get a comprehensive profile of a team including standings and recent games.
+
+    Provides team identity, current standings, and the last 5 games for context
+    on recent performance and trajectory.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name, or roster_id (int).
+        week: Week number for standings. Defaults to current effective week.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "team": {
+                "team_name": str,
+                "manager_name": str
+            },
+            "standings": {
+                "wins": int,
+                "losses": int,
+                "ties": int,
+                "record": str,  # e.g., "7-3" or "7-3-1"
+                "rank": int,
+                "points_for": float,
+                "points_against": float,
+                "streak_type": str | None,  # "W" or "L"
+                "streak_len": int | None
+            },
+            "recent_games": [
+                {
+                    "week": int,
+                    "team_a": str,
+                    "team_b": str,
+                    "points_a": float,
+                    "points_b": float,
+                    "manager_a": str,
+                    "manager_b": str
+                },
+                ...  # Last 5 games, most recent first
+            ]
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {**resolved, "as_of_week": week}
+    roster_id = resolved["roster_id"]
+
+    team = fetch_one(
+        conn,
+        """
+        SELECT league_id, roster_id, team_name, manager_name
+        FROM team_profiles
+        WHERE league_id = :league_id AND roster_id = :roster_id
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+    if not team:
+        return {"roster_id": roster_id, "found": False, "as_of_week": week}
+
+    standings = None
+    effective_week = week
+
+    if effective_week is not None:
+        standings = fetch_one(
+            conn,
+            """
+            SELECT wins, losses, ties, points_for, points_against, rank, streak_type, streak_len
+            FROM standings
+            WHERE league_id = :league_id AND season = :season
+              AND roster_id = :roster_id AND week = :week
+            """,
+            {
+                "league_id": league_id,
+                "season": season,
+                "roster_id": roster_id,
+                "week": effective_week,
+            },
+        )
+        if standings:
+            standings["record"] = format_record(
+                standings.get("wins"),
+                standings.get("losses"),
+                standings.get("ties"),
+            )
+
+    recent_games = fetch_all(
+        conn,
+        """
+        SELECT
+            g.week,
+            g.matchup_id,
+            g.roster_id_a,
+            g.roster_id_b,
+            g.points_a,
+            g.points_b,
+            g.winner_roster_id,
+            tpa.team_name AS team_a,
+            tpb.team_name AS team_b,
+            tpa.manager_name AS manager_a,
+            tpb.manager_name AS manager_b
+        FROM games g
+        LEFT JOIN team_profiles tpa
+            ON tpa.league_id = g.league_id AND tpa.roster_id = g.roster_id_a
+        LEFT JOIN team_profiles tpb
+            ON tpb.league_id = g.league_id AND tpb.roster_id = g.roster_id_b
+        WHERE g.league_id = :league_id AND g.season = :season
+          AND (g.roster_id_a = :roster_id OR g.roster_id_b = :roster_id)
+        ORDER BY week DESC
+        LIMIT 5
+        """,
+        {"league_id": league_id, "season": season, "roster_id": roster_id},
+    )
+
+    return {
+        "found": True,
+        "as_of_week": effective_week,
+        "team": clean_team_profile(team),
+        "standings": strip_id_fields(standings),
+        "recent_games": strip_id_fields_list(recent_games),
+    }
+
+
+def get_team_schedule(
+    conn, league_id: str, season: str, roster_key: Any
+) -> dict[str, Any]:
+    """Get the full season schedule for a team with game-by-game results.
+
+    Shows all regular season and playoff games with opponent, scores, results,
+    and cumulative record after each week. Useful for analyzing a team's
+    season trajectory and strength of schedule.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name, or roster_id (int).
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "team_name": str,
+            "regular_season_games": [
+                {
+                    "week": int,
+                    "opponent_name": str,
+                    "team_points": float,
+                    "opponent_points": float,
+                    "result": str,  # "W", "L", or "T"
+                    "record_after_week": str  # e.g., "5-2"
+                },
+                ...
+            ],
+            "playoff_games": [...]  # Same structure, for playoff weeks
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {**resolved, "as_of_week": None}
+    roster_id = resolved["roster_id"]
+
+    roster_row = fetch_one(
+        conn,
+        """
+        SELECT record_string
+        FROM rosters
+        WHERE league_id = :league_id AND roster_id = :roster_id
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+    record_string = roster_row.get("record_string") if roster_row else None
+
+    league_row = fetch_one(
+        conn,
+        """
+        SELECT league_average_match, playoff_week_start
+        FROM leagues
+        WHERE league_id = :league_id AND season = :season
+        """,
+        {"league_id": league_id, "season": season},
+    )
+    league_average_match = league_row.get("league_average_match") if league_row else None
+    playoff_week_start = league_row.get("playoff_week_start") if league_row else None
+    chars_per_week = 2 if league_average_match == 1 else 1
+
+    rows = fetch_all(
+        conn,
+        """
+        SELECT
+            g.week,
+            g.matchup_id,
+            g.roster_id_a,
+            g.roster_id_b,
+            g.points_a,
+            g.points_b,
+            g.winner_roster_id,
+            tpa.team_name AS team_a,
+            tpb.team_name AS team_b
+        FROM games g
+        LEFT JOIN team_profiles tpa
+            ON tpa.league_id = g.league_id AND tpa.roster_id = g.roster_id_a
+        LEFT JOIN team_profiles tpb
+            ON tpb.league_id = g.league_id AND tpb.roster_id = g.roster_id_b
+        WHERE g.league_id = :league_id AND g.season = :season
+          AND (g.roster_id_a = :roster_id OR g.roster_id_b = :roster_id)
+        ORDER BY g.week ASC, g.matchup_id ASC
+        """,
+        {"league_id": league_id, "season": season, "roster_id": roster_id},
+    )
+
+    context = fetch_one(
+        conn,
+        """
+        SELECT effective_week FROM season_context
+        WHERE league_id = :league_id
+        """,
+        {"league_id": league_id},
+    )
+    current_week = context.get("effective_week") if context else None
+
+    def _record_for_week(week: int | None) -> str | None:
+        if not record_string or week is None:
+            return None
+        if current_week is not None and week > int(current_week):
+            return None
+        record_value = "".join(ch for ch in str(record_string).upper() if ch.strip())
+        if not record_value:
+            return None
+        cutoff = int(week) * chars_per_week
+        if len(record_value) < cutoff:
+            return None
+        wins = 0
+        losses = 0
+        ties = 0
+        for outcome in record_value[:cutoff]:
+            if outcome == "W":
+                wins += 1
+            elif outcome == "L":
+                losses += 1
+            elif outcome == "T":
+                ties += 1
+        return format_record(wins, losses, ties)
+
+    schedule_regular: list[dict[str, Any]] = []
+    schedule_playoffs: list[dict[str, Any]] = []
+
+    for row in rows:
+        week = row.get("week")
+        is_team_a = row.get("roster_id_a") == roster_id
+        team_points = row.get("points_a") if is_team_a else row.get("points_b")
+        opponent_points = row.get("points_b") if is_team_a else row.get("points_a")
+        opponent_name = row.get("team_b") if is_team_a else row.get("team_a")
+
+        # Try record_string first for result
+        result = None
+        if record_string and week is not None:
+            record_value = "".join(ch for ch in str(record_string).upper() if ch.strip())
+            end_idx = int(week) * chars_per_week
+            start_idx = end_idx - chars_per_week
+            if len(record_value) >= end_idx:
+                result = record_value[start_idx:end_idx]
+
+        # Fall back to game data
+        if result is None:
+            winner_id = row.get("winner_roster_id")
+            if winner_id is not None:
+                result = "W" if int(winner_id) == int(roster_id) else "L"
+            elif team_points is not None and opponent_points is not None:
+                if team_points > opponent_points:
+                    result = "W"
+                elif team_points < opponent_points:
+                    result = "L"
+                else:
+                    result = "T"
+
+        entry: dict[str, Any] = {
+            "week": week,
+            "opponent_name": opponent_name,
+            "team_points": team_points,
+            "opponent_points": opponent_points,
+            "result": result,
+        }
+        record = _record_for_week(int(week)) if week is not None else None
+        if record is not None:
+            entry["record_after_week"] = record
+        if playoff_week_start is not None and week is not None and int(week) >= int(
+            playoff_week_start
+        ):
+            schedule_playoffs.append(entry)
+        else:
+            schedule_regular.append(entry)
+
+    return {
+        "found": True,
+        "as_of_week": current_week,
+        "team_name": resolved.get("team_name"),
+        "regular_season_games": schedule_regular,
+        "playoff_games": schedule_playoffs,
+    }
+
+
+def get_roster_at_cutoff(conn, league_id: str, roster_key: Any) -> dict[str, Any]:
+    """Get a team's current roster composition.
+
+    Returns all players on the roster organized by role (starter/bench) and
+    position. Also includes draft picks currently owned by this team.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name, or roster_id (int).
+
+    Returns:
+        {
+            "found": True,
+            "team": {
+                "team_name": str,
+                "manager_name": str
+            },
+            "roster": {
+                "starters": {
+                    "qb": [{"player_name": str, "position": str, "nfl_team": str, ...}],
+                    "rb": [...], "wr": [...], "te": [...], "k": [...], "def": [...]
+                },
+                "bench": {...}  # Same structure
+            },
+            "picks": [
+                {
+                    "season": str,
+                    "round": int,
+                    "original_team_name": str,
+                    "current_team_name": str
+                },
+                ...
+            ]
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {**resolved}
+    roster_id = resolved["roster_id"]
+
+    team = fetch_one(
+        conn,
+        """
+        SELECT league_id, roster_id, team_name, manager_name
+        FROM team_profiles
+        WHERE league_id = :league_id AND roster_id = :roster_id
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+
+    players = fetch_all(
+        conn,
+        """
+        SELECT
+            rp.player_id,
+            rp.role,
+            p.full_name,
+            p.full_name AS player_name,
+            p.position,
+            p.nfl_team,
+            p.status,
+            p.injury_status
+        FROM roster_players rp
+        LEFT JOIN players p
+            ON p.player_id = rp.player_id
+        WHERE rp.league_id = :league_id AND rp.roster_id = :roster_id
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+
+    picks = fetch_all(
+        conn,
+        """
+        SELECT
+            dp.season,
+            dp.round,
+            dp.original_roster_id,
+            dp.current_roster_id,
+            tpo.team_name AS original_team_name,
+            tpc.team_name AS current_team_name
+        FROM draft_picks dp
+        LEFT JOIN team_profiles tpo
+            ON tpo.league_id = dp.league_id AND tpo.roster_id = dp.original_roster_id
+        LEFT JOIN team_profiles tpc
+            ON tpc.league_id = dp.league_id AND tpc.roster_id = dp.current_roster_id
+        WHERE dp.league_id = :league_id AND dp.current_roster_id = :roster_id
+        ORDER BY dp.season ASC, dp.round ASC
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+
+    if not team and not players and not picks:
+        return {"found": False, "roster_key": roster_key}
+
+    roster = organize_players_by_role_and_position(strip_id_fields_list(players))
+
+    return {
+        "found": True,
+        "team": clean_team_profile(team),
+        "roster": roster,
+        "picks": strip_id_fields_list(picks),
+    }
+
+
+def get_roster_snapshot(
+    conn, league_id: str, season: str, roster_key: Any, week: int
+) -> dict[str, Any]:
+    """Get a team's roster as it was during a specific week.
+
+    Returns the players who were on the roster that week with their points
+    scored, organized by role and position. Useful for historical analysis
+    and reviewing past lineup decisions.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        roster_key: Team name, manager name, or roster_id (int).
+        week: The week number to query.
+
+    Returns:
+        {
+            "found": True,
+            "as_of_week": int,
+            "team": {
+                "team_name": str,
+                "manager_name": str
+            },
+            "roster": {
+                "starters": {
+                    "qb": [{"player_name": str, "points": float, ...}],
+                    "rb": [...], "wr": [...], "te": [...], "k": [...], "def": [...]
+                },
+                "bench": {...}  # Same structure
+            }
+        }
+
+        Returns {"found": False, "roster_key": ...} if team or week data not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {**resolved}
+    roster_id = resolved["roster_id"]
+
+    players = fetch_all(
+        conn,
+        """
+        SELECT
+            pp.player_id,
+            pp.role,
+            pp.points,
+            p.full_name AS player_name,
+            p.position,
+            p.nfl_team
+        FROM player_performances pp
+        LEFT JOIN players p
+            ON p.player_id = pp.player_id
+        WHERE pp.league_id = :league_id
+          AND pp.season = :season
+          AND pp.roster_id = :roster_id
+          AND pp.week = :week
+        """,
+        {
+            "league_id": league_id,
+            "season": season,
+            "roster_id": roster_id,
+            "week": week,
+        },
+    )
+    if not players:
+        return {"found": False, "roster_key": roster_key, "week": week}
+
+    team = fetch_one(
+        conn,
+        """
+        SELECT league_id, roster_id, team_name, manager_name
+        FROM team_profiles
+        WHERE league_id = :league_id AND roster_id = :roster_id
+        """,
+        {"league_id": league_id, "roster_id": roster_id},
+    )
+
+    roster = organize_players_by_role_and_position(strip_id_fields_list(players))
+
+    return {
+        "found": True,
+        "as_of_week": week,
+        "team": clean_team_profile(team),
+        "roster": roster,
+    }

--- a/backend/services/datalayer/query/curated/transactions.py
+++ b/backend/services/datalayer/query/curated/transactions.py
@@ -1,0 +1,238 @@
+"""Transaction query functions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._helpers import fetch_all, strip_id_fields_list
+from ._resolvers import resolve_roster_id
+
+
+def _fetch_transaction_rows(
+    conn,
+    league_id: str,
+    season: str,
+    week_from: int,
+    week_to: int,
+    roster_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch raw transaction rows from the database."""
+    params: dict[str, Any] = {
+        "league_id": league_id,
+        "season": season,
+        "week_from": week_from,
+        "week_to": week_to,
+    }
+    roster_filter = ""
+    if roster_id is not None:
+        params["roster_id"] = roster_id
+        roster_filter = """
+        AND t.transaction_id IN (
+            SELECT transaction_id
+            FROM transaction_moves
+            WHERE roster_id = :roster_id
+        )
+        """
+
+    return fetch_all(
+        conn,
+        f"""
+        SELECT
+            t.week,
+            t.transaction_id,
+            t.type,
+            t.status,
+            t.created_ts,
+            tm.asset_type,
+            tm.direction,
+            tm.roster_id,
+            tm.player_id,
+            p.full_name AS player_name,
+            p.position,
+            p.age,
+            p.years_exp,
+            tm.bid_amount,
+            tm.pick_season,
+            tm.pick_round,
+            tm.pick_original_roster_id,
+            tm.pick_id,
+            tm.from_roster_id,
+            tm.to_roster_id,
+            tp.team_name,
+            tp_orig.team_name AS pick_original_team_name
+        FROM transactions t
+        LEFT JOIN transaction_moves tm
+            ON tm.transaction_id = t.transaction_id
+        LEFT JOIN players p
+            ON p.player_id = tm.player_id
+        LEFT JOIN team_profiles tp
+            ON tp.league_id = t.league_id AND tp.roster_id = tm.roster_id
+        LEFT JOIN team_profiles tp_orig
+            ON tp_orig.league_id = t.league_id AND tp_orig.roster_id = tm.pick_original_roster_id
+        WHERE t.league_id = :league_id
+          AND t.season = :season
+          AND t.week BETWEEN :week_from AND :week_to
+        {roster_filter}
+        ORDER BY t.week DESC, t.created_ts DESC;
+        """,
+        params,
+    )
+
+
+def _group_transaction_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group raw transaction rows into structured transactions."""
+    grouped: dict[str, dict[str, Any]] = {}
+    ordered: list[dict[str, Any]] = []
+    details_by_team: dict[str, dict[str, dict[str, Any]]] = {}
+
+    for row in rows:
+        transaction_id = row["transaction_id"]
+        if transaction_id not in grouped:
+            grouped[transaction_id] = {
+                "week": row["week"],
+                "type": row["type"],
+                "status": row["status"],
+                "created_ts": row["created_ts"],
+            }
+            details_by_team[transaction_id] = {}
+            ordered.append(grouped[transaction_id])
+
+        asset_type = row.get("asset_type")
+        direction = row.get("direction")
+        if asset_type is None and direction is None:
+            continue
+
+        asset = {
+            "asset_type": asset_type,
+            "player_name": row.get("player_name"),
+            "position": row.get("position"),
+            "age": row.get("age"),
+            "years_exp": row.get("years_exp"),
+            "pick_season": row.get("pick_season"),
+            "pick_round": row.get("pick_round"),
+            "pick_original_team_name": row.get("pick_original_team_name"),
+        }
+        asset = {key: value for key, value in asset.items() if value is not None}
+
+        if direction in {"add", "pick_in"}:
+            bucket = "assets_received"
+        elif direction in {"drop", "pick_out"}:
+            bucket = "assets_sent"
+        else:
+            bucket = "assets_received"
+
+        if row.get("bid_amount") is not None and row.get("type") != "trade":
+            grouped[transaction_id]["bid_amount"] = row.get("bid_amount")
+
+        team_name = row.get("team_name") or "Unknown"
+        details = details_by_team[transaction_id].setdefault(
+            team_name,
+            {"team_name": team_name, "assets_sent": [], "assets_received": []},
+        )
+        details[bucket].append(asset)
+
+    for transaction_id, grouped_row in grouped.items():
+        grouped_row["details"] = list(details_by_team[transaction_id].values())
+
+    return strip_id_fields_list(ordered)
+
+
+def get_transactions(
+    conn, league_id: str, season: str, week_from: int, week_to: int
+) -> list[dict[str, Any]]:
+    """Get all transactions (trades, waivers, free agent pickups) in a week range.
+
+    Returns grouped transactions showing what each team sent and received.
+    Useful for tracking roster moves and analyzing trade activity.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier (unused, kept for API consistency).
+        week_from: Starting week (inclusive).
+        week_to: Ending week (inclusive).
+
+    Returns:
+        [
+            {
+                "week": int,
+                "type": str,  # "trade", "waiver", "free_agent"
+                "status": str,  # "complete", "failed", etc.
+                "created_ts": int,  # Unix timestamp
+                "bid_amount": int | None,  # For waiver claims
+                "details": [
+                    {
+                        "team_name": str,
+                        "assets_received": [
+                            {
+                                "asset_type": str,  # "player" or "pick"
+                                "player_name": str | None,
+                                "position": str | None,
+                                "pick_season": str | None,
+                                "pick_round": int | None,
+                                "pick_original_team_name": str | None
+                            },
+                            ...
+                        ],
+                        "assets_sent": [...]  # Same structure
+                    },
+                    ...  # One entry per team involved
+                ]
+            },
+            ...
+        ]
+    """
+    rows = _fetch_transaction_rows(conn, league_id, season, week_from, week_to)
+    return _group_transaction_rows(rows)
+
+
+def get_team_transactions(
+    conn,
+    league_id: str,
+    season: str,
+    week_from: int,
+    week_to: int,
+    roster_key: Any,
+) -> dict[str, Any]:
+    """Get a specific team's transactions in a week range.
+
+    Returns grouped transactions showing what the team sent and received.
+
+    Args:
+        conn: SQLite database connection.
+        league_id: The league identifier.
+        week_from: Starting week (inclusive).
+        week_to: Ending week (inclusive).
+        roster_key: Team name, manager name, or roster_id.
+
+    Returns:
+        {
+            "found": True,
+            "team_name": str,
+            "week_from": int,
+            "week_to": int,
+            "transactions": [...]  # Same structure as get_transactions
+        }
+
+        Returns {"found": False, "roster_key": ...} if team not found.
+    """
+    resolved = resolve_roster_id(conn, league_id, roster_key)
+    if not resolved.get("found"):
+        return {"found": False, "roster_key": roster_key}
+
+    rows = _fetch_transaction_rows(
+        conn,
+        league_id,
+        season,
+        week_from,
+        week_to,
+        roster_id=resolved["roster_id"],
+    )
+    transactions = _group_transaction_rows(rows)
+
+    return {
+        "found": True,
+        "team_name": resolved.get("team_name"),
+        "week_from": week_from,
+        "week_to": week_to,
+        "transactions": transactions,
+    }

--- a/backend/services/datalayer/query/guarded_sql.py
+++ b/backend/services/datalayer/query/guarded_sql.py
@@ -1,0 +1,181 @@
+"""Hardened read-only SQL escape hatch for frozen snapshot artifacts."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from datetime import date, datetime
+from decimal import Decimal
+import math
+import sqlite3
+import time
+from typing import Any
+
+
+MAX_SQL_ROWS = 200
+SQL_DEADLINE_SECONDS = 2.0
+_PROGRESS_INSTRUCTIONS = 1_000
+_FILESYSTEM_FUNCTIONS = {"load_extension", "readfile", "writefile"}
+
+
+def run_guarded_sql(
+    connection: sqlite3.Connection,
+    query: str,
+    params: Mapping[str, Any] | None = None,
+    *,
+    limit: int = MAX_SQL_ROWS,
+    allowed_tables: frozenset[str],
+) -> dict[str, Any]:
+    """Execute one bounded read statement against an immutable artifact."""
+
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 200:
+        raise ValueError("SQL row limit must be an integer from 1 through 200")
+    statement = _validate_statement(query)
+    deadline = time.monotonic() + SQL_DEADLINE_SECONDS
+    timed_out = False
+
+    def progress() -> int:
+        nonlocal timed_out
+        timed_out = time.monotonic() >= deadline
+        return 1 if timed_out else 0
+
+    connection.set_authorizer(_authorizer(allowed_tables))
+    connection.set_progress_handler(progress, _PROGRESS_INSTRUCTIONS)
+    cursor: sqlite3.Cursor | None = None
+    try:
+        cursor = connection.execute(statement, params or {})
+        columns = [item[0] for item in cursor.description or ()]
+        rows = [
+            tuple(_json_safe_cell(value) for value in row)
+            for row in cursor.fetchmany(limit)
+        ]
+        return {"columns": columns, "rows": rows, "row_count": len(rows)}
+    except sqlite3.Error as error:
+        if timed_out:
+            raise TimeoutError("SQL execution deadline exceeded") from error
+        raise ValueError(f"SQL query could not be executed: {error}") from error
+    finally:
+        if cursor is not None:
+            cursor.close()
+        connection.set_progress_handler(None, 0)
+        connection.set_authorizer(None)
+
+
+def _authorizer(allowed_tables: frozenset[str]):
+    allowed_actions = {sqlite3.SQLITE_SELECT, sqlite3.SQLITE_FUNCTION}
+    recursive = getattr(sqlite3, "SQLITE_RECURSIVE", None)
+    if recursive is not None:
+        allowed_actions.add(recursive)
+
+    def authorize(
+        action: int,
+        argument_1: str | None,
+        argument_2: str | None,
+        database: str | None,
+        source: str | None,
+    ) -> int:
+        del source
+        if action == sqlite3.SQLITE_READ:
+            return (
+                sqlite3.SQLITE_OK
+                if database == "main" and argument_1 in allowed_tables
+                else sqlite3.SQLITE_DENY
+            )
+        if action == sqlite3.SQLITE_FUNCTION:
+            function_name = (argument_2 or argument_1 or "").lower()
+            if function_name in _FILESYSTEM_FUNCTIONS:
+                return sqlite3.SQLITE_DENY
+        return sqlite3.SQLITE_OK if action in allowed_actions else sqlite3.SQLITE_DENY
+
+    return authorize
+
+
+def _validate_statement(query: str) -> str:
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("SQL query must be a non-empty string")
+    masked = _mask_comments_and_quotes(query)
+    segments = [segment for segment in masked.split(";") if segment.strip()]
+    if len(segments) != 1:
+        raise ValueError("Exactly one SQL statement is allowed")
+    semicolon = masked.find(";")
+    if semicolon >= 0 and any(part.strip() for part in masked.split(";")[1:]):
+        raise ValueError("Exactly one SQL statement is allowed")
+    first = segments[0].lstrip().split(None, 1)[0].lower()
+    if first not in {"select", "with"}:
+        raise ValueError("Only SELECT or WITH ... SELECT queries are allowed")
+    statement = query[:semicolon] if semicolon >= 0 else query
+    return statement.strip()
+
+
+def _mask_comments_and_quotes(query: str) -> str:
+    masked = list(query)
+    index = 0
+    length = len(query)
+    while index < length:
+        char = query[index]
+        next_char = query[index + 1] if index + 1 < length else ""
+        if char == "-" and next_char == "-":
+            start = index
+            index += 2
+            while index < length and query[index] not in "\r\n":
+                index += 1
+            _blank(masked, start, index)
+            continue
+        if char == "/" and next_char == "*":
+            start = index
+            end = query.find("*/", index + 2)
+            if end < 0:
+                raise ValueError("Unterminated SQL block comment")
+            index = end + 2
+            _blank(masked, start, index)
+            continue
+        if char in {"'", '"', "`"}:
+            start = index
+            quote = char
+            index += 1
+            while index < length:
+                if query[index] == quote:
+                    if index + 1 < length and query[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            else:
+                raise ValueError("Unterminated SQL quoted value")
+            _blank(masked, start, index)
+            continue
+        if char == "[":
+            start = index
+            end = query.find("]", index + 1)
+            if end < 0:
+                raise ValueError("Unterminated SQL quoted identifier")
+            index = end + 1
+            _blank(masked, start, index)
+            continue
+        index += 1
+    return "".join(masked)
+
+
+def _blank(masked: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if masked[index] not in "\r\n":
+            masked[index] = " "
+
+
+def _json_safe_cell(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("SQL result contains a non-finite number")
+        return value
+    if isinstance(value, bytes):
+        return "base64:" + base64.b64encode(value).decode("ascii")
+    if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError("SQL result contains a non-finite number")
+        return format(value, "f")
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    raise ValueError(f"SQL result contains unsupported {type(value).__name__} value")

--- a/backend/services/datalayer/query/runtime.py
+++ b/backend/services/datalayer/query/runtime.py
@@ -1,0 +1,460 @@
+"""Context-managed query runtime for one immutable data snapshot."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import json
+from pathlib import Path
+import re
+import sqlite3
+from typing import Any, Self
+from uuid import UUID
+
+from backend.services.datalayer.canonical_json import canonical_json_bytes, parse_json_bytes
+from backend.services.datalayer.contracts import ReadyDataSnapshot
+from backend.services.datalayer.query.curated import (
+    get_bench_analysis,
+    get_league_snapshot,
+    get_player_summary,
+    get_player_weekly_log,
+    get_playoff_bracket,
+    get_roster_at_cutoff,
+    get_roster_snapshot,
+    get_season_leaders,
+    get_standings,
+    get_team_dossier,
+    get_team_game,
+    get_team_game_with_players,
+    get_team_playoff_path,
+    get_team_schedule,
+    get_team_transactions,
+    get_transactions,
+    get_week_games,
+    get_week_games_with_players,
+    get_week_player_leaderboard,
+)
+from backend.services.datalayer.query.guarded_sql import run_guarded_sql
+from backend.services.datalayer.snapshot_sqlite.schema import (
+    SQLITE_APPLICATION_ID,
+    SQLITE_USER_VERSION,
+    get_snapshot_schema,
+)
+from backend.services.datalayer.versions import SNAPSHOT_PROJECTION_VERSION
+
+
+_CONSTRUCTION_TOKEN = object()
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class FrozenSnapshotInvalid(RuntimeError):
+    """A purported ready artifact does not match its sealed snapshot identity."""
+
+
+class FrozenLeagueData:
+    """Read-only curated access to one verified frozen SQLite artifact."""
+
+    def __init__(self, token: object) -> None:
+        if token is not _CONSTRUCTION_TOKEN:
+            raise TypeError("Use FrozenLeagueData.open(ready_snapshot)")
+        self._connection: sqlite3.Connection | None = None
+        self._league_id = ""
+        self._season = ""
+        self._through_week = 0
+        self._allowed_tables: frozenset[str] = frozenset()
+
+    @classmethod
+    def open(cls, ready_snapshot: ReadyDataSnapshot) -> Self:
+        if not isinstance(ready_snapshot, ReadyDataSnapshot):
+            raise TypeError("ready_snapshot must be a ReadyDataSnapshot")
+        if ready_snapshot.snapshot_projection_version != SNAPSHOT_PROJECTION_VERSION:
+            raise FrozenSnapshotInvalid("snapshot projection version is unsupported")
+        schema = get_snapshot_schema(ready_snapshot.snapshot_projection_version)
+        connection = _open_immutable(ready_snapshot.artifact.path)
+        instance = cls(_CONSTRUCTION_TOKEN)
+        try:
+            metadata = _validate_artifact(connection, ready_snapshot, schema.tables)
+            instance._connection = connection
+            instance._league_id = metadata["sleeper_league_id"]
+            instance._season = str(metadata["season_year"])
+            instance._through_week = int(metadata["through_week"])
+            instance._allowed_tables = frozenset(schema.tables)
+            return instance
+        except Exception:
+            connection.close()
+            raise
+
+    def __enter__(self) -> Self:
+        self._conn()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        del exc_type, exc_value, traceback
+        connection, self._connection = self._connection, None
+        if connection is not None:
+            connection.close()
+
+    def _conn(self) -> sqlite3.Connection:
+        if self._connection is None:
+            raise RuntimeError("FrozenLeagueData is closed")
+        return self._connection
+
+    def _week(self, week: int | None) -> int:
+        resolved = self._through_week if week is None else week
+        if isinstance(resolved, bool) or not isinstance(resolved, int):
+            raise ValueError("week must be an integer")
+        if not 1 <= resolved <= self._through_week:
+            raise ValueError(f"week must be from 1 through {self._through_week}")
+        return resolved
+
+    def _range(self, week_from: int, week_to: int) -> tuple[int, int]:
+        start = self._week(week_from)
+        end = self._week(week_to)
+        if start > end:
+            raise ValueError("week_from cannot be greater than week_to")
+        return start, end
+
+    def get_league_snapshot(self, week: int | None = None) -> dict[str, Any]:
+        return get_league_snapshot(
+            self._conn(), self._league_id, self._season, self._week(week)
+        )
+
+    def get_bench_analysis(
+        self, roster_key: Any = None, week: int | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return get_bench_analysis(
+            self._conn(),
+            self._league_id,
+            self._season,
+            self._week(week),
+            roster_key,
+        )
+
+    def get_standings(self, week: int | None = None) -> dict[str, Any]:
+        return get_standings(
+            self._conn(), self._league_id, self._season, self._week(week)
+        )
+
+    def get_team_dossier(
+        self, roster_key: Any, week: int | None = None
+    ) -> dict[str, Any]:
+        return get_team_dossier(
+            self._conn(),
+            self._league_id,
+            self._season,
+            roster_key,
+            self._week(week),
+        )
+
+    def get_team_schedule(self, roster_key: Any) -> dict[str, Any]:
+        return get_team_schedule(
+            self._conn(), self._league_id, self._season, roster_key
+        )
+
+    def get_week_games(self, week: int | None = None) -> list[dict[str, Any]]:
+        return get_week_games(
+            self._conn(), self._league_id, self._season, self._week(week)
+        )
+
+    def get_week_games_with_players(
+        self, week: int | None = None
+    ) -> list[dict[str, Any]]:
+        return get_week_games_with_players(
+            self._conn(), self._league_id, self._season, self._week(week)
+        )
+
+    def get_team_game(
+        self, roster_key: Any, week: int | None = None
+    ) -> dict[str, Any]:
+        return get_team_game(
+            self._conn(),
+            self._league_id,
+            self._season,
+            self._week(week),
+            roster_key,
+        )
+
+    def get_team_game_with_players(
+        self, roster_key: Any, week: int | None = None
+    ) -> dict[str, Any]:
+        return get_team_game_with_players(
+            self._conn(),
+            self._league_id,
+            self._season,
+            self._week(week),
+            roster_key,
+        )
+
+    def get_week_player_leaderboard(
+        self, week: int | None = None, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        return get_week_player_leaderboard(
+            self._conn(),
+            self._league_id,
+            self._season,
+            self._week(week),
+            limit=limit,
+        )
+
+    def get_season_leaders(
+        self,
+        *,
+        week_from: int | None = None,
+        week_to: int | None = None,
+        position: str | None = None,
+        roster_key: Any = None,
+        role: str | None = None,
+        sort_by: str = "total",
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        if week_from is not None:
+            self._week(week_from)
+        if week_to is not None:
+            self._week(week_to)
+        if week_from is not None and week_to is not None and week_from > week_to:
+            raise ValueError("week_from cannot be greater than week_to")
+        return get_season_leaders(
+            self._conn(),
+            self._league_id,
+            self._season,
+            week_from=week_from,
+            week_to=week_to,
+            position=position,
+            roster_key=roster_key,
+            role=role,
+            sort_by=sort_by,
+            limit=limit,
+        )
+
+    def get_transactions(self, week_from: int, week_to: int) -> list[dict[str, Any]]:
+        start, end = self._range(week_from, week_to)
+        return get_transactions(
+            self._conn(), self._league_id, self._season, start, end
+        )
+
+    def get_team_transactions(
+        self, roster_key: Any, week_from: int, week_to: int
+    ) -> dict[str, Any]:
+        start, end = self._range(week_from, week_to)
+        return get_team_transactions(
+            self._conn(), self._league_id, self._season, start, end, roster_key
+        )
+
+    def get_week_transactions(self, week: int | None = None) -> list[dict[str, Any]]:
+        resolved = self._week(week)
+        return get_transactions(
+            self._conn(), self._league_id, self._season, resolved, resolved
+        )
+
+    def get_team_week_transactions(
+        self,
+        roster_key: Any,
+        week_from: int | None = None,
+        week_to: int | None = None,
+    ) -> dict[str, Any]:
+        start = self._week(week_from)
+        end = self._week(week_to if week_to is not None else start)
+        if start > end:
+            raise ValueError("week_from cannot be greater than week_to")
+        return get_team_transactions(
+            self._conn(), self._league_id, self._season, start, end, roster_key
+        )
+
+    def get_player_summary(self, player_key: Any) -> dict[str, Any]:
+        return get_player_summary(self._conn(), player_key)
+
+    def get_player_weekly_log(
+        self,
+        player_key: Any,
+        week_from: int | None = None,
+        week_to: int | None = None,
+    ) -> dict[str, Any]:
+        if week_from is not None:
+            self._week(week_from)
+        if week_to is not None:
+            self._week(week_to)
+        if week_from is not None and week_to is not None and week_from > week_to:
+            raise ValueError("week_from cannot be greater than week_to")
+        return get_player_weekly_log(
+            self._conn(),
+            self._league_id,
+            self._season,
+            player_key,
+            week_from=week_from,
+            week_to=week_to,
+        )
+
+    def get_roster_at_cutoff(self, roster_key: Any) -> dict[str, Any]:
+        return get_roster_at_cutoff(self._conn(), self._league_id, roster_key)
+
+    def get_roster_snapshot(self, roster_key: Any, week: int) -> dict[str, Any]:
+        return get_roster_snapshot(
+            self._conn(),
+            self._league_id,
+            self._season,
+            roster_key,
+            self._week(week),
+        )
+
+    def get_playoff_bracket(self, bracket_type: str | None = None) -> dict[str, Any]:
+        return get_playoff_bracket(
+            self._conn(), self._league_id, self._season, bracket_type
+        )
+
+    def get_team_playoff_path(self, roster_key: Any) -> dict[str, Any]:
+        return get_team_playoff_path(
+            self._conn(), self._league_id, self._season, roster_key
+        )
+
+    def run_sql(
+        self,
+        query: str,
+        params: Mapping[str, Any] | None = None,
+        *,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        return run_guarded_sql(
+            self._conn(),
+            query,
+            params,
+            limit=limit,
+            allowed_tables=self._allowed_tables,
+        )
+
+
+def _open_immutable(path: Path) -> sqlite3.Connection:
+    try:
+        connection = sqlite3.connect(
+            f"{path.as_uri()}?mode=ro&immutable=1",
+            uri=True,
+            check_same_thread=False,
+        )
+    except (OSError, sqlite3.Error, ValueError) as error:
+        raise FrozenSnapshotInvalid("snapshot SQLite artifact is unavailable") from error
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _validate_artifact(
+    connection: sqlite3.Connection,
+    snapshot: ReadyDataSnapshot,
+    expected_tables: Mapping[str, Any],
+) -> dict[str, Any]:
+    try:
+        integrity = connection.execute("PRAGMA integrity_check").fetchone()
+        application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+        user_version = connection.execute("PRAGMA user_version").fetchone()[0]
+        table_names = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_schema WHERE type = 'table'"
+            )
+        }
+        rows = connection.execute("SELECT * FROM snapshot_metadata").fetchall()
+    except sqlite3.Error as error:
+        raise FrozenSnapshotInvalid("snapshot SQLite metadata is unreadable") from error
+    if integrity is None or integrity[0] != "ok":
+        raise FrozenSnapshotInvalid("snapshot SQLite integrity check failed")
+    if application_id != SQLITE_APPLICATION_ID or user_version != SQLITE_USER_VERSION:
+        raise FrozenSnapshotInvalid("snapshot SQLite version markers differ")
+    if table_names != set(expected_tables):
+        raise FrozenSnapshotInvalid("snapshot SQLite table set differs")
+    if len(rows) != 1:
+        raise FrozenSnapshotInvalid("snapshot metadata singleton is invalid")
+    metadata = dict(rows[0])
+    expected = {
+        "competition_id": str(snapshot.competition_id),
+        "primary_competition_season_id": str(snapshot.primary_competition_season_id),
+        "through_week": snapshot.through_week,
+        "as_of_date": snapshot.as_of_date.isoformat(),
+        "build_key": snapshot.build_key,
+        "snapshot_projection_version": snapshot.snapshot_projection_version,
+    }
+    if any(metadata.get(key) != value for key, value in expected.items()):
+        raise FrozenSnapshotInvalid("snapshot metadata differs from ready identity")
+    selected_requests = _validate_canonical_json(
+        metadata.get("selected_requests_json"), expected_list=True
+    )
+    _validate_manifest_entries(selected_requests)
+    warning_json = _validate_canonical_json(
+        metadata.get("completeness_warnings_json"), expected_list=True
+    )
+    expected_warnings = [
+        warning.model_dump(mode="json") for warning in snapshot.completeness_warnings
+    ]
+    if warning_json != expected_warnings:
+        raise FrozenSnapshotInvalid("snapshot completeness warnings differ")
+    if not isinstance(metadata.get("sleeper_league_id"), str):
+        raise FrozenSnapshotInvalid("snapshot league identity is invalid")
+    if not isinstance(metadata.get("season_year"), int):
+        raise FrozenSnapshotInvalid("snapshot season identity is invalid")
+    league = connection.execute(
+        """
+        SELECT league_id, season FROM leagues
+        WHERE league_id = :league_id AND season = :season
+        """,
+        {
+            "league_id": metadata["sleeper_league_id"],
+            "season": str(metadata["season_year"]),
+        },
+    ).fetchall()
+    context = connection.execute(
+        """
+        SELECT effective_week FROM season_context
+        WHERE league_id = :league_id
+        """,
+        {"league_id": metadata["sleeper_league_id"]},
+    ).fetchall()
+    if len(league) != 1 or len(context) != 1:
+        raise FrozenSnapshotInvalid("snapshot league metadata is inconsistent")
+    if context[0]["effective_week"] != metadata["through_week"]:
+        raise FrozenSnapshotInvalid("snapshot cutoff metadata is inconsistent")
+    return metadata
+
+
+def _validate_canonical_json(value: Any, *, expected_list: bool) -> Any:
+    if not isinstance(value, str):
+        raise FrozenSnapshotInvalid("snapshot manifest metadata is invalid")
+    try:
+        parsed = parse_json_bytes(value.encode("utf-8"))
+        canonical = canonical_json_bytes(parsed).decode("utf-8")
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise FrozenSnapshotInvalid("snapshot manifest metadata is invalid") from error
+    if canonical != value or (expected_list and not isinstance(parsed, list)):
+        raise FrozenSnapshotInvalid("snapshot manifest metadata is not canonical")
+    return parsed
+
+
+def _validate_manifest_entries(entries: Any) -> None:
+    required = {
+        "request_id",
+        "endpoint_kind",
+        "scope_key",
+        "selection_role",
+        "response_sha256",
+    }
+    if not isinstance(entries, list) or not entries:
+        raise FrozenSnapshotInvalid("snapshot request manifest is empty")
+    request_ids: set[str] = set()
+    scope_keys: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != required:
+            raise FrozenSnapshotInvalid("snapshot request manifest entry is invalid")
+        try:
+            request_id = str(UUID(entry["request_id"]))
+        except (AttributeError, TypeError, ValueError) as error:
+            raise FrozenSnapshotInvalid(
+                "snapshot request manifest entry is invalid"
+            ) from error
+        scope_value = entry["scope_key"]
+        if isinstance(scope_value, dict) and set(scope_value) == {"value"}:
+            scope_value = scope_value["value"]
+        strings = (entry["endpoint_kind"], scope_value, entry["selection_role"])
+        if any(not isinstance(item, str) or not item for item in strings):
+            raise FrozenSnapshotInvalid("snapshot request manifest entry is invalid")
+        sha256 = entry["response_sha256"]
+        if not isinstance(sha256, str) or _SHA256.fullmatch(sha256) is None:
+            raise FrozenSnapshotInvalid("snapshot request manifest entry is invalid")
+        if request_id in request_ids or scope_value in scope_keys:
+            raise FrozenSnapshotInvalid("snapshot request manifest contains duplicates")
+        request_ids.add(request_id)
+        scope_keys.add(scope_value)

--- a/backend/services/datalayer/snapshot_sqlite/__init__.py
+++ b/backend/services/datalayer/snapshot_sqlite/__init__.py
@@ -1,6 +1,8 @@
 """Snapshot-only SQLite schema, projections, and materialization."""
 
 from backend.services.datalayer.snapshot_sqlite.schema import (
+    SQLITE_APPLICATION_ID,
+    SQLITE_USER_VERSION,
     SnapshotSchema,
     get_snapshot_schema,
 )
@@ -20,6 +22,8 @@ from backend.services.datalayer.snapshot_sqlite.materializer import (
 
 __all__ = [
     "SnapshotProjection",
+    "SQLITE_APPLICATION_ID",
+    "SQLITE_USER_VERSION",
     "SQLiteSnapshotMaterializer",
     "SnapshotArtifactInvalid",
     "SnapshotSchema",

--- a/backend/services/datalayer/snapshot_sqlite/materializer.py
+++ b/backend/services/datalayer/snapshot_sqlite/materializer.py
@@ -22,10 +22,11 @@ from backend.services.datalayer.snapshot_sqlite.projection import (
     SnapshotProjection,
     project_source_records,
 )
-from backend.services.datalayer.snapshot_sqlite.schema import get_snapshot_schema
-
-
-SQLITE_APPLICATION_ID = 0x41494441
+from backend.services.datalayer.snapshot_sqlite.schema import (
+    SQLITE_APPLICATION_ID,
+    SQLITE_USER_VERSION,
+    get_snapshot_schema,
+)
 _WEEK_TABLES = (
     "matchups",
     "player_performances",
@@ -85,7 +86,9 @@ class SQLiteSnapshotMaterializer:
                     connection.exec_driver_sql(
                         f"PRAGMA application_id = {SQLITE_APPLICATION_ID}"
                     )
-                    connection.exec_driver_sql("PRAGMA user_version = 1")
+                    connection.exec_driver_sql(
+                        f"PRAGMA user_version = {SQLITE_USER_VERSION}"
+                    )
                     schema.metadata.create_all(connection)
                     for table_name in schema.table_order:
                         table = schema.tables[table_name]
@@ -138,7 +141,10 @@ def verify_snapshot_file(
             raise SnapshotArtifactInvalid("snapshot SQLite integrity check failed")
         application_id = connection.execute("PRAGMA application_id").fetchone()[0]
         user_version = connection.execute("PRAGMA user_version").fetchone()[0]
-        if application_id != SQLITE_APPLICATION_ID or user_version != 1:
+        if (
+            application_id != SQLITE_APPLICATION_ID
+            or user_version != SQLITE_USER_VERSION
+        ):
             raise SnapshotArtifactInvalid("snapshot SQLite version markers differ")
         tables = {
             row[0]

--- a/backend/services/datalayer/snapshot_sqlite/schema.py
+++ b/backend/services/datalayer/snapshot_sqlite/schema.py
@@ -19,6 +19,10 @@ from sqlalchemy import (
 )
 
 
+SQLITE_APPLICATION_ID = 0x41494441
+SQLITE_USER_VERSION = 1
+
+
 SNAPSHOT_TABLE_ORDER = (
     "leagues",
     "season_context",

--- a/backend/tests/services/datalayer/test_frozen_query_imports.py
+++ b/backend/tests/services/datalayer/test_frozen_query_imports.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+
+QUERY_ROOT = Path(__file__).parents[3] / "services" / "datalayer" / "query"
+FORBIDDEN_PREFIXES = (
+    "backend.database",
+    "backend.resources",
+    "backend.services.datalayer.refresh_service",
+    "backend.services.datalayer.snapshot_service",
+    "backend.services.datalayer.sleeper",
+    "datalayer",
+    "reporter_memory",
+    "reporter_v2",
+)
+
+
+def test_frozen_query_runtime_has_no_forbidden_imports() -> None:
+    violations = []
+    for path in QUERY_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            for name in names:
+                if name.startswith(FORBIDDEN_PREFIXES):
+                    violations.append(f"{path.name}:{node.lineno}:{name}")
+    assert violations == []

--- a/backend/tests/services/datalayer/test_frozen_query_runtime.py
+++ b/backend/tests/services/datalayer/test_frozen_query_runtime.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from backend.services.datalayer import (
+    FrozenLeagueData,
+    FrozenSnapshotInvalid,
+    ReadyDataSnapshot,
+    SnapshotRequest,
+    VerifiedLocalArtifact,
+)
+from backend.services.datalayer.canonical_json import parse_json_bytes
+from backend.services.datalayer.snapshot_selection import (
+    SelectedRequestManifest,
+    SelectedRequestManifestEntry,
+    plan_snapshot_requirements,
+)
+from backend.services.datalayer.snapshot_service import (
+    SnapshotEndpointRecords,
+    SnapshotMaterializationInput,
+)
+from backend.services.datalayer.snapshot_sqlite import SQLiteSnapshotMaterializer
+from backend.services.datalayer.sleeper.endpoints import (
+    normalize_league,
+    normalize_league_rosters,
+    normalize_league_users,
+    normalize_losers_bracket,
+    normalize_matchups,
+    normalize_nfl_state,
+    normalize_player_catalog,
+    normalize_traded_picks,
+    normalize_transactions,
+    normalize_winners_bracket,
+)
+from backend.services.datalayer.sleeper.scope import EndpointKind
+from backend.tests.services.datalayer.test_snapshot_source_projection import (
+    FIXTURES,
+    _context,
+    _fixture_input,
+)
+
+
+GOLDEN = (
+    Path(__file__).parents[4]
+    / "datalayer"
+    / "tests"
+    / "characterization"
+    / "golden"
+    / "legacy_query_outputs.json"
+)
+
+
+@pytest.fixture
+def ready_snapshot(tmp_path: Path) -> Iterator[ReadyDataSnapshot]:
+    materialization = _fixture_input()
+    artifact = SQLiteSnapshotMaterializer(tmp_path / "staging").materialize(
+        materialization
+    )
+    ready = _ready(materialization, artifact)
+    try:
+        yield ready
+    finally:
+        artifact.path.unlink(missing_ok=True)
+
+
+def test_full_regular_query_contract_matches_legacy_golden(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    expected = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        actual = {
+            "league_snapshot": data.get_league_snapshot(week=2),
+            "bench_analysis_league": data.get_bench_analysis(week=2),
+            "bench_analysis_team": data.get_bench_analysis("Alpha", week=2),
+            "standings": data.get_standings(week=2),
+            "team_dossier_by_name": data.get_team_dossier("alpha", week=2),
+            "team_dossier_by_manager": data.get_team_dossier("Alice", week=2),
+            "team_dossier_by_id": data.get_team_dossier("1", week=2),
+            "team_dossier_not_found": data.get_team_dossier("missing", week=2),
+            "team_schedule": data.get_team_schedule("Alpha"),
+            "week_games": data.get_week_games(week=2),
+            "week_games_default": data.get_week_games(),
+            "week_games_with_players": data.get_week_games_with_players(week=2),
+            "team_game": data.get_team_game("Alpha", week=2),
+            "team_game_with_players": data.get_team_game_with_players(
+                "Alpha", week=2
+            ),
+            "week_player_leaderboard": data.get_week_player_leaderboard(
+                week=2, limit=3
+            ),
+            "season_leaders": data.get_season_leaders(limit=3),
+            "season_leaders_filtered": data.get_season_leaders(
+                week_from=2,
+                week_to=2,
+                position="QB",
+                roster_key="Alice",
+                role="starter",
+                sort_by="avg",
+                limit=3,
+            ),
+            "transactions": data.get_transactions(1, 2),
+            "team_transactions": data.get_team_transactions("Alpha", 1, 2),
+            "week_transactions": data.get_week_transactions(week=2),
+            "team_week_transactions": data.get_team_week_transactions(
+                "Alpha", week_from=2
+            ),
+            "player_summary_by_name": data.get_player_summary("player one"),
+            "player_summary_by_id": data.get_player_summary("p1"),
+            "player_summary_not_found": data.get_player_summary("missing"),
+            "player_weekly_log": data.get_player_weekly_log("Player One"),
+            "player_weekly_log_filtered": data.get_player_weekly_log(
+                "p1", week_from=2, week_to=2
+            ),
+            "roster_current_by_name": data.get_roster_at_cutoff("Alpha"),
+            "roster_current_by_manager": data.get_roster_at_cutoff("Alice"),
+            "roster_snapshot": data.get_roster_snapshot("1", week=1),
+            "sql_named_params_and_limit": data.run_sql(
+                "SELECT roster_id, points FROM matchups "
+                "WHERE week = :week ORDER BY roster_id",
+                {"week": 2},
+                limit=1,
+            ),
+        }
+
+    regular_keys = set(actual)
+    expected = {key: expected[key] for key in regular_keys}
+    normalized_actual = _json_round_trip(_without_volatile_player_state(actual))
+    normalized_expected = _without_volatile_player_state(expected)
+    assert _contract_shape(normalized_actual) == _contract_shape(normalized_expected)
+    stable_keys = {
+        "bench_analysis_league",
+        "bench_analysis_team",
+        "team_schedule",
+        "week_games",
+        "week_games_default",
+        "week_games_with_players",
+        "team_game",
+        "team_game_with_players",
+        "week_player_leaderboard",
+        "season_leaders",
+        "season_leaders_filtered",
+        "player_weekly_log",
+        "player_weekly_log_filtered",
+        "roster_current_by_name",
+        "roster_current_by_manager",
+        "roster_snapshot",
+        "sql_named_params_and_limit",
+    }
+    assert {key: normalized_actual[key] for key in stable_keys} == {
+        key: normalized_expected[key] for key in stable_keys
+    }
+
+
+def test_playoff_query_contract_matches_legacy_golden(tmp_path: Path) -> None:
+    materialization = _fixture_input_for_week(18)
+    artifact = SQLiteSnapshotMaterializer(tmp_path / "staging").materialize(
+        materialization
+    )
+    try:
+        with FrozenLeagueData.open(_ready(materialization, artifact)) as data:
+            actual = {
+                "playoff_brackets": data.get_playoff_bracket(),
+                "playoff_winners": data.get_playoff_bracket("winners"),
+                "team_playoff_path": data.get_team_playoff_path("Alice"),
+            }
+        expected = json.loads(GOLDEN.read_text(encoding="utf-8"))
+        assert _json_round_trip(actual) == {key: expected[key] for key in actual}
+    finally:
+        artifact.path.unlink(missing_ok=True)
+
+
+def test_runtime_defaults_to_cutoff_and_rejects_out_of_domain_weeks(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        assert data.get_week_games() == data.get_week_games(2)
+        for invalid in (0, 3, True, "2"):
+            with pytest.raises(ValueError, match="week"):
+                data.get_week_games(invalid)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="week_from"):
+            data.get_transactions(2, 1)
+
+
+def test_curated_queries_exclude_decoy_seasons(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+) -> None:
+    decoy = _mutated_copy_many(
+        ready_snapshot.artifact.path,
+        tmp_path / "decoy-season.sqlite",
+        (
+            (
+                "INSERT INTO games VALUES "
+                "('123', '2023', 2, 99, 1, 2, 999, 0, 1, 0)",
+                (),
+            ),
+            (
+                "INSERT INTO player_performances VALUES "
+                "('123', '2023', 2, 'p1', 1, 99, 999, 'starter')",
+                (),
+            ),
+            (
+                "INSERT INTO transactions "
+                "(league_id, season, week, transaction_id, type) "
+                "VALUES ('123', '2023', 2, 'decoy', 'decoy')",
+                (),
+            ),
+            (
+                "INSERT INTO playoff_matchups "
+                "(league_id, season, bracket_type, node_key, round, matchup_id) "
+                "VALUES ('123', '2023', 'winners', 'decoy', 1, 99)",
+                (),
+            ),
+        ),
+    )
+    with FrozenLeagueData.open(
+        ready_snapshot.model_copy(update={"artifact": decoy})
+    ) as data:
+        assert len(data.get_week_games(2)) == 1
+        assert data.get_season_leaders(limit=1)[0]["total_points"] == 130.5
+        assert all(item["type"] != "decoy" for item in data.get_transactions(1, 2))
+        assert data.get_playoff_bracket() == {"found": False}
+
+
+def test_name_resolvers_preserve_ambiguity_results(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+) -> None:
+    ambiguous = _mutated_copy_many(
+        ready_snapshot.artifact.path,
+        tmp_path / "ambiguous.sqlite",
+        (
+            (
+                "INSERT INTO team_profiles "
+                "(league_id, roster_id, team_name, manager_name) "
+                "VALUES ('123', 3, 'Alpha', 'Another Manager')",
+                (),
+            ),
+            (
+                "INSERT INTO players (player_id, full_name, position) "
+                "VALUES ('duplicate-p1', 'Player One', 'QB')",
+                (),
+            ),
+        ),
+    )
+    with FrozenLeagueData.open(
+        ready_snapshot.model_copy(update={"artifact": ambiguous})
+    ) as data:
+        team = data.get_team_dossier("Alpha")
+        player = data.get_player_summary("Player One")
+
+    assert team["found"] is False
+    assert len(team["matches"]) == 2
+    assert player["found"] is False
+    assert len(player["matches"]) == 2
+
+
+def test_context_exit_closes_runtime_deterministically(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    data = FrozenLeagueData.open(ready_snapshot)
+    with data:
+        assert data.get_league_snapshot()["found"] is True
+
+    with pytest.raises(RuntimeError, match="closed"):
+        data.get_league_snapshot()
+
+
+@pytest.mark.parametrize(
+    ("column", "replacement"),
+    [
+        ("build_key", "b" * 64),
+        ("competition_id", "33333333-3333-3333-3333-333333333333"),
+        ("primary_competition_season_id", "44444444-4444-4444-4444-444444444444"),
+        ("through_week", 1),
+        ("as_of_date", "2024-09-18"),
+        ("snapshot_projection_version", "2"),
+    ],
+)
+def test_internal_identity_mismatches_fail_closed(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+    column: str,
+    replacement: object,
+) -> None:
+    changed = _mutated_copy(
+        ready_snapshot.artifact.path,
+        tmp_path / f"wrong-{column}.sqlite",
+        f'UPDATE snapshot_metadata SET "{column}" = ?',
+        (replacement,),
+    )
+    with pytest.raises(FrozenSnapshotInvalid, match="metadata"):
+        FrozenLeagueData.open(ready_snapshot.model_copy(update={"artifact": changed}))
+
+
+def test_manifest_warning_and_table_corruption_fail_closed(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+) -> None:
+    noncanonical = _mutated_copy(
+        ready_snapshot.artifact.path,
+        tmp_path / "noncanonical.sqlite",
+        "UPDATE snapshot_metadata SET selected_requests_json = '[ ]'",
+    )
+    with pytest.raises(FrozenSnapshotInvalid, match="manifest"):
+        FrozenLeagueData.open(
+            ready_snapshot.model_copy(update={"artifact": noncanonical})
+        )
+
+    missing_table = _mutated_copy(
+        ready_snapshot.artifact.path,
+        tmp_path / "missing-table.sqlite",
+        "DROP TABLE games",
+    )
+    with pytest.raises(FrozenSnapshotInvalid, match="table set"):
+        FrozenLeagueData.open(
+            ready_snapshot.model_copy(update={"artifact": missing_table})
+        )
+
+    with pytest.raises(FrozenSnapshotInvalid, match="warnings"):
+        FrozenLeagueData.open(
+            ready_snapshot.model_copy(update={"completeness_warnings": ()})
+        )
+
+
+def test_unavailable_and_unsupported_snapshots_fail_before_querying(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+) -> None:
+    missing = ready_snapshot.artifact.__class__(
+        path=(tmp_path / "missing.sqlite").resolve(),
+        storage_key=ready_snapshot.artifact.storage_key,
+        sha256=ready_snapshot.artifact.sha256,
+        byte_length=ready_snapshot.artifact.byte_length,
+    )
+    with pytest.raises(FrozenSnapshotInvalid, match="unavailable"):
+        FrozenLeagueData.open(ready_snapshot.model_copy(update={"artifact": missing}))
+    with pytest.raises(FrozenSnapshotInvalid, match="unsupported"):
+        FrozenLeagueData.open(
+            ready_snapshot.model_copy(update={"snapshot_projection_version": "2"})
+        )
+
+
+def test_constructor_and_public_surface_exclude_legacy_lifecycle(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with pytest.raises(TypeError, match="open"):
+        FrozenLeagueData(object())
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        assert not hasattr(data, "load")
+        assert not hasattr(data, "save_to_file")
+        assert not hasattr(data, "get_roster_current")
+
+
+def _ready(materialization, artifact) -> ReadyDataSnapshot:
+    sha256 = artifact.sha256
+    return ReadyDataSnapshot(
+        id=UUID(int=99),
+        competition_id=materialization.planning_context.competition_id,
+        primary_competition_season_id=(
+            materialization.planning_context.competition_season_id
+        ),
+        through_week=materialization.request.through_week,
+        as_of_date=materialization.request.as_of_date,
+        build_key=materialization.build_key,
+        snapshot_projection_version=materialization.snapshot_projection_version,
+        artifact=VerifiedLocalArtifact(
+            path=artifact.path.resolve(),
+            storage_key=f"snapshots/sha256/{sha256[:2]}/{sha256}.sqlite",
+            sha256=sha256,
+            byte_length=artifact.byte_length,
+        ),
+        completeness_warnings=artifact.completeness_warnings,
+    )
+
+
+def _fixture_input_for_week(through_week: int) -> SnapshotMaterializationInput:
+    request = SnapshotRequest(
+        competition_season_id=_fixture_input().request.competition_season_id,
+        through_week=through_week,
+        as_of_date=date(2024, 12, 31),
+    )
+    context = _context()
+    requirements = plan_snapshot_requirements(request, context)
+    normalizers = {
+        EndpointKind.LEAGUE: normalize_league,
+        EndpointKind.LEAGUE_USERS: normalize_league_users,
+        EndpointKind.NFL_STATE: normalize_nfl_state,
+        EndpointKind.PLAYER_CATALOG: normalize_player_catalog,
+        EndpointKind.LEAGUE_ROSTERS: normalize_league_rosters,
+        EndpointKind.TRADED_PICKS: normalize_traded_picks,
+        EndpointKind.MATCHUPS: normalize_matchups,
+        EndpointKind.TRANSACTIONS: normalize_transactions,
+        EndpointKind.WINNERS_BRACKET: normalize_winners_bracket,
+        EndpointKind.LOSERS_BRACKET: normalize_losers_bracket,
+    }
+    fixed_files = {
+        EndpointKind.LEAGUE: "league.json",
+        EndpointKind.LEAGUE_USERS: "users.json",
+        EndpointKind.NFL_STATE: "state.json",
+        EndpointKind.PLAYER_CATALOG: "players.json",
+        EndpointKind.LEAGUE_ROSTERS: "rosters.json",
+        EndpointKind.TRADED_PICKS: "traded_picks.json",
+        EndpointKind.WINNERS_BRACKET: "winners_bracket.json",
+        EndpointKind.LOSERS_BRACKET: "losers_bracket.json",
+    }
+    manifest = []
+    endpoints = []
+    for index, requirement in enumerate(requirements.entries, start=1):
+        endpoint = requirement.request
+        filename = fixed_files.get(endpoint.endpoint_kind)
+        if endpoint.endpoint_kind is EndpointKind.MATCHUPS and endpoint.week <= 2:
+            filename = f"matchups_week{endpoint.week}.json"
+        elif endpoint.endpoint_kind is EndpointKind.TRANSACTIONS and endpoint.week <= 2:
+            filename = f"transactions_week{endpoint.week}.json"
+        payload = parse_json_bytes((FIXTURES / filename).read_bytes()) if filename else []
+        entry = SelectedRequestManifestEntry(
+            request_id=UUID(int=index),
+            endpoint_kind=endpoint.endpoint_kind,
+            scope_key=endpoint.scope_key,
+            selection_role=requirement.selection_role,
+            response_sha256=f"{index:064x}",
+        )
+        manifest.append(entry)
+        endpoints.append(
+            SnapshotEndpointRecords(
+                manifest_entry=entry,
+                records=normalizers[endpoint.endpoint_kind](payload, endpoint),
+            )
+        )
+    return SnapshotMaterializationInput(
+        request=request,
+        planning_context=context,
+        build_key="c" * 64,
+        snapshot_projection_version="1",
+        manifest=SelectedRequestManifest(entries=tuple(manifest)),
+        endpoint_records=tuple(endpoints),
+    )
+
+
+def _without_volatile_player_state(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: (
+                None
+                if key in {"nfl_team", "status", "injury_status"}
+                else _without_volatile_player_state(item)
+            )
+            for key, item in value.items()
+            if key not in {"age", "years_exp"}
+        }
+    if isinstance(value, list):
+        return [_without_volatile_player_state(item) for item in value]
+    return value
+
+
+def _contract_shape(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _contract_shape(item) for key, item in sorted(value.items())}
+    if isinstance(value, list):
+        shapes = {_stable_json(_contract_shape(item)) for item in value}
+        return [json.loads(item) for item in sorted(shapes)]
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "number"
+    return type(value).__name__
+
+
+def _json_round_trip(value: Any) -> Any:
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _mutated_copy(
+    source: Path,
+    target: Path,
+    statement: str,
+    params: tuple[object, ...] = (),
+) -> VerifiedLocalArtifact:
+    target.write_bytes(source.read_bytes())
+    connection = sqlite3.connect(target)
+    try:
+        connection.execute(statement, params)
+        connection.commit()
+    finally:
+        connection.close()
+    content = target.read_bytes()
+    sha256 = hashlib.sha256(content).hexdigest()
+    return VerifiedLocalArtifact(
+        path=target.resolve(),
+        storage_key=f"snapshots/sha256/{sha256[:2]}/{sha256}.sqlite",
+        sha256=sha256,
+        byte_length=len(content),
+    )
+
+
+def _mutated_copy_many(
+    source: Path,
+    target: Path,
+    statements: tuple[tuple[str, tuple[object, ...]], ...],
+) -> VerifiedLocalArtifact:
+    target.write_bytes(source.read_bytes())
+    connection = sqlite3.connect(target)
+    try:
+        for statement, params in statements:
+            connection.execute(statement, params)
+        connection.commit()
+    finally:
+        connection.close()
+    content = target.read_bytes()
+    sha256 = hashlib.sha256(content).hexdigest()
+    return VerifiedLocalArtifact(
+        path=target.resolve(),
+        storage_key=f"snapshots/sha256/{sha256[:2]}/{sha256}.sqlite",
+        sha256=sha256,
+        byte_length=len(content),
+    )

--- a/backend/tests/services/datalayer/test_guarded_snapshot_sql.py
+++ b/backend/tests/services/datalayer/test_guarded_snapshot_sql.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.services.datalayer import FrozenLeagueData, ReadyDataSnapshot
+from backend.services.datalayer.query import guarded_sql
+from backend.tests.services.datalayer.test_frozen_query_runtime import ready_snapshot
+
+
+def test_select_cte_named_params_comments_and_quoted_keywords_are_allowed(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        assert data.run_sql(
+            "-- safe\nWITH chosen AS ("
+            "SELECT roster_id, points FROM matchups WHERE week = :week"
+            ") SELECT roster_id, 'DROP TABLE players' AS note "
+            "FROM chosen ORDER BY roster_id",
+            {"week": 2},
+        ) == {
+            "columns": ["roster_id", "note"],
+            "rows": [(1, "DROP TABLE players"), (2, "DROP TABLE players")],
+            "row_count": 2,
+        }
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "",
+        "DELETE FROM players",
+        "PRAGMA table_info(players)",
+        "ATTACH DATABASE 'elsewhere.sqlite' AS other",
+        "SELECT * FROM players; DROP TABLE players",
+        "SELECT * FROM sqlite_schema",
+        "SELECT * FROM pragma_database_list",
+        "WITH changed AS (DELETE FROM players RETURNING *) SELECT * FROM changed",
+        "SELECT load_extension('elsewhere')",
+        "SELECT readfile('elsewhere')",
+    ],
+)
+def test_non_read_or_artifact_escape_sql_is_rejected(
+    ready_snapshot: ReadyDataSnapshot,
+    statement: str,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        with pytest.raises(ValueError):
+            data.run_sql(statement)
+
+
+def test_runtime_limit_cannot_be_bypassed_by_query_limit(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        result = data.run_sql(
+            "WITH RECURSIVE numbers(n) AS ("
+            "SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 500"
+            ") SELECT n FROM numbers LIMIT 500",
+            limit=7,
+        )
+        assert result["row_count"] == 7
+        assert result["rows"][-1] == (7,)
+        for invalid in (0, 201, True, 1.5):
+            with pytest.raises(ValueError, match="limit"):
+                data.run_sql("SELECT 1", limit=invalid)  # type: ignore[arg-type]
+
+
+def test_deadline_interrupts_expensive_recursive_query(
+    ready_snapshot: ReadyDataSnapshot,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guarded_sql, "SQL_DEADLINE_SECONDS", 0.0)
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        with pytest.raises(TimeoutError, match="deadline"):
+            data.run_sql(
+                "WITH RECURSIVE numbers(n) AS ("
+                "SELECT 1 UNION ALL SELECT n + 1 FROM numbers"
+                ") SELECT SUM(n) FROM numbers"
+            )
+        assert data.run_sql("SELECT 1")["rows"] == [(1,)]
+
+
+def test_results_are_json_safe_and_non_finite_values_fail_closed(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        result = data.run_sql("SELECT CAST('abc' AS BLOB) AS content")
+        assert result["rows"] == [("base64:YWJj",)]
+        json.dumps(result, allow_nan=False)
+        with pytest.raises(ValueError, match="non-finite"):
+            data.run_sql("SELECT 1e999 AS infinity")
+
+
+def test_immutable_connection_rejects_writes_even_beyond_parser(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        with pytest.raises(ValueError):
+            data.run_sql("WITH candidate AS (SELECT 1) UPDATE players SET age = 0")


### PR DESCRIPTION
## Summary

- add `FrozenLeagueData.open(ReadyDataSnapshot)` as the sole, context-managed
  query runtime over verified Layer 9 SQLite artifacts
- migrate the complete curated league, team, roster, player, transaction, and
  playoff query surface to direct `sqlite3` with sealed league/season isolation
- add hardened read-only SQL with statement parsing, SQLite authorization,
  independent row caps, execution deadlines, and deterministic JSON values
- centralize SQLite format markers and reject corrupt, mismatched, unsupported,
  unavailable, or non-canonical artifacts before exposing any query methods

## Stack boundary

This is Layer 10 in datalayer stack #123 and is based directly on Layer 9 PR
#138. It intentionally leaves legacy loading, reporter tools, generation,
routes, and compatibility mapping unchanged; those remain in Layers 11–14.

## Verification

- focused frozen-runtime tests: `31 passed`
- cumulative non-live datalayer tests: `336 passed, 46 skipped`
- exact Alembic lifecycle and metadata drift check at sole head `0007`: passed
- inherited live PostgreSQL snapshot/constraint gate: `16 passed`
- complete live repository suite: `743 passed, 1 skipped`
- compilation, import-boundary, 99-column, and diff checks: passed
