### PR TITLE
Move reporter data tools to frozen snapshots

### DIFF
--- a/reporter_v2/docs/runner-design.md
+++ b/reporter_v2/docs/runner-design.md
@@ -90,7 +90,7 @@ RunLog:         all events
 ```
 
 Tools receive only the slice of state they need — brief tools get
-`ArtifactStore` + `RunLog`, datalayer tools get `SleeperLeagueData`, persistent
+`ArtifactStore` + `RunLog`, datalayer tools get `FrozenLeagueData`, persistent
 tools get `reporter_memory.ContextStore`.
 
 ## Tool Inventory
@@ -100,7 +100,7 @@ tools get `reporter_memory.ContextStore`.
 | **Procedure** | `load_procedure` |
 | **Brief** | `save_fact`, `save_storyline`, `set_outline`, `read_brief`, `set_style`, `set_bias` |
 | **Article** | `write_section`, `read_article`, `read_section`, `rewrite_section`, `set_section_order`, `submit_article` |
-| **Datalayer** (18) | `league_snapshot`, `standings`, `week_games`, `week_player_leaderboard`, `season_leaders`, `bench_analysis`, `transactions`, `team_dossier`, `team_game`, `team_schedule`, `roster_current`, `roster_snapshot`, `team_transactions`, `player_summary`, `player_weekly_log`, `playoff_bracket`, `team_playoff_path`, `run_sql` |
+| **Datalayer** (18) | `league_snapshot`, `standings`, `week_games`, `week_player_leaderboard`, `season_leaders`, `bench_analysis`, `transactions`, `team_dossier`, `team_game`, `team_schedule`, `roster_at_cutoff`, `roster_snapshot`, `team_transactions`, `player_summary`, `player_weekly_log`, `playoff_bracket`, `team_playoff_path`, `run_sql` |
 | **Persistent context** | `save_persistent_storyline`, `save_team_context`, `save_league_note`, `load_persistent_storylines`, `load_team_context`, `load_league_notes` |
 
 Persistent context is implemented in `reporter_memory/`, not `datalayer/`.

--- a/reporter_v2/runner/tools/datalayer_tools.py
+++ b/reporter_v2/runner/tools/datalayer_tools.py
@@ -1,4 +1,4 @@
-"""Datalayer tool adapters for the reporter v2 runner."""
+"""Reporter-owned tools over one frozen league-data snapshot."""
 
 from __future__ import annotations
 
@@ -6,28 +6,328 @@ import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from datalayer.tools import SLEEPER_TOOLS, create_tool_handlers
 from reporter_v2.runner.models import ToolDef
 from reporter_v2.runner.tools.registry import ToolRegistry
 
 if TYPE_CHECKING:
-    from datalayer.sleeper_data import SleeperLeagueData
+    from backend.services.datalayer import FrozenLeagueData
 
 
-DATALAYER_TOOL_SPECS: list[ToolDef] = SLEEPER_TOOLS
+def _week_property(description: str = "Week number (1-18).") -> dict[str, str]:
+    return {"type": "integer", "description": description}
+
+
+def _roster_property() -> dict[str, str]:
+    return {
+        "type": "string",
+        "description": "Team name, manager name, or roster_id as a string.",
+    }
+
+
+def _tool(
+    name: str,
+    description: str,
+    properties: dict[str, dict[str, Any]],
+    required: tuple[str, ...] = (),
+) -> ToolDef:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": list(required),
+            },
+        },
+    }
+
+
+DATALAYER_TOOL_SPECS: list[ToolDef] = [
+    _tool(
+        "league_snapshot",
+        "Get a comprehensive league snapshot for a week, including standings, "
+        "matchup results, and transactions.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "week_games",
+        "Get every matchup for a week with full player-by-player breakdowns.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "team_game",
+        "Get one team's game for a week with full player-by-player breakdowns.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+        },
+        ("roster_key",),
+    ),
+    _tool(
+        "week_player_leaderboard",
+        "Get the top-scoring players for a week, ranked by fantasy points.",
+        {
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+            "limit": {
+                "type": "integer",
+                "description": "Maximum players to return. Default is 10.",
+            },
+        },
+    ),
+    _tool(
+        "team_dossier",
+        "Get a team profile with standings, record, streak, and recent games.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property(
+                "Week number for standings. Omit for snapshot cutoff."
+            ),
+        },
+        ("roster_key",),
+    ),
+    _tool(
+        "team_schedule",
+        "Get a team's snapshot-bounded schedule with opponents, scores, results, "
+        "and cumulative record.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "roster_at_cutoff",
+        "Get a team's roster composition at the selected snapshot cutoff, organized "
+        "by role and position, plus draft picks owned.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "roster_snapshot",
+        "Get a team's roster and player scores during a specific week.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property("Week number to query."),
+        },
+        ("roster_key", "week"),
+    ),
+    _tool(
+        "transactions",
+        "Get all grouped trades, waivers, and free-agent pickups in a week range.",
+        {
+            "week_from": _week_property("Starting week (inclusive)."),
+            "week_to": _week_property("Ending week (inclusive)."),
+        },
+        ("week_from", "week_to"),
+    ),
+    _tool(
+        "team_transactions",
+        "Get one team's trades, waivers, and free-agent pickups in a week range.",
+        {
+            "roster_key": _roster_property(),
+            "week_from": _week_property("Starting week (inclusive)."),
+            "week_to": _week_property("Ending week (inclusive)."),
+        },
+        ("roster_key", "week_from", "week_to"),
+    ),
+    _tool(
+        "bench_analysis",
+        "Get starter-versus-bench scoring for a week, league-wide or for one team.",
+        {
+            "roster_key": {
+                "type": "string",
+                "description": "Optional team identifier. Omit for league-wide mode.",
+            },
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+        },
+    ),
+    _tool(
+        "standings",
+        "Get league standings, records, points, rank, and streaks for a week.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "player_summary",
+        "Get an NFL player's snapshot metadata, including position, team, status, "
+        "and injury information.",
+        {
+            "player_key": {
+                "type": "string",
+                "description": "Player name or player_id.",
+            }
+        },
+        ("player_key",),
+    ),
+    _tool(
+        "player_weekly_log",
+        "Get a player's weekly fantasy points, lineup role, fantasy team, totals, "
+        "and averages.",
+        {
+            "player_key": {
+                "type": "string",
+                "description": "Player name or player_id.",
+            },
+            "week_from": _week_property(
+                "Starting week (inclusive). Omit for full snapshot."
+            ),
+            "week_to": _week_property(
+                "Ending week (inclusive). Omit for full snapshot."
+            ),
+        },
+        ("player_key",),
+    ),
+    _tool(
+        "season_leaders",
+        "Get top players across the snapshot by total or average fantasy points, with "
+        "optional week, position, team, and role filters.",
+        {
+            "week_from": _week_property(
+                "Starting week (inclusive). Omit for full snapshot."
+            ),
+            "week_to": _week_property(
+                "Ending week (inclusive). Omit for full snapshot."
+            ),
+            "position": {
+                "type": "string",
+                "description": "Filter to a single position.",
+            },
+            "roster_key": {
+                "type": "string",
+                "description": "Filter to one team's players.",
+            },
+            "role": {
+                "type": "string",
+                "description": "Filter by lineup role.",
+                "enum": ["starter", "bench"],
+            },
+            "sort_by": {
+                "type": "string",
+                "description": "Rank by total or average points.",
+                "enum": ["total", "avg"],
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results. Default 10, maximum 30.",
+            },
+        },
+    ),
+    _tool(
+        "playoff_bracket",
+        "Get playoff bracket structure, results, progression, and placements from the "
+        "selected snapshot.",
+        {
+            "bracket_type": {
+                "type": "string",
+                "description": "Filter to winners or losers. Omit for both.",
+                "enum": ["winners", "losers"],
+            }
+        },
+    ),
+    _tool(
+        "team_playoff_path",
+        "Get one team's playoff opponents, results, placement, and elimination or "
+        "championship status.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "run_sql",
+        "Execute one guarded read-only query against the selected frozen SQLite "
+        "snapshot for advanced analysis.",
+        {
+            "query": {
+                "type": "string",
+                "description": (
+                    "A single SELECT query. Available tables: leagues, "
+                    "season_context, users, rosters, team_profiles, draft_picks, "
+                    "players, matchups, player_performances, games, roster_players, "
+                    "transactions, transaction_moves, playoff_matchups, standings, "
+                    "and snapshot_metadata."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum rows to return. Default is 200.",
+            },
+        },
+        ("query",),
+    ),
+]
 
 
 def register_datalayer_tools(
     registry: ToolRegistry,
-    data: SleeperLeagueData,
+    data: FrozenLeagueData,
 ) -> None:
-    """Register all Sleeper datalayer tools in the runner registry."""
-    handlers = create_tool_handlers(data)
-
+    """Register reporter data tools over an already-open frozen snapshot."""
+    handlers = _create_tool_handlers(data)
     for spec in DATALAYER_TOOL_SPECS:
         name = spec["function"]["name"]
-        handler = handlers[name]
-        registry.register(name, _json_handler(handler), spec)
+        registry.register(name, _json_handler(handlers[name]), spec)
+
+
+def _create_tool_handlers(
+    data: FrozenLeagueData,
+) -> dict[str, Callable[..., Any]]:
+    return {
+        "league_snapshot": lambda week=None: data.get_league_snapshot(week),
+        "week_games": lambda week=None: data.get_week_games_with_players(week),
+        "team_game": lambda roster_key, week=None: (
+            data.get_team_game_with_players(roster_key, week)
+        ),
+        "week_player_leaderboard": lambda week=None, limit=10: (
+            data.get_week_player_leaderboard(week, limit)
+        ),
+        "team_dossier": lambda roster_key, week=None: (
+            data.get_team_dossier(roster_key, week)
+        ),
+        "team_schedule": lambda roster_key: data.get_team_schedule(roster_key),
+        "roster_at_cutoff": lambda roster_key: data.get_roster_at_cutoff(roster_key),
+        "roster_snapshot": lambda roster_key, week: (
+            data.get_roster_snapshot(roster_key, week)
+        ),
+        "transactions": lambda week_from, week_to: (
+            data.get_transactions(week_from, week_to)
+        ),
+        "team_transactions": lambda roster_key, week_from, week_to: (
+            data.get_team_transactions(roster_key, week_from, week_to)
+        ),
+        "bench_analysis": lambda roster_key=None, week=None: (
+            data.get_bench_analysis(roster_key, week)
+        ),
+        "standings": lambda week=None: data.get_standings(week),
+        "player_summary": lambda player_key: data.get_player_summary(player_key),
+        "player_weekly_log": lambda player_key, week_from=None, week_to=None: (
+            data.get_player_weekly_log(
+                player_key,
+                week_from=week_from,
+                week_to=week_to,
+            )
+        ),
+        "season_leaders": (
+            lambda week_from=None,
+            week_to=None,
+            position=None,
+            roster_key=None,
+            role=None,
+            sort_by="total",
+            limit=10: data.get_season_leaders(
+                week_from=week_from,
+                week_to=week_to,
+                position=position,
+                roster_key=roster_key,
+                role=role,
+                sort_by=sort_by,
+                limit=limit,
+            )
+        ),
+        "playoff_bracket": lambda bracket_type=None: (
+            data.get_playoff_bracket(bracket_type)
+        ),
+        "team_playoff_path": lambda roster_key: (
+            data.get_team_playoff_path(roster_key)
+        ),
+        "run_sql": lambda query, limit=200: data.run_sql(query, limit=limit),
+    }
 
 
 def _json_handler(handler: Callable[..., Any]) -> Callable[..., str]:

--- a/reporter_v2/tests/test_datalayer_tools.py
+++ b/reporter_v2/tests/test_datalayer_tools.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 
+import pytest
+
+from backend.services.datalayer import FrozenLeagueData, ReadyDataSnapshot
+from backend.tests.services.datalayer.test_frozen_query_runtime import (
+    _without_volatile_player_state,
+    ready_snapshot,
+)
 from datalayer.tools import SLEEPER_TOOLS
 from reporter_v2.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_SPECS,
@@ -20,7 +29,7 @@ EXPECTED_TOOL_NAMES = [
     "week_player_leaderboard",
     "team_dossier",
     "team_schedule",
-    "roster_current",
+    "roster_at_cutoff",
     "roster_snapshot",
     "transactions",
     "team_transactions",
@@ -35,7 +44,7 @@ EXPECTED_TOOL_NAMES = [
 ]
 
 
-class FakeSleeperLeagueData:
+class FakeFrozenLeagueData:
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
 
@@ -79,8 +88,8 @@ class FakeSleeperLeagueData:
     def get_team_schedule(self, roster_key: Any) -> dict[str, Any]:
         return self._record("get_team_schedule", roster_key)
 
-    def get_roster_current(self, roster_key: Any) -> dict[str, Any]:
-        return self._record("get_roster_current", roster_key)
+    def get_roster_at_cutoff(self, roster_key: Any) -> dict[str, Any]:
+        return self._record("get_roster_at_cutoff", roster_key)
 
     def get_roster_snapshot(self, roster_key: Any, week: int) -> dict[str, Any]:
         return self._record("get_roster_snapshot", roster_key, week)
@@ -152,9 +161,9 @@ class FakeSleeperLeagueData:
         return self._record("run_sql", query, limit=limit)
 
 
-def registered_registry() -> tuple[ToolRegistry, FakeSleeperLeagueData]:
+def registered_registry() -> tuple[ToolRegistry, FakeFrozenLeagueData]:
     registry = ToolRegistry()
-    data = FakeSleeperLeagueData()
+    data = FakeFrozenLeagueData()
     register_datalayer_tools(registry, data)  # type: ignore[arg-type]
     return registry, data
 
@@ -163,11 +172,22 @@ def decode(result: str) -> Any:
     return json.loads(result)
 
 
-def test_datalayer_tool_specs_come_from_sleeper_tools() -> None:
-    assert DATALAYER_TOOL_SPECS is SLEEPER_TOOLS
+def test_reporter_owns_compatible_frozen_tool_specs() -> None:
+    assert DATALAYER_TOOL_SPECS is not SLEEPER_TOOLS
     assert [
         spec["function"]["name"] for spec in DATALAYER_TOOL_SPECS
     ] == EXPECTED_TOOL_NAMES
+    legacy_by_name = {spec["function"]["name"]: spec for spec in SLEEPER_TOOLS}
+    for spec in DATALAYER_TOOL_SPECS:
+        name = spec["function"]["name"]
+        legacy_name = "roster_current" if name == "roster_at_cutoff" else name
+        assert _without_descriptions(spec["function"]["parameters"]) == (
+            _without_descriptions(
+                legacy_by_name[legacy_name]["function"]["parameters"]
+            )
+        )
+
+    assert "roster_current" not in EXPECTED_TOOL_NAMES
 
 
 def test_register_all_datalayer_tools() -> None:
@@ -227,3 +247,264 @@ def test_run_sql_passes_default_and_explicit_limit() -> None:
         ("run_sql", ("SELECT * FROM games",), {"limit": 200}),
         ("run_sql", ("SELECT * FROM games",), {"limit": 20}),
     ]
+    with pytest.raises(TypeError):
+        handler(query="SELECT * FROM games", params={"week": 2})
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "expected_call"),
+    [
+        ("league_snapshot", {}, ("get_league_snapshot", (None,), {})),
+        ("week_games", {"week": 2}, ("get_week_games_with_players", (2,), {})),
+        (
+            "team_game",
+            {"roster_key": "Alpha", "week": 2},
+            ("get_team_game_with_players", ("Alpha", 2), {}),
+        ),
+        (
+            "week_player_leaderboard",
+            {"week": 2, "limit": 3},
+            ("get_week_player_leaderboard", (2, 3), {}),
+        ),
+        (
+            "team_dossier",
+            {"roster_key": "Alpha", "week": 2},
+            ("get_team_dossier", ("Alpha", 2), {}),
+        ),
+        (
+            "team_schedule",
+            {"roster_key": "Alpha"},
+            ("get_team_schedule", ("Alpha",), {}),
+        ),
+        (
+            "roster_at_cutoff",
+            {"roster_key": "Alpha"},
+            ("get_roster_at_cutoff", ("Alpha",), {}),
+        ),
+        (
+            "roster_snapshot",
+            {"roster_key": "Alpha", "week": 1},
+            ("get_roster_snapshot", ("Alpha", 1), {}),
+        ),
+        (
+            "transactions",
+            {"week_from": 1, "week_to": 2},
+            ("get_transactions", (1, 2), {}),
+        ),
+        (
+            "team_transactions",
+            {"roster_key": "Alpha", "week_from": 1, "week_to": 2},
+            ("get_team_transactions", ("Alpha", 1, 2), {}),
+        ),
+        (
+            "bench_analysis",
+            {},
+            ("get_bench_analysis", (None, None), {}),
+        ),
+        ("standings", {}, ("get_standings", (None,), {})),
+        (
+            "player_summary",
+            {"player_key": "p1"},
+            ("get_player_summary", ("p1",), {}),
+        ),
+        (
+            "player_weekly_log",
+            {"player_key": "p1", "week_from": 1, "week_to": 2},
+            (
+                "get_player_weekly_log",
+                ("p1",),
+                {"week_from": 1, "week_to": 2},
+            ),
+        ),
+        (
+            "season_leaders",
+            {"position": "QB", "limit": 3},
+            (
+                "get_season_leaders",
+                (),
+                {
+                    "week_from": None,
+                    "week_to": None,
+                    "position": "QB",
+                    "roster_key": None,
+                    "role": None,
+                    "sort_by": "total",
+                    "limit": 3,
+                },
+            ),
+        ),
+        (
+            "playoff_bracket",
+            {},
+            ("get_playoff_bracket", (None,), {}),
+        ),
+        (
+            "team_playoff_path",
+            {"roster_key": "Alpha"},
+            ("get_team_playoff_path", ("Alpha",), {}),
+        ),
+        (
+            "run_sql",
+            {"query": "SELECT * FROM games", "limit": 2},
+            ("run_sql", ("SELECT * FROM games",), {"limit": 2}),
+        ),
+    ],
+)
+def test_every_tool_delegates_to_the_frozen_runtime(
+    tool_name: str,
+    arguments: dict[str, Any],
+    expected_call: tuple[str, tuple[Any, ...], dict[str, Any]],
+) -> None:
+    registry, data = registered_registry()
+    handler = registry.get_handler(tool_name)
+
+    assert handler is not None
+    decode(handler(**arguments))
+
+    assert data.calls == [expected_call]
+
+
+def test_all_tools_execute_against_a_real_frozen_artifact(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    calls = {
+        "league_snapshot": {"week": 2},
+        "week_games": {"week": 2},
+        "team_game": {"roster_key": "Alpha", "week": 2},
+        "week_player_leaderboard": {"week": 2, "limit": 3},
+        "team_dossier": {"roster_key": "Alpha", "week": 2},
+        "team_schedule": {"roster_key": "Alpha"},
+        "roster_at_cutoff": {"roster_key": "Alpha"},
+        "roster_snapshot": {"roster_key": "Alpha", "week": 1},
+        "transactions": {"week_from": 1, "week_to": 2},
+        "team_transactions": {
+            "roster_key": "Alpha",
+            "week_from": 1,
+            "week_to": 2,
+        },
+        "bench_analysis": {"roster_key": "Alpha", "week": 2},
+        "standings": {"week": 2},
+        "player_summary": {"player_key": "p1"},
+        "player_weekly_log": {
+            "player_key": "p1",
+            "week_from": 1,
+            "week_to": 2,
+        },
+        "season_leaders": {
+            "week_from": 1,
+            "week_to": 2,
+            "position": "QB",
+            "roster_key": "Alpha",
+            "role": "starter",
+            "sort_by": "total",
+            "limit": 3,
+        },
+        "playoff_bracket": {},
+        "team_playoff_path": {"roster_key": "Alpha"},
+        "run_sql": {
+            "query": "SELECT week, matchup_id FROM games ORDER BY week",
+            "limit": 2,
+        },
+    }
+
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        registry = ToolRegistry()
+        register_datalayer_tools(registry, data)
+        results = {
+            name: decode(registry.get_handler(name)(**arguments))  # type: ignore[misc]
+            for name, arguments in calls.items()
+        }
+
+    golden_path = (
+        Path(__file__).parents[2]
+        / "datalayer"
+        / "tests"
+        / "characterization"
+        / "golden"
+        / "legacy_query_outputs.json"
+    )
+    golden = json.loads(golden_path.read_text(encoding="utf-8"))
+    assert set(results) == set(EXPECTED_TOOL_NAMES)
+    stable_results = _without_volatile_player_state(results)
+    stable_golden = _without_volatile_player_state(golden)
+    assert stable_results["week_games"] == stable_golden["week_games_with_players"]
+    assert stable_results["team_game"] == stable_golden["team_game_with_players"]
+    assert stable_results["team_schedule"] == stable_golden["team_schedule"]
+    assert stable_results["roster_at_cutoff"] == stable_golden[
+        "roster_current_by_name"
+    ]
+    assert results["run_sql"]["row_count"] == 2
+
+
+def test_missing_entities_remain_safe_tool_results(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        registry = ToolRegistry()
+        register_datalayer_tools(registry, data)
+        missing = {
+            "team": decode(
+                registry.get_handler("team_dossier")(
+                    roster_key="missing", week=2
+                )  # type: ignore[misc]
+            ),
+            "roster": decode(
+                registry.get_handler("roster_at_cutoff")(
+                    roster_key="missing"
+                )  # type: ignore[misc]
+            ),
+            "player": decode(
+                registry.get_handler("player_summary")(
+                    player_key="missing"
+                )  # type: ignore[misc]
+            ),
+        }
+
+    assert all(result["found"] is False for result in missing.values())
+
+
+def test_reporter_adapter_and_datalayer_import_boundaries() -> None:
+    root = Path(__file__).parents[2]
+    adapter = root / "reporter_v2" / "runner" / "tools" / "datalayer_tools.py"
+    adapter_imports = _imports(adapter)
+    assert not any(
+        name == "datalayer" or name.startswith("datalayer.")
+        for name in adapter_imports
+    )
+    assert not any(name.startswith("backend.resources") for name in adapter_imports)
+    assert not any(name.startswith("backend.database") for name in adapter_imports)
+
+    datalayer_paths = [
+        *(root / "datalayer").rglob("*.py"),
+        *(root / "backend" / "services" / "datalayer").rglob("*.py"),
+    ]
+    reverse_imports = {
+        name
+        for path in datalayer_paths
+        for name in _imports(path)
+        if name == "reporter_v2" or name.startswith("reporter_v2.")
+    }
+    assert reverse_imports == set()
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def _without_descriptions(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _without_descriptions(item)
+            for key, item in value.items()
+            if key != "description"
+        }
+    if isinstance(value, list):
+        return [_without_descriptions(item) for item in value]
+    return value


### PR DESCRIPTION
## Summary

- move all 18 reporter data tool schemas and handlers under reporter ownership
  and delegate them directly to an already-open `FrozenLeagueData` runtime
- replace ambiguous `roster_current` with snapshot-relative
  `roster_at_cutoff` while preserving the remaining tool names, input schemas,
  defaults, JSON outputs, and safe not-found behavior
- prove every tool against a real fixture-built immutable artifact and enforce
  that reporter adapters cannot import legacy loading, source, resource, or
  PostgreSQL paths

## Stack boundary

This is Layer 11 in datalayer stack #123 and is based directly on Layer 10 PR
#139. It intentionally leaves snapshot resolution, generation pinning, model
execution composition, memory lifecycle, CLI cutover, and legacy removal to
Layers 12-14.

## Verification

- focused reporter adapter suite: `27 passed`
- complete reporter v2 suite: `144 passed`
- frozen runtime plus adapter gate: `58 passed`
- cumulative non-live datalayer gate: `345 passed, 4 skipped`
- complete non-live repository suite: `632 passed, 133 skipped`
- exact Alembic lifecycle and metadata drift check at sole head `0007`: passed
- complete live repository suite: `764 passed, 1 skipped`
- compilation, import-boundary, 99-column, and diff checks: passed
