### PR TITLE
feat(reporter): copy engine into backend service

### DIFF
--- a/backend/services/reporter/__init__.py
+++ b/backend/services/reporter/__init__.py
@@ -1,0 +1,26 @@
+"""Platform reporter service public surface."""
+
+from backend.services.reporter.config import (
+    BiasProfile,
+    ReportConfig,
+    TimeRange,
+    ToneControls,
+)
+from backend.services.reporter.generator import generate_article
+from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.schemas import ArticleOutput
+from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+__all__ = [
+    "ArticleOutput",
+    "BiasProfile",
+    "ProcedureHistoryMode",
+    "ReportConfig",
+    "Runner",
+    "RunnerConfig",
+    "TimeRange",
+    "ToneControls",
+    "ToolRegistry",
+    "generate_article",
+]

--- a/backend/services/reporter/config.py
+++ b/backend/services/reporter/config.py
@@ -1,0 +1,142 @@
+"""Configuration models for reporter v2 article generation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class TimeRange(BaseModel):
+    """Time range for article coverage."""
+
+    week_start: int = Field(description="Starting week, inclusive")
+    week_end: int = Field(description="Ending week, inclusive")
+
+    @classmethod
+    def single_week(cls, week: int) -> TimeRange:
+        """Create a range for a single week."""
+        return cls(week_start=week, week_end=week)
+
+    @classmethod
+    def range(cls, start: int, end: int) -> TimeRange:
+        """Create a multi-week range."""
+        return cls(week_start=start, week_end=end)
+
+
+class ToneControls(BaseModel):
+    """Tone knobs for article voice."""
+
+    snark_level: int = Field(default=1, ge=0, le=3)
+    hype_level: int = Field(default=1, ge=0, le=3)
+    seriousness: int = Field(default=1, ge=0, le=3)
+
+
+class BiasProfile(BaseModel):
+    """Bias configuration for framing only, never facts."""
+
+    favored_teams: list[str] = Field(default_factory=list)
+    disfavored_teams: list[str] = Field(default_factory=list)
+    intensity: int = Field(default=1, ge=0, le=3)
+
+
+class ReportConfig(BaseModel):
+    """User-facing article generation configuration."""
+
+    time_range: TimeRange
+    focus_hints: list[str] = Field(default_factory=list)
+    avoid_topics: list[str] = Field(default_factory=list)
+    focus_teams: list[str] = Field(default_factory=list)
+
+    voice: str = "sports columnist"
+    tone: ToneControls = Field(default_factory=ToneControls)
+    profanity_policy: str = "none"
+
+    bias_profile: BiasProfile | None = None
+
+    length_target: int = 1000
+    evidence_policy: str = "standard"
+
+    custom_instructions: str = ""
+
+    @classmethod
+    def for_week(
+        cls,
+        week: int,
+        *,
+        voice: str = "sports columnist",
+        snark_level: int = 1,
+        hype_level: int = 1,
+        focus_hints: list[str] | None = None,
+        custom_instructions: str = "",
+    ) -> ReportConfig:
+        """Convenience constructor for a single-week report."""
+        return cls(
+            time_range=TimeRange.single_week(week),
+            voice=voice,
+            tone=ToneControls(snark_level=snark_level, hype_level=hype_level),
+            focus_hints=focus_hints or [],
+            custom_instructions=custom_instructions,
+        )
+
+    @classmethod
+    def for_week_range(
+        cls,
+        week_start: int,
+        week_end: int,
+        *,
+        voice: str = "sports columnist",
+        focus_hints: list[str] | None = None,
+    ) -> ReportConfig:
+        """Convenience constructor for a multi-week report."""
+        return cls(
+            time_range=TimeRange.range(week_start, week_end),
+            voice=voice,
+            focus_hints=focus_hints or [],
+        )
+
+    def with_bias(
+        self,
+        favored: list[str] | None = None,
+        disfavored: list[str] | None = None,
+        intensity: int = 2,
+    ) -> ReportConfig:
+        """Return a copy with bias configuration added."""
+        return self.model_copy(
+            update={
+                "bias_profile": BiasProfile(
+                    favored_teams=favored or [],
+                    disfavored_teams=disfavored or [],
+                    intensity=intensity,
+                )
+            }
+        )
+
+    def get_bias_instructions(self) -> str:
+        """Generate bias instructions for the model prompt."""
+        if not self.bias_profile:
+            return ""
+
+        bias = self.bias_profile
+        if not bias.favored_teams and not bias.disfavored_teams:
+            return ""
+
+        lines = ["## Bias Instructions (framing only, never change facts)"]
+        if bias.favored_teams:
+            teams = ", ".join(bias.favored_teams)
+            if bias.intensity == 1:
+                lines.append(f"- Use positive language when describing {teams}")
+            elif bias.intensity == 2:
+                lines.append(f"- Frame {teams} enthusiastically; lead with positives")
+            else:
+                lines.append(f"- Celebrate {teams} with high energy")
+
+        if bias.disfavored_teams:
+            teams = ", ".join(bias.disfavored_teams)
+            if bias.intensity == 1:
+                lines.append(f"- Use neutral or brief language for {teams}")
+            elif bias.intensity == 2:
+                lines.append(f"- Light teasing is allowed when describing {teams}")
+            else:
+                lines.append(f"- Roast {teams} playfully; emphasize failures")
+
+        lines.append("- NEVER change actual scores, records, or statistics")
+        return "\n".join(lines)

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -1,0 +1,271 @@
+"""Composition root for platform reporter article generation.
+
+Owns product wiring that the Runner must not know about:
+- tool registration (brief, article, procedure, datalayer, memory)
+- CompletionClient construction from settings / injectable fakes
+- brief meta seeding from league data + ReportConfig
+- system/user prompt construction
+- memory run lifecycle (mark_stale / persist-on-submit via memory_lifecycle)
+
+The Runner only receives a registry, client, RunnerConfig, and optional
+pre-seeded ArtifactStore.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from backend.services.reporter.config import ReportConfig
+from backend.services.reporter.runner.completion import (
+    CompletionClient,
+    CompletionFn,
+    CompletionSettings,
+    make_completion_client,
+)
+from backend.services.reporter.runner.memory_lifecycle import (
+    finalize_memory_run,
+    prepare_memory_run,
+)
+from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.schemas import ArticleOutput, BriefMeta, ReportBrief
+from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
+from backend.services.reporter.runner.tools.article_tools import register_article_tools
+from backend.services.reporter.runner.tools.brief_tools import register_brief_tools
+from backend.services.reporter.runner.tools.datalayer_tools import register_datalayer_tools
+from backend.services.reporter.runner.tools.persistent_tools import register_persistent_tools
+from backend.services.reporter.runner.tools.procedure_tools import register_procedure_tools
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from backend.services.datalayer import FrozenLeagueData
+    from reporter_memory.context_store import ContextStore
+
+
+async def generate_article(
+    data: FrozenLeagueData,
+    config: ReportConfig,
+    *,
+    context_store: ContextStore | None = None,
+    client: CompletionClient | None = None,
+    completion: CompletionSettings | None = None,
+    runner_config: RunnerConfig | None = None,
+    log_path: Path | None = None,
+    complete: CompletionFn | None = None,
+    allow_memory_writes: bool = True,
+) -> ArticleOutput:
+    """Generate an article with the single-loop v2 runner.
+
+    Args:
+        data: Already-open immutable league snapshot runtime.
+        config: Article intent (weeks, voice, tone, bias, instructions).
+        context_store: Optional persistent memory; enables memory tools.
+        client: Pre-built completion client. Mutually exclusive with complete=.
+        completion: Settings used when constructing a client (or wrapping complete=).
+        runner_config: Loop policy owned by Runner (max_turns, procedure mode).
+        log_path: Optional streaming run-log path.
+        complete: Injectable completion fn for tests. Mutually exclusive with client=.
+        allow_memory_writes: When False (eval mode), skip memory mutations
+            (lifecycle + in-run memory tools).
+    """
+    week = config.time_range.week_end
+    prepare_memory_run(
+        context_store,
+        week=week,
+        allow_writes=allow_memory_writes,
+    )
+
+    registry = _build_registry(
+        data,
+        context_store=context_store,
+        week=week,
+        allow_memory_writes=allow_memory_writes,
+    )
+    resolved_client = _resolve_client(
+        client=client,
+        completion=completion,
+        complete=complete,
+    )
+
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    league_id, league_name = _get_league_metadata(data)
+    artifacts = ArtifactStore(
+        brief=ReportBrief(
+            meta=BriefMeta(
+                league_id=league_id,
+                league_name=league_name,
+                week_start=config.time_range.week_start,
+                week_end=config.time_range.week_end,
+            )
+        )
+    )
+
+    runner = Runner(
+        registry,
+        client=resolved_client,
+        config=runner_config or RunnerConfig(),
+        log_path=log_path,
+        artifacts=artifacts,
+    )
+
+    output = await runner.run(_build_system_prompt(), _build_user_message(config))
+    finalize_memory_run(
+        context_store,
+        output,
+        week=week,
+        allow_writes=allow_memory_writes,
+    )
+    return output
+
+
+def _build_registry(
+    data: FrozenLeagueData,
+    *,
+    context_store: ContextStore | None,
+    week: int,
+    allow_memory_writes: bool,
+) -> ToolRegistry:
+    registry = ToolRegistry()
+    register_brief_tools(registry)
+    register_article_tools(registry)
+    register_procedure_tools(registry)
+    register_datalayer_tools(registry, data)
+    if context_store is not None:
+        register_persistent_tools(
+            registry,
+            context_store,
+            week=week,
+            resolve_roster_fn=_make_roster_resolver(data),
+            allow_memory_writes=allow_memory_writes,
+        )
+    return registry
+
+
+def _resolve_client(
+    *,
+    client: CompletionClient | None,
+    completion: CompletionSettings | None,
+    complete: CompletionFn | None,
+) -> CompletionClient:
+    if client is not None and complete is not None:
+        raise ValueError("Pass client= or complete=, not both.")
+    if client is not None:
+        return client
+
+    settings = completion or CompletionSettings()
+    if complete is not None:
+        return CompletionClient(complete, settings)
+    return make_completion_client(settings)
+
+
+def _build_system_prompt() -> str:
+    path = Path(__file__).resolve().parent / "prompts" / "system.md"
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _build_user_message(config: ReportConfig) -> str:
+    lines = [
+        "Generate a fantasy football article with these requirements.",
+        "",
+        "Coverage:",
+        f"- Weeks: {config.time_range.week_start}-{config.time_range.week_end}",
+        f"- Target length: about {config.length_target} words",
+        f"- Evidence policy: {config.evidence_policy}",
+        "",
+        "Voice and tone:",
+        f"- Voice: {config.voice}",
+        f"- Snark level: {config.tone.snark_level}",
+        f"- Hype level: {config.tone.hype_level}",
+        f"- Seriousness: {config.tone.seriousness}",
+        f"- Profanity policy: {config.profanity_policy}",
+    ]
+
+    _append_list(lines, "Focus hints", config.focus_hints)
+    _append_list(lines, "Focus teams", config.focus_teams)
+    _append_list(lines, "Avoid topics", config.avoid_topics)
+
+    bias_instructions = config.get_bias_instructions()
+    if bias_instructions:
+        lines.extend(["", bias_instructions])
+
+    if config.custom_instructions.strip():
+        lines.extend(["", "Custom instructions:", config.custom_instructions.strip()])
+
+    lines.extend(
+        [
+            "",
+            "Start by loading the `research` procedure. Build the brief as you go, "
+            "then use the storyline, drafting, and verification procedures as needed.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _append_list(lines: list[str], label: str, values: list[str]) -> None:
+    if values:
+        lines.append(f"- {label}: {', '.join(values)}")
+
+
+def _make_roster_resolver(
+    data: FrozenLeagueData,
+) -> Callable[[str], dict[str, Any]]:
+    def resolve(roster_key: str) -> dict[str, Any]:
+        key = str(roster_key).strip()
+        if not key:
+            return {"found": False, "roster_key": roster_key}
+
+        if key.isdigit():
+            query = """
+                SELECT r.roster_id, tp.team_name
+                FROM rosters AS r
+                LEFT JOIN team_profiles AS tp
+                  ON tp.league_id = r.league_id
+                 AND tp.roster_id = r.roster_id
+                WHERE r.roster_id = :roster_id
+            """
+            params: dict[str, Any] = {"roster_id": int(key)}
+        else:
+            query = """
+                SELECT roster_id, team_name
+                FROM team_profiles
+                WHERE (team_name IS NOT NULL AND lower(team_name) = lower(:key))
+                   OR (manager_name IS NOT NULL AND lower(manager_name) = lower(:key))
+                ORDER BY team_name ASC, manager_name ASC
+            """
+            params = {"key": key}
+
+        try:
+            result = data.run_sql(query, params, limit=2)
+        except (RuntimeError, TypeError, ValueError):
+            return {"found": False, "roster_key": roster_key}
+
+        matches = [
+            dict(zip(result.get("columns", ()), row, strict=True))
+            for row in result.get("rows", ())
+        ]
+        if not matches:
+            return {"found": False, "roster_key": roster_key}
+        if len(matches) > 1:
+            return {
+                "found": False,
+                "roster_key": roster_key,
+                "matches": matches,
+            }
+        return {"found": True, **matches[0]}
+
+    return resolve
+
+
+def _get_league_metadata(data: FrozenLeagueData) -> tuple[str, str]:
+    try:
+        result = data.run_sql("SELECT league_id, name FROM leagues LIMIT 1", limit=1)
+    except (RuntimeError, TypeError, ValueError):
+        return "", ""
+    rows = result.get("rows", ())
+    if not rows:
+        return "", ""
+    league_id, league_name = rows[0]
+    return str(league_id or ""), str(league_name or "")

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -1,0 +1,69 @@
+# Drafting Procedure
+
+You are writing the article from the brief artifact. Use `read_brief`, then write article sections with article tools. Do not call datalayer tools while drafting unless you discover the brief is missing a required fact; if that happens, switch back to `research`.
+
+## Operating Rules
+
+- The brief is the source of truth. Use only saved facts, storylines, outline, style, and bias.
+- Treat `memory_callbacks` as verified brief material, but still name the old event and current payoff in prose.
+- Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
+- Numeric claims must match the fact `numbers` values or the fact `claim_text`.
+- Follow the outline unless it is stale or incomplete. If it is stale, switch to `storyline` to refresh it.
+- Write in sections with `write_section`. Do not submit the article from this procedure unless verification is explicitly skipped by the user or guardrails force wrap-up.
+
+## Drafting Flow
+
+1. Call `read_brief`.
+2. Check staleness information. If the outline or storylines are stale, switch to `storyline` before writing.
+3. Identify the lead storyline and section order from the outline.
+4. Write one focused section at a time with `write_section(name, content)`.
+5. Use `read_article` after major sections to inspect flow and coverage.
+6. Use `rewrite_section` for local improvements instead of rewriting the full article.
+7. Switch to `verification` when the draft is complete.
+
+## Writing Standards
+
+- Open with the best material, not a generic recap sentence.
+- Use concrete details from facts rather than vague claims.
+- Prioritize priority-1 storylines, then priority-2 storylines, then quick hits.
+- For callback paragraphs, clearly state what happened then, what happened now, and why the meaning changed.
+- Do not use vague continuity phrases such as "this has been brewing," "the storyline continues," or "it came full circle" unless the paragraph names the old event and the new payoff.
+- Keep paragraphs focused. Standard sections should usually be 2-5 paragraphs.
+- Use Markdown:
+  - `#` for the headline if the opening section includes one.
+  - `##` for major section headings.
+  - `**bold**` for emphasis when useful.
+- Match the requested target length. As a practical guide:
+  - 500 words: 1-2 storylines.
+  - 1000 words: 3-4 storylines.
+  - 1500+ words: broader weekly coverage or deeper analysis.
+
+## Voice And Bias
+
+Apply `style` consistently:
+
+- Sports columnist: informed, sharp, and personable.
+- Snarky columnist: witty and irreverent, with playful jabs.
+- Hype broadcaster: high energy, dramatic, and celebratory.
+- Beat reporter: factual, measured, and analysis-heavy.
+- Custom voices: satisfy the user's request while preserving factual grounding.
+
+Apply `bias` as framing only:
+
+- Favored teams can get more enthusiastic language, more prominent placement, and more charitable framing.
+- Disfavored teams can get skepticism or playful roasting.
+- The score, record, ranking, transaction, and player points must remain exactly what the facts say.
+
+## Section Naming
+
+Use stable, descriptive section names for article tools, such as:
+
+- `headline_and_lead`
+- `lead_story`
+- `standings_shift`
+- `quick_hits`
+- `transactions`
+- `playoff_picture`
+- `closing`
+
+Before switching to verification, make sure each required outline fact appears in an article section and the article has a coherent opening, body, and close.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -1,0 +1,100 @@
+# Research Procedure
+
+You are gathering verified fantasy football facts for the article brief. Use datalayer tools to inspect the league, then save only confirmed claims with `save_fact`. Do not draft article prose in this procedure.
+
+## Operating Rules
+
+- If you are returning to research after another procedure has run, call `read_brief` first so you know which facts already exist and what is stale.
+- Start broad, then drill down. Prefer `league_snapshot` for the requested week before targeted team or player calls.
+- Every saved fact must be traceable to one or more tool calls through `data_refs`.
+- Save specific, reusable facts rather than commentary. The article voice comes later.
+- Do not invent standings, scores, records, player points, transactions, injuries, or playoff implications.
+- Bias can guide what you investigate, but it must not change which facts you save.
+- If persistent context tools are available and the request may depend on league history, load relevant storylines, team context, and league notes as research leads only.
+- Retrieved persistent memories are not facts. Verify both the older receipt and the current-week payoff before saving a callback fact or storyline.
+- If the runner announces the hard tool limit, stop researching and move directly toward submitting the best article possible with the artifacts already available.
+
+## Default Research Flow
+
+1. Establish the request scope: week or week range, focus teams, focus topics, article type, target tone, and any teams to favor or roast.
+2. Call `league_snapshot(week=N)` for a single-week article, or use the available week and standings tools for a multi-week request.
+3. Inspect the main scoreboard and standings movement. Look for upsets, blowouts, close games, streaks, playoff movement, and season-best or season-worst performances.
+4. Run the memory scout loop when the request or data suggests long-running context:
+   - Extract the current-week fact map: scores, margins, standings movement, playoff stakes, current matchups, top players, transactions, focus teams, and requested framing.
+   - Generate narrative hypotheses from the current week. Ask what changed meaning, reversed, paid off, collapsed, became funny, or now has stakes.
+   - Prefer `search_story_memory` with current entities/events, then `get_memory_candidate` for promising leads. Use `load_persistent_storylines` only for a broad dump.
+   - Call `plan_memory_verification` on promising candidates to get required fact roles and suggested datalayer calls.
+   - Verify the old event with datalayer tools or a verified memory receipt, and verify the current event with current-run datalayer facts.
+   - Save old-event and current-event facts with `save_fact`, then use `record_memory_verification` and `save_memory_callback` if available.
+   - Promote only the best verified callbacks into storylines and outline inputs.
+   - Persist durable evidence with `save_memory_event`, `upsert_storyline_memory_card`, and `save_storyline_trigger` when an arc should matter later. Mark usage with `mark_memory_used`.
+5. Call targeted tools for the strongest leads:
+   - `team_game(roster_key, week=N)` for player-level detail in a specific matchup.
+   - `team_dossier(roster_key, week=N)` for recent form, record, and broader context.
+   - `week_player_leaderboard(week=N, limit=10)` for top performers.
+   - `transactions(week_from=N, week_to=N)` or `team_transactions(...)` for trade, waiver, or roster-move angles.
+   - `player_weekly_log(...)` or `player_summary(...)` for trend checks on a featured player.
+   - `playoff_bracket(...)` and `team_playoff_path(...)` when the article has playoff stakes.
+6. Save the strongest facts with `save_fact`. Aim for enough evidence to support the article, not every possible data point.
+7. When the evidence base is ready, switch to `storyline` to organize facts into narrative threads and an outline.
+
+## Memory Scout Requirements
+
+Run the full scout loop for:
+
+- Trades, trade retrospectives, waivers, drops, and former-team angles.
+- Playoffs, playoff paths, rematches, rivalries, and revenge games.
+- Power rankings, retrospectives, full-season arcs, and season awards.
+- Any focused team that has persistent context.
+
+For standard weekly recaps, do a lightweight scan for:
+
+- Repeated opponents, rematches, or prior close games.
+- Playoff matchups with regular-season history.
+- Top performers tied to old trades, waiver adds, drops, or former teams.
+- Current transactions that should be re-evaluated later.
+
+Evaluate candidate callbacks for interestingness separately from retrieval relevance. Prefer callbacks with surprise, stakes, reversal, payoff, specificity, league-reader value, comedy value, evidence strength, and fit with the requested article.
+
+## Fact Quality
+
+Good facts are precise, sourced, and useful in more than one sentence. Include the exact numbers the writer will need.
+
+```json
+{
+  "id": "fact_week8_taco_win",
+  "claim_text": "Team Taco defeated The Waiver Wire 142.3-98.7 in Week 8.",
+  "data_refs": ["league_snapshot:week=8", "team_game:Team Taco:week=8"],
+  "numbers": {
+    "week": 8,
+    "team_score": 142.3,
+    "opponent_score": 98.7,
+    "margin": 43.6
+  },
+  "category": "score"
+}
+```
+
+Use stable IDs that describe the fact. Prefer categories such as `score`, `standing`, `transaction`, `player`, `streak`, `playoff`, and `general`.
+
+## What To Look For
+
+- Upsets: lower-ranked or struggling teams beating favorites.
+- Blowouts: dominant wins, especially margins around 30 points or more.
+- Nail-biters: games decided by fewer than 5 points.
+- Streaks: winning or losing runs, especially 3 or more games.
+- Breakouts: player or team performances that stand out from recent history.
+- Collapses: favorites or strong teams missing expectations.
+- Transactions: trades, waivers, and roster moves that affected the week.
+- Continuing arcs: previous storylines that changed, intensified, or resolved.
+- Playoff pressure: seed movement, elimination risk, byes, and bracket paths.
+
+## Stopping Criteria
+
+Move to `storyline` when you have enough verified facts to support the requested article:
+
+- Short focused article: 5-8 strong facts.
+- Standard weekly recap: 10-20 strong facts.
+- Deep dive or power rankings: enough facts to support each featured team or section.
+
+If tool limits are approaching, stop researching, save the best facts you already have, and switch to `storyline`. If the hard limit has already been reached, do not make more research calls.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -1,0 +1,111 @@
+# Storyline Procedure
+
+You are turning verified facts into a usable article plan. Read the current brief, create storylines from saved facts, set style and bias, and build an outline. Do not draft final article prose here.
+
+## Operating Rules
+
+- Use `read_brief` first unless you just saved all relevant facts in the immediately preceding turn.
+- Every storyline must be supported by existing fact IDs. If a needed fact is missing, switch back to `research` and get it.
+- Storyline summaries may interpret the data, but they must not add new factual claims.
+- Set the outline after the main storylines are saved. If `read_brief` reports stale outline or storyline IDs later, refresh the affected plan.
+- Bias is framing only. Use `set_bias` to preserve the user's framing preferences without altering scores, records, or outcomes.
+- Callback storylines must be supported by both an old-event fact or verified memory receipt and a current-event fact.
+
+## Storyline Creation
+
+Create 3-6 storylines for a standard weekly recap and fewer for narrow requests. Use `save_storyline` for each narrative thread.
+
+Priority guidance:
+
+- `1`: lead story. Major upset, playoff swing, dominant performance, season-defining trend, or request-specific focus.
+- `2`: secondary story. Close game, important streak, notable breakout, trade fallout, or standings movement.
+- `3`: useful color. Routine wins, smaller stat nuggets, or supporting angles.
+- `4-5`: minor mentions that should only appear if space allows.
+
+Good storyline:
+
+```json
+{
+  "id": "story_taco_statement_win",
+  "headline": "Team Taco Turns A Win Into A Warning Shot",
+  "summary": "Team Taco's 142.3-98.7 Week 8 win was more than a comfortable result. The margin and player-level production make it a lead candidate for the week's biggest statement.",
+  "supporting_fact_ids": ["fact_week8_taco_win", "fact_week8_taco_top_players"],
+  "priority": 1,
+  "tags": ["blowout", "contender", "week_8"]
+}
+```
+
+## Style And Bias
+
+Use `set_style` to translate the request into writing controls:
+
+- `voice`: examples include `sports columnist`, `snarky columnist`, `hype broadcaster`, `beat reporter`, or a custom voice from the user.
+- `pacing`: `fast`, `moderate`, or `deliberate`.
+- `humor_level`: 0 for none, 1 for light, 2 for moderate, 3 for heavy.
+- `formality`: `formal`, `casual`, or `irreverent`.
+
+Use `set_bias` if the user asked to favor or roast teams:
+
+- `favored_teams`: teams to frame positively.
+- `disfavored_teams`: teams to frame skeptically or mockingly.
+- `intensity`: 0-3.
+- `framing_rules`: short reminders such as "celebrate wins, downplay losses" or "roast missed expectations, but keep all numbers exact".
+
+## Outline Creation
+
+Use `set_outline` to create the writing plan. Each section should include:
+
+- `title`: concise section heading.
+- `bullet_points`: what the section must accomplish.
+- `required_fact_ids`: exact facts the writer must use.
+- `storyline_ids`: storylines that belong in the section.
+
+Default weekly recap structure:
+
+1. Opening hook: lead with the priority-1 storyline and set the week's theme.
+2. Lead story: give the strongest matchup or narrative enough room.
+3. Supporting storylines: cover the next 2-3 important arcs.
+4. Quick hits: short notes for lower-priority items, top performers, or transactions.
+5. Standings or outlook: playoff implications, next-week stakes, or season trajectory.
+6. Closing: resolve the article with the strongest takeaway.
+
+For power rankings, build one section per rank or rank tier. For team deep dives, build sections around record, recent games, roster strengths or weaknesses, transactions, and outlook.
+
+## Persistent Context
+
+If persistent context tools are available, save narrative state before drafting:
+
+- Prefer `upsert_storyline_memory_card` for durable arcs (with evidence events and trigger specs when available). `save_persistent_storyline` remains a thinner compatibility wrapper.
+- Use `save_memory_event` for source-backed evidence and `save_storyline_trigger` for dormant callbacks.
+- Use `save_team_context` for researched teams whose trajectory changed.
+- Use `save_league_note` for league-wide context such as season themes, trade activity, or rivalries.
+- Use `save_memory_callback` for verified callbacks that belong in the brief, if the callback was not already saved during research.
+- Use `plan_memory_verification` / `record_memory_verification` when researching whether a retrieved lead is draftable.
+- Use `mark_memory_used` when a retrieved candidate is drafted, used as research context, or discarded.
+
+Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:
+
+- `trade_payoff`
+- `trade_regret`
+- `trade_flop`
+- `revenge_game`
+- `regular_season_sweep`
+- `playoff_reversal`
+- `close_game_callback`
+- `waiver_hero`
+- `rivalry_escalation`
+- `lineup_mistake_repeat`
+
+When persistent tool fields do not exist for arc metadata, use structured text in the persistent storyline summary:
+
+```text
+Arc type: trade_regret
+Origin week: 3
+Involved: Team A, Team B, Player X, Player Y
+Receipt: Team A traded Player X for Player Y before Week 3.
+Why it may matter later: Player X could swing a playoff matchup against Team A.
+Next callback trigger: Team A faces Team B, Player X faces Team A, or either side loses a playoff game because of the trade assets.
+Verification needed before use: confirm original trade receipt and current payoff with saved brief facts.
+```
+
+When the brief has facts, storylines, outline, style, and bias ready, switch to `drafting`.

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,0 +1,74 @@
+# Verification Procedure
+
+You are checking the drafted article against the brief artifact. Your job is to find unsupported or incorrect claims, correct them with `rewrite_section`, and submit only when the article is grounded.
+
+## Operating Rules
+
+- Call both `read_article` and `read_brief` before judging the draft.
+- Verify every numeric or factual claim against saved facts.
+- Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
+- If the brief is missing evidence for a necessary claim, switch to `research` instead of guessing.
+- If the outline or storylines are stale, switch to `storyline` before final verification.
+- Treat callback claims as factual claims. They need evidence for both the older event and the current event.
+
+## Claims To Check
+
+Check all claims involving:
+
+- Scores and matchup winners.
+- Team records, standings ranks, playoff seeds, and playoff paths.
+- Player fantasy points and leaderboard placement.
+- Transaction counts, trade participants, waiver adds, and dropped players.
+- Margins of victory or defeat.
+- Streak lengths and week ranges.
+- Any superlative such as "highest", "first", "best", "worst", or "season high".
+- Any callback, revenge, regret, reversal, payoff, rematch, rivalry, or "full circle" claim.
+
+Flavor claims can be looser, but they must not imply unsupported facts.
+
+## Callback Checks
+
+For every callback paragraph:
+
+- Map the older event to a saved fact ID or a verified memory receipt.
+- Map the current payoff to a current-run saved fact ID.
+- If the callback appears in `memory_callbacks`, confirm its `old_event_fact_id` and `current_event_fact_id` both exist in the brief.
+- Confirm the paragraph explains what happened then, what happened now, and why the meaning changed.
+- Treat unsourced narrative memory as research context only, not prose support.
+- Reject or soften callbacks where the older event is real but the current payoff is weak, incidental, or not proven.
+
+## Verification Flow
+
+1. Call `read_article`.
+2. Call `read_brief`.
+3. Extract each factual claim from the article section by section.
+4. Match each claim to a fact ID. Use exact numbers from `numbers` when available.
+5. Classify issues:
+   - `error`: wrong score, winner, record, player points, transaction, or other critical fact.
+   - `warning`: unsupported superlative, ambiguous rounding, or overstatement.
+   - `info`: stylistic claim that is not directly factual but may be too strong.
+6. Correct `error` issues with `rewrite_section`.
+7. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
+8. Call `read_article` again after corrections.
+9. Call `submit_article` only after the draft passes verification.
+
+## Correction Policy
+
+When rewriting a section:
+
+- Preserve the section's purpose and voice.
+- Change only the unsupported or incorrect parts unless the whole section depends on bad information.
+- Replace unsupported numbers with sourced numbers, or remove the claim.
+- Replace unsupported superlatives with grounded phrasing, such as "one of the week's strongest performances" if the brief supports it.
+- Keep bias within the allowed framing rules. Roasting is allowed only when the factual premise is true.
+
+## Final Checklist
+
+Before `submit_article`, confirm:
+
+- The article has at least one section and a clear Markdown structure.
+- All required outline facts are represented or intentionally omitted for a defensible reason.
+- All scores, records, rankings, and player points match the brief.
+- No datalayer-only facts appear in the article unless they were saved in the brief.
+- Bias changes word choice and emphasis only, never facts.
+- The article is readable and close to the target length.

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -1,0 +1,29 @@
+You are an AI fantasy football reporter for a Sleeper league.
+
+Your job is to research the league data, build a verified brief, draft a Markdown article, verify it against the brief, and call `submit_article()` when finished.
+
+Core rules:
+- Ground factual claims in tool data. Save important claims with `save_fact()` before relying on them.
+- Bias is framing only. Never alter scores, records, statistics, transaction details, or player names.
+- Keep evidence traceable through `data_refs` that identify the source tool and arguments.
+- Use persistent context only as narrative memory. It is a source of research leads, not article-ready truth.
+- Treat retrieved memories as candidate callbacks. Re-verify old-event receipts and current-week payoffs before drafting from them.
+- Dormant storylines are valuable when this week's events create a meaningful reversal, payoff, revenge angle, regret arc, or stakes change.
+- You may move backward in the workflow when needed. If drafting reveals a gap, return to research.
+
+Workflow:
+- Load procedures as needed with `load_procedure()`.
+- Use brief tools to save facts, storylines, style, bias, and outline.
+- Use article tools to write, read, rewrite, order, and submit sections.
+- Use datalayer tools for Sleeper league facts.
+- Use persistent tools, when available, to read and save cross-week narrative context.
+- Use `plan_memory_verification()` / `record_memory_verification()` when available to plan and record callback evidence checks.
+- Use `save_memory_callback()`, when available, to save verified callbacks into the brief after both old and current facts are saved.
+
+Available procedure names:
+- `research`
+- `storyline`
+- `drafting`
+- `verification`
+
+Do not end with a normal assistant message. Finish by calling `submit_article()`.

--- a/backend/services/reporter/runner/__init__.py
+++ b/backend/services/reporter/runner/__init__.py
@@ -1,0 +1,16 @@
+"""Reporter v2 runner package."""
+
+from __future__ import annotations
+
+from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.schemas import ArticleOutput
+from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+__all__ = [
+    "ArticleOutput",
+    "ProcedureHistoryMode",
+    "Runner",
+    "RunnerConfig",
+    "ToolRegistry",
+]

--- a/backend/services/reporter/runner/completion.py
+++ b/backend/services/reporter/runner/completion.py
@@ -1,0 +1,318 @@
+"""Resilient LiteLLM completion with retry and model fallback."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Exception type names from litellm / openai / httpx that are worth retrying.
+_RETRYABLE_TYPE_NAMES = frozenset(
+    {
+        "RateLimitError",
+        "ServiceUnavailableError",
+        "APIConnectionError",
+        "APITimeoutError",
+        "Timeout",
+        "InternalServerError",
+        "BadGatewayError",
+        "GatewayTimeoutError",
+    }
+)
+
+_RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+
+_RETRYABLE_MESSAGE_FRAGMENTS = (
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "overloaded",
+    "temporarily unavailable",
+    "timeout",
+    "timed out",
+    "connection reset",
+    "connection aborted",
+    "unable to get json response",
+    "expecting value",
+    "jsondecodeerror",
+    "empty response",
+    "503",
+    "502",
+    "504",
+    "429",
+)
+
+_RETRY_AFTER_RE = re.compile(
+    r"try again in\s+(\d+(?:\.\d+)?)\s*(ms|s|sec|secs|second|seconds)?",
+    re.IGNORECASE,
+)
+
+
+class CompletionFn(Protocol):
+    async def __call__(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[Any],
+        tools: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any: ...
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be at least 0")
+        if self.base_delay <= 0:
+            raise ValueError("base_delay must be greater than 0")
+        if self.max_delay <= 0:
+            raise ValueError("max_delay must be greater than 0")
+        if self.max_delay < self.base_delay:
+            raise ValueError("max_delay must be greater than or equal to base_delay")
+
+
+@dataclass(frozen=True)
+class CompletionSettings:
+    model: str | None = None
+    fallback_models: tuple[str, ...] = ()
+    retry: RetryPolicy = field(default_factory=RetryPolicy)
+
+    def model_chain(self) -> tuple[str, ...]:
+        """Deduped [model] + fallbacks, skipping empties."""
+        chain: list[str] = []
+        seen: set[str] = set()
+        for candidate in (self.model, *self.fallback_models):
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            chain.append(candidate)
+        return tuple(chain)
+
+
+class CompletionClient:
+    """Owns completion settings for one article run; call with request payload only."""
+
+    def __init__(
+        self,
+        complete: CompletionFn,
+        settings: CompletionSettings,
+    ) -> None:
+        self._complete = complete
+        self._settings = settings
+
+    @property
+    def settings(self) -> CompletionSettings:
+        return self._settings
+
+    async def complete(
+        self,
+        *,
+        messages: list[Any],
+        tools: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Retry + model fallback using owned settings; kwargs are request-only.
+
+        For each model in ``settings.model_chain()``:
+        1. Attempt the call.
+        2. On a retryable error, wait with exponential backoff and retry up to
+           ``settings.retry.max_retries`` additional times on the same model.
+        3. If that model is exhausted, move to the next fallback model.
+        4. Non-retryable errors are raised immediately.
+        """
+        models = self._settings.model_chain()
+        if not models:
+            # Preserve callers that inject fakes without configuring a model.
+            return await self._complete(
+                model=self._settings.model,
+                messages=messages,
+                tools=tools,
+                **kwargs,
+            )
+
+        retry = self._settings.retry
+        last_error: BaseException | None = None
+        for model_index, candidate in enumerate(models):
+            for attempt in range(retry.max_retries + 1):
+                try:
+                    return await self._complete(
+                        model=candidate,
+                        messages=messages,
+                        tools=tools,
+                        **kwargs,
+                    )
+                except Exception as exc:
+                    if not is_retryable_error(exc):
+                        raise
+
+                    last_error = exc
+                    is_last_attempt = attempt >= retry.max_retries
+                    is_last_model = model_index >= len(models) - 1
+
+                    if is_last_attempt and is_last_model:
+                        break
+
+                    if is_last_attempt:
+                        logger.warning(
+                            "Model %s exhausted after %d retries (%s); "
+                            "falling back to %s",
+                            candidate,
+                            retry.max_retries,
+                            exc,
+                            models[model_index + 1],
+                        )
+                        break
+
+                    delay = retry_delay_seconds(
+                        attempt,
+                        base_delay=retry.base_delay,
+                        max_delay=retry.max_delay,
+                        error=exc,
+                    )
+                    logger.warning(
+                        "Retryable error on model %s (attempt %d/%d): %s; "
+                        "retrying in %.2fs",
+                        candidate,
+                        attempt + 1,
+                        retry.max_retries + 1,
+                        exc,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+
+        assert last_error is not None
+        raise last_error
+
+
+def make_completion_client(settings: CompletionSettings) -> CompletionClient:
+    """Build a CompletionClient with the default LiteLLM transport."""
+    return CompletionClient(make_litellm_completion(), settings)
+
+
+def is_retryable_error(exc: BaseException) -> bool:
+    """Return True when the error looks transient / rate-limited."""
+    type_name = type(exc).__name__
+    if type_name in _RETRYABLE_TYPE_NAMES:
+        return True
+
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(exc, "status", None)
+    if status in _RETRYABLE_STATUS_CODES:
+        return True
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        response_status = getattr(response, "status_code", None)
+        if response_status in _RETRYABLE_STATUS_CODES:
+            return True
+
+    message = str(exc).lower()
+    return any(fragment in message for fragment in _RETRYABLE_MESSAGE_FRAGMENTS)
+
+
+def retry_delay_seconds(
+    attempt: int,
+    *,
+    base_delay: float,
+    max_delay: float,
+    error: BaseException | None = None,
+) -> float:
+    """Exponential backoff with full jitter for retry attempt N (0-indexed).
+
+    When the provider suggests a wait ("Please try again in 3.188s"), honor that
+    floor so TPM rate limits are not immediately re-hit.
+    """
+    ceiling = min(max_delay, base_delay * (2**attempt))
+    delay = random.uniform(0, ceiling)
+    suggested = suggested_retry_delay_seconds(error) if error is not None else None
+    if suggested is not None:
+        delay = max(delay, min(max_delay, suggested + random.uniform(0.05, 0.35)))
+    return delay
+
+
+def suggested_retry_delay_seconds(exc: BaseException | None) -> float | None:
+    """Parse provider-suggested retry delays from rate-limit errors."""
+    if exc is None:
+        return None
+
+    header_delay = _retry_after_header_seconds(exc)
+    if header_delay is not None:
+        return header_delay
+
+    match = _RETRY_AFTER_RE.search(str(exc))
+    if match is None:
+        return None
+    value = float(match.group(1))
+    unit = (match.group(2) or "s").lower()
+    if unit == "ms":
+        return value / 1000.0
+    return value
+
+
+def _retry_after_header_seconds(exc: BaseException) -> float | None:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("retry-after")  # type: ignore[call-arg]
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def make_litellm_completion() -> CompletionFn:
+    """Return the default LiteLLM async completion function."""
+    import litellm
+
+    async def complete(**kwargs: Any) -> Any:
+        model = kwargs.get("model")
+        if kwargs.get("tools") and _requires_none_reasoning_with_tools(model):
+            kwargs.setdefault("reasoning_effort", "none")
+        return await litellm.acompletion(**kwargs)
+
+    return complete
+
+
+def _requires_none_reasoning_with_tools(model: str | None) -> bool:
+    """Some OpenAI reasoning models reject tools unless reasoning_effort is none."""
+    if not model:
+        return False
+
+    lowered = model.lower()
+    if "luna" in lowered or "gpt-5.6" in lowered:
+        return True
+
+    try:
+        import litellm
+
+        info = litellm.model_cost.get(model) or {}
+        if not info:
+            bare = model.split("/", 1)[-1]
+            info = litellm.model_cost.get(bare) or {}
+        return bool(
+            info.get("supports_reasoning")
+            and info.get("supports_none_reasoning_effort")
+            and info.get("supports_function_calling")
+        )
+    except Exception:
+        return False

--- a/backend/services/reporter/runner/memory_lifecycle.py
+++ b/backend/services/reporter/runner/memory_lifecycle.py
@@ -1,0 +1,66 @@
+"""Pre/post memory hooks for a reporter v2 article run.
+
+Owns mark_stale before the agent loop and persist-on-submit afterward.
+Tool registration stays in the article generator; this module only handles
+run lifecycle around an existing ContextStore.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from backend.services.reporter.runner.schemas import ArticleOutput, ReportBrief
+
+if TYPE_CHECKING:
+    from reporter_memory.context_store import ContextStore
+
+
+def prepare_memory_run(
+    context_store: ContextStore | None,
+    *,
+    week: int,
+    allow_writes: bool,
+) -> None:
+    """Mark week-scoped memory stale before a writable run."""
+    if context_store is not None and allow_writes:
+        context_store.mark_stale(week)
+
+
+def persist_brief_facts(
+    context_store: ContextStore,
+    brief: ReportBrief,
+    *,
+    week: int,
+) -> None:
+    """Persist verified brief facts under their final brief storylines."""
+    for storyline in brief.storylines:
+        facts = [brief.get_fact(fact_id) for fact_id in storyline.supporting_fact_ids]
+        payload = [
+            {
+                "id": fact.id,
+                "claim_text": fact.claim_text,
+                "data_refs": fact.data_refs,
+                "numbers": fact.numbers,
+                "category": fact.category,
+            }
+            for fact in facts
+            if fact is not None
+        ]
+        if payload:
+            context_store.persist_facts(payload, storyline.id, week=week)
+
+
+def finalize_memory_run(
+    context_store: ContextStore | None,
+    output: ArticleOutput,
+    *,
+    week: int,
+    allow_writes: bool,
+) -> None:
+    """Persist brief facts after a successful submit when writes are allowed."""
+    if (
+        allow_writes
+        and context_store is not None
+        and output.run_log_summary.get("submitted") is True
+    ):
+        persist_brief_facts(context_store, output.brief, week=week)

--- a/backend/services/reporter/runner/models.py
+++ b/backend/services/reporter/runner/models.py
@@ -1,0 +1,133 @@
+"""Minimal chat-completion models for the v2 runner."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+ToolDef = dict[str, Any]
+ChatMessage = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A normalized model-requested tool call."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+def tool_result_message(call: ToolCall, result: Any) -> ChatMessage:
+    """Build an OpenAI-format tool result message."""
+    content = result if isinstance(result, str) else json.dumps(result, default=str)
+    return {
+        "role": "tool",
+        "tool_call_id": call.id,
+        "name": call.name,
+        "content": content,
+    }
+
+
+def assistant_tool_call_message(
+    calls: list[ToolCall],
+    response: Any | None = None,
+) -> ChatMessage:
+    """Build the assistant message that must precede tool result messages."""
+    source_message = _first_message(response) if response is not None else None
+    content = _read_attr(source_message, "content")
+    message: ChatMessage = {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": json.dumps(call.arguments, default=str),
+                },
+            }
+            for call in calls
+        ],
+    }
+
+    reasoning_content = _read_attr(source_message, "reasoning_content")
+    if reasoning_content is not None:
+        # DeepSeek thinking-mode responses must be passed back verbatim on
+        # subsequent turns, or the API rejects the tool result turn.
+        message["reasoning_content"] = reasoning_content
+
+    provider_specific_fields = _read_attr(source_message, "provider_specific_fields")
+    if provider_specific_fields is not None:
+        message["provider_specific_fields"] = provider_specific_fields
+
+    return message
+
+
+def extract_tool_calls(response: Any) -> list[ToolCall]:
+    """Extract normalized tool calls from a litellm/OpenAI-style response."""
+    message = _first_message(response)
+    if message is None:
+        return []
+
+    raw_calls = _read_attr(message, "tool_calls", []) or []
+    calls: list[ToolCall] = []
+    for raw_call in raw_calls:
+        function = _read_attr(raw_call, "function", {}) or {}
+        calls.append(
+            ToolCall(
+                id=str(_read_attr(raw_call, "id", "")),
+                name=str(_read_attr(function, "name", "")),
+                arguments=_parse_arguments(_read_attr(function, "arguments", {})),
+            )
+        )
+    return calls
+
+
+def extract_text(response: Any) -> str | None:
+    """Extract assistant text from a litellm/OpenAI-style response."""
+    message = _first_message(response)
+    if message is None:
+        return None
+
+    content = _read_attr(message, "content")
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            text = _read_attr(item, "text")
+            if isinstance(text, str):
+                parts.append(text)
+        return "".join(parts) or None
+    return str(content)
+
+
+def _first_message(response: Any) -> Any | None:
+    choices = _read_attr(response, "choices", []) or []
+    if not choices:
+        return None
+    return _read_attr(choices[0], "message")
+
+
+def _parse_arguments(arguments: Any) -> dict[str, Any]:
+    if arguments in (None, ""):
+        return {}
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        parsed = json.loads(arguments)
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValueError("Tool call arguments must be a JSON object.")
+
+
+def _read_attr(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)

--- a/backend/services/reporter/runner/run_log.py
+++ b/backend/services/reporter/runner/run_log.py
@@ -1,0 +1,224 @@
+"""Run log for tracking all events during a runner session."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, TextIO
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, PrivateAttr
+
+
+class ProcedureSwitch(BaseModel):
+    from_procedure: str | None
+    to_procedure: str
+    turn: int
+
+
+class RunLogEntry(BaseModel):
+    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
+    turn: int = 0
+    event_type: str
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunLog(BaseModel):
+    session_id: str = Field(default_factory=lambda: str(uuid4())[:8])
+    started_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    entries: list[RunLogEntry] = Field(default_factory=list)
+
+    _stream_file: TextIO | None = PrivateAttr(default=None)
+    _start_time: datetime = PrivateAttr(default_factory=datetime.now)
+
+    def _add(self, entry: RunLogEntry) -> None:
+        self.entries.append(entry)
+        self._stream_entry(entry)
+
+    def add_tool_call(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+        result_summary: str,
+        duration_ms: int,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="tool_call",
+                data={
+                    "tool_name": tool_name,
+                    "params": params,
+                    "result_summary": result_summary,
+                    "duration_ms": duration_ms,
+                },
+            )
+        )
+
+    def add_procedure_switch(
+        self,
+        from_proc: str | None,
+        to_proc: str,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="procedure_switch",
+                data={"from_procedure": from_proc, "to_procedure": to_proc},
+            )
+        )
+
+    def add_artifact_write(
+        self,
+        artifact: str,
+        operation: str,
+        key: str,
+        revision: int | None = None,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="artifact_write",
+                data={
+                    "artifact": artifact,
+                    "operation": operation,
+                    "key": key,
+                    "brief_revision": revision,
+                },
+            )
+        )
+
+    def add_model_text(self, text_preview: str, *, turn: int) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="model_text",
+                data={"text_preview": text_preview[:200]},
+            )
+        )
+
+    def add_guardrail(
+        self,
+        guardrail_type: str,
+        current: int,
+        limit: int,
+        *,
+        turn: int,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="guardrail",
+                data={
+                    "guardrail_type": guardrail_type,
+                    "current_count": current,
+                    "limit": limit,
+                },
+            )
+        )
+
+    def add_completion(self, stats: dict[str, Any], *, turn: int) -> None:
+        self._add(RunLogEntry(turn=turn, event_type="completion", data=stats))
+
+    @property
+    def tool_call_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.event_type == "tool_call")
+
+    @property
+    def procedure_history(self) -> list[ProcedureSwitch]:
+        switches: list[ProcedureSwitch] = []
+        for entry in self.entries:
+            if entry.event_type == "procedure_switch":
+                switches.append(
+                    ProcedureSwitch(
+                        from_procedure=entry.data.get("from_procedure"),
+                        to_procedure=entry.data["to_procedure"],
+                        turn=entry.turn,
+                    )
+                )
+        return switches
+
+    def start_streaming(self, path: Path) -> None:
+        self._stream_file = open(path, "w", encoding="utf-8")
+        self._stream_file.write(f"# Run Log: {self.session_id}\n")
+        self._stream_file.write(f"Started: {self.started_at}\n\n")
+        self._stream_file.flush()
+
+    def stop_streaming(self) -> None:
+        if self._stream_file is None:
+            return
+
+        self._stream_file.write(f"\nCompleted: {datetime.now().isoformat()}\n")
+        self._stream_file.write(f"Total tool calls: {self.tool_call_count}\n")
+        self._stream_file.close()
+        self._stream_file = None
+
+    def _stream_entry(self, entry: RunLogEntry) -> None:
+        if self._stream_file is None:
+            return
+
+        elapsed = self._format_elapsed(entry)
+        line = self._format_entry(entry, elapsed)
+        self._stream_file.write(line + "\n")
+        self._stream_file.flush()
+
+    def _format_elapsed(self, entry: RunLogEntry) -> str:
+        delta = datetime.fromisoformat(entry.timestamp) - self._start_time
+        minutes, seconds = divmod(int(delta.total_seconds()), 60)
+        return f"[{minutes:02d}:{seconds:02d}]"
+
+    def _format_entry(self, entry: RunLogEntry, elapsed: str) -> str:
+        data = entry.data
+        if entry.event_type == "procedure_switch":
+            previous = (
+                f" (was: {data['from_procedure']})"
+                if data.get("from_procedure")
+                else ""
+            )
+            return f"{elapsed} Loaded procedure: {data['to_procedure']}{previous}"
+        if entry.event_type == "tool_call":
+            duration_ms = data.get("duration_ms", 0)
+            params = self._format_params(data.get("params", {}))
+            return (
+                f"{elapsed} {data['tool_name']}({params}) -> "
+                f"{data['result_summary']} [{duration_ms}ms]"
+            )
+        if entry.event_type == "artifact_write":
+            revision = (
+                f" -> brief rev {data['brief_revision']}"
+                if data.get("brief_revision")
+                else ""
+            )
+            return f"{elapsed} {data['operation']}({data['key']}){revision}"
+        if entry.event_type == "model_text":
+            return f"{elapsed} Model: {data['text_preview'][:80]}"
+        if entry.event_type == "guardrail":
+            return (
+                f"{elapsed} GUARDRAIL: {data['guardrail_type']} "
+                f"({data['current_count']}/{data['limit']})"
+            )
+        if entry.event_type == "completion":
+            return f"{elapsed} COMPLETE: {json.dumps(data)}"
+        return f"{elapsed} {entry.event_type}: {data}"
+
+    @staticmethod
+    def _format_params(params: Any, *, max_chars: int = 300) -> str:
+        if not params:
+            return ""
+
+        formatted = json.dumps(
+            params,
+            sort_keys=True,
+            ensure_ascii=False,
+            default=str,
+        )
+        if len(formatted) <= max_chars:
+            return formatted
+        return formatted[: max_chars - 3] + "..."

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -1,0 +1,236 @@
+"""Core v2 runner loop.
+
+The Runner is the agent engine: it owns the message loop, tool execution,
+procedure-message compaction, and ArticleOutput assembly. It does not know
+about Sleeper, ReportConfig, memory, or which tools are registered — callers
+(typically generate_article) wire those in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from backend.services.reporter.runner.completion import CompletionClient, CompletionFn, CompletionSettings
+from backend.services.reporter.runner.models import (
+    ChatMessage,
+    ToolCall,
+    assistant_tool_call_message,
+    extract_text,
+    extract_tool_calls,
+    tool_result_message,
+)
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.schemas import ArticleOutput
+from backend.services.reporter.runner.state import (
+    ArtifactStore,
+    ProcedureHistoryMode,
+    ProcedureState,
+    RunnerConfig,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+__all__ = ["CompletionFn", "Runner"]
+
+
+class Runner:
+    """Single-loop runner that drives research, drafting, and verification."""
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        client: CompletionClient | None = None,
+        complete: CompletionFn | None = None,
+        config: RunnerConfig | None = None,
+        log_path: Path | None = None,
+        artifacts: ArtifactStore | None = None,
+    ) -> None:
+        if client is not None and complete is not None:
+            raise ValueError("Pass client= or complete=, not both.")
+        if client is not None:
+            self._client = client
+        elif complete is not None:
+            # Test convenience: wrap a raw completion fn without litellm.
+            self._client = CompletionClient(complete, CompletionSettings())
+        else:
+            raise TypeError("Runner requires client= (or complete= for tests).")
+
+        self.registry = registry
+        self.config = config or RunnerConfig()
+        self.artifacts = artifacts or ArtifactStore()
+        self.procedures = ProcedureState()
+        self.log = RunLog()
+        self.tool_context = ToolContext(
+            artifacts=self.artifacts,
+            procedures=self.procedures,
+            log=self.log,
+        )
+        self.registry.set_context(self.tool_context)
+        self._procedure_message_idx: int | None = None
+        self._submitted = False
+
+        if log_path is not None:
+            self.log.start_streaming(log_path)
+
+    @property
+    def client(self) -> CompletionClient:
+        return self._client
+
+    async def run(self, system_prompt: str, user_message: str) -> ArticleOutput:
+        messages: list[ChatMessage] = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        turn = 0
+
+        try:
+            while turn < self.config.max_turns and not self._submitted:
+                turn += 1
+                response = await self._client.complete(
+                    messages=list(messages),
+                    tools=self.registry.tool_specs,
+                )
+
+                calls = extract_tool_calls(response)
+                if calls:
+                    self.registry.set_turn(turn)
+                    messages.append(assistant_tool_call_message(calls, response))
+                    results = await self._execute_tool_batch(calls, turn)
+                    for call, result_content in zip(calls, results):
+                        if call.name == "load_procedure":
+                            self._append_procedure_message(messages, call, result_content)
+                        else:
+                            messages.append(tool_result_message(call, result_content))
+
+                    continue
+
+                text = extract_text(response)
+                if text:
+                    self.log.add_model_text(text, turn=turn)
+                    messages.append({"role": "assistant", "content": text})
+                    break
+
+                break
+
+            self.log.add_completion(
+                {
+                    "total_turns": turn,
+                    "total_tool_calls": self.log.tool_call_count,
+                    "submitted": self._submitted,
+                },
+                turn=turn,
+            )
+            return ArticleOutput(
+                article=self.artifacts.article.to_markdown(),
+                brief=self.artifacts.brief,
+                run_log_summary={
+                    "session_id": self.log.session_id,
+                    "total_tool_calls": self.log.tool_call_count,
+                    "total_turns": turn,
+                    "procedures_loaded": [
+                        procedure.to_procedure
+                        for procedure in self.log.procedure_history
+                    ],
+                    "submitted": self._submitted,
+                },
+                run_log_entries=[
+                    entry.model_dump(mode="json") for entry in self.log.entries
+                ],
+            )
+        finally:
+            self.log.stop_streaming()
+
+    async def _execute_tool_batch(
+        self,
+        calls: list[ToolCall],
+        turn: int,
+    ) -> list[str]:
+        executed = await asyncio.gather(
+            *[self._execute_tool(call, turn) for call in calls]
+        )
+        return list(executed)
+
+    async def _execute_tool(self, call: ToolCall, turn: int) -> str:
+        handler = self.registry.get_handler(call.name)
+        if handler is None:
+            result: Any = {"error": f"Unknown tool: {call.name}"}
+            result_content = self._as_tool_result_content(result)
+            self.log.add_tool_call(call.name, call.arguments, result_content, 0, turn=turn)
+            return result_content
+
+        start = time.time()
+        try:
+            result = handler(**call.arguments)
+            if asyncio.iscoroutine(result):
+                result = await result
+        except Exception as exc:
+            result = {"error": str(exc)}
+
+        duration_ms = int((time.time() - start) * 1000)
+        result_content = self._as_tool_result_content(result)
+        self.log.add_tool_call(
+            call.name,
+            call.arguments,
+            self._summarize_result(result_content),
+            duration_ms,
+            turn=turn,
+        )
+
+        if call.name == "submit_article" and self._is_successful_submit(result_content):
+            self._submitted = True
+
+        return result_content
+
+    def _append_procedure_message(
+        self,
+        messages: list[ChatMessage],
+        call: ToolCall,
+        content: str,
+    ) -> None:
+        """Append procedure output, compacting prior output when configured."""
+        if (
+            self.config.procedure_history_mode == ProcedureHistoryMode.REPLACE
+            and self._procedure_message_idx is not None
+        ):
+            messages[self._procedure_message_idx]["content"] = "[procedure replaced]"
+
+        messages.append(tool_result_message(call, content))
+        if self.config.procedure_history_mode == ProcedureHistoryMode.REPLACE:
+            self._procedure_message_idx = len(messages) - 1
+
+    @staticmethod
+    def _as_tool_result_content(result: Any) -> str:
+        if isinstance(result, str):
+            return result
+        return json.dumps(result, default=str)
+
+    @staticmethod
+    def _is_successful_submit(result: str) -> bool:
+        try:
+            data = json.loads(result)
+        except json.JSONDecodeError:
+            return False
+        return isinstance(data, dict) and data.get("ok") is True
+
+    @staticmethod
+    def _summarize_result(result: str) -> str:
+        if len(result) <= 100:
+            return result
+
+        try:
+            data = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return result[:80] + "..."
+
+        if isinstance(data, dict):
+            if "error" in data:
+                return f"error: {str(data['error'])[:80]}"
+            return f"dict with {len(data)} keys"
+        if isinstance(data, list):
+            return f"{len(data)} items"
+        return result[:80] + "..."

--- a/backend/services/reporter/runner/schemas.py
+++ b/backend/services/reporter/runner/schemas.py
@@ -1,0 +1,156 @@
+"""V2 report brief, article, and supporting schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class BriefMeta(BaseModel):
+    league_name: str = ""
+    league_id: str = ""
+    week_start: int = 0
+    week_end: int = 0
+    article_type: str = "custom"
+
+
+class Fact(BaseModel):
+    id: str
+    claim_text: str
+    data_refs: list[str] = Field(default_factory=list)
+    numbers: dict[str, Any] = Field(default_factory=dict)
+    category: str = "general"
+
+
+class Storyline(BaseModel):
+    id: str
+    headline: str
+    summary: str
+    supporting_fact_ids: list[str] = Field(default_factory=list)
+    priority: int = Field(default=2, ge=1, le=5)
+    tags: list[str] = Field(default_factory=list)
+    revision_at_set: int = 0
+
+
+class Section(BaseModel):
+    title: str
+    bullet_points: list[str] = Field(default_factory=list)
+    required_fact_ids: list[str] = Field(default_factory=list)
+    storyline_ids: list[str] = Field(default_factory=list)
+
+
+class Outline(BaseModel):
+    sections: list[Section] = Field(default_factory=list)
+    revision_at_set: int = 0
+
+
+class ResolvedStyle(BaseModel):
+    voice: str = "sports columnist"
+    pacing: str = "moderate"
+    humor_level: int = Field(default=1, ge=0, le=3)
+    formality: str = "casual"
+
+
+class ResolvedBias(BaseModel):
+    favored_teams: list[str] = Field(default_factory=list)
+    disfavored_teams: list[str] = Field(default_factory=list)
+    intensity: int = Field(default=0, ge=0, le=3)
+    framing_rules: list[str] = Field(default_factory=list)
+
+
+class MemoryCallback(BaseModel):
+    id: str
+    callback_type: str
+    claim_text: str
+    old_event_fact_id: str
+    current_event_fact_id: str
+    why_now: str
+    interestingness_reason: str = ""
+    memory_refs: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+
+
+class ReportBrief(BaseModel):
+    revision: int = 0
+    meta: BriefMeta = Field(default_factory=BriefMeta)
+    facts: list[Fact] = Field(default_factory=list)
+    memory_callbacks: list[MemoryCallback] = Field(default_factory=list)
+    storylines: list[Storyline] = Field(default_factory=list)
+    outline: Outline = Field(default_factory=Outline)
+    style: ResolvedStyle = Field(default_factory=ResolvedStyle)
+    bias: ResolvedBias = Field(default_factory=ResolvedBias)
+
+    def get_fact(self, fact_id: str) -> Fact | None:
+        for fact in self.facts:
+            if fact.id == fact_id:
+                return fact
+        return None
+
+    def get_memory_callback(self, callback_id: str) -> MemoryCallback | None:
+        for callback in self.memory_callbacks:
+            if callback.id == callback_id:
+                return callback
+        return None
+
+    def bump_revision(self) -> int:
+        self.revision += 1
+        return self.revision
+
+    def staleness_info(self) -> dict[str, Any]:
+        """Return staleness flags for outline and storylines."""
+        info: dict[str, Any] = {}
+        if self.outline.sections and self.outline.revision_at_set < self.revision:
+            gap = self.revision - self.outline.revision_at_set
+            info["outline_stale"] = True
+            info["outline_gap"] = f"{gap} mutation(s) since outline was set"
+
+        stale_storylines = []
+        for storyline in self.storylines:
+            if storyline.revision_at_set < self.revision:
+                stale_storylines.append(storyline.id)
+        if stale_storylines:
+            info["stale_storyline_ids"] = stale_storylines
+        return info
+
+
+class ArticleSection(BaseModel):
+    name: str
+    content: str
+
+
+class Article(BaseModel):
+    sections: list[ArticleSection] = Field(default_factory=list)
+    section_order: list[str] = Field(default_factory=list)
+
+    def get_section(self, name: str) -> ArticleSection | None:
+        for section in self.sections:
+            if section.name == name:
+                return section
+        return None
+
+    def set_section(self, name: str, content: str) -> None:
+        existing = self.get_section(name)
+        if existing:
+            existing.content = content
+        else:
+            self.sections.append(ArticleSection(name=name, content=content))
+            self.section_order.append(name)
+
+    def to_markdown(self) -> str:
+        ordered = self.section_order or [section.name for section in self.sections]
+        parts = []
+        for name in ordered:
+            section = self.get_section(name)
+            if section:
+                parts.append(section.content)
+        return "\n\n".join(parts)
+
+
+class ArticleOutput(BaseModel):
+    article: str
+    brief: ReportBrief
+    run_log_summary: dict[str, Any] = Field(default_factory=dict)
+    run_log_entries: list[dict[str, Any]] = Field(default_factory=list)
+    generated_at: str = Field(default_factory=lambda: datetime.now().isoformat())

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -1,0 +1,28 @@
+"""Runner state containers."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from backend.services.reporter.runner.schemas import Article, ReportBrief
+
+
+class ProcedureHistoryMode(str, Enum):
+    REPLACE = "replace"
+    APPEND = "append"
+
+
+class ArtifactStore(BaseModel):
+    brief: ReportBrief = Field(default_factory=ReportBrief)
+    article: Article = Field(default_factory=Article)
+
+
+class ProcedureState(BaseModel):
+    active: str | None = None
+
+
+class RunnerConfig(BaseModel):
+    max_turns: int = 60
+    procedure_history_mode: ProcedureHistoryMode = ProcedureHistoryMode.REPLACE

--- a/backend/services/reporter/runner/tools/__init__.py
+++ b/backend/services/reporter/runner/tools/__init__.py
@@ -1,0 +1,73 @@
+"""Runner v2 tool implementations."""
+
+from backend.services.reporter.runner.tools.article_tools import (
+    ARTICLE_TOOL_SPECS,
+    read_article,
+    read_section,
+    register_article_tools,
+    rewrite_section,
+    set_section_order,
+    submit_article,
+    write_section,
+)
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS,
+    read_brief,
+    register_brief_tools,
+    save_fact,
+    save_memory_callback,
+    save_storyline,
+    set_bias,
+    set_outline,
+    set_style,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.datalayer_tools import (
+    DATALAYER_TOOL_SPECS,
+    register_datalayer_tools,
+)
+from backend.services.reporter.runner.tools.memory_tools import (
+    MEMORY_TOOL_SPECS,
+    register_memory_tools,
+)
+from backend.services.reporter.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS,
+    register_persistent_tools,
+)
+from backend.services.reporter.runner.tools.procedure_tools import (
+    PROCEDURE_TOOL_SPECS,
+    load_procedure,
+    register_procedure_tools,
+)
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+__all__ = [
+    "ARTICLE_TOOL_SPECS",
+    "BRIEF_TOOL_SPECS",
+    "DATALAYER_TOOL_SPECS",
+    "MEMORY_TOOL_SPECS",
+    "PERSISTENT_TOOL_SPECS",
+    "PROCEDURE_TOOL_SPECS",
+    "ToolContext",
+    "ToolRegistry",
+    "load_procedure",
+    "read_article",
+    "read_brief",
+    "read_section",
+    "register_article_tools",
+    "register_brief_tools",
+    "rewrite_section",
+    "register_datalayer_tools",
+    "register_memory_tools",
+    "register_persistent_tools",
+    "register_procedure_tools",
+    "save_fact",
+    "save_memory_callback",
+    "save_storyline",
+    "set_section_order",
+    "set_bias",
+    "set_outline",
+    "set_style",
+    "submit_article",
+    "write_section",
+]

--- a/backend/services/reporter/runner/tools/article_tools.py
+++ b/backend/services/reporter/runner/tools/article_tools.py
@@ -1,0 +1,269 @@
+"""Article artifact tools for reporter v2."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.schemas import ArticleSection
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+ARTICLE_TOOL_SPECS: list[ToolDef] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write_section",
+            "description": "Create or overwrite a named article section.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Stable section name, such as opening or playoff_race.",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Markdown content for the section.",
+                    },
+                },
+                "required": ["name", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_article",
+            "description": "Read all article sections in display order.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_section",
+            "description": "Read one named article section.",
+            "parameters": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "rewrite_section",
+            "description": "Replace an existing named article section.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+                "required": ["name", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_section_order",
+            "description": "Set the display order of all existing article sections.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "All existing section names in desired display order.",
+                    },
+                },
+                "required": ["names"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_article",
+            "description": (
+                "Signal that the article is complete. Call this exactly once after "
+                "drafting and verification are done."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+def register_article_tools(registry: ToolRegistry) -> None:
+    """Register all article artifact tools against a ToolRegistry."""
+    handlers = {
+        "write_section": write_section,
+        "read_article": read_article,
+        "read_section": read_section,
+        "rewrite_section": rewrite_section,
+        "set_section_order": set_section_order,
+        "submit_article": submit_article,
+    }
+    for spec in ARTICLE_TOOL_SPECS:
+        name = spec["function"]["name"]
+        registry.register_context_tool(name, handlers[name], spec)
+
+
+def write_section(ctx: ToolContext, *, name: str, content: str) -> str:
+    """Create or overwrite a named article section."""
+    ctx.artifacts.article.set_section(name, content)
+    ctx.log.add_artifact_write(
+        "article",
+        "write_section",
+        name,
+        turn=ctx.turn,
+    )
+    return _json(
+        {
+            "ok": True,
+            "section_count": len(ctx.artifacts.article.sections),
+            "section_order": ctx.artifacts.article.section_order,
+        }
+    )
+
+
+def read_article(ctx: ToolContext) -> str:
+    """Return all article sections in display order."""
+    sections = _ordered_sections(
+        ctx.artifacts.article.sections,
+        ctx.artifacts.article.section_order,
+    )
+    markdown = ctx.artifacts.article.to_markdown()
+    return _json(
+        {
+            "ok": True,
+            "sections": [_section_payload(section) for section in sections],
+            "section_count": len(ctx.artifacts.article.sections),
+            "total_word_count": _word_count(markdown),
+        }
+    )
+
+
+def read_section(ctx: ToolContext, *, name: str) -> str:
+    """Return a single article section by name."""
+    section = ctx.artifacts.article.get_section(name)
+    if section is None:
+        return _error(f"Section not found: {name}", name=name)
+
+    return _json({"ok": True, "section": _section_payload(section)})
+
+
+def rewrite_section(ctx: ToolContext, *, name: str, content: str) -> str:
+    """Replace an existing section."""
+    section = ctx.artifacts.article.get_section(name)
+    if section is None:
+        return _error(f"Section not found: {name}", name=name)
+
+    section.content = content
+    ctx.log.add_artifact_write(
+        "article",
+        "rewrite_section",
+        name,
+        turn=ctx.turn,
+    )
+    return _json(
+        {
+            "ok": True,
+            "section": _section_payload(section),
+            "section_count": len(ctx.artifacts.article.sections),
+        }
+    )
+
+
+def set_section_order(ctx: ToolContext, *, names: list[str]) -> str:
+    """Set the display order of article sections."""
+    existing_names = [section.name for section in ctx.artifacts.article.sections]
+    unknown_names = [name for name in names if name not in existing_names]
+    missing_names = [name for name in existing_names if name not in names]
+    duplicate_names = _duplicate_names(names)
+
+    if unknown_names or missing_names or duplicate_names:
+        return _json(
+            {
+                "ok": False,
+                "error": "Section order must include each existing section exactly once.",
+                "unknown_names": unknown_names,
+                "missing_names": missing_names,
+                "duplicate_names": duplicate_names,
+            }
+        )
+
+    ctx.artifacts.article.section_order = list(names)
+    ctx.log.add_artifact_write(
+        "article",
+        "set_section_order",
+        "section_order",
+        turn=ctx.turn,
+    )
+    return _json({"ok": True, "section_order": ctx.artifacts.article.section_order})
+
+
+def submit_article(ctx: ToolContext) -> str:
+    """Signal article completion and return the final article."""
+    article = ctx.artifacts.article
+    if not article.sections:
+        return _error("Cannot submit an empty article.")
+
+    markdown = article.to_markdown()
+    stats = {
+        "section_count": len(article.sections),
+        "total_word_count": _word_count(markdown),
+        "total_char_count": len(markdown),
+    }
+    ctx.log.add_completion(stats, turn=ctx.turn)
+    return _json({"ok": True, "article": markdown, "stats": stats})
+
+
+def _ordered_sections(
+    sections: list[ArticleSection],
+    section_order: list[str],
+) -> list[ArticleSection]:
+    if not section_order:
+        return sections
+
+    by_name = {section.name: section for section in sections}
+    ordered = [by_name[name] for name in section_order if name in by_name]
+    unordered = [section for section in sections if section.name not in section_order]
+    return ordered + unordered
+
+
+def _section_payload(section: ArticleSection) -> dict[str, Any]:
+    return {
+        "name": section.name,
+        "content": section.content,
+        "word_count": _word_count(section.content),
+    }
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"[A-Za-z0-9]+(?:[.'-][A-Za-z0-9]+)*", text))
+
+
+def _duplicate_names(names: list[str]) -> list[str]:
+    seen = set()
+    duplicates = []
+    for name in names:
+        if name in seen and name not in duplicates:
+            duplicates.append(name)
+        seen.add(name)
+    return duplicates
+
+
+def _error(message: str, **extra: Any) -> str:
+    return _json({"ok": False, "error": message, **extra})
+
+
+def _json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload)

--- a/backend/services/reporter/runner/tools/brief_tools.py
+++ b/backend/services/reporter/runner/tools/brief_tools.py
@@ -1,0 +1,522 @@
+"""Brief artifact tools for runner v2."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import ValidationError
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.schemas import (
+    Fact,
+    MemoryCallback,
+    Outline,
+    ResolvedBias,
+    ResolvedStyle,
+    Storyline,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+BRIEF_TOOL_SPECS: list[ToolDef] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_fact",
+            "description": (
+                "Add or update a verified fact in the report brief. Every numeric "
+                "or factual claim used in the article should be grounded in saved "
+                "facts with data references."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Stable fact ID, such as fact_001.",
+                    },
+                    "claim_text": {
+                        "type": "string",
+                        "description": "Human-readable factual claim.",
+                    },
+                    "data_refs": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Tool/data references that sourced the claim, such as "
+                            "league_snapshot:week=8."
+                        ),
+                    },
+                    "numbers": {
+                        "type": "object",
+                        "description": "Important numeric values extracted from the claim.",
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "Fact category such as score, standing, player, transaction.",
+                    },
+                },
+                "required": ["id", "claim_text", "data_refs"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memory_callback",
+            "description": (
+                "Add or update a verified memory callback in the report brief. "
+                "Use this only after the old event and current payoff have both "
+                "been saved as facts."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Stable callback ID, such as callback_trade_regret.",
+                    },
+                    "callback_type": {
+                        "type": "string",
+                        "description": (
+                            "Callback type such as trade_regret, revenge_game, "
+                            "waiver_hero, or close_game_callback."
+                        ),
+                    },
+                    "claim_text": {
+                        "type": "string",
+                        "description": (
+                            "Verified callback claim that links the old event to "
+                            "the current payoff."
+                        ),
+                    },
+                    "old_event_fact_id": {
+                        "type": "string",
+                        "description": "Saved fact ID proving the older receipt.",
+                    },
+                    "current_event_fact_id": {
+                        "type": "string",
+                        "description": "Saved fact ID proving the current payoff.",
+                    },
+                    "why_now": {
+                        "type": "string",
+                        "description": (
+                            "Why the current week changes the meaning of the old event."
+                        ),
+                    },
+                    "interestingness_reason": {
+                        "type": "string",
+                        "description": (
+                            "Why this callback is worth drafting: stakes, reversal, "
+                            "comedy value, specificity, or article fit."
+                        ),
+                    },
+                    "memory_refs": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Optional persistent memory IDs or labels that led to "
+                            "the callback investigation."
+                        ),
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "id",
+                    "callback_type",
+                    "claim_text",
+                    "old_event_fact_id",
+                    "current_event_fact_id",
+                    "why_now",
+                ],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_storyline",
+            "description": (
+                "Add or update a narrative storyline in the brief, backed by saved "
+                "fact IDs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Stable storyline ID, such as story_001.",
+                    },
+                    "headline": {"type": "string"},
+                    "summary": {
+                        "type": "string",
+                        "description": "Short narrative summary grounded in facts.",
+                    },
+                    "supporting_fact_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "priority": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "1 is lead-story priority; 5 is minor.",
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["id", "headline", "summary", "supporting_fact_ids"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_outline",
+            "description": "Replace the planned article outline in the brief.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "bullet_points": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "required_fact_ids": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "storyline_ids": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                            "required": ["title"],
+                        },
+                    },
+                },
+                "required": ["sections"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_brief",
+            "description": "Read the current report brief and staleness metadata.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_style",
+            "description": "Set the resolved article voice and style controls.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "voice": {"type": "string"},
+                    "pacing": {"type": "string"},
+                    "humor_level": {"type": "integer", "minimum": 0, "maximum": 3},
+                    "formality": {"type": "string"},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_bias",
+            "description": (
+                "Set bias framing rules. Bias affects word choice and emphasis only, "
+                "never scores, records, statistics, or other facts."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "favored_teams": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "disfavored_teams": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "intensity": {"type": "integer", "minimum": 0, "maximum": 3},
+                    "framing_rules": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+            },
+        },
+    },
+]
+
+
+def register_brief_tools(registry: ToolRegistry) -> None:
+    """Register all brief artifact tools against a ToolRegistry."""
+    handlers = {
+        "save_fact": save_fact,
+        "save_memory_callback": save_memory_callback,
+        "save_storyline": save_storyline,
+        "set_outline": set_outline,
+        "read_brief": read_brief,
+        "set_style": set_style,
+        "set_bias": set_bias,
+    }
+    for spec in BRIEF_TOOL_SPECS:
+        name = spec["function"]["name"]
+        registry.register_context_tool(name, handlers[name], spec)
+
+
+def save_fact(
+    ctx: ToolContext,
+    *,
+    id: str,
+    claim_text: str,
+    data_refs: list[str],
+    numbers: dict[str, Any] | None = None,
+    category: str = "general",
+) -> str:
+    """Add or update a verified fact in the brief."""
+    if not claim_text.strip():
+        return _error("claim_text must be non-empty")
+    if not data_refs:
+        return _error("data_refs must contain at least one reference")
+
+    fact = Fact(
+        id=id,
+        claim_text=claim_text,
+        data_refs=data_refs,
+        numbers=numbers or {},
+        category=category,
+    )
+    brief = ctx.artifacts.brief
+    operation = "update_fact" if brief.get_fact(id) is not None else "save_fact"
+    _upsert_by_id(brief.facts, fact)
+    revision = brief.bump_revision()
+    ctx.log.add_artifact_write("brief", operation, id, revision, turn=ctx.turn)
+    return _success({"fact_id": id, "brief_revision": revision})
+
+
+def save_memory_callback(
+    ctx: ToolContext,
+    *,
+    id: str,
+    callback_type: str,
+    claim_text: str,
+    old_event_fact_id: str,
+    current_event_fact_id: str,
+    why_now: str,
+    interestingness_reason: str = "",
+    memory_refs: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> str:
+    """Add or update a verified memory callback in the brief."""
+    for field_name, value in {
+        "callback_type": callback_type,
+        "claim_text": claim_text,
+        "old_event_fact_id": old_event_fact_id,
+        "current_event_fact_id": current_event_fact_id,
+        "why_now": why_now,
+    }.items():
+        if not value.strip():
+            return _error(f"{field_name} must be non-empty")
+
+    brief = ctx.artifacts.brief
+    missing_fact_ids = [
+        fact_id
+        for fact_id in [old_event_fact_id, current_event_fact_id]
+        if brief.get_fact(fact_id) is None
+    ]
+    if missing_fact_ids:
+        return _error(
+            "memory callbacks require verified fact ids",
+            {"missing_fact_ids": missing_fact_ids},
+        )
+
+    callback = MemoryCallback(
+        id=id,
+        callback_type=callback_type,
+        claim_text=claim_text,
+        old_event_fact_id=old_event_fact_id,
+        current_event_fact_id=current_event_fact_id,
+        why_now=why_now,
+        interestingness_reason=interestingness_reason,
+        memory_refs=memory_refs or [],
+        tags=tags or [],
+    )
+    operation = (
+        "update_memory_callback"
+        if brief.get_memory_callback(id) is not None
+        else "save_memory_callback"
+    )
+    _upsert_by_id(brief.memory_callbacks, callback)
+    revision = brief.bump_revision()
+    ctx.log.add_artifact_write("brief", operation, id, revision, turn=ctx.turn)
+    return _success({"callback_id": id, "brief_revision": revision})
+
+
+def save_storyline(
+    ctx: ToolContext,
+    *,
+    id: str,
+    headline: str,
+    summary: str,
+    supporting_fact_ids: list[str],
+    priority: int = 2,
+    tags: list[str] | None = None,
+) -> str:
+    """Add or update a storyline in the brief."""
+    brief = ctx.artifacts.brief
+    fact_ids = {fact.id for fact in brief.facts}
+    missing_fact_ids = [
+        fact_id for fact_id in supporting_fact_ids if fact_id not in fact_ids
+    ]
+    if missing_fact_ids:
+        return _error(
+            "supporting_fact_ids contains unknown fact ids",
+            {"missing_fact_ids": missing_fact_ids},
+        )
+
+    revision = brief.bump_revision()
+    try:
+        storyline = Storyline(
+            id=id,
+            headline=headline,
+            summary=summary,
+            supporting_fact_ids=supporting_fact_ids,
+            priority=priority,
+            tags=tags or [],
+            revision_at_set=revision,
+        )
+    except ValidationError as exc:
+        brief.revision -= 1
+        return _error("invalid storyline", {"details": _validation_details(exc)})
+
+    operation = (
+        "update_storyline"
+        if any(existing.id == id for existing in brief.storylines)
+        else "save_storyline"
+    )
+    _upsert_by_id(brief.storylines, storyline)
+    ctx.log.add_artifact_write("brief", operation, id, revision, turn=ctx.turn)
+    return _success({"storyline_id": id, "brief_revision": revision})
+
+
+def set_outline(ctx: ToolContext, *, sections: list[dict[str, Any]]) -> str:
+    """Replace the article outline."""
+    brief = ctx.artifacts.brief
+    revision = brief.bump_revision()
+    try:
+        brief.outline = Outline(sections=sections, revision_at_set=revision)
+    except ValidationError as exc:
+        brief.revision -= 1
+        return _error("invalid outline", {"details": _validation_details(exc)})
+
+    ctx.log.add_artifact_write(
+        "brief", "set_outline", "outline", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def set_style(
+    ctx: ToolContext,
+    *,
+    voice: str = "sports columnist",
+    pacing: str = "moderate",
+    humor_level: int = 1,
+    formality: str = "casual",
+) -> str:
+    """Set resolved article style."""
+    try:
+        style = ResolvedStyle(
+            voice=voice,
+            pacing=pacing,
+            humor_level=humor_level,
+            formality=formality,
+        )
+    except ValidationError as exc:
+        return _error("invalid style", {"details": _validation_details(exc)})
+
+    ctx.artifacts.brief.style = style
+    revision = ctx.artifacts.brief.bump_revision()
+    ctx.log.add_artifact_write(
+        "brief", "set_style", "style", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def set_bias(
+    ctx: ToolContext,
+    *,
+    favored_teams: list[str] | None = None,
+    disfavored_teams: list[str] | None = None,
+    intensity: int = 0,
+    framing_rules: list[str] | None = None,
+) -> str:
+    """Set resolved article bias."""
+    try:
+        bias = ResolvedBias(
+            favored_teams=favored_teams or [],
+            disfavored_teams=disfavored_teams or [],
+            intensity=intensity,
+            framing_rules=framing_rules or [],
+        )
+    except ValidationError as exc:
+        return _error("invalid bias", {"details": _validation_details(exc)})
+
+    ctx.artifacts.brief.bias = bias
+    revision = ctx.artifacts.brief.bump_revision()
+    ctx.log.add_artifact_write(
+        "brief", "set_bias", "bias", revision, turn=ctx.turn
+    )
+    return _success({"brief_revision": revision})
+
+
+def read_brief(ctx: ToolContext) -> str:
+    """Return the current brief and staleness metadata."""
+    brief_dict = ctx.artifacts.brief.model_dump()
+    brief_dict["staleness_info"] = ctx.artifacts.brief.staleness_info()
+    return _json(brief_dict)
+
+
+def _upsert_by_id(items: list[Any], item: Any) -> None:
+    for index, existing in enumerate(items):
+        if existing.id == item.id:
+            items[index] = item
+            return
+    items.append(item)
+
+
+def _success(data: dict[str, Any]) -> str:
+    return _json({"ok": True, **data})
+
+
+def _error(message: str, extra: dict[str, Any] | None = None) -> str:
+    payload = {"ok": False, "error": message}
+    if extra:
+        payload.update(extra)
+    return _json(payload)
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True)
+
+
+def _validation_details(exc: ValidationError) -> list[dict[str, Any]]:
+    return [
+        {
+            "loc": list(error["loc"]),
+            "msg": error["msg"],
+            "type": error["type"],
+        }
+        for error in exc.errors()
+    ]

--- a/backend/services/reporter/runner/tools/context.py
+++ b/backend/services/reporter/runner/tools/context.py
@@ -1,0 +1,16 @@
+"""Context object injected into runner v2 tools."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+
+
+@dataclass
+class ToolContext:
+    artifacts: ArtifactStore
+    procedures: ProcedureState
+    log: RunLog
+    turn: int = 0

--- a/backend/services/reporter/runner/tools/datalayer_tools.py
+++ b/backend/services/reporter/runner/tools/datalayer_tools.py
@@ -1,0 +1,337 @@
+"""Reporter-owned tools over one frozen league-data snapshot."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from backend.services.datalayer import FrozenLeagueData
+
+
+def _week_property(description: str = "Week number (1-18).") -> dict[str, str]:
+    return {"type": "integer", "description": description}
+
+
+def _roster_property() -> dict[str, str]:
+    return {
+        "type": "string",
+        "description": "Team name, manager name, or roster_id as a string.",
+    }
+
+
+def _tool(
+    name: str,
+    description: str,
+    properties: dict[str, dict[str, Any]],
+    required: tuple[str, ...] = (),
+) -> ToolDef:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": list(required),
+            },
+        },
+    }
+
+
+DATALAYER_TOOL_SPECS: list[ToolDef] = [
+    _tool(
+        "league_snapshot",
+        "Get a comprehensive league snapshot for a week, including standings, "
+        "matchup results, and transactions.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "week_games",
+        "Get every matchup for a week with full player-by-player breakdowns.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "team_game",
+        "Get one team's game for a week with full player-by-player breakdowns.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+        },
+        ("roster_key",),
+    ),
+    _tool(
+        "week_player_leaderboard",
+        "Get the top-scoring players for a week, ranked by fantasy points.",
+        {
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+            "limit": {
+                "type": "integer",
+                "description": "Maximum players to return. Default is 10.",
+            },
+        },
+    ),
+    _tool(
+        "team_dossier",
+        "Get a team profile with standings, record, streak, and recent games.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property(
+                "Week number for standings. Omit for snapshot cutoff."
+            ),
+        },
+        ("roster_key",),
+    ),
+    _tool(
+        "team_schedule",
+        "Get a team's snapshot-bounded schedule with opponents, scores, results, "
+        "and cumulative record.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "roster_at_cutoff",
+        "Get a team's roster composition at the selected snapshot cutoff, organized "
+        "by role and position, plus draft picks owned.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "roster_snapshot",
+        "Get a team's roster and player scores during a specific week.",
+        {
+            "roster_key": _roster_property(),
+            "week": _week_property("Week number to query."),
+        },
+        ("roster_key", "week"),
+    ),
+    _tool(
+        "transactions",
+        "Get all grouped trades, waivers, and free-agent pickups in a week range.",
+        {
+            "week_from": _week_property("Starting week (inclusive)."),
+            "week_to": _week_property("Ending week (inclusive)."),
+        },
+        ("week_from", "week_to"),
+    ),
+    _tool(
+        "team_transactions",
+        "Get one team's trades, waivers, and free-agent pickups in a week range.",
+        {
+            "roster_key": _roster_property(),
+            "week_from": _week_property("Starting week (inclusive)."),
+            "week_to": _week_property("Ending week (inclusive)."),
+        },
+        ("roster_key", "week_from", "week_to"),
+    ),
+    _tool(
+        "bench_analysis",
+        "Get starter-versus-bench scoring for a week, league-wide or for one team.",
+        {
+            "roster_key": {
+                "type": "string",
+                "description": "Optional team identifier. Omit for league-wide mode.",
+            },
+            "week": _week_property("Week number. Omit for snapshot cutoff."),
+        },
+    ),
+    _tool(
+        "standings",
+        "Get league standings, records, points, rank, and streaks for a week.",
+        {"week": _week_property("Week number. Omit for snapshot cutoff.")},
+    ),
+    _tool(
+        "player_summary",
+        "Get an NFL player's snapshot metadata, including position, team, status, "
+        "and injury information.",
+        {
+            "player_key": {
+                "type": "string",
+                "description": "Player name or player_id.",
+            }
+        },
+        ("player_key",),
+    ),
+    _tool(
+        "player_weekly_log",
+        "Get a player's weekly fantasy points, lineup role, fantasy team, totals, "
+        "and averages.",
+        {
+            "player_key": {
+                "type": "string",
+                "description": "Player name or player_id.",
+            },
+            "week_from": _week_property(
+                "Starting week (inclusive). Omit for full snapshot."
+            ),
+            "week_to": _week_property(
+                "Ending week (inclusive). Omit for full snapshot."
+            ),
+        },
+        ("player_key",),
+    ),
+    _tool(
+        "season_leaders",
+        "Get top players across the snapshot by total or average fantasy points, with "
+        "optional week, position, team, and role filters.",
+        {
+            "week_from": _week_property(
+                "Starting week (inclusive). Omit for full snapshot."
+            ),
+            "week_to": _week_property(
+                "Ending week (inclusive). Omit for full snapshot."
+            ),
+            "position": {
+                "type": "string",
+                "description": "Filter to a single position.",
+            },
+            "roster_key": {
+                "type": "string",
+                "description": "Filter to one team's players.",
+            },
+            "role": {
+                "type": "string",
+                "description": "Filter by lineup role.",
+                "enum": ["starter", "bench"],
+            },
+            "sort_by": {
+                "type": "string",
+                "description": "Rank by total or average points.",
+                "enum": ["total", "avg"],
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum results. Default 10, maximum 30.",
+            },
+        },
+    ),
+    _tool(
+        "playoff_bracket",
+        "Get playoff bracket structure, results, progression, and placements from the "
+        "selected snapshot.",
+        {
+            "bracket_type": {
+                "type": "string",
+                "description": "Filter to winners or losers. Omit for both.",
+                "enum": ["winners", "losers"],
+            }
+        },
+    ),
+    _tool(
+        "team_playoff_path",
+        "Get one team's playoff opponents, results, placement, and elimination or "
+        "championship status.",
+        {"roster_key": _roster_property()},
+        ("roster_key",),
+    ),
+    _tool(
+        "run_sql",
+        "Execute one guarded read-only query against the selected frozen SQLite "
+        "snapshot for advanced analysis.",
+        {
+            "query": {
+                "type": "string",
+                "description": (
+                    "A single SELECT query. Available tables: leagues, "
+                    "season_context, users, rosters, team_profiles, draft_picks, "
+                    "players, matchups, player_performances, games, roster_players, "
+                    "transactions, transaction_moves, playoff_matchups, standings, "
+                    "and snapshot_metadata."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum rows to return. Default is 200.",
+            },
+        },
+        ("query",),
+    ),
+]
+
+
+def register_datalayer_tools(
+    registry: ToolRegistry,
+    data: FrozenLeagueData,
+) -> None:
+    """Register reporter data tools over an already-open frozen snapshot."""
+    handlers = _create_tool_handlers(data)
+    for spec in DATALAYER_TOOL_SPECS:
+        name = spec["function"]["name"]
+        registry.register(name, _json_handler(handlers[name]), spec)
+
+
+def _create_tool_handlers(
+    data: FrozenLeagueData,
+) -> dict[str, Callable[..., Any]]:
+    return {
+        "league_snapshot": lambda week=None: data.get_league_snapshot(week),
+        "week_games": lambda week=None: data.get_week_games_with_players(week),
+        "team_game": lambda roster_key, week=None: (
+            data.get_team_game_with_players(roster_key, week)
+        ),
+        "week_player_leaderboard": lambda week=None, limit=10: (
+            data.get_week_player_leaderboard(week, limit)
+        ),
+        "team_dossier": lambda roster_key, week=None: (
+            data.get_team_dossier(roster_key, week)
+        ),
+        "team_schedule": lambda roster_key: data.get_team_schedule(roster_key),
+        "roster_at_cutoff": lambda roster_key: data.get_roster_at_cutoff(roster_key),
+        "roster_snapshot": lambda roster_key, week: (
+            data.get_roster_snapshot(roster_key, week)
+        ),
+        "transactions": lambda week_from, week_to: (
+            data.get_transactions(week_from, week_to)
+        ),
+        "team_transactions": lambda roster_key, week_from, week_to: (
+            data.get_team_transactions(roster_key, week_from, week_to)
+        ),
+        "bench_analysis": lambda roster_key=None, week=None: (
+            data.get_bench_analysis(roster_key, week)
+        ),
+        "standings": lambda week=None: data.get_standings(week),
+        "player_summary": lambda player_key: data.get_player_summary(player_key),
+        "player_weekly_log": lambda player_key, week_from=None, week_to=None: (
+            data.get_player_weekly_log(
+                player_key,
+                week_from=week_from,
+                week_to=week_to,
+            )
+        ),
+        "season_leaders": (
+            lambda week_from=None,
+            week_to=None,
+            position=None,
+            roster_key=None,
+            role=None,
+            sort_by="total",
+            limit=10: data.get_season_leaders(
+                week_from=week_from,
+                week_to=week_to,
+                position=position,
+                roster_key=roster_key,
+                role=role,
+                sort_by=sort_by,
+                limit=limit,
+            )
+        ),
+        "playoff_bracket": lambda bracket_type=None: (
+            data.get_playoff_bracket(bracket_type)
+        ),
+        "team_playoff_path": lambda roster_key: (
+            data.get_team_playoff_path(roster_key)
+        ),
+        "run_sql": lambda query, limit=200: data.run_sql(query, limit=limit),
+    }
+
+
+def _json_handler(handler: Callable[..., Any]) -> Callable[..., str]:
+    def wrapped_handler(**kwargs: Any) -> str:
+        return json.dumps(handler(**kwargs), default=str)
+
+    return wrapped_handler

--- a/backend/services/reporter/runner/tools/memory_tools.py
+++ b/backend/services/reporter/runner/tools/memory_tools.py
@@ -1,0 +1,850 @@
+"""Agent-facing storyline memory search and write tools."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from reporter_memory.search import (
+    get_memory_candidate,
+    normalize_verification_fact_links,
+    plan_memory_verification,
+    search_story_memory,
+    validate_verified_fact_links,
+)
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from reporter_memory.context_store import ContextStore
+
+
+MEMORY_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_story_memory",
+            "description": (
+                "Search persistent story memory for ranked leads relevant to the "
+                "current article. Returns candidates with score components, matched "
+                "triggers/entities, and verification hints. Leads are not article-"
+                "ready facts."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "week": {
+                        "type": "integer",
+                        "description": "Article week. Defaults to the current run week.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Free-text memory search query.",
+                    },
+                    "article_request": {
+                        "type": "string",
+                        "description": "Optional article request text for lexical hints.",
+                    },
+                    "current_entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": (
+                            "Entities involved this week. Prefer "
+                            "{entity_type, entity_id, display_name?}."
+                        ),
+                    },
+                    "current_events": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": (
+                            "Current-week events with optional event_type, "
+                            "transaction_id, matchup_id, and entities."
+                        ),
+                    },
+                    "trigger_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "filters": {"type": "object"},
+                    "include_resolved": {"type": "boolean", "default": False},
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 25,
+                        "default": 10,
+                    },
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_memory_candidate",
+            "description": (
+                "Expand one memory candidate with linked events, persisted facts, "
+                "history, triggers, and source refs. Use after search_story_memory."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                    },
+                    "owner_id": {"type": "string"},
+                },
+                "required": ["owner_type", "owner_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memory_event",
+            "description": (
+                "Save source-backed event evidence for later callbacks. "
+                "confidence=verified requires at least one source_ref."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "event_type": {"type": "string"},
+                    "week": {"type": "integer"},
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "importance": {"type": "integer"},
+                    "confidence": {
+                        "type": "string",
+                        "enum": ["verified", "inferred", "needs_verification"],
+                    },
+                    "source_refs": {
+                        "type": "array",
+                        "items": {},
+                    },
+                    "numbers": {"type": "object"},
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                    "transaction_id": {"type": "string"},
+                    "matchup_id": {"type": "string"},
+                },
+                "required": ["id", "event_type", "week", "headline", "summary"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "upsert_storyline_memory_card",
+            "description": (
+                "Create or update a storyline memory card with optional evidence "
+                "event links and trigger specs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "stale", "resolved"],
+                    },
+                    "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "importance": {"type": "integer"},
+                    "arc_type": {"type": "string"},
+                    "origin_week": {"type": "integer"},
+                    "future_callback_condition": {"type": "string"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "team_keys": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "entities": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": "Optional entities; team entities become team_ids.",
+                    },
+                    "evidence_event_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "trigger_specs": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                },
+                "required": ["id", "headline", "summary", "status"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_storyline_trigger",
+            "description": "Save or update a dormant callback trigger.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "storyline_id": {"type": "string"},
+                    "event_id": {"type": "string"},
+                    "trigger_type": {"type": "string"},
+                    "target_week": {"type": "integer"},
+                    "condition": {"type": "object"},
+                    "fire_policy": {
+                        "type": "string",
+                        "enum": ["one_shot", "recurring", "until_resolved"],
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["open", "fired", "expired", "resolved"],
+                    },
+                },
+                "required": ["trigger_type"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "mark_memory_used",
+            "description": (
+                "Record how a memory candidate was used this week. For one-shot "
+                "triggers, article_callback marks fired and discarded marks resolved."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {"type": "string"},
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "week": {"type": "integer"},
+                    "usage": {
+                        "type": "string",
+                        "enum": [
+                            "article_callback",
+                            "research_context",
+                            "discarded",
+                        ],
+                    },
+                    "linked_storyline_id": {"type": "string"},
+                    "fact_links": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "reason": {"type": "string"},
+                },
+                "required": ["candidate_id", "usage"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "plan_memory_verification",
+            "description": (
+                "Plan how to verify a memory candidate callback. Returns required "
+                "fact roles and suggested datalayer calls. Does not verify claims."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {
+                        "type": "string",
+                        "description": "Memory owner ID from search_story_memory.",
+                    },
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "current_week": {
+                        "type": "integer",
+                        "description": "Current article week. Defaults to run week.",
+                    },
+                    "callback_id": {
+                        "type": "string",
+                        "description": "Optional brief callback ID being planned.",
+                    },
+                    "intended_callback_claim": {
+                        "type": "string",
+                        "description": "Optional claim the agent hopes to verify.",
+                    },
+                },
+                "required": ["candidate_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "record_memory_verification",
+            "description": (
+                "Record verification outcome for a memory candidate. status="
+                "verified requires origin_receipt and current_payoff fact links "
+                "that already exist in the brief."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "candidate_id": {"type": "string"},
+                    "owner_type": {
+                        "type": "string",
+                        "enum": ["storyline", "event", "trigger", "story_event"],
+                        "default": "storyline",
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "verified",
+                            "rejected",
+                            "needs_more_evidence",
+                        ],
+                    },
+                    "fact_links": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "role": {
+                                    "type": "string",
+                                    "description": (
+                                        "Fact role such as origin_receipt or "
+                                        "current_payoff."
+                                    ),
+                                },
+                                "fact_id": {"type": "string"},
+                            },
+                            "required": ["fact_id"],
+                        },
+                        "description": (
+                            "Linked brief fact IDs. Prefer objects with role + "
+                            "fact_id. Strings are accepted as unscoped fact IDs."
+                        ),
+                    },
+                    "reason": {"type": "string"},
+                    "week": {"type": "integer"},
+                    "callback_id": {
+                        "type": "string",
+                        "description": "Optional brief memory callback ID.",
+                    },
+                    "linked_storyline_id": {"type": "string"},
+                },
+                "required": ["candidate_id", "status"],
+            },
+        },
+    },
+]
+
+
+MEMORY_TOOL_SPECS: list[ToolDef] = MEMORY_TOOLS
+
+
+def memory_write_blocked_result(tool_name: str) -> str:
+    """JSON result returned when eval mode disables memory writes."""
+    return json.dumps(
+        {
+            "ok": True,
+            "saved": False,
+            "persisted": False,
+            "recorded": False,
+            "eval_mode": True,
+            "message": (
+                f"{tool_name} skipped: memory writes disabled in eval mode"
+            ),
+        }
+    )
+
+
+def register_memory_tools(
+    registry: ToolRegistry,
+    context_store: ContextStore,
+    week: int,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+    *,
+    allow_memory_writes: bool = True,
+) -> None:
+    """Register search and write/usage memory tools."""
+    week_default = week
+
+    def search_story_memory_tool(
+        *,
+        week: int | None = None,
+        query: str | None = None,
+        article_request: str | None = None,
+        current_entities: list[dict[str, Any]] | None = None,
+        current_events: list[dict[str, Any]] | None = None,
+        trigger_types: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        include_resolved: bool = False,
+        limit: int = 10,
+    ) -> str:
+        results = search_story_memory(
+            context_store,
+            week=week if week is not None else week_default,
+            query=query,
+            article_request=article_request,
+            current_entities=current_entities,
+            current_events=current_events,
+            trigger_types=trigger_types,
+            filters=filters,
+            include_resolved=include_resolved,
+            limit=limit,
+        )
+        return _json({"ok": True, "candidates": results, "count": len(results)})
+
+    def get_memory_candidate_tool(*, owner_type: str, owner_id: str) -> str:
+        candidate = get_memory_candidate(context_store, owner_type, owner_id)
+        if candidate is None:
+            return _json(
+                {
+                    "ok": False,
+                    "found": False,
+                    "error": f"No candidate for {owner_type}:{owner_id}",
+                }
+            )
+        return _json({"ok": True, "found": True, "candidate": candidate})
+
+    def save_memory_event(
+        *,
+        id: str,
+        event_type: str,
+        week: int,
+        headline: str,
+        summary: str,
+        importance: int = 1,
+        confidence: str = "needs_verification",
+        source_refs: list[Any] | None = None,
+        numbers: dict[str, Any] | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        transaction_id: str | None = None,
+        matchup_id: str | None = None,
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("save_memory_event")
+        try:
+            context_store.upsert_story_event(
+                {
+                    "id": id,
+                    "event_type": event_type,
+                    "week": week,
+                    "headline": headline,
+                    "summary": summary,
+                    "importance": importance,
+                    "confidence": confidence,
+                    "source_refs": source_refs or [],
+                    "numbers": numbers or {},
+                    "transaction_id": transaction_id,
+                    "matchup_id": matchup_id,
+                }
+            )
+        except ValueError as exc:
+            return _json({"ok": False, "saved": False, "error": str(exc)})
+
+        if entities is not None:
+            context_store.replace_story_event_entities(id, entities)
+        return _json({"ok": True, "saved": True, "id": id, "confidence": confidence})
+
+    def upsert_storyline_memory_card(
+        *,
+        id: str,
+        headline: str,
+        summary: str,
+        status: str,
+        priority: int = 2,
+        importance: int | None = None,
+        arc_type: str | None = None,
+        origin_week: int | None = None,
+        future_callback_condition: str | None = None,
+        tags: list[str] | None = None,
+        team_keys: list[str] | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        evidence_event_ids: list[str] | None = None,
+        trigger_specs: list[dict[str, Any]] | None = None,
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("upsert_storyline_memory_card")
+        team_ids, unresolved_team_keys = _resolve_team_keys(
+            team_keys or [], resolve_roster_fn
+        )
+        for entity in entities or []:
+            entity_type = entity.get("entity_type", entity.get("type"))
+            if entity_type != "team":
+                continue
+            entity_id = entity.get("entity_id", entity.get("id"))
+            try:
+                team_ids.append(int(entity_id))
+            except (TypeError, ValueError):
+                unresolved_team_keys.append(str(entity_id))
+
+        # Deduplicate while preserving order.
+        deduped_team_ids = list(dict.fromkeys(team_ids))
+
+        storyline: dict[str, Any] = {
+            "id": id,
+            "headline": headline,
+            "summary": summary,
+            "status": status,
+            "priority": priority,
+            "tags": tags or [],
+            "team_ids": deduped_team_ids,
+        }
+        if importance is not None:
+            storyline["importance"] = importance
+        if arc_type is not None:
+            storyline["arc_type"] = arc_type
+        if origin_week is not None:
+            storyline["origin_week"] = origin_week
+        if future_callback_condition is not None:
+            storyline["future_callback_condition"] = future_callback_condition
+
+        context_store.upsert_storyline(storyline, week=week_default)
+
+        linked_events: list[str] = []
+        for event_id in evidence_event_ids or []:
+            context_store.link_storyline_event(id, event_id, "evidence")
+            linked_events.append(event_id)
+
+        saved_triggers: list[str] = []
+        for spec in trigger_specs or []:
+            trigger_id = spec.get("id") or f"trigger_{id}_{uuid.uuid4().hex[:8]}"
+            context_store.upsert_storyline_trigger(
+                {
+                    "id": trigger_id,
+                    "storyline_id": id,
+                    "event_id": spec.get("event_id"),
+                    "trigger_type": spec["trigger_type"],
+                    "target_week": spec.get("target_week"),
+                    "condition": spec.get("condition", {}),
+                    "fire_policy": spec.get("fire_policy", "one_shot"),
+                    "status": spec.get("status", "open"),
+                }
+            )
+            saved_triggers.append(trigger_id)
+
+        payload: dict[str, Any] = {
+            "ok": True,
+            "saved": True,
+            "id": id,
+            "status": status,
+            "team_ids": deduped_team_ids,
+            "linked_events": linked_events,
+            "triggers": saved_triggers,
+        }
+        if unresolved_team_keys:
+            payload["unresolved_team_keys"] = unresolved_team_keys
+        return _json(payload)
+
+    def save_storyline_trigger(
+        *,
+        trigger_type: str,
+        id: str | None = None,
+        storyline_id: str | None = None,
+        event_id: str | None = None,
+        target_week: int | None = None,
+        condition: dict[str, Any] | None = None,
+        fire_policy: str = "one_shot",
+        status: str = "open",
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("save_storyline_trigger")
+        trigger_id = id or f"trigger_{uuid.uuid4().hex[:12]}"
+        context_store.upsert_storyline_trigger(
+            {
+                "id": trigger_id,
+                "storyline_id": storyline_id,
+                "event_id": event_id,
+                "trigger_type": trigger_type,
+                "target_week": target_week,
+                "condition": condition or {},
+                "fire_policy": fire_policy,
+                "status": status,
+            }
+        )
+        return _json(
+            {
+                "ok": True,
+                "saved": True,
+                "id": trigger_id,
+                "trigger_type": trigger_type,
+                "status": status,
+            }
+        )
+
+    def mark_memory_used(
+        *,
+        candidate_id: str,
+        usage: str,
+        owner_type: str = "storyline",
+        week: int | None = None,
+        linked_storyline_id: str | None = None,
+        fact_links: list[str] | None = None,
+        reason: str | None = None,
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("mark_memory_used")
+        used_week = week if week is not None else week_default
+        normalized_type = (
+            "event" if owner_type == "story_event" else owner_type
+        )
+        access_id = context_store.record_memory_access(
+            owner_type=normalized_type,
+            owner_id=candidate_id,
+            week=used_week,
+            usage=usage,
+            linked_storyline_id=linked_storyline_id,
+            fact_links=fact_links,
+            reason=reason,
+        )
+
+        trigger_update = None
+        if normalized_type == "trigger":
+            trigger = context_store.get_trigger(candidate_id)
+            if trigger and trigger.get("fire_policy", "one_shot") == "one_shot":
+                if usage == "article_callback":
+                    context_store.update_trigger_status(
+                        candidate_id, status="fired", fired_week=used_week
+                    )
+                    trigger_update = "fired"
+                elif usage == "discarded":
+                    context_store.update_trigger_status(
+                        candidate_id, status="resolved", fired_week=used_week
+                    )
+                    trigger_update = "resolved"
+
+        return _json(
+            {
+                "ok": True,
+                "recorded": True,
+                "access_id": access_id,
+                "candidate_id": candidate_id,
+                "owner_type": normalized_type,
+                "usage": usage,
+                "trigger_update": trigger_update,
+            }
+        )
+
+    def plan_memory_verification_tool(
+        *,
+        candidate_id: str,
+        owner_type: str = "storyline",
+        current_week: int | None = None,
+        callback_id: str | None = None,
+        intended_callback_claim: str | None = None,
+    ) -> str:
+        plan = plan_memory_verification(
+            context_store,
+            candidate_id=candidate_id,
+            owner_type=owner_type,
+            current_week=current_week if current_week is not None else week_default,
+            callback_id=callback_id,
+            intended_callback_claim=intended_callback_claim,
+        )
+        if plan is None:
+            return _json(
+                {
+                    "ok": False,
+                    "found": False,
+                    "error": f"No candidate for {owner_type}:{candidate_id}",
+                }
+            )
+        return _json({"ok": True, **plan})
+
+    def record_memory_verification(
+        ctx: ToolContext,
+        *,
+        candidate_id: str,
+        status: str,
+        owner_type: str = "storyline",
+        fact_links: list[Any] | None = None,
+        reason: str | None = None,
+        week: int | None = None,
+        callback_id: str | None = None,
+        linked_storyline_id: str | None = None,
+    ) -> str:
+        if status not in {"verified", "rejected", "needs_more_evidence"}:
+            return _json(
+                {
+                    "ok": False,
+                    "recorded": False,
+                    "error": (
+                        "status must be verified, rejected, or needs_more_evidence"
+                    ),
+                }
+            )
+
+        normalized_type = (
+            "event" if owner_type == "story_event" else owner_type
+        )
+        candidate = get_memory_candidate(
+            context_store, normalized_type, candidate_id
+        )
+        if candidate is None:
+            return _json(
+                {
+                    "ok": False,
+                    "recorded": False,
+                    "error": f"No candidate for {owner_type}:{candidate_id}",
+                }
+            )
+
+        normalized_links = normalize_verification_fact_links(fact_links)
+        if status == "verified":
+            missing_roles = validate_verified_fact_links(normalized_links)
+            if missing_roles:
+                return _json(
+                    {
+                        "ok": False,
+                        "recorded": False,
+                        "error": (
+                            "verified callbacks require origin_receipt and "
+                            "current_payoff fact links"
+                        ),
+                        "missing_roles": missing_roles,
+                    }
+                )
+
+            brief = ctx.artifacts.brief
+            missing_fact_ids = [
+                link["fact_id"]
+                for link in normalized_links
+                if brief.get_fact(link["fact_id"]) is None
+            ]
+            if missing_fact_ids:
+                return _json(
+                    {
+                        "ok": False,
+                        "recorded": False,
+                        "error": "verification fact_links must exist in the brief",
+                        "missing_fact_ids": missing_fact_ids,
+                    }
+                )
+
+            if callback_id:
+                callback = brief.get_memory_callback(callback_id)
+                if callback is None:
+                    return _json(
+                        {
+                            "ok": False,
+                            "recorded": False,
+                            "error": f"Unknown brief callback_id: {callback_id}",
+                        }
+                    )
+
+        if not allow_memory_writes:
+            return _json(
+                {
+                    "ok": True,
+                    "recorded": False,
+                    "persisted": False,
+                    "eval_mode": True,
+                    "candidate_id": candidate_id,
+                    "owner_type": normalized_type,
+                    "status": status,
+                    "fact_links": normalized_links,
+                    "callback_id": callback_id,
+                    "message": (
+                        "record_memory_verification validated but skipped "
+                        "persistent access write in eval mode"
+                    ),
+                }
+            )
+
+        used_week = week if week is not None else week_default
+        access_reason = reason
+        if callback_id:
+            suffix = f"callback_id={callback_id}"
+            access_reason = f"{reason}; {suffix}" if reason else suffix
+
+        access_id = context_store.record_memory_access(
+            owner_type=normalized_type,
+            owner_id=candidate_id,
+            week=used_week,
+            usage=f"verification_{status}",
+            linked_storyline_id=linked_storyline_id,
+            fact_links=[
+                (
+                    f"{link['role']}:{link['fact_id']}"
+                    if link["role"]
+                    else link["fact_id"]
+                )
+                for link in normalized_links
+            ],
+            reason=access_reason,
+        )
+
+        return _json(
+            {
+                "ok": True,
+                "recorded": True,
+                "access_id": access_id,
+                "candidate_id": candidate_id,
+                "owner_type": normalized_type,
+                "status": status,
+                "fact_links": normalized_links,
+                "callback_id": callback_id,
+            }
+        )
+
+    handlers = {
+        "search_story_memory": search_story_memory_tool,
+        "get_memory_candidate": get_memory_candidate_tool,
+        "save_memory_event": save_memory_event,
+        "upsert_storyline_memory_card": upsert_storyline_memory_card,
+        "save_storyline_trigger": save_storyline_trigger,
+        "mark_memory_used": mark_memory_used,
+        "plan_memory_verification": plan_memory_verification_tool,
+    }
+    for spec in MEMORY_TOOL_SPECS:
+        name = spec["function"]["name"]
+        if name == "record_memory_verification":
+            registry.register_context_tool(
+                name, record_memory_verification, spec
+            )
+            continue
+        registry.register(name, handlers[name], spec)
+
+
+def _resolve_team_keys(
+    team_keys: list[str],
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> tuple[list[int], list[str]]:
+    team_ids: list[int] = []
+    unresolved_team_keys: list[str] = []
+    for key in team_keys:
+        roster_id = _resolve_roster_id(key, resolve_roster_fn)
+        if roster_id is None:
+            unresolved_team_keys.append(key)
+        else:
+            team_ids.append(roster_id)
+    return team_ids, unresolved_team_keys
+
+
+def _resolve_roster_id(
+    roster_key: str,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> int | None:
+    if resolve_roster_fn is not None:
+        result = resolve_roster_fn(roster_key)
+        if result.get("found"):
+            return int(result["roster_id"])
+        return None
+
+    try:
+        return int(roster_key)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, default=str)

--- a/backend/services/reporter/runner/tools/persistent_tools.py
+++ b/backend/services/reporter/runner/tools/persistent_tools.py
@@ -1,0 +1,280 @@
+"""Legacy persistent context load/save tools for reporter v2.
+
+Search and richer write/usage tools live in memory_tools.py. This module keeps
+the original load/save surface and registers both sets together.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.memory_tools import (
+    MEMORY_TOOL_SPECS,
+    memory_write_blocked_result,
+    register_memory_tools,
+)
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from reporter_memory.context_store import ContextStore
+
+
+LEGACY_PERSISTENT_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_persistent_storyline",
+            "description": (
+                "Create or update a persistent storyline that carries across weeks. "
+                "Use this for multi-week narrative arcs likely to matter in future "
+                "articles."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": (
+                            "Stable storyline ID. Use an existing ID to update, or "
+                            "a new ID like 'story_2024_w8_001' to create."
+                        ),
+                    },
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "stale", "resolved"],
+                    },
+                    "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "team_keys": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Team names or roster IDs involved in the arc.",
+                    },
+                },
+                "required": ["id", "headline", "summary", "status"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_team_context",
+            "description": (
+                "Save or update persistent narrative context for one team. This "
+                "replaces that team's previous note."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "roster_key": {
+                        "type": "string",
+                        "description": "Team name or roster ID.",
+                    },
+                    "narrative": {
+                        "type": "string",
+                        "description": "Summary of the team's current situation.",
+                    },
+                    "outlook": {
+                        "type": "string",
+                        "enum": [
+                            "rebuilding",
+                            "contending",
+                            "middling",
+                            "surging",
+                            "fading",
+                        ],
+                    },
+                },
+                "required": ["roster_key", "narrative"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_league_note",
+            "description": (
+                "Save or update a league-wide persistent note. Uses key-value pairs; "
+                "the same key overwrites the previous value."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "description": (
+                            "Note key such as 'season_theme', 'trade_activity', "
+                            "'rivalry_notes', or custom."
+                        ),
+                    },
+                    "value": {"type": "string"},
+                },
+                "required": ["key", "value"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_persistent_storylines",
+            "description": (
+                "Load active and stale persistent storylines, including available "
+                "history and persisted supporting facts."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_team_context",
+            "description": "Load all persistent team context notes.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "load_league_notes",
+            "description": "Load all persistent league context notes.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+PERSISTENT_TOOLS = LEGACY_PERSISTENT_TOOLS + MEMORY_TOOL_SPECS
+PERSISTENT_TOOL_SPECS: list[ToolDef] = PERSISTENT_TOOLS
+
+
+def register_persistent_tools(
+    registry: ToolRegistry,
+    context_store: ContextStore,
+    week: int,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+    *,
+    allow_memory_writes: bool = True,
+) -> None:
+    """Register legacy load/save tools and the agent memory tool surface."""
+
+    def save_persistent_storyline(
+        *,
+        id: str,
+        headline: str,
+        summary: str,
+        status: str,
+        priority: int = 2,
+        tags: list[str] | None = None,
+        team_keys: list[str] | None = None,
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("save_persistent_storyline")
+        # Legacy wrapper over the richer storyline memory card tool.
+        handler = registry.get_handler("upsert_storyline_memory_card")
+        assert handler is not None
+        return handler(
+            id=id,
+            headline=headline,
+            summary=summary,
+            status=status,
+            priority=priority,
+            tags=tags,
+            team_keys=team_keys,
+        )
+
+    def save_team_context(
+        *,
+        roster_key: str,
+        narrative: str,
+        outlook: str | None = None,
+    ) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("save_team_context")
+        roster_id = _resolve_roster_id(roster_key, resolve_roster_fn)
+        if roster_id is None:
+            return _json(
+                {
+                    "ok": False,
+                    "saved": False,
+                    "error": f"Could not resolve team: {roster_key}",
+                }
+            )
+
+        context_store.upsert_team_context(
+            roster_id,
+            narrative,
+            outlook,
+            week=week,
+        )
+        return _json(
+            {
+                "ok": True,
+                "saved": True,
+                "roster_id": roster_id,
+                "roster_key": roster_key,
+            }
+        )
+
+    def save_league_note(*, key: str, value: str) -> str:
+        if not allow_memory_writes:
+            return memory_write_blocked_result("save_league_note")
+        context_store.upsert_league_context(key, value, week=week)
+        return _json({"ok": True, "saved": True, "key": key})
+
+    def load_persistent_storylines() -> str:
+        storylines = context_store.get_storylines()
+        enriched = context_store.get_enriched_storylines(
+            [storyline["id"] for storyline in storylines]
+        )
+        return _json(enriched)
+
+    def load_team_context() -> str:
+        return _json(context_store.get_all_team_context())
+
+    def load_league_notes() -> str:
+        return _json(context_store.get_league_context())
+
+    handlers = {
+        "save_persistent_storyline": save_persistent_storyline,
+        "save_team_context": save_team_context,
+        "save_league_note": save_league_note,
+        "load_persistent_storylines": load_persistent_storylines,
+        "load_team_context": load_team_context,
+        "load_league_notes": load_league_notes,
+    }
+    for spec in LEGACY_PERSISTENT_TOOLS:
+        name = spec["function"]["name"]
+        registry.register(name, handlers[name], spec)
+
+    register_memory_tools(
+        registry,
+        context_store,
+        week=week,
+        resolve_roster_fn=resolve_roster_fn,
+        allow_memory_writes=allow_memory_writes,
+    )
+
+
+def _resolve_roster_id(
+    roster_key: str,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None,
+) -> int | None:
+    if resolve_roster_fn is not None:
+        result = resolve_roster_fn(roster_key)
+        if result.get("found"):
+            return int(result["roster_id"])
+        return None
+
+    try:
+        return int(roster_key)
+    except (TypeError, ValueError):
+        return None
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, default=str)

--- a/backend/services/reporter/runner/tools/procedure_tools.py
+++ b/backend/services/reporter/runner/tools/procedure_tools.py
@@ -1,0 +1,69 @@
+"""Procedure-loading tools for the reporter v2 runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
+VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
+
+PROCEDURE_TOOL_SPECS: list[ToolDef] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "load_procedure",
+            "description": (
+                "Load the current operating procedure. Use this before research, "
+                "storyline synthesis, drafting, and verification work."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": sorted(VALID_PROCEDURES),
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+    },
+]
+
+
+def register_procedure_tools(registry: ToolRegistry) -> None:
+    """Register procedure-loading tools against a ToolRegistry."""
+    registry.register_context_tool(
+        "load_procedure",
+        load_procedure,
+        PROCEDURE_TOOL_SPECS[0],
+    )
+
+
+def load_procedure(ctx: ToolContext, *, name: str) -> str:
+    """Load a procedure by name and return its markdown text."""
+    if name not in VALID_PROCEDURES:
+        return json.dumps(
+            {
+                "error": (
+                    f"Unknown procedure: {name}. "
+                    f"Valid: {sorted(VALID_PROCEDURES)}"
+                )
+            }
+        )
+
+    path = PROCEDURE_DIR / f"{name}.md"
+    if not path.exists():
+        return json.dumps({"error": f"Procedure file not found: {path}"})
+
+    previous = ctx.procedures.active
+    ctx.procedures.active = name
+    ctx.log.add_procedure_switch(previous, name, turn=ctx.turn)
+
+    return path.read_text(encoding="utf-8")

--- a/backend/services/reporter/runner/tools/registry.py
+++ b/backend/services/reporter/runner/tools/registry.py
@@ -1,0 +1,58 @@
+"""Tool registry for the v2 runner."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.context import ToolContext
+
+
+class ToolRegistry:
+    """Maps tool names to handlers and exposes gateway tool specs."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, Callable[..., Any]] = {}
+        self._specs: dict[str, ToolDef] = {}
+        self._context: ToolContext | None = None
+
+    def set_context(self, context: ToolContext) -> None:
+        self._context = context
+
+    def register(
+        self,
+        name: str,
+        handler: Callable[..., Any],
+        spec: ToolDef,
+    ) -> None:
+        self._handlers[name] = handler
+        self._specs[name] = spec
+
+    def register_context_tool(
+        self,
+        name: str,
+        handler: Callable[..., Any],
+        spec: ToolDef,
+    ) -> None:
+        def bound_handler(**kwargs: Any) -> Any:
+            if self._context is None:
+                raise RuntimeError("ToolRegistry context has not been set.")
+            return handler(self._context, **kwargs)
+
+        self.register(name, bound_handler, spec)
+
+    def get_handler(self, name: str) -> Callable[..., Any] | None:
+        return self._handlers.get(name)
+
+    def set_turn(self, turn: int) -> None:
+        if self._context is not None:
+            self._context.turn = turn
+
+    @property
+    def tool_specs(self) -> list[ToolDef]:
+        return list(self._specs.values())
+
+    @property
+    def tool_names(self) -> list[str]:
+        return list(self._handlers.keys())

--- a/backend/tests/services/reporter/conftest.py
+++ b/backend/tests/services/reporter/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures for reporter v2 tests."""
+
+import pytest
+
+
+@pytest.fixture
+def sample_v2_brief_dict():
+    return {
+        "revision": 2,
+        "meta": {
+            "league_name": "Test League",
+            "league_id": "12345",
+            "week_start": 8,
+            "week_end": 8,
+            "article_type": "weekly_recap",
+        },
+        "facts": [
+            {
+                "id": "fact_001",
+                "claim_text": "Team Taco defeated The Waiver Wire 142.3-98.7",
+                "data_refs": ["week_games:week=8"],
+                "numbers": {"team_score": 142.3, "opponent_score": 98.7},
+                "category": "score",
+            },
+            {
+                "id": "fact_002",
+                "claim_text": "Team Taco is now 7-1",
+                "data_refs": ["league_snapshot:week=8"],
+                "numbers": {"wins": 7, "losses": 1},
+                "category": "standing",
+            },
+        ],
+        "storylines": [
+            {
+                "id": "story_001",
+                "headline": "Taco Tuesday Massacre",
+                "summary": "Team Taco dominated with a 43-point victory.",
+                "supporting_fact_ids": ["fact_001"],
+                "priority": 1,
+                "tags": ["blowout"],
+                "revision_at_set": 2,
+            }
+        ],
+        "outline": {
+            "sections": [
+                {
+                    "title": "Introduction",
+                    "bullet_points": ["Hook with lead storyline"],
+                    "required_fact_ids": ["fact_001"],
+                    "storyline_ids": ["story_001"],
+                }
+            ],
+            "revision_at_set": 2,
+        },
+        "style": {
+            "voice": "sports columnist",
+            "pacing": "moderate",
+            "humor_level": 1,
+            "formality": "casual",
+        },
+        "bias": {
+            "favored_teams": [],
+            "disfavored_teams": [],
+            "intensity": 0,
+            "framing_rules": [],
+        },
+    }

--- a/backend/tests/services/reporter/test_article_tools.py
+++ b/backend/tests/services/reporter/test_article_tools.py
@@ -1,0 +1,196 @@
+"""Tests for reporter v2 article artifact tools."""
+
+from __future__ import annotations
+
+import json
+
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools.article_tools import (
+    read_article,
+    read_section,
+    rewrite_section,
+    set_section_order,
+    submit_article,
+    write_section,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+
+
+def make_ctx() -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(session_id="testlog"),
+        turn=3,
+    )
+
+
+def decode(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_write_section() -> None:
+    ctx = make_ctx()
+
+    first = decode(write_section(ctx, name="opening", content="# Opening\n\nHello."))
+    second = decode(write_section(ctx, name="closing", content="# Closing\n\nBye."))
+
+    assert first["ok"] is True
+    assert second["section_count"] == 2
+    assert ctx.artifacts.article.section_order == ["opening", "closing"]
+    assert ctx.artifacts.article.to_markdown() == "# Opening\n\nHello.\n\n# Closing\n\nBye."
+    assert [entry.data["operation"] for entry in ctx.log.entries] == [
+        "write_section",
+        "write_section",
+    ]
+
+
+def test_write_section_overwrite() -> None:
+    ctx = make_ctx()
+
+    write_section(ctx, name="opening", content="First draft")
+    result = decode(write_section(ctx, name="opening", content="Second draft"))
+
+    assert result["section_count"] == 1
+    assert ctx.artifacts.article.get_section("opening").content == "Second draft"
+    assert ctx.artifacts.article.section_order == ["opening"]
+
+
+def test_read_article() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello league.")
+    write_section(ctx, name="closing", content="# Closing\n\nGood night.")
+
+    result = decode(read_article(ctx))
+
+    assert result["ok"] is True
+    assert result["section_count"] == 2
+    assert result["total_word_count"] == 6
+    assert [section["name"] for section in result["sections"]] == ["opening", "closing"]
+    assert result["sections"][0]["content"] == "# Opening\n\nHello league."
+
+
+def test_read_section() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello.")
+
+    result = decode(read_section(ctx, name="opening"))
+
+    assert result == {
+        "ok": True,
+        "section": {
+            "name": "opening",
+            "content": "# Opening\n\nHello.",
+            "word_count": 2,
+        },
+    }
+
+
+def test_read_section_missing() -> None:
+    ctx = make_ctx()
+
+    result = decode(read_section(ctx, name="missing"))
+
+    assert result["ok"] is False
+    assert result["name"] == "missing"
+    assert "not found" in result["error"]
+
+
+def test_rewrite_section_exists() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="First draft")
+
+    result = decode(rewrite_section(ctx, name="opening", content="Final draft"))
+
+    assert result["ok"] is True
+    assert result["section"]["content"] == "Final draft"
+    assert ctx.artifacts.article.get_section("opening").content == "Final draft"
+    assert ctx.log.entries[-1].data == {
+        "artifact": "article",
+        "operation": "rewrite_section",
+        "key": "opening",
+        "brief_revision": None,
+    }
+
+
+def test_rewrite_section_missing() -> None:
+    ctx = make_ctx()
+
+    result = decode(rewrite_section(ctx, name="missing", content="Nope."))
+
+    assert result["ok"] is False
+    assert result["name"] == "missing"
+    assert ctx.log.entries == []
+
+
+def test_set_section_order() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+    write_section(ctx, name="c", content="# C")
+
+    result = decode(set_section_order(ctx, names=["c", "a", "b"]))
+    article = decode(read_article(ctx))
+
+    assert result == {"ok": True, "section_order": ["c", "a", "b"]}
+    assert [section["name"] for section in article["sections"]] == ["c", "a", "b"]
+    assert ctx.artifacts.article.to_markdown() == "# C\n\n# A\n\n# B"
+
+
+def test_set_section_order_rejects_unknown_or_missing_names() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+
+    result = decode(set_section_order(ctx, names=["b", "c"]))
+
+    assert result["ok"] is False
+    assert result["unknown_names"] == ["c"]
+    assert result["missing_names"] == ["a"]
+    assert result["duplicate_names"] == []
+    assert ctx.artifacts.article.section_order == ["a", "b"]
+
+
+def test_set_section_order_rejects_duplicate_names() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="a", content="# A")
+    write_section(ctx, name="b", content="# B")
+
+    result = decode(set_section_order(ctx, names=["a", "a", "b"]))
+
+    assert result["ok"] is False
+    assert result["unknown_names"] == []
+    assert result["missing_names"] == []
+    assert result["duplicate_names"] == ["a"]
+    assert ctx.artifacts.article.section_order == ["a", "b"]
+
+
+def test_submit_article_empty() -> None:
+    ctx = make_ctx()
+
+    result = decode(submit_article(ctx))
+
+    assert result["ok"] is False
+    assert "empty article" in result["error"]
+    assert ctx.log.entries == []
+
+
+def test_submit_article() -> None:
+    ctx = make_ctx()
+    write_section(ctx, name="opening", content="# Opening\n\nHello league.")
+    write_section(ctx, name="closing", content="# Closing\n\nGood night.")
+
+    result = decode(submit_article(ctx))
+
+    assert result == {
+        "ok": True,
+        "article": "# Opening\n\nHello league.\n\n# Closing\n\nGood night.",
+        "stats": {
+            "section_count": 2,
+            "total_word_count": 6,
+            "total_char_count": 48,
+        },
+    }
+    assert ctx.log.entries[-1].event_type == "completion"
+    assert ctx.log.entries[-1].data == result["stats"]

--- a/backend/tests/services/reporter/test_brief_tools.py
+++ b/backend/tests/services/reporter/test_brief_tools.py
@@ -1,0 +1,321 @@
+"""Tests for runner v2 brief artifact tools."""
+
+import json
+
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools import (
+    ToolContext,
+    read_brief,
+    save_fact,
+    save_memory_callback,
+    save_storyline,
+    set_bias,
+    set_outline,
+    set_style,
+)
+
+
+def make_ctx() -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=3,
+    )
+
+
+def parse_result(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_save_fact_valid():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(
+            ctx,
+            id="fact_001",
+            claim_text="Team Taco scored 142.3 points.",
+            data_refs=["week_games:week=8"],
+            numbers={"points": 142.3},
+            category="score",
+        )
+    )
+
+    assert result == {"ok": True, "fact_id": "fact_001", "brief_revision": 1}
+    assert ctx.artifacts.brief.revision == 1
+    assert ctx.artifacts.brief.facts[0].id == "fact_001"
+    assert ctx.artifacts.brief.facts[0].numbers == {"points": 142.3}
+    assert ctx.log.entries[-1].event_type == "artifact_write"
+    assert ctx.log.entries[-1].data["key"] == "fact_001"
+
+
+def test_save_fact_empty_data_refs():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=[])
+    )
+
+    assert result["ok"] is False
+    assert "data_refs" in result["error"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.facts == []
+    assert ctx.log.entries == []
+
+
+def test_save_fact_empty_claim():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_fact(ctx, id="fact_001", claim_text="  ", data_refs=["source"])
+    )
+
+    assert result["ok"] is False
+    assert "claim_text" in result["error"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.facts == []
+
+
+def test_save_fact_upsert():
+    ctx = make_ctx()
+    save_fact(
+        ctx,
+        id="fact_001",
+        claim_text="Original claim.",
+        data_refs=["source:old"],
+    )
+
+    result = parse_result(
+        save_fact(
+            ctx,
+            id="fact_001",
+            claim_text="Replacement claim.",
+            data_refs=["source:new"],
+            category="updated",
+        )
+    )
+
+    assert result["brief_revision"] == 2
+    assert len(ctx.artifacts.brief.facts) == 1
+    assert ctx.artifacts.brief.facts[0].claim_text == "Replacement claim."
+    assert ctx.artifacts.brief.facts[0].data_refs == ["source:new"]
+    assert ctx.log.entries[-1].data["operation"] == "update_fact"
+
+
+def test_save_memory_callback_valid():
+    ctx = make_ctx()
+    save_fact(
+        ctx,
+        id="fact_old_trade",
+        claim_text="Team A traded Player X before Week 3.",
+        data_refs=["transactions:week_to=3"],
+        category="transaction",
+    )
+    save_fact(
+        ctx,
+        id="fact_current_payoff",
+        claim_text="Player X scored 24.1 points against Team A in Week 8.",
+        data_refs=["team_game:week=8"],
+        category="player",
+    )
+
+    result = parse_result(
+        save_memory_callback(
+            ctx,
+            id="callback_trade_regret",
+            callback_type="trade_regret",
+            claim_text=(
+                "Team A's Week 3 trade looked worse after Player X scored 24.1 "
+                "points against them in Week 8."
+            ),
+            old_event_fact_id="fact_old_trade",
+            current_event_fact_id="fact_current_payoff",
+            why_now="The traded-away player directly hurt his former manager.",
+            interestingness_reason="Specific revenge payoff with trade regret.",
+            memory_refs=["story_2024_w3_trade"],
+            tags=["trade_regret", "week_8"],
+        )
+    )
+
+    assert result == {
+        "ok": True,
+        "callback_id": "callback_trade_regret",
+        "brief_revision": 3,
+    }
+    callback = ctx.artifacts.brief.memory_callbacks[0]
+    assert callback.old_event_fact_id == "fact_old_trade"
+    assert callback.current_event_fact_id == "fact_current_payoff"
+    assert callback.memory_refs == ["story_2024_w3_trade"]
+    assert ctx.log.entries[-1].data["operation"] == "save_memory_callback"
+
+
+def test_save_memory_callback_requires_existing_fact_ids():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_old_trade", claim_text="A trade happened.", data_refs=["source"])
+
+    result = parse_result(
+        save_memory_callback(
+            ctx,
+            id="callback_trade_regret",
+            callback_type="trade_regret",
+            claim_text="A callback claim.",
+            old_event_fact_id="fact_old_trade",
+            current_event_fact_id="missing_current_fact",
+            why_now="The current payoff needs proof.",
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["missing_fact_ids"] == ["missing_current_fact"]
+    assert ctx.artifacts.brief.memory_callbacks == []
+
+
+def test_save_memory_callback_upsert():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_old", claim_text="Old event.", data_refs=["old"])
+    save_fact(ctx, id="fact_current", claim_text="Current event.", data_refs=["current"])
+    save_memory_callback(
+        ctx,
+        id="callback_001",
+        callback_type="revenge_game",
+        claim_text="Original callback.",
+        old_event_fact_id="fact_old",
+        current_event_fact_id="fact_current",
+        why_now="Original reason.",
+    )
+
+    result = parse_result(
+        save_memory_callback(
+            ctx,
+            id="callback_001",
+            callback_type="revenge_game",
+            claim_text="Updated callback.",
+            old_event_fact_id="fact_old",
+            current_event_fact_id="fact_current",
+            why_now="Updated reason.",
+        )
+    )
+
+    assert result["brief_revision"] == 4
+    assert len(ctx.artifacts.brief.memory_callbacks) == 1
+    assert ctx.artifacts.brief.memory_callbacks[0].claim_text == "Updated callback."
+    assert ctx.log.entries[-1].data["operation"] == "update_memory_callback"
+
+
+def test_save_storyline_valid():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=["source"])
+
+    result = parse_result(
+        save_storyline(
+            ctx,
+            id="story_001",
+            headline="Big Swing",
+            summary="A major matchup changed the standings.",
+            supporting_fact_ids=["fact_001"],
+            priority=1,
+            tags=["standings"],
+        )
+    )
+
+    assert result == {"ok": True, "storyline_id": "story_001", "brief_revision": 2}
+    assert len(ctx.artifacts.brief.storylines) == 1
+    assert ctx.artifacts.brief.storylines[0].revision_at_set == 2
+    assert ctx.artifacts.brief.storylines[0].tags == ["standings"]
+
+
+def test_save_storyline_invalid_fact_ids():
+    ctx = make_ctx()
+
+    result = parse_result(
+        save_storyline(
+            ctx,
+            id="story_001",
+            headline="Unsupported",
+            summary="This has no facts.",
+            supporting_fact_ids=["missing_fact"],
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["missing_fact_ids"] == ["missing_fact"]
+    assert ctx.artifacts.brief.revision == 0
+    assert ctx.artifacts.brief.storylines == []
+
+
+def test_set_outline():
+    ctx = make_ctx()
+
+    result = parse_result(
+        set_outline(
+            ctx,
+            sections=[
+                {
+                    "title": "Lead",
+                    "bullet_points": ["Open with Team Taco."],
+                    "required_fact_ids": ["fact_001"],
+                    "storyline_ids": ["story_001"],
+                }
+            ],
+        )
+    )
+
+    assert result == {"ok": True, "brief_revision": 1}
+    assert ctx.artifacts.brief.outline.revision_at_set == 1
+    assert ctx.artifacts.brief.outline.sections[0].title == "Lead"
+    assert ctx.log.entries[-1].data["operation"] == "set_outline"
+
+
+def test_set_style_and_bias():
+    ctx = make_ctx()
+
+    style_result = parse_result(
+        set_style(
+            ctx,
+            voice="beat reporter",
+            pacing="fast",
+            humor_level=2,
+            formality="sharp casual",
+        )
+    )
+    bias_result = parse_result(
+        set_bias(
+            ctx,
+            favored_teams=["Team Taco"],
+            disfavored_teams=["Waiver Wire"],
+            intensity=2,
+            framing_rules=["Praise decisive wins."],
+        )
+    )
+
+    assert style_result == {"ok": True, "brief_revision": 1}
+    assert bias_result == {"ok": True, "brief_revision": 2}
+    assert ctx.artifacts.brief.style.voice == "beat reporter"
+    assert ctx.artifacts.brief.bias.favored_teams == ["Team Taco"]
+
+
+def test_read_brief_staleness():
+    ctx = make_ctx()
+    set_outline(ctx, sections=[{"title": "Lead"}])
+    save_fact(ctx, id="fact_001", claim_text="A later claim.", data_refs=["source"])
+
+    result = parse_result(read_brief(ctx))
+
+    assert result["revision"] == 2
+    assert result["staleness_info"] == {
+        "outline_stale": True,
+        "outline_gap": "1 mutation(s) since outline was set",
+    }
+
+
+def test_read_brief_no_staleness():
+    ctx = make_ctx()
+    save_fact(ctx, id="fact_001", claim_text="A claim.", data_refs=["source"])
+    set_outline(ctx, sections=[{"title": "Lead", "required_fact_ids": ["fact_001"]}])
+
+    result = parse_result(read_brief(ctx))
+
+    assert result["revision"] == 2
+    assert result["staleness_info"] == {}

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -1,0 +1,221 @@
+"""Side-by-side characterization of legacy and copied reporter behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from backend.services.reporter.config import ReportConfig, TimeRange, ToneControls
+from backend.services.reporter.generator import (
+    _build_system_prompt as copied_system_prompt,
+)
+from backend.services.reporter.generator import (
+    _build_user_message as copied_user_message,
+)
+from backend.services.reporter.generator import generate_article as copied_generate
+from backend.services.reporter.runner.models import ToolCall as CopiedToolCall
+from backend.services.reporter.runner.schemas import (
+    Article,
+    ArticleOutput,
+    ReportBrief,
+)
+from backend.services.reporter.runner.tools.article_tools import (
+    ARTICLE_TOOL_SPECS as COPIED_ARTICLE_TOOLS,
+)
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS as COPIED_BRIEF_TOOLS,
+)
+from backend.services.reporter.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS as COPIED_PERSISTENT_TOOLS,
+)
+from backend.services.reporter.runner.tools.procedure_tools import (
+    PROCEDURE_TOOL_SPECS as COPIED_PROCEDURE_TOOLS,
+)
+from reporter_v2.config import ReportConfig as LegacyReportConfig
+from reporter_v2.runner.article_generator import (
+    _build_system_prompt as legacy_system_prompt,
+)
+from reporter_v2.runner.article_generator import (
+    _build_user_message as legacy_user_message,
+)
+from reporter_v2.runner.article_generator import generate_article as legacy_generate
+from reporter_v2.runner.schemas import (
+    Article as LegacyArticle,
+)
+from reporter_v2.runner.schemas import (
+    ArticleOutput as LegacyArticleOutput,
+)
+from reporter_v2.runner.schemas import (
+    ReportBrief as LegacyReportBrief,
+)
+from reporter_v2.runner.tools.article_tools import (
+    ARTICLE_TOOL_SPECS as LEGACY_ARTICLE_TOOLS,
+)
+from reporter_v2.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS as LEGACY_BRIEF_TOOLS,
+)
+from reporter_v2.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS as LEGACY_PERSISTENT_TOOLS,
+)
+from reporter_v2.runner.tools.procedure_tools import (
+    PROCEDURE_TOOL_SPECS as LEGACY_PROCEDURE_TOOLS,
+)
+
+
+ROOT = Path(__file__).parents[4]
+
+
+class DualLeagueData:
+    """Small fake satisfying both the legacy and frozen generator seams."""
+
+    league_id = "league_123"
+    effective_week = 8
+    _query_conn = None
+
+    def run_sql(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        del params, limit
+        if "FROM leagues" in query:
+            return {
+                "columns": ["league_id", "name"],
+                "rows": [[self.league_id, ""]],
+                "row_count": 1,
+            }
+        return {"columns": [], "rows": [], "row_count": 0}
+
+
+class ScriptedCompletion:
+    def __init__(self) -> None:
+        self.responses = [
+            _response(
+                CopiedToolCall(
+                    id="write",
+                    name="write_section",
+                    arguments={"name": "main", "content": "# Week 8\n\nTaco won."},
+                )
+            ),
+            _response(
+                CopiedToolCall(
+                    id="submit",
+                    name="submit_article",
+                    arguments={},
+                )
+            ),
+        ]
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        del kwargs
+        return self.responses.pop(0)
+
+
+def _response(call: CopiedToolCall) -> Any:
+    raw_call = SimpleNamespace(
+        id=call.id,
+        function=SimpleNamespace(
+            name=call.name,
+            arguments=json.dumps(call.arguments),
+        ),
+    )
+    message = SimpleNamespace(content=None, tool_calls=[raw_call])
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _stable_output(output: Any) -> dict[str, Any]:
+    summary = dict(output.run_log_summary)
+    summary.pop("session_id", None)
+    entries = []
+    for entry in output.run_log_entries:
+        data = dict(entry["data"])
+        data.pop("duration_ms", None)
+        entries.append(
+            {
+                "turn": entry["turn"],
+                "event_type": entry["event_type"],
+                "data": data,
+            }
+        )
+    return {
+        "article": output.article,
+        "brief": output.brief.model_dump(mode="json"),
+        "summary": summary,
+        "entries": entries,
+    }
+
+
+def test_public_config_and_artifact_schemas_match_legacy() -> None:
+    config = ReportConfig(
+        time_range=TimeRange.range(7, 8),
+        focus_hints=["playoff race"],
+        tone=ToneControls(snark_level=2, hype_level=3, seriousness=1),
+    ).with_bias(favored=["Team Taco"], intensity=2)
+
+    assert config.model_dump(mode="json") == LegacyReportConfig.model_validate(
+        config.model_dump(mode="json")
+    ).model_dump(mode="json")
+    assert ReportConfig.model_json_schema() == LegacyReportConfig.model_json_schema()
+    assert ReportBrief.model_json_schema() == LegacyReportBrief.model_json_schema()
+    assert Article.model_json_schema() == LegacyArticle.model_json_schema()
+    assert ArticleOutput.model_json_schema() == LegacyArticleOutput.model_json_schema()
+
+
+def test_prompts_and_non_data_tool_contracts_match_legacy() -> None:
+    config = ReportConfig.for_week(
+        8,
+        voice="deadpan beat writer",
+        snark_level=2,
+        focus_hints=["bench disasters"],
+        custom_instructions="End with one clean callback.",
+    )
+
+    assert copied_system_prompt() == legacy_system_prompt()
+    assert copied_user_message(config) == legacy_user_message(
+        LegacyReportConfig.model_validate(config.model_dump(mode="json"))
+    )
+    assert COPIED_BRIEF_TOOLS == LEGACY_BRIEF_TOOLS
+    assert COPIED_ARTICLE_TOOLS == LEGACY_ARTICLE_TOOLS
+    assert COPIED_PROCEDURE_TOOLS == LEGACY_PROCEDURE_TOOLS
+    assert COPIED_PERSISTENT_TOOLS == LEGACY_PERSISTENT_TOOLS
+
+
+def test_prompt_and_procedure_assets_match_legacy() -> None:
+    legacy = ROOT / "reporter_v2"
+    copied = ROOT / "backend" / "services" / "reporter"
+
+    for relative_path in (
+        "prompts/system.md",
+        "procedures/drafting.md",
+        "procedures/research.md",
+        "procedures/storyline.md",
+        "procedures/verification.md",
+    ):
+        assert (copied / relative_path).read_bytes() == (
+            legacy / relative_path
+        ).read_bytes()
+
+
+def test_generator_and_runner_output_match_legacy() -> None:
+    data = DualLeagueData()
+    copied = asyncio.run(
+        copied_generate(
+            data,  # type: ignore[arg-type]
+            ReportConfig.for_week(8),
+            complete=ScriptedCompletion(),
+        )
+    )
+    legacy = asyncio.run(
+        legacy_generate(
+            data,  # type: ignore[arg-type]
+            LegacyReportConfig.for_week(8),
+            complete=ScriptedCompletion(),
+        )
+    )
+
+    assert _stable_output(copied) == _stable_output(legacy)

--- a/backend/tests/services/reporter/test_completion.py
+++ b/backend/tests/services/reporter/test_completion.py
@@ -1,0 +1,278 @@
+"""Tests for resilient completion retry and model fallback."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.reporter.runner.completion import (
+    CompletionClient,
+    CompletionSettings,
+    RetryPolicy,
+    is_retryable_error,
+    retry_delay_seconds,
+)
+from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+from backend.tests.services.reporter.test_runner import make_response, run
+
+
+class RateLimitError(Exception):
+    """Stand-in for provider rate-limit errors."""
+
+    def __init__(self, message: str = "Rate limit exceeded", *, status_code: int = 429):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class SequenceCompletion:
+    """Completion fn that returns or raises items from a prebuilt sequence."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.requests: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        if not self.outcomes:
+            return make_response(text="empty")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def make_client(
+    complete: SequenceCompletion,
+    *,
+    model: str | None = None,
+    fallback_models: tuple[str, ...] = (),
+    retry: RetryPolicy | None = None,
+) -> CompletionClient:
+    return CompletionClient(
+        complete,
+        CompletionSettings(
+            model=model,
+            fallback_models=fallback_models,
+            retry=retry or RetryPolicy(),
+        ),
+    )
+
+
+def test_is_retryable_detects_rate_limit_by_type_and_status() -> None:
+    assert is_retryable_error(RateLimitError())
+    assert is_retryable_error(Exception("HTTP 429 too many requests"))
+    assert not is_retryable_error(ValueError("bad request"))
+
+
+def test_is_retryable_detects_empty_provider_json_response() -> None:
+    class APIError(Exception):
+        pass
+
+    assert is_retryable_error(
+        APIError(
+            "DeepseekException - Unable to get json response - "
+            "Expecting value: line 1 column 1 (char 0), Original Response: "
+        )
+    )
+    assert not is_retryable_error(APIError("invalid api key"))
+
+
+def test_requires_none_reasoning_with_tools_for_luna() -> None:
+    from backend.services.reporter.runner.completion import _requires_none_reasoning_with_tools
+
+    assert _requires_none_reasoning_with_tools("gpt-5.6-luna")
+    assert _requires_none_reasoning_with_tools("openai/gpt-5.6-luna")
+    assert not _requires_none_reasoning_with_tools("deepseek/deepseek-v4-pro")
+    assert not _requires_none_reasoning_with_tools(None)
+
+
+def test_retry_policy_validation() -> None:
+    with pytest.raises(ValueError, match="max_retries"):
+        RetryPolicy(max_retries=-1)
+    with pytest.raises(ValueError, match="base_delay"):
+        RetryPolicy(base_delay=0)
+    with pytest.raises(ValueError, match="max_delay"):
+        RetryPolicy(base_delay=2.0, max_delay=1.0)
+
+
+def test_completion_settings_model_chain_dedupes() -> None:
+    settings = CompletionSettings(
+        model="primary",
+        fallback_models=("fallback", "primary", "", "other"),
+    )
+    assert settings.model_chain() == ("primary", "fallback", "other")
+    assert CompletionSettings().model_chain() == ()
+
+
+def test_retry_delay_is_bounded(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "backend.services.reporter.runner.completion.random.uniform",
+        lambda _low, high: high,
+    )
+    assert retry_delay_seconds(0, base_delay=1.0, max_delay=30.0) == 1.0
+    assert retry_delay_seconds(5, base_delay=1.0, max_delay=30.0) == 30.0
+
+
+def test_retry_delay_honors_provider_suggested_wait(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "backend.services.reporter.runner.completion.random.uniform",
+        lambda low, high: low if high >= 3 else high,
+    )
+    delay = retry_delay_seconds(
+        0,
+        base_delay=1.0,
+        max_delay=30.0,
+        error=RateLimitError("Please try again in 3.188s."),
+    )
+    assert delay >= 3.188
+    assert delay <= 30.0
+
+
+def test_suggested_retry_delay_parses_message() -> None:
+    from backend.services.reporter.runner.completion import suggested_retry_delay_seconds
+
+    assert suggested_retry_delay_seconds(
+        RateLimitError("Please try again in 3.188s.")
+    ) == 3.188
+    assert suggested_retry_delay_seconds(
+        RateLimitError("Please try again in 250ms")
+    ) == 0.25
+    assert suggested_retry_delay_seconds(ValueError("nope")) is None
+
+
+def test_client_retries_same_model_then_succeeds(monkeypatch) -> None:
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr("backend.services.reporter.runner.completion.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "backend.services.reporter.runner.completion.random.uniform",
+        lambda _low, high: high,
+    )
+
+    complete = SequenceCompletion(
+        [
+            RateLimitError("429"),
+            RateLimitError("429"),
+            make_response(text="ok"),
+        ]
+    )
+    client = make_client(
+        complete,
+        model="primary",
+        retry=RetryPolicy(max_retries=3, base_delay=1.0, max_delay=30.0),
+    )
+
+    result = run(client.complete(messages=[]))
+
+    assert result.choices[0].message.content == "ok"
+    assert [req["model"] for req in complete.requests] == [
+        "primary",
+        "primary",
+        "primary",
+    ]
+    assert sleeps == [1.0, 2.0]
+
+
+def test_client_falls_back_after_retries(monkeypatch) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("backend.services.reporter.runner.completion.asyncio.sleep", fake_sleep)
+
+    complete = SequenceCompletion(
+        [
+            RateLimitError("primary-1"),
+            RateLimitError("primary-2"),
+            RateLimitError("primary-3"),
+            RateLimitError("primary-4"),
+            make_response(text="fallback-ok"),
+        ]
+    )
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=3, base_delay=0.01, max_delay=0.01),
+    )
+
+    result = run(client.complete(messages=[]))
+
+    assert result.choices[0].message.content == "fallback-ok"
+    models = [req["model"] for req in complete.requests]
+    assert models == ["primary", "primary", "primary", "primary", "fallback"]
+
+
+def test_client_raises_non_retryable_immediately() -> None:
+    complete = SequenceCompletion([ValueError("invalid request")])
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=3),
+    )
+
+    with pytest.raises(ValueError, match="invalid request"):
+        run(client.complete(messages=[]))
+
+    assert [req["model"] for req in complete.requests] == ["primary"]
+
+
+def test_client_raises_after_all_models_exhausted(monkeypatch) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("backend.services.reporter.runner.completion.asyncio.sleep", fake_sleep)
+
+    complete = SequenceCompletion(
+        [
+            RateLimitError("a1"),
+            RateLimitError("a2"),
+            RateLimitError("b1"),
+            RateLimitError("b2"),
+        ]
+    )
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=1, base_delay=0.01, max_delay=0.01),
+    )
+
+    with pytest.raises(RateLimitError, match="b2"):
+        run(client.complete(messages=[]))
+
+
+def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("backend.services.reporter.runner.completion.asyncio.sleep", fake_sleep)
+
+    complete = SequenceCompletion(
+        [
+            RateLimitError("primary down"),
+            make_response(text="from fallback"),
+        ]
+    )
+    runner = Runner(
+        ToolRegistry(),
+        client=make_client(
+            complete,
+            model="gpt-primary",
+            fallback_models=("gpt-fallback",),
+            retry=RetryPolicy(max_retries=0),
+        ),
+    )
+
+    output = run(runner.run("system", "user"))
+
+    assert "from fallback" in str(runner.log.entries) or output.article == ""
+    assert [req["model"] for req in complete.requests] == [
+        "gpt-primary",
+        "gpt-fallback",
+    ]

--- a/backend/tests/services/reporter/test_datalayer_tools.py
+++ b/backend/tests/services/reporter/test_datalayer_tools.py
@@ -1,0 +1,551 @@
+"""Tests for runner v2 datalayer tool adapters."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.services.datalayer import FrozenLeagueData, ReadyDataSnapshot
+from backend.services.reporter.generator import (
+    _get_league_metadata,
+    _make_roster_resolver,
+)
+from backend.tests.services.datalayer.test_frozen_query_runtime import (
+    _without_volatile_player_state,
+    ready_snapshot,
+)
+from datalayer.tools import SLEEPER_TOOLS
+from backend.services.reporter.runner.tools.datalayer_tools import (
+    DATALAYER_TOOL_SPECS,
+    register_datalayer_tools,
+)
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+EXPECTED_TOOL_NAMES = [
+    "league_snapshot",
+    "week_games",
+    "team_game",
+    "week_player_leaderboard",
+    "team_dossier",
+    "team_schedule",
+    "roster_at_cutoff",
+    "roster_snapshot",
+    "transactions",
+    "team_transactions",
+    "bench_analysis",
+    "standings",
+    "player_summary",
+    "player_weekly_log",
+    "season_leaders",
+    "playoff_bracket",
+    "team_playoff_path",
+    "run_sql",
+]
+
+
+class FakeFrozenLeagueData:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def _record(
+        self,
+        name: str,
+        *args: Any,
+        result: Any | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        self.calls.append((name, args, kwargs))
+        return result if result is not None else {"tool": name}
+
+    def get_league_snapshot(self, week: int | None = None) -> dict[str, Any]:
+        return self._record("get_league_snapshot", week)
+
+    def get_week_games_with_players(
+        self, week: int | None = None
+    ) -> list[dict[str, Any]]:
+        return self._record(
+            "get_week_games_with_players",
+            week,
+            result=[{"tool": "get_week_games_with_players", "week": week}],
+        )
+
+    def get_team_game_with_players(
+        self, roster_key: Any, week: int | None = None
+    ) -> dict[str, Any]:
+        return self._record("get_team_game_with_players", roster_key, week)
+
+    def get_week_player_leaderboard(
+        self, week: int | None = None, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        return self._record("get_week_player_leaderboard", week, limit, result=[])
+
+    def get_team_dossier(
+        self, roster_key: Any, week: int | None = None
+    ) -> dict[str, Any]:
+        return self._record("get_team_dossier", roster_key, week)
+
+    def get_team_schedule(self, roster_key: Any) -> dict[str, Any]:
+        return self._record("get_team_schedule", roster_key)
+
+    def get_roster_at_cutoff(self, roster_key: Any) -> dict[str, Any]:
+        return self._record("get_roster_at_cutoff", roster_key)
+
+    def get_roster_snapshot(self, roster_key: Any, week: int) -> dict[str, Any]:
+        return self._record("get_roster_snapshot", roster_key, week)
+
+    def get_transactions(self, week_from: int, week_to: int) -> list[dict[str, Any]]:
+        return self._record("get_transactions", week_from, week_to, result=[])
+
+    def get_team_transactions(
+        self, roster_key: Any, week_from: int, week_to: int
+    ) -> dict[str, Any]:
+        return self._record("get_team_transactions", roster_key, week_from, week_to)
+
+    def get_bench_analysis(
+        self, roster_key: Any = None, week: int | None = None
+    ) -> dict[str, Any]:
+        return self._record("get_bench_analysis", roster_key, week)
+
+    def get_standings(self, week: int | None = None) -> dict[str, Any]:
+        return self._record("get_standings", week)
+
+    def get_player_summary(self, player_key: Any) -> dict[str, Any]:
+        return self._record("get_player_summary", player_key)
+
+    def get_player_weekly_log(
+        self,
+        player_key: Any,
+        week_from: int | None = None,
+        week_to: int | None = None,
+    ) -> dict[str, Any]:
+        return self._record(
+            "get_player_weekly_log",
+            player_key,
+            week_from=week_from,
+            week_to=week_to,
+        )
+
+    def get_season_leaders(
+        self,
+        *,
+        week_from: int | None = None,
+        week_to: int | None = None,
+        position: str | None = None,
+        roster_key: Any = None,
+        role: str | None = None,
+        sort_by: str = "total",
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        return self._record(
+            "get_season_leaders",
+            week_from=week_from,
+            week_to=week_to,
+            position=position,
+            roster_key=roster_key,
+            role=role,
+            sort_by=sort_by,
+            limit=limit,
+            result=[],
+        )
+
+    def get_playoff_bracket(
+        self, bracket_type: str | None = None
+    ) -> dict[str, Any]:
+        return self._record("get_playoff_bracket", bracket_type)
+
+    def get_team_playoff_path(self, roster_key: Any) -> dict[str, Any]:
+        return self._record("get_team_playoff_path", roster_key)
+
+    def run_sql(self, query: str, *, limit: int = 200) -> dict[str, Any]:
+        return self._record("run_sql", query, limit=limit)
+
+
+def registered_registry() -> tuple[ToolRegistry, FakeFrozenLeagueData]:
+    registry = ToolRegistry()
+    data = FakeFrozenLeagueData()
+    register_datalayer_tools(registry, data)  # type: ignore[arg-type]
+    return registry, data
+
+
+def decode(result: str) -> Any:
+    return json.loads(result)
+
+
+def test_reporter_owns_compatible_frozen_tool_specs() -> None:
+    assert DATALAYER_TOOL_SPECS is not SLEEPER_TOOLS
+    assert [
+        spec["function"]["name"] for spec in DATALAYER_TOOL_SPECS
+    ] == EXPECTED_TOOL_NAMES
+    legacy_by_name = {spec["function"]["name"]: spec for spec in SLEEPER_TOOLS}
+    for spec in DATALAYER_TOOL_SPECS:
+        name = spec["function"]["name"]
+        legacy_name = "roster_current" if name == "roster_at_cutoff" else name
+        assert _without_descriptions(spec["function"]["parameters"]) == (
+            _without_descriptions(
+                legacy_by_name[legacy_name]["function"]["parameters"]
+            )
+        )
+
+    assert "roster_current" not in EXPECTED_TOOL_NAMES
+
+
+def test_register_all_datalayer_tools() -> None:
+    registry, _ = registered_registry()
+
+    assert registry.tool_names == EXPECTED_TOOL_NAMES
+    assert registry.tool_specs == DATALAYER_TOOL_SPECS
+
+
+def test_datalayer_handler_returns_json() -> None:
+    registry, data = registered_registry()
+    handler = registry.get_handler("team_dossier")
+
+    assert handler is not None
+    result = decode(handler(roster_key="Team Taco", week=8))
+
+    assert result == {"tool": "get_team_dossier"}
+    assert data.calls == [("get_team_dossier", ("Team Taco", 8), {})]
+
+
+def test_optional_defaults_flow_through_v1_handler_map() -> None:
+    registry, data = registered_registry()
+    handler = registry.get_handler("week_games")
+
+    assert handler is not None
+    result = decode(handler())
+
+    assert result == [{"tool": "get_week_games_with_players", "week": None}]
+    assert data.calls == [("get_week_games_with_players", (None,), {})]
+
+
+def test_registered_handlers_do_not_share_late_bound_method() -> None:
+    registry, data = registered_registry()
+    team_handler = registry.get_handler("team_schedule")
+    player_handler = registry.get_handler("player_summary")
+
+    assert team_handler is not None
+    assert player_handler is not None
+    decode(team_handler(roster_key="Team Taco"))
+    decode(player_handler(player_key="Patrick Mahomes"))
+
+    assert data.calls == [
+        ("get_team_schedule", ("Team Taco",), {}),
+        ("get_player_summary", ("Patrick Mahomes",), {}),
+    ]
+
+
+def test_run_sql_passes_default_and_explicit_limit() -> None:
+    registry, data = registered_registry()
+    handler = registry.get_handler("run_sql")
+
+    assert handler is not None
+    decode(handler(query="SELECT * FROM games"))
+    decode(handler(query="SELECT * FROM games", limit=20))
+
+    assert data.calls == [
+        ("run_sql", ("SELECT * FROM games",), {"limit": 200}),
+        ("run_sql", ("SELECT * FROM games",), {"limit": 20}),
+    ]
+    with pytest.raises(TypeError):
+        handler(query="SELECT * FROM games", params={"week": 2})
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "expected_call"),
+    [
+        ("league_snapshot", {}, ("get_league_snapshot", (None,), {})),
+        ("week_games", {"week": 2}, ("get_week_games_with_players", (2,), {})),
+        (
+            "team_game",
+            {"roster_key": "Alpha", "week": 2},
+            ("get_team_game_with_players", ("Alpha", 2), {}),
+        ),
+        (
+            "week_player_leaderboard",
+            {"week": 2, "limit": 3},
+            ("get_week_player_leaderboard", (2, 3), {}),
+        ),
+        (
+            "team_dossier",
+            {"roster_key": "Alpha", "week": 2},
+            ("get_team_dossier", ("Alpha", 2), {}),
+        ),
+        (
+            "team_schedule",
+            {"roster_key": "Alpha"},
+            ("get_team_schedule", ("Alpha",), {}),
+        ),
+        (
+            "roster_at_cutoff",
+            {"roster_key": "Alpha"},
+            ("get_roster_at_cutoff", ("Alpha",), {}),
+        ),
+        (
+            "roster_snapshot",
+            {"roster_key": "Alpha", "week": 1},
+            ("get_roster_snapshot", ("Alpha", 1), {}),
+        ),
+        (
+            "transactions",
+            {"week_from": 1, "week_to": 2},
+            ("get_transactions", (1, 2), {}),
+        ),
+        (
+            "team_transactions",
+            {"roster_key": "Alpha", "week_from": 1, "week_to": 2},
+            ("get_team_transactions", ("Alpha", 1, 2), {}),
+        ),
+        (
+            "bench_analysis",
+            {},
+            ("get_bench_analysis", (None, None), {}),
+        ),
+        ("standings", {}, ("get_standings", (None,), {})),
+        (
+            "player_summary",
+            {"player_key": "p1"},
+            ("get_player_summary", ("p1",), {}),
+        ),
+        (
+            "player_weekly_log",
+            {"player_key": "p1", "week_from": 1, "week_to": 2},
+            (
+                "get_player_weekly_log",
+                ("p1",),
+                {"week_from": 1, "week_to": 2},
+            ),
+        ),
+        (
+            "season_leaders",
+            {"position": "QB", "limit": 3},
+            (
+                "get_season_leaders",
+                (),
+                {
+                    "week_from": None,
+                    "week_to": None,
+                    "position": "QB",
+                    "roster_key": None,
+                    "role": None,
+                    "sort_by": "total",
+                    "limit": 3,
+                },
+            ),
+        ),
+        (
+            "playoff_bracket",
+            {},
+            ("get_playoff_bracket", (None,), {}),
+        ),
+        (
+            "team_playoff_path",
+            {"roster_key": "Alpha"},
+            ("get_team_playoff_path", ("Alpha",), {}),
+        ),
+        (
+            "run_sql",
+            {"query": "SELECT * FROM games", "limit": 2},
+            ("run_sql", ("SELECT * FROM games",), {"limit": 2}),
+        ),
+    ],
+)
+def test_every_tool_delegates_to_the_frozen_runtime(
+    tool_name: str,
+    arguments: dict[str, Any],
+    expected_call: tuple[str, tuple[Any, ...], dict[str, Any]],
+) -> None:
+    registry, data = registered_registry()
+    handler = registry.get_handler(tool_name)
+
+    assert handler is not None
+    decode(handler(**arguments))
+
+    assert data.calls == [expected_call]
+
+
+def test_all_tools_execute_against_a_real_frozen_artifact(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    calls = {
+        "league_snapshot": {"week": 2},
+        "week_games": {"week": 2},
+        "team_game": {"roster_key": "Alpha", "week": 2},
+        "week_player_leaderboard": {"week": 2, "limit": 3},
+        "team_dossier": {"roster_key": "Alpha", "week": 2},
+        "team_schedule": {"roster_key": "Alpha"},
+        "roster_at_cutoff": {"roster_key": "Alpha"},
+        "roster_snapshot": {"roster_key": "Alpha", "week": 1},
+        "transactions": {"week_from": 1, "week_to": 2},
+        "team_transactions": {
+            "roster_key": "Alpha",
+            "week_from": 1,
+            "week_to": 2,
+        },
+        "bench_analysis": {"roster_key": "Alpha", "week": 2},
+        "standings": {"week": 2},
+        "player_summary": {"player_key": "p1"},
+        "player_weekly_log": {
+            "player_key": "p1",
+            "week_from": 1,
+            "week_to": 2,
+        },
+        "season_leaders": {
+            "week_from": 1,
+            "week_to": 2,
+            "position": "QB",
+            "roster_key": "Alpha",
+            "role": "starter",
+            "sort_by": "total",
+            "limit": 3,
+        },
+        "playoff_bracket": {},
+        "team_playoff_path": {"roster_key": "Alpha"},
+        "run_sql": {
+            "query": "SELECT week, matchup_id FROM games ORDER BY week",
+            "limit": 2,
+        },
+    }
+
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        registry = ToolRegistry()
+        register_datalayer_tools(registry, data)
+        results = {
+            name: decode(registry.get_handler(name)(**arguments))  # type: ignore[misc]
+            for name, arguments in calls.items()
+        }
+
+    golden_path = (
+        Path(__file__).parents[4]
+        / "datalayer"
+        / "tests"
+        / "characterization"
+        / "golden"
+        / "legacy_query_outputs.json"
+    )
+    golden = json.loads(golden_path.read_text(encoding="utf-8"))
+    assert set(results) == set(EXPECTED_TOOL_NAMES)
+    stable_results = _without_volatile_player_state(results)
+    stable_golden = _without_volatile_player_state(golden)
+    assert stable_results["week_games"] == stable_golden["week_games_with_players"]
+    assert stable_results["team_game"] == stable_golden["team_game_with_players"]
+    assert stable_results["team_schedule"] == stable_golden["team_schedule"]
+    assert stable_results["roster_at_cutoff"] == stable_golden[
+        "roster_current_by_name"
+    ]
+    assert results["run_sql"]["row_count"] == 2
+
+
+def test_missing_entities_remain_safe_tool_results(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        registry = ToolRegistry()
+        register_datalayer_tools(registry, data)
+        missing = {
+            "team": decode(
+                registry.get_handler("team_dossier")(
+                    roster_key="missing", week=2
+                )  # type: ignore[misc]
+            ),
+            "roster": decode(
+                registry.get_handler("roster_at_cutoff")(
+                    roster_key="missing"
+                )  # type: ignore[misc]
+            ),
+            "player": decode(
+                registry.get_handler("player_summary")(
+                    player_key="missing"
+                )  # type: ignore[misc]
+            ),
+        }
+
+    assert all(result["found"] is False for result in missing.values())
+
+
+def test_generator_metadata_and_legacy_roster_resolution_use_public_frozen_sql(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        resolve_roster = _make_roster_resolver(data)
+
+        assert _get_league_metadata(data) == ("123", "Test League")
+        assert resolve_roster("Alpha") == {
+            "found": True,
+            "roster_id": 1,
+            "team_name": "Alpha",
+        }
+        assert resolve_roster("Alice") == {
+            "found": True,
+            "roster_id": 1,
+            "team_name": "Alpha",
+        }
+        assert resolve_roster("2") == {
+            "found": True,
+            "roster_id": 2,
+            "team_name": "Beta",
+        }
+        assert resolve_roster("missing") == {
+            "found": False,
+            "roster_key": "missing",
+        }
+
+
+def test_reporter_adapter_and_datalayer_import_boundaries() -> None:
+    root = Path(__file__).parents[4]
+    adapter = (
+        root
+        / "backend"
+        / "services"
+        / "reporter"
+        / "runner"
+        / "tools"
+        / "datalayer_tools.py"
+    )
+    adapter_imports = _imports(adapter)
+    assert not any(
+        name == "datalayer" or name.startswith("datalayer.")
+        for name in adapter_imports
+    )
+    assert not any(name.startswith("backend.resources") for name in adapter_imports)
+    assert not any(name.startswith("backend.database") for name in adapter_imports)
+
+    datalayer_paths = [
+        *(root / "datalayer").rglob("*.py"),
+        *(root / "backend" / "services" / "datalayer").rglob("*.py"),
+    ]
+    reverse_imports = {
+        name
+        for path in datalayer_paths
+        for name in _imports(path)
+        if name == "backend.services.reporter"
+        or name.startswith("backend.services.reporter.")
+    }
+    assert reverse_imports == set()
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def _without_descriptions(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _without_descriptions(item)
+            for key, item in value.items()
+            if key != "description"
+        }
+    if isinstance(value, list):
+        return [_without_descriptions(item) for item in value]
+    return value

--- a/backend/tests/services/reporter/test_import_boundaries.py
+++ b/backend/tests/services/reporter/test_import_boundaries.py
@@ -1,0 +1,61 @@
+"""Dependency-boundary tests for the copied reporter service."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPORTER_ROOT = Path(__file__).parents[4] / "backend" / "services" / "reporter"
+
+
+def test_reporter_does_not_import_legacy_or_persistence_layers() -> None:
+    forbidden_prefixes = (
+        "backend.database",
+        "backend.resources",
+        "datalayer",
+        "reporter_v2",
+        "sqlalchemy",
+    )
+    imports = {
+        imported
+        for path in REPORTER_ROOT.rglob("*.py")
+        for imported in _imports(path)
+    }
+
+    assert not {
+        imported
+        for imported in imports
+        if any(
+            imported == prefix or imported.startswith(f"{prefix}.")
+            for prefix in forbidden_prefixes
+        )
+    }
+
+
+def test_reporter_has_no_reverse_dependency_from_datalayer() -> None:
+    root = Path(__file__).parents[4]
+    datalayer_paths = [
+        *(root / "datalayer").rglob("*.py"),
+        *(root / "backend" / "services" / "datalayer").rglob("*.py"),
+    ]
+    reverse_imports = {
+        imported
+        for path in datalayer_paths
+        for imported in _imports(path)
+        if imported == "backend.services.reporter"
+        or imported.startswith("backend.services.reporter.")
+    }
+
+    assert reverse_imports == set()
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -1,0 +1,525 @@
+"""Integration tests for the copied platform reporter generator."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from reporter_memory.context_store import ContextStore
+from backend.services.reporter.config import ReportConfig, TimeRange
+from backend.services.reporter.runner.completion import CompletionSettings
+from backend.services.reporter.runner.memory_lifecycle import persist_brief_facts
+from backend.services.reporter.generator import generate_article
+from backend.services.reporter.runner.models import ToolCall
+from backend.services.reporter.runner.schemas import Fact, ReportBrief, Storyline
+
+
+class FakeCompletion:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        if not self.responses:
+            return make_response(text="Done.")
+        return self.responses.pop(0)
+
+
+class FakeFrozenLeagueData:
+    def get_league_snapshot(self, week: int | None = None) -> dict[str, Any]:
+        return {
+            "week": week,
+            "standings": [
+                {"team_name": "Team Taco", "wins": 7, "losses": 1, "rank": 1},
+                {"team_name": "Waiver Wire", "wins": 2, "losses": 6, "rank": 8},
+            ],
+            "games": [
+                {
+                    "winner_team_name": "Team Taco",
+                    "loser_team_name": "Waiver Wire",
+                    "winner_points": 142.3,
+                    "loser_points": 98.7,
+                }
+            ],
+        }
+
+    def run_sql(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        del params, limit
+        if "FROM leagues" in query:
+            return {
+                "columns": ["league_id", "name"],
+                "rows": [["league_123", "Test League"]],
+                "row_count": 1,
+            }
+        return {"columns": [], "rows": [], "row_count": 0}
+
+
+def make_response(
+    *,
+    text: str | None = None,
+    tool_calls: list[ToolCall] | None = None,
+) -> Any:
+    raw_calls = [
+        SimpleNamespace(
+            id=call.id,
+            function=SimpleNamespace(
+                name=call.name,
+                arguments=json.dumps(call.arguments),
+            ),
+        )
+        for call in tool_calls or []
+    ]
+    message = SimpleNamespace(content=text, tool_calls=raw_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def tool_call(
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    call_id: str | None = None,
+) -> ToolCall:
+    return ToolCall(
+        id=call_id or f"call_{name}",
+        name=name,
+        arguments=arguments or {},
+    )
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def make_persistence_completion(*, submit: bool = True) -> FakeCompletion:
+    responses = [
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "save_fact",
+                    {
+                        "id": "fact_score",
+                        "claim_text": "Team Taco beat Waiver Wire 142.3-98.7.",
+                        "data_refs": ["league_snapshot:week=8"],
+                        "numbers": {"winner_points": 142.3, "loser_points": 98.7},
+                        "category": "score",
+                    },
+                    "call_fact_score",
+                ),
+                tool_call(
+                    "save_fact",
+                    {
+                        "id": "fact_record",
+                        "claim_text": "Team Taco improved to 7-1.",
+                        "data_refs": ["league_snapshot:week=8"],
+                        "numbers": {"wins": 7, "losses": 1},
+                        "category": "standing",
+                    },
+                    "call_fact_record",
+                ),
+            ]
+        ),
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "save_storyline",
+                    {
+                        "id": "story_taco",
+                        "headline": "Taco Takes Control",
+                        "summary": "Team Taco paired a blowout win with a 7-1 record.",
+                        "supporting_fact_ids": ["fact_score", "fact_record"],
+                        "priority": 1,
+                        "tags": ["blowout", "standings"],
+                    },
+                    "call_story",
+                )
+            ]
+        ),
+        make_response(
+            tool_calls=[
+                tool_call(
+                    "write_section",
+                    {
+                        "name": "lead",
+                        "content": "# Taco Takes Control\n\nTeam Taco won big.",
+                    },
+                    "call_write",
+                )
+            ]
+        ),
+    ]
+    if submit:
+        responses.append(make_response(tool_calls=[tool_call("submit_article")]))
+    return FakeCompletion(responses)
+
+
+def test_generate_article_end_to_end_tool_loop() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "research"}, "call_1")]),
+            make_response(tool_calls=[tool_call("league_snapshot", {"week": 8}, "call_2")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_score",
+                            "claim_text": "Team Taco beat Waiver Wire 142.3-98.7.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"winner_points": 142.3, "loser_points": 98.7},
+                            "category": "score",
+                        },
+                        "call_3",
+                    ),
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_record",
+                            "claim_text": "Team Taco improved to 7-1.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 7, "losses": 1},
+                            "category": "standing",
+                        },
+                        "call_4",
+                    ),
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_waiver",
+                            "claim_text": "Waiver Wire fell to 2-6.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 2, "losses": 6},
+                            "category": "standing",
+                        },
+                        "call_5",
+                    ),
+                ]
+            ),
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "storyline"}, "call_6")]),
+            make_response(tool_calls=[tool_call("read_brief", call_id="call_7")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_storyline",
+                        {
+                            "id": "story_taco",
+                            "headline": "Taco Takes Control",
+                            "summary": "Team Taco paired a blowout win with a 7-1 record.",
+                            "supporting_fact_ids": ["fact_score", "fact_record"],
+                            "priority": 1,
+                            "tags": ["blowout", "standings"],
+                        },
+                        "call_8",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "set_outline",
+                        {
+                            "sections": [
+                                {
+                                    "title": "Lead",
+                                    "bullet_points": ["Open on Team Taco's blowout."],
+                                    "required_fact_ids": ["fact_score", "fact_record"],
+                                    "storyline_ids": ["story_taco"],
+                                },
+                                {
+                                    "title": "Fallout",
+                                    "bullet_points": ["Note Waiver Wire's slide."],
+                                    "required_fact_ids": ["fact_waiver"],
+                                    "storyline_ids": [],
+                                },
+                            ]
+                        },
+                        "call_9",
+                    ),
+                    tool_call(
+                        "set_style",
+                        {
+                            "voice": "sports columnist",
+                            "pacing": "fast",
+                            "humor_level": 1,
+                            "formality": "casual",
+                        },
+                        "call_10",
+                    ),
+                ]
+            ),
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "drafting"}, "call_11")]),
+            make_response(tool_calls=[tool_call("read_brief", call_id="call_12")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "write_section",
+                        {
+                            "name": "lead",
+                            "content": "# Taco Takes Control\n\nTeam Taco beat Waiver Wire 142.3-98.7 and moved to 7-1.",
+                        },
+                        "call_13",
+                    ),
+                    tool_call(
+                        "write_section",
+                        {
+                            "name": "fallout",
+                            "content": "# Fallout\n\nWaiver Wire fell to 2-6 after the loss.",
+                        },
+                        "call_14",
+                    ),
+                ]
+            ),
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "verification"}, "call_15")]),
+            make_response(tool_calls=[tool_call("read_article", call_id="call_16")]),
+            make_response(tool_calls=[tool_call("read_brief", call_id="call_17")]),
+            make_response(tool_calls=[tool_call("submit_article", call_id="call_18")]),
+        ]
+    )
+
+    output = run(
+        generate_article(
+            FakeFrozenLeagueData(),
+            ReportConfig(
+                time_range=TimeRange.single_week(8),
+                custom_instructions="weekly recap",
+            ),
+            completion=CompletionSettings(model="test-model"),
+            complete=complete,
+        )
+    )
+
+    assert "Team Taco beat Waiver Wire 142.3-98.7" in output.article
+    assert output.brief.meta.league_id == "league_123"
+    assert output.brief.meta.week_start == 8
+    assert len(output.brief.facts) == 3
+    assert output.brief.storylines[0].headline == "Taco Takes Control"
+    assert output.run_log_summary["submitted"] is True
+    assert output.run_log_summary["procedures_loaded"] == [
+        "research",
+        "storyline",
+        "drafting",
+        "verification",
+    ]
+    assert any(
+        entry["event_type"] == "tool_call"
+        and entry["data"]["tool_name"] == "league_snapshot"
+        and entry["data"]["params"] == {"week": 8}
+        for entry in output.run_log_entries
+    )
+    first_request = complete.requests[0]
+    assert first_request["model"] == "test-model"
+    tool_names = [spec["function"]["name"] for spec in first_request["tools"]]
+    assert "save_fact" in tool_names
+    assert "save_memory_callback" in tool_names
+    assert "write_section" in tool_names
+    assert "league_snapshot" in tool_names
+
+
+def test_generate_article_allows_backtracking_from_drafting_to_research() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "drafting"}, "call_1")]),
+            make_response(tool_calls=[tool_call("read_brief", call_id="call_2")]),
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "research"}, "call_3")]),
+            make_response(tool_calls=[tool_call("league_snapshot", {"week": 8}, "call_4")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_late",
+                            "claim_text": "Team Taco was 7-1 after week 8.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 7, "losses": 1},
+                            "category": "standing",
+                        },
+                        "call_5",
+                    )
+                ]
+            ),
+            make_response(tool_calls=[tool_call("load_procedure", {"name": "drafting"}, "call_6")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "write_section",
+                        {
+                            "name": "lead",
+                            "content": "# Lead\n\nTeam Taco was 7-1 after week 8.",
+                        },
+                        "call_7",
+                    )
+                ]
+            ),
+            make_response(tool_calls=[tool_call("submit_article", call_id="call_8")]),
+        ]
+    )
+
+    output = run(
+        generate_article(
+            FakeFrozenLeagueData(),
+            ReportConfig(time_range=TimeRange.single_week(8)),
+            complete=complete,
+        )
+    )
+
+    assert output.run_log_summary["submitted"] is True
+    assert output.run_log_summary["procedures_loaded"] == [
+        "drafting",
+        "research",
+        "drafting",
+    ]
+    assert output.brief.facts[0].id == "fact_late"
+    assert "Team Taco was 7-1" in output.article
+
+
+def test_generate_article_persists_storyline_facts_after_submit(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        output = run(
+            generate_article(
+                FakeFrozenLeagueData(),
+                ReportConfig(time_range=TimeRange.single_week(8)),
+                context_store=context_store,
+                complete=make_persistence_completion(),
+            )
+        )
+
+        facts = context_store.get_storyline_facts("story_taco")
+        facts_by_id = {fact["fact_id"]: fact for fact in facts}
+
+        assert output.run_log_summary["submitted"] is True
+        assert set(facts_by_id) == {"fact_score", "fact_record"}
+        assert facts_by_id["fact_score"]["claim_text"] == (
+            "Team Taco beat Waiver Wire 142.3-98.7."
+        )
+        assert facts_by_id["fact_score"]["numbers"] == {
+            "winner_points": 142.3,
+            "loser_points": 98.7,
+        }
+    finally:
+        context_store.close()
+
+
+def test_generate_article_post_run_fact_persistence_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        for _ in range(2):
+            run(
+                generate_article(
+                    FakeFrozenLeagueData(),
+                    ReportConfig(time_range=TimeRange.single_week(8)),
+                    context_store=context_store,
+                    complete=make_persistence_completion(),
+                )
+            )
+
+        facts = context_store.get_storyline_facts("story_taco")
+
+        assert {fact["fact_id"] for fact in facts} == {"fact_score", "fact_record"}
+    finally:
+        context_store.close()
+
+
+def test_persist_brief_facts_skips_missing_supporting_fact_ids(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    brief = ReportBrief(
+        facts=[
+            Fact(
+                id="fact_saved",
+                claim_text="A supported fact.",
+                data_refs=["source"],
+            )
+        ],
+        storylines=[
+            Storyline(
+                id="story_partial",
+                headline="Partial Story",
+                summary="One support ID is stale.",
+                supporting_fact_ids=["fact_saved", "fact_missing"],
+            )
+        ],
+    )
+    try:
+        persist_brief_facts(context_store, brief, week=8)
+
+        facts = context_store.get_storyline_facts("story_partial")
+
+        assert [fact["fact_id"] for fact in facts] == ["fact_saved"]
+    finally:
+        context_store.close()
+
+
+def test_generate_article_does_not_persist_facts_without_submit(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        output = run(
+            generate_article(
+                FakeFrozenLeagueData(),
+                ReportConfig(time_range=TimeRange.single_week(8)),
+                context_store=context_store,
+                complete=make_persistence_completion(submit=False),
+            )
+        )
+
+        assert output.run_log_summary["submitted"] is False
+        assert context_store.get_storyline_facts("story_taco") == []
+    finally:
+        context_store.close()
+
+
+def test_generate_article_eval_mode_skips_post_run_fact_persistence(
+    tmp_path: Path,
+) -> None:
+    context_store = ContextStore(
+        tmp_path / "context.db",
+        league_id="league_123",
+        season="2024",
+    )
+    try:
+        output = run(
+            generate_article(
+                FakeFrozenLeagueData(),
+                ReportConfig(time_range=TimeRange.single_week(8)),
+                context_store=context_store,
+                complete=make_persistence_completion(),
+                allow_memory_writes=False,
+            )
+        )
+
+        assert output.run_log_summary["submitted"] is True
+        assert context_store.get_storyline_facts("story_taco") == []
+        assert context_store.get_storylines() == []
+    finally:
+        context_store.close()

--- a/backend/tests/services/reporter/test_persistent_tools.py
+++ b/backend/tests/services/reporter/test_persistent_tools.py
@@ -1,0 +1,588 @@
+"""Tests for reporter v2 persistent context tools."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from reporter_memory.context_store import ContextStore
+from backend.services.reporter.runner.tools.persistent_tools import (
+    PERSISTENT_TOOL_SPECS,
+    register_persistent_tools,
+)
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+@pytest.fixture
+def store() -> ContextStore:
+    context_store = ContextStore(
+        ":memory:",
+        league_id="league_123",
+        season="2024",
+    )
+    yield context_store
+    context_store.close()
+
+
+def registered_registry(
+    store: ContextStore,
+    *,
+    week: int = 8,
+    resolve_roster_fn: Callable[[str], dict[str, Any]] | None = None,
+    allow_memory_writes: bool = True,
+) -> ToolRegistry:
+    registry = ToolRegistry()
+    register_persistent_tools(
+        registry,
+        store,
+        week=week,
+        resolve_roster_fn=resolve_roster_fn,
+        allow_memory_writes=allow_memory_writes,
+    )
+    return registry
+
+
+def decode(result: str) -> Any:
+    return json.loads(result)
+
+
+def test_registers_persistent_tools(store: ContextStore) -> None:
+    registry = registered_registry(store)
+
+    assert registry.tool_names[:6] == [
+        "save_persistent_storyline",
+        "save_team_context",
+        "save_league_note",
+        "load_persistent_storylines",
+        "load_team_context",
+        "load_league_notes",
+    ]
+    assert "search_story_memory" in registry.tool_names
+    assert "get_memory_candidate" in registry.tool_names
+    assert "save_memory_event" in registry.tool_names
+    assert "upsert_storyline_memory_card" in registry.tool_names
+    assert "save_storyline_trigger" in registry.tool_names
+    assert "mark_memory_used" in registry.tool_names
+    assert "plan_memory_verification" in registry.tool_names
+    assert "record_memory_verification" in registry.tool_names
+    assert registry.tool_specs == PERSISTENT_TOOL_SPECS
+
+
+def test_save_and_load_storyline(store: ContextStore) -> None:
+    def resolve_roster(roster_key: str) -> dict[str, Any]:
+        return {"found": roster_key == "Team Taco", "roster_id": 3}
+
+    registry = registered_registry(store, week=8, resolve_roster_fn=resolve_roster)
+    save_handler = registry.get_handler("save_persistent_storyline")
+    load_handler = registry.get_handler("load_persistent_storylines")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(
+            id="story_2024_w8_001",
+            headline="Taco Surges",
+            summary="Team Taco's playoff push is getting loud.",
+            status="active",
+            priority=1,
+            tags=["playoffs", "streak"],
+            team_keys=["Team Taco", "Unknown Team"],
+        )
+    )
+    storylines = decode(load_handler())
+
+    assert save_result["ok"] is True
+    assert save_result["saved"] is True
+    assert save_result["id"] == "story_2024_w8_001"
+    assert save_result["status"] == "active"
+    assert save_result["team_ids"] == [3]
+    assert save_result["unresolved_team_keys"] == ["Unknown Team"]
+    assert len(storylines) == 1
+    assert storylines[0]["id"] == "story_2024_w8_001"
+    assert storylines[0]["headline"] == "Taco Surges"
+    assert storylines[0]["summary"] == "Team Taco's playoff push is getting loud."
+    assert storylines[0]["priority"] == 1
+    assert storylines[0]["tags"] == ["playoffs", "streak"]
+    assert storylines[0]["team_ids"] == [3]
+    assert storylines[0]["week_created"] == 8
+    assert storylines[0]["history"] == []
+    assert storylines[0]["facts"] == []
+
+
+def test_save_team_context(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_handler = registry.get_handler("save_team_context")
+    load_handler = registry.get_handler("load_team_context")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(
+            roster_key="7",
+            narrative="A strong contender with a fragile running back room.",
+            outlook="contending",
+        )
+    )
+    team_context = decode(load_handler())
+
+    assert save_result == {
+        "ok": True,
+        "saved": True,
+        "roster_id": 7,
+        "roster_key": "7",
+    }
+    assert len(team_context) == 1
+    assert team_context[0]["roster_id"] == 7
+    assert team_context[0]["narrative"] == (
+        "A strong contender with a fragile running back room."
+    )
+    assert team_context[0]["outlook"] == "contending"
+    assert team_context[0]["week_last_updated"] == 9
+
+
+def test_save_team_context_unresolved_team(store: ContextStore) -> None:
+    registry = registered_registry(store)
+    handler = registry.get_handler("save_team_context")
+
+    assert handler is not None
+    result = decode(handler(roster_key="Team Taco", narrative="Unresolved."))
+
+    assert result == {
+        "ok": False,
+        "saved": False,
+        "error": "Could not resolve team: Team Taco",
+    }
+    assert store.get_all_team_context() == []
+
+
+def test_save_and_load_league_note(store: ContextStore) -> None:
+    registry = registered_registry(store, week=10)
+    save_handler = registry.get_handler("save_league_note")
+    load_handler = registry.get_handler("load_league_notes")
+
+    assert save_handler is not None
+    assert load_handler is not None
+    save_result = decode(
+        save_handler(key="season_theme", value="Every contender has a flaw.")
+    )
+    notes = decode(load_handler())
+
+    assert save_result == {"ok": True, "saved": True, "key": "season_theme"}
+    assert notes == {"season_theme": "Every contender has a flaw."}
+
+
+def test_load_empty_context(store: ContextStore) -> None:
+    registry = registered_registry(store)
+
+    load_storylines = registry.get_handler("load_persistent_storylines")
+    load_team_context = registry.get_handler("load_team_context")
+    load_league_notes = registry.get_handler("load_league_notes")
+
+    assert load_storylines is not None
+    assert load_team_context is not None
+    assert load_league_notes is not None
+    assert decode(load_storylines()) == []
+    assert decode(load_team_context()) == []
+    assert decode(load_league_notes()) == {}
+
+
+def test_save_memory_event_and_search(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_event = registry.get_handler("save_memory_event")
+    upsert_card = registry.get_handler("upsert_storyline_memory_card")
+    save_trigger = registry.get_handler("save_storyline_trigger")
+    search = registry.get_handler("search_story_memory")
+    get_candidate = registry.get_handler("get_memory_candidate")
+
+    assert save_event is not None
+    assert upsert_card is not None
+    assert save_trigger is not None
+    assert search is not None
+    assert get_candidate is not None
+
+    event_result = decode(
+        save_event(
+            id="event_trade_1",
+            event_type="trade",
+            week=3,
+            headline="Team A sends Player X away",
+            summary="Team A traded Player X to Team B.",
+            importance=7,
+            confidence="verified",
+            source_refs=["transactions:week=3"],
+            entities=[
+                {
+                    "entity_type": "player",
+                    "entity_id": "player_x",
+                    "display_name": "Player X",
+                    "role": "asset_sent",
+                }
+            ],
+        )
+    )
+    card_result = decode(
+        upsert_card(
+            id="story_trade",
+            headline="Trade Arc",
+            summary="A trade that may matter later.",
+            status="active",
+            importance=8,
+            arc_type="trade_regret",
+            evidence_event_ids=["event_trade_1"],
+            trigger_specs=[
+                {
+                    "id": "trigger_trade_callback",
+                    "trigger_type": "trade_evaluation",
+                    "target_week": 9,
+                    "condition": {"player_id": "player_x"},
+                }
+            ],
+        )
+    )
+    search_result = decode(
+        search(
+            week=9,
+            current_entities=[
+                {"entity_type": "player", "entity_id": "player_x"},
+            ],
+        )
+    )
+    candidate = decode(
+        get_candidate(owner_type="storyline", owner_id="story_trade")
+    )
+
+    assert event_result["ok"] is True
+    assert card_result["ok"] is True
+    assert card_result["linked_events"] == ["event_trade_1"]
+    assert search_result["count"] >= 1
+    assert search_result["candidates"][0]["owner_id"] == "story_trade"
+    assert "score_components" in search_result["candidates"][0]
+    assert candidate["found"] is True
+    assert candidate["candidate"]["events"][0]["id"] == "event_trade_1"
+
+
+def test_save_memory_event_verified_requires_source(store: ContextStore) -> None:
+    registry = registered_registry(store)
+    handler = registry.get_handler("save_memory_event")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            id="event_bad",
+            event_type="trade",
+            week=1,
+            headline="No source",
+            summary="Claims verification without evidence.",
+            confidence="verified",
+        )
+    )
+    assert result["ok"] is False
+    assert "source ref" in result["error"]
+
+
+def test_mark_memory_used_updates_one_shot_trigger(store: ContextStore) -> None:
+    registry = registered_registry(store, week=9)
+    save_trigger = registry.get_handler("save_storyline_trigger")
+    mark_used = registry.get_handler("mark_memory_used")
+    assert save_trigger is not None
+    assert mark_used is not None
+
+    decode(
+        save_trigger(
+            id="trigger_1",
+            trigger_type="rematch",
+            target_week=9,
+            fire_policy="one_shot",
+        )
+    )
+    result = decode(
+        mark_used(
+            candidate_id="trigger_1",
+            owner_type="trigger",
+            usage="article_callback",
+            reason="Used in callback paragraph.",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["trigger_update"] == "fired"
+    trigger = store.get_trigger("trigger_1")
+    assert trigger is not None
+    assert trigger["status"] == "fired"
+    assert trigger["fired_week"] == 9
+
+
+def _seed_trade_arc(store: ContextStore) -> None:
+    store.upsert_storyline(
+        {
+            "id": "story_trade",
+            "headline": "Trade Arc",
+            "summary": "Team A sent Player X away and may regret it.",
+            "status": "active",
+            "importance": 8,
+            "arc_type": "trade_regret",
+            "tags": ["trade", "regret"],
+            "team_ids": [1],
+        },
+        week=3,
+    )
+    store.upsert_story_event(
+        {
+            "id": "event_trade_1",
+            "week": 3,
+            "event_type": "trade",
+            "headline": "Team A sends Player X away",
+            "summary": "Team A traded Player X to Team B.",
+            "importance": 7,
+            "confidence": "verified",
+            "source_refs": ["transactions:week=3"],
+            "transaction_id": "txn_123",
+        }
+    )
+    store.replace_story_event_entities(
+        "event_trade_1",
+        [
+            {
+                "entity_type": "team",
+                "entity_id": "1",
+                "display_name": "Team A",
+                "role": "seller",
+            },
+            {
+                "entity_type": "player",
+                "entity_id": "player_x",
+                "display_name": "Player X",
+                "role": "asset_sent",
+            },
+        ],
+    )
+    store.link_storyline_event("story_trade", "event_trade_1", "origin")
+    store.upsert_storyline_trigger(
+        {
+            "id": "trigger_trade_callback",
+            "storyline_id": "story_trade",
+            "event_id": "event_trade_1",
+            "trigger_type": "trade_evaluation",
+            "target_week": 9,
+            "condition": {"player_id": "player_x", "former_roster_id": 1},
+            "fire_policy": "one_shot",
+        }
+    )
+
+
+def test_plan_memory_verification_returns_hints(store: ContextStore) -> None:
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    handler = registry.get_handler("plan_memory_verification")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            owner_type="storyline",
+            intended_callback_claim="Player X is punishing Team A.",
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["found"] is True
+    assert result["origin_week"] == 3
+    assert result["trigger_type"] == "trade_evaluation"
+    assert result["required_fact_roles"] == [
+        "origin_receipt",
+        "current_payoff",
+    ]
+    assert any(
+        call.startswith("transactions(week_from=3")
+        for call in result["suggested_datalayer_calls"]
+    )
+    assert any(
+        "team_game(roster_key=Team A, week=9)" in call
+        for call in result["suggested_datalayer_calls"]
+    )
+
+
+def test_record_memory_verification_requires_roles_and_facts(
+    store: ContextStore,
+) -> None:
+    from backend.services.reporter.runner.run_log import RunLog
+    from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+    from backend.services.reporter.runner.tools.brief_tools import save_fact
+    from backend.services.reporter.runner.tools.context import ToolContext
+
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    ctx = ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=1,
+    )
+    registry.set_context(ctx)
+    handler = registry.get_handler("record_memory_verification")
+    assert handler is not None
+
+    missing_roles = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[{"role": "origin_receipt", "fact_id": "fact_old"}],
+        )
+    )
+    assert missing_roles["ok"] is False
+    assert "origin_receipt" not in missing_roles["missing_roles"]
+    assert "current_payoff" in missing_roles["missing_roles"]
+
+    missing_facts = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[
+                {"role": "origin_receipt", "fact_id": "fact_old"},
+                {"role": "current_payoff", "fact_id": "fact_now"},
+            ],
+        )
+    )
+    assert missing_facts["ok"] is False
+    assert set(missing_facts["missing_fact_ids"]) == {"fact_old", "fact_now"}
+
+    save_fact(
+        ctx,
+        id="fact_old",
+        claim_text="Team A traded Player X in week 3.",
+        data_refs=["transactions:week=3"],
+    )
+    save_fact(
+        ctx,
+        id="fact_now",
+        claim_text="Player X scored 28 against Team A in week 9.",
+        data_refs=["team_game:Team A:week=9"],
+    )
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            status="verified",
+            fact_links=[
+                {"role": "origin_receipt", "fact_id": "fact_old"},
+                {"role": "current_payoff", "fact_id": "fact_now"},
+            ],
+            reason="Both receipt and payoff confirmed.",
+        )
+    )
+    assert result["ok"] is True
+    assert result["recorded"] is True
+    assert result["status"] == "verified"
+    assert result["access_id"] >= 1
+
+
+def test_record_memory_verification_allows_rejection_without_facts(
+    store: ContextStore,
+) -> None:
+    from backend.services.reporter.runner.run_log import RunLog
+    from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+    from backend.services.reporter.runner.tools.context import ToolContext
+
+    _seed_trade_arc(store)
+    registry = registered_registry(store, week=9)
+    registry.set_context(
+        ToolContext(
+            artifacts=ArtifactStore(),
+            procedures=ProcedureState(),
+            log=RunLog(),
+        )
+    )
+    handler = registry.get_handler("record_memory_verification")
+    assert handler is not None
+
+    result = decode(
+        handler(
+            candidate_id="story_trade",
+            status="rejected",
+            reason="Payoff is too weak.",
+        )
+    )
+    assert result["ok"] is True
+    assert result["status"] == "rejected"
+
+
+def test_eval_mode_blocks_memory_writes_but_allows_reads(store: ContextStore) -> None:
+    def resolve_roster(roster_key: str) -> dict[str, Any]:
+        return {"found": roster_key == "Team Taco", "roster_id": 3}
+
+    writable = registered_registry(store, week=8, resolve_roster_fn=resolve_roster)
+    save_handler = writable.get_handler("save_persistent_storyline")
+    assert save_handler is not None
+    decode(
+        save_handler(
+            id="story_seed",
+            headline="Seed Arc",
+            summary="Existing memory for eval reads.",
+            status="active",
+            priority=1,
+            tags=["seed"],
+            team_keys=["Team Taco"],
+        )
+    )
+
+    before = len(store.get_storylines())
+    registry = registered_registry(
+        store,
+        week=9,
+        resolve_roster_fn=resolve_roster,
+        allow_memory_writes=False,
+    )
+    blocked_save = registry.get_handler("save_persistent_storyline")
+    blocked_event = registry.get_handler("save_memory_event")
+    blocked_upsert = registry.get_handler("upsert_storyline_memory_card")
+    load_handler = registry.get_handler("load_persistent_storylines")
+    search_handler = registry.get_handler("search_story_memory")
+    assert blocked_save is not None
+    assert blocked_event is not None
+    assert blocked_upsert is not None
+    assert load_handler is not None
+    assert search_handler is not None
+
+    save_result = decode(
+        blocked_save(
+            id="story_eval_should_not_persist",
+            headline="Should Not Persist",
+            summary="Eval mode must not write this.",
+            status="active",
+            priority=1,
+            tags=["eval"],
+            team_keys=["Team Taco"],
+        )
+    )
+    event_result = decode(
+        blocked_event(
+            id="event_eval_should_not_persist",
+            event_type="trade",
+            week=9,
+            headline="Blocked Event",
+            summary="Should not hit the DB.",
+        )
+    )
+    upsert_result = decode(
+        blocked_upsert(
+            id="story_eval_upsert_blocked",
+            headline="Blocked Upsert",
+            summary="Should not hit the DB.",
+            status="active",
+        )
+    )
+    loaded = decode(load_handler())
+    searched = decode(search_handler(week=9, query="Seed"))
+
+    assert save_result["ok"] is True
+    assert save_result["saved"] is False
+    assert save_result["eval_mode"] is True
+    assert event_result["eval_mode"] is True
+    assert upsert_result["eval_mode"] is True
+    assert len(store.get_storylines()) == before
+    assert any(item["id"] == "story_seed" for item in loaded)
+    assert searched["ok"] is True
+    assert searched["count"] >= 1

--- a/backend/tests/services/reporter/test_procedure_tools.py
+++ b/backend/tests/services/reporter/test_procedure_tools.py
@@ -1,0 +1,87 @@
+"""Tests for backend.services.reporter procedure-loading tools."""
+
+from __future__ import annotations
+
+import json
+
+from backend.services.reporter.runner.run_log import RunLog, ProcedureSwitch
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools import procedure_tools
+from backend.services.reporter.runner.tools.procedure_tools import load_procedure
+
+
+def make_context(*, turn: int = 0) -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=turn,
+    )
+
+
+def test_load_valid_procedure(tmp_path, monkeypatch) -> None:
+    procedure_text = "# Research\n\nGather the facts first.\n"
+    (tmp_path / "research.md").write_text(procedure_text, encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context(turn=2)
+
+    result = load_procedure(ctx, name="research")
+
+    assert result == procedure_text
+    assert ctx.procedures.active == "research"
+
+
+def test_load_invalid_procedure() -> None:
+    ctx = make_context()
+
+    result = json.loads(load_procedure(ctx, name="bogus"))
+
+    assert result == {
+        "error": (
+            "Unknown procedure: bogus. "
+            "Valid: ['drafting', 'research', 'storyline', 'verification']"
+        )
+    }
+    assert ctx.procedures.active is None
+    assert ctx.log.procedure_history == []
+
+
+def test_load_missing_procedure_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context()
+
+    result = json.loads(load_procedure(ctx, name="research"))
+
+    assert result == {"error": f"Procedure file not found: {tmp_path / 'research.md'}"}
+    assert ctx.procedures.active is None
+    assert ctx.log.procedure_history == []
+
+
+def test_procedure_switch_logged(tmp_path, monkeypatch) -> None:
+    (tmp_path / "research.md").write_text("research text", encoding="utf-8")
+    (tmp_path / "drafting.md").write_text("drafting text", encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context(turn=4)
+
+    load_procedure(ctx, name="research")
+    ctx.turn = 7
+    load_procedure(ctx, name="drafting")
+
+    assert ctx.log.procedure_history == [
+        ProcedureSwitch(from_procedure=None, to_procedure="research", turn=4),
+        ProcedureSwitch(from_procedure="research", to_procedure="drafting", turn=7),
+    ]
+
+
+def test_procedure_state_updated(tmp_path, monkeypatch) -> None:
+    (tmp_path / "storyline.md").write_text("storyline text", encoding="utf-8")
+    (tmp_path / "verification.md").write_text("verification text", encoding="utf-8")
+    monkeypatch.setattr(procedure_tools, "PROCEDURE_DIR", tmp_path)
+    ctx = make_context()
+
+    load_procedure(ctx, name="storyline")
+    assert ctx.procedures.active == "storyline"
+
+    load_procedure(ctx, name="verification")
+    assert ctx.procedures.active == "verification"

--- a/backend/tests/services/reporter/test_run_log.py
+++ b/backend/tests/services/reporter/test_run_log.py
@@ -1,0 +1,122 @@
+"""Tests for backend.services.reporter runner run logs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from backend.services.reporter.runner.run_log import RunLog, RunLogEntry, ProcedureSwitch
+
+
+def test_add_tool_call() -> None:
+    log = RunLog(session_id="test1234")
+
+    log.add_tool_call(
+        "standings",
+        {"week": 8},
+        "12 teams in standings",
+        42,
+        turn=3,
+    )
+
+    assert log.tool_call_count == 1
+    assert len(log.entries) == 1
+
+    entry = log.entries[0]
+    assert entry.event_type == "tool_call"
+    assert entry.turn == 3
+    assert entry.data == {
+        "tool_name": "standings",
+        "params": {"week": 8},
+        "result_summary": "12 teams in standings",
+        "duration_ms": 42,
+    }
+
+
+def test_procedure_history() -> None:
+    log = RunLog()
+
+    log.add_procedure_switch(None, "research", turn=1)
+    log.add_tool_call("league_snapshot", {}, "snapshot loaded", 10, turn=2)
+    log.add_procedure_switch("research", "drafting", turn=5)
+
+    assert log.procedure_history == [
+        ProcedureSwitch(from_procedure=None, to_procedure="research", turn=1),
+        ProcedureSwitch(from_procedure="research", to_procedure="drafting", turn=5),
+    ]
+
+
+def test_streaming(tmp_path) -> None:
+    path = tmp_path / "run-log.md"
+    log = RunLog(session_id="stream01", started_at="2026-05-18T10:00:00")
+
+    log.start_streaming(path)
+    log.add_procedure_switch(None, "research", turn=1)
+    log.add_tool_call("standings", {"week": 8}, "12 teams", 25, turn=2)
+    log.add_artifact_write("brief", "save_fact", "fact_001", revision=1, turn=3)
+    log.add_model_text("Drafting a lead from the standings.", turn=4)
+    log.add_guardrail("tool_limit", 40, 50, turn=5)
+    log.add_completion({"status": "done"}, turn=6)
+    log.stop_streaming()
+
+    content = path.read_text(encoding="utf-8")
+    assert content.startswith("# Run Log: stream01\nStarted: 2026-05-18T10:00:00")
+    assert "Loaded procedure: research" in content
+    assert 'standings({"week": 8}) -> 12 teams [25ms]' in content
+    assert "save_fact(fact_001) -> brief rev 1" in content
+    assert "Model: Drafting a lead from the standings." in content
+    assert "GUARDRAIL: tool_limit (40/50)" in content
+    assert 'COMPLETE: {"status": "done"}' in content
+    assert "Completed:" in content
+    assert "Total tool calls: 1" in content
+    assert log._stream_file is None
+
+
+def test_streaming_truncates_long_tool_arguments(tmp_path) -> None:
+    path = tmp_path / "run-log.md"
+    log = RunLog(session_id="stream02")
+
+    log.start_streaming(path)
+    log.add_tool_call("write_section", {"content": "x" * 500}, "ok", 1, turn=1)
+    log.stop_streaming()
+
+    content = path.read_text(encoding="utf-8")
+    assert 'write_section({"content": "' in content
+    assert "..." in content
+    assert '"content": "' + ("x" * 500) not in content
+    assert log.entries[0].data["params"] == {"content": "x" * 500}
+
+
+def test_format_elapsed() -> None:
+    log = RunLog()
+    log._start_time = datetime(2026, 5, 18, 10, 0, 0)
+    entry = RunLogEntry(
+        timestamp=(log._start_time + timedelta(minutes=2, seconds=7)).isoformat(),
+        event_type="model_text",
+        data={"text_preview": "hello"},
+    )
+
+    assert log._format_elapsed(entry) == "[02:07]"
+
+
+def test_model_text_truncates_to_200_chars() -> None:
+    log = RunLog()
+
+    log.add_model_text("x" * 250, turn=1)
+
+    assert len(log.entries[0].data["text_preview"]) == 200
+
+
+def test_artifact_write_metadata_with_optional_revision() -> None:
+    log = RunLog()
+
+    log.add_artifact_write("brief", "set_outline", "outline", turn=7)
+
+    entry = log.entries[0]
+    assert entry.event_type == "artifact_write"
+    assert entry.turn == 7
+    assert entry.data == {
+        "artifact": "brief",
+        "operation": "set_outline",
+        "key": "outline",
+        "brief_revision": None,
+    }

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -1,0 +1,402 @@
+"""Tests for the reporter v2 runner loop."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
+from backend.services.reporter.runner.models import ToolCall
+from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+class FakeCompletion:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        if not self.responses:
+            return make_response()
+        return self.responses.pop(0)
+
+
+def make_response(
+    *,
+    text: str | None = None,
+    tool_calls: list[ToolCall] | None = None,
+    reasoning_content: str | None = None,
+) -> Any:
+    raw_calls = [
+        SimpleNamespace(
+            id=call.id,
+            function=SimpleNamespace(
+                name=call.name,
+                arguments=json.dumps(call.arguments),
+            ),
+        )
+        for call in tool_calls or []
+    ]
+    message = SimpleNamespace(
+        content=text,
+        reasoning_content=reasoning_content,
+        tool_calls=raw_calls,
+    )
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def tool_def(name: str, description: str = "Test tool") -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def registry_with(
+    name: str,
+    handler: Callable[..., Any],
+    *,
+    description: str = "Test tool",
+) -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(name, handler, tool_def(name, description))
+    return registry
+
+
+def tool_call(
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    call_id: str = "call_1",
+) -> ToolCall:
+    return ToolCall(id=call_id, name=name, arguments=arguments or {})
+
+
+def test_tool_registry_exposes_specs_and_names() -> None:
+    registry = registry_with("lookup", lambda: "{}")
+
+    assert registry.tool_names == ["lookup"]
+    assert registry.tool_specs == [tool_def("lookup")]
+    assert registry.get_handler("lookup") is not None
+    assert registry.get_handler("missing") is None
+
+
+def test_runner_context_tool_dispatch_updates_turn() -> None:
+    seen_turns: list[int] = []
+
+    def context_tool(ctx: ToolContext) -> str:
+        seen_turns.append(ctx.turn)
+        return "{}"
+
+    registry = ToolRegistry()
+    registry.register_context_tool("context_tool", context_tool, tool_def("context_tool"))
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("context_tool")]),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry, complete=complete)
+
+    run(runner.run("system", "user"))
+
+    assert seen_turns == [1]
+    assert runner.tool_context.artifacts is runner.artifacts
+    assert runner.tool_context.procedures is runner.procedures
+    assert runner.tool_context.log is runner.log
+
+
+def test_runner_simple_text_response() -> None:
+    complete = FakeCompletion([make_response(text="Done.")])
+    runner = Runner(ToolRegistry(), complete=complete)
+
+    output = run(runner.run("system", "user"))
+
+    assert output.article == ""
+    assert output.run_log_summary["total_turns"] == 1
+    assert output.run_log_summary["total_tool_calls"] == 0
+    assert runner.log.entries[0].event_type == "model_text"
+    assert complete.requests[0]["messages"][0]["role"] == "system"
+    assert complete.requests[0]["messages"][1]["role"] == "user"
+    assert complete.requests[0]["model"] is None
+
+
+def test_runner_passes_explicit_model_override() -> None:
+    complete = FakeCompletion([make_response(text="Done.")])
+    runner = Runner(
+        ToolRegistry(),
+        client=CompletionClient(
+            complete,
+            CompletionSettings(model="claude-sonnet-4-6"),
+        ),
+    )
+
+    run(runner.run("system", "user"))
+
+    assert complete.requests[0]["model"] == "claude-sonnet-4-6"
+
+
+def test_runner_tool_call_dispatch() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def handler(*, value: int) -> dict[str, Any]:
+        calls.append({"value": value})
+        return {"ok": True, "value": value}
+
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup", {"value": 7})]),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry_with("lookup", handler), complete=complete)
+
+    output = run(runner.run("system", "user"))
+
+    assert calls == [{"value": 7}]
+    assert output.run_log_summary["total_tool_calls"] == 1
+    assert len(complete.requests) == 2
+    assistant_message = complete.requests[1]["messages"][-2]
+    result_message = complete.requests[1]["messages"][-1]
+    assert assistant_message["role"] == "assistant"
+    assert assistant_message["tool_calls"][0]["id"] == "call_1"
+    assert result_message["role"] == "tool"
+    assert result_message["tool_call_id"] == "call_1"
+    assert result_message["content"] == '{"ok": true, "value": 7}'
+
+
+def test_runner_carries_tool_call_history_after_tool_call() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup")]),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry_with("lookup", lambda: "{}"), complete=complete)
+
+    run(runner.run("system", "user"))
+
+    second_request_messages = complete.requests[1]["messages"]
+    assert second_request_messages[-2] == {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+    }
+    assert second_request_messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "lookup",
+        "content": "{}",
+    }
+
+
+def test_runner_preserves_reasoning_content_in_tool_call_history() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("lookup")],
+                reasoning_content="reasoning payload",
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry_with("lookup", lambda: "{}"), complete=complete)
+
+    run(runner.run("system", "user"))
+
+    assistant_message = complete.requests[1]["messages"][-2]
+    assert assistant_message["reasoning_content"] == "reasoning payload"
+
+
+def test_runner_submit_article_breaks_loop() -> None:
+    def submit_article() -> str:
+        return '{"ok": true}'
+
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("submit_article")]),
+            make_response(text="Should not be requested."),
+        ]
+    )
+    runner = Runner(registry_with("submit_article", submit_article), complete=complete)
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["submitted"] is True
+    assert output.run_log_summary["total_turns"] == 1
+    assert len(complete.requests) == 1
+
+
+def test_runner_failed_submit_article_does_not_break_loop() -> None:
+    def submit_article() -> str:
+        return '{"ok": false, "error": "Cannot submit an empty article."}'
+
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("submit_article")]),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry_with("submit_article", submit_article), complete=complete)
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["submitted"] is False
+    assert output.run_log_summary["total_turns"] == 2
+    assert len(complete.requests) == 2
+
+
+def test_runner_does_not_limit_tool_calls() -> None:
+    calls: list[str] = []
+
+    def lookup() -> str:
+        calls.append("lookup")
+        return "{}"
+
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup", call_id="call_1")]),
+            make_response(tool_calls=[tool_call("lookup", call_id="call_2")]),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(
+        registry_with("lookup", lookup),
+        complete=complete,
+        config=RunnerConfig(max_turns=5),
+    )
+
+    output = run(runner.run("system", "user"))
+
+    assert calls == ["lookup", "lookup"]
+    assert output.run_log_summary["total_tool_calls"] == 2
+    assert not any(entry.event_type == "guardrail" for entry in runner.log.entries)
+
+
+def test_runner_procedure_replacement() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "research"}, "call_1")
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "drafting"}, "call_2")
+                ]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(
+        registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
+        complete=complete,
+        config=RunnerConfig(procedure_history_mode="replace"),
+    )
+
+    run(runner.run("system", "user"))
+
+    third_request_messages = complete.requests[2]["messages"]
+    procedure_messages = [
+        message
+        for message in third_request_messages
+        if message.get("role") == "tool" and message.get("name") == "load_procedure"
+    ]
+    active_procedure_messages = [
+        message
+        for message in procedure_messages
+        if message.get("content") != "[procedure replaced]"
+    ]
+    assert len(active_procedure_messages) == 1
+    assert active_procedure_messages[0]["tool_call_id"] == "call_2"
+    assert active_procedure_messages[0]["content"] == "# Drafting"
+    assert any(
+        message["tool_call_id"] == "call_1"
+        and message["content"] == "[procedure replaced]"
+        for message in procedure_messages
+    )
+
+
+def test_runner_procedure_append_mode() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "research"}, "call_1")
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call("load_procedure", {"name": "drafting"}, "call_2")
+                ]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(
+        registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
+        complete=complete,
+        config=RunnerConfig(procedure_history_mode=ProcedureHistoryMode.APPEND),
+    )
+
+    run(runner.run("system", "user"))
+
+    third_request_messages = complete.requests[2]["messages"]
+    procedure_messages = [
+        message
+        for message in third_request_messages
+        if message.get("role") == "tool" and message.get("name") == "load_procedure"
+    ]
+    assert [
+        (message["tool_call_id"], message["content"])
+        for message in procedure_messages
+    ] == [
+        ("call_1", "# Research"),
+        ("call_2", "# Drafting"),
+    ]
+    assert all(
+        message["content"] != "[procedure replaced]"
+        for message in procedure_messages
+    )
+
+
+def test_runner_max_turns() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup", call_id="call_1")]),
+            make_response(tool_calls=[tool_call("lookup", call_id="call_2")]),
+            make_response(tool_calls=[tool_call("lookup", call_id="call_3")]),
+        ]
+    )
+    runner = Runner(
+        registry_with("lookup", lambda: "{}"),
+        complete=complete,
+        config=RunnerConfig(max_turns=2),
+    )
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["total_turns"] == 2
+    assert output.run_log_summary["total_tool_calls"] == 2
+    assert len(complete.requests) == 2

--- a/backend/tests/services/reporter/test_schemas.py
+++ b/backend/tests/services/reporter/test_schemas.py
@@ -1,0 +1,199 @@
+"""Tests for reporter v2 schemas and state containers."""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.services.reporter.runner.schemas import (
+    Article,
+    ArticleOutput,
+    Fact,
+    ReportBrief,
+    Storyline,
+)
+from backend.services.reporter.runner.state import (
+    ArtifactStore,
+    ProcedureHistoryMode,
+    ProcedureState,
+    RunnerConfig,
+)
+
+
+class TestFact:
+    def test_basic_fact(self):
+        fact = Fact(
+            id="fact_001",
+            claim_text="Team Taco scored 142.3 points",
+            data_refs=["week_games:week=8"],
+            numbers={"points": 142.3},
+            category="score",
+        )
+
+        assert fact.id == "fact_001"
+        assert fact.claim_text == "Team Taco scored 142.3 points"
+        assert fact.data_refs == ["week_games:week=8"]
+        assert fact.numbers["points"] == 142.3
+        assert fact.category == "score"
+
+    def test_fact_defaults(self):
+        fact = Fact(id="fact_002", claim_text="Something happened")
+
+        assert fact.category == "general"
+        assert fact.data_refs == []
+        assert fact.numbers == {}
+
+
+class TestStoryline:
+    def test_basic_storyline(self):
+        storyline = Storyline(
+            id="story_001",
+            headline="Upset Alert",
+            summary="The underdog pulled off an upset.",
+            supporting_fact_ids=["fact_001", "fact_002"],
+            priority=1,
+            revision_at_set=3,
+        )
+
+        assert storyline.priority == 1
+        assert storyline.revision_at_set == 3
+        assert len(storyline.supporting_fact_ids) == 2
+
+    @pytest.mark.parametrize("priority", [0, 6])
+    def test_priority_bounds(self, priority):
+        with pytest.raises(ValidationError):
+            Storyline(
+                id="story_001",
+                headline="Invalid Priority",
+                summary="This priority is outside the allowed range.",
+                priority=priority,
+            )
+
+
+class TestReportBrief:
+    def test_from_dict(self, sample_v2_brief_dict):
+        brief = ReportBrief.model_validate(sample_v2_brief_dict)
+
+        assert brief.revision == 2
+        assert brief.meta.league_name == "Test League"
+        assert len(brief.facts) == 2
+        assert len(brief.storylines) == 1
+        assert len(brief.outline.sections) == 1
+
+    def test_get_fact(self, sample_v2_brief_dict):
+        brief = ReportBrief.model_validate(sample_v2_brief_dict)
+
+        fact = brief.get_fact("fact_001")
+        assert fact is not None
+        assert fact.claim_text == "Team Taco defeated The Waiver Wire 142.3-98.7"
+        assert brief.get_fact("nonexistent") is None
+
+    def test_bump_revision(self):
+        brief = ReportBrief()
+
+        assert brief.revision == 0
+        assert brief.bump_revision() == 1
+        assert brief.revision == 1
+
+    def test_staleness_info_empty_when_artifacts_are_current(
+        self, sample_v2_brief_dict
+    ):
+        brief = ReportBrief.model_validate(sample_v2_brief_dict)
+
+        assert brief.staleness_info() == {}
+
+    def test_staleness_info_reports_stale_outline_and_storylines(
+        self, sample_v2_brief_dict
+    ):
+        brief = ReportBrief.model_validate(sample_v2_brief_dict)
+        brief.bump_revision()
+
+        assert brief.staleness_info() == {
+            "outline_stale": True,
+            "outline_gap": "1 mutation(s) since outline was set",
+            "stale_storyline_ids": ["story_001"],
+        }
+
+    def test_staleness_info_skips_empty_outline(self):
+        brief = ReportBrief(revision=2)
+
+        assert brief.staleness_info() == {}
+
+
+class TestArticle:
+    def test_set_and_get_section(self):
+        article = Article()
+
+        article.set_section("opening", "# Opening\n\nHello.")
+        section = article.get_section("opening")
+
+        assert section is not None
+        assert section.content == "# Opening\n\nHello."
+        assert article.section_order == ["opening"]
+
+    def test_set_section_updates_existing_without_duplicate_order(self):
+        article = Article()
+
+        article.set_section("opening", "First draft")
+        article.set_section("opening", "Second draft")
+
+        assert len(article.sections) == 1
+        assert article.get_section("opening").content == "Second draft"
+        assert article.section_order == ["opening"]
+
+    def test_to_markdown_uses_section_order(self):
+        article = Article()
+        article.set_section("opening", "# Opening")
+        article.set_section("closing", "# Closing")
+        article.section_order = ["closing", "opening"]
+
+        assert article.to_markdown() == "# Closing\n\n# Opening"
+
+    def test_to_markdown_uses_section_list_when_order_empty(self):
+        article = Article()
+        article.set_section("opening", "# Opening")
+        article.set_section("closing", "# Closing")
+        article.section_order = []
+
+        assert article.to_markdown() == "# Opening\n\n# Closing"
+
+
+class TestArticleOutput:
+    def test_roundtrip_serialization(self, sample_v2_brief_dict):
+        brief = ReportBrief.model_validate(sample_v2_brief_dict)
+        output = ArticleOutput(
+            article="# Week 8 Recap\n\nContent here...",
+            brief=brief,
+            run_log_summary={"tool_calls": 3},
+            run_log_entries=[
+                {
+                    "event_type": "tool_call",
+                    "data": {"tool_name": "standings", "params": {"week": 8}},
+                }
+            ],
+        )
+
+        roundtripped = ArticleOutput.model_validate(output.model_dump())
+
+        assert roundtripped.article.startswith("# Week 8")
+        assert roundtripped.brief.meta.league_name == "Test League"
+        assert roundtripped.run_log_summary == {"tool_calls": 3}
+        assert roundtripped.run_log_entries[0]["data"]["params"] == {"week": 8}
+        assert roundtripped.generated_at is not None
+
+
+class TestRunnerState:
+    def test_artifact_store_defaults(self):
+        store = ArtifactStore()
+
+        assert isinstance(store.brief, ReportBrief)
+        assert isinstance(store.article, Article)
+
+    def test_procedure_state_defaults(self):
+        state = ProcedureState()
+
+        assert state.active is None
+
+    def test_runner_config_defaults(self):
+        config = RunnerConfig()
+
+        assert config.max_turns == 60
+        assert config.procedure_history_mode == ProcedureHistoryMode.REPLACE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ include = ["backend*", "datalayer*", "reporter_v2*", "reporter_memory*"]
 
 [tool.setuptools.package-data]
 reporter_v2 = ["procedures/*.md", "prompts/*.md"]
+"backend.services.reporter" = ["procedures/*.md", "prompts/*.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["backend/tests", "datalayer/tests", "reporter_memory/tests", "reporter_v2/tests"]


### PR DESCRIPTION
# PR: Copy reporter engine into backend service

Stack base: `codex/generation-0`

## Summary

- copy Reporter V2 configuration, generator/runner internals, prompts, procedures, tools, and relevant tests into `backend/services/reporter`
- recreate the 18-tool direct `FrozenLeagueData` adapter, including `roster_at_cutoff`
- adapt the copied generator to use only the frozen runtime's public guarded query surface for metadata and temporary legacy roster resolution
- add side-by-side legacy characterization, real frozen-artifact coverage, and import-boundary enforcement
- leave `reporter_v2` unchanged as the characterization oracle

## Boundaries

- no generation persistence, execution recording, artifact persistence, or typed-memory cutover in this PR
- no source datalayer facade, SQLAlchemy, PostgreSQL resource, or private-connection imports in the copied reporter
- legacy memory remains temporary and isolated to the copied behavior until the typed-memory adapter slice

## Verification

- `136 passed` — `backend/tests/services/reporter`
- `123 passed` — `reporter_v2/tests`
- `259 passed, 4 skipped` — `backend/tests/services/datalayer`
- `1 passed, 12 skipped` — `backend/tests/services/memory`
- Python 3.11 compile check and `git diff --check`

The skips require PostgreSQL test configuration or unavailable Windows symlink support.
