### PR TITLE
feat(reporting): align artifact storage contract

### DIFF
--- a/backend/database/models/reporting/artifacts.py
+++ b/backend/database/models/reporting/artifacts.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from sqlalchemy import (
+    CheckConstraint,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -23,12 +24,27 @@ class Artifact(Base):
     __tablename__ = "artifacts"
     __table_args__ = (
         UniqueConstraint(
-            "generation_id", "kind", "name", name="uq_artifacts_generation_kind_name"
+            "generation_id", "path", name="uq_artifacts_generation_path"
         ),
         UniqueConstraint(
             "id", "generation_id", name="uq_artifacts_id_generation"
         ),
-        Index("ix_artifacts_generation_kind", "generation_id", "kind"),
+        CheckConstraint(
+            "(finalized_version_id IS NULL) = (finalized_at IS NULL)",
+            name="finalization_shape",
+        ),
+        ForeignKeyConstraint(
+            ["finalized_version_id", "id", "generation_id"],
+            [
+                "reporting.artifact_versions.id",
+                "reporting.artifact_versions.artifact_id",
+                "reporting.artifact_versions.generation_id",
+            ],
+            name="fk_artifacts_finalized_version_same_artifact",
+            ondelete="RESTRICT",
+            use_alter=True,
+        ),
+        Index("ix_artifacts_generation_path", "generation_id", "path"),
         {"schema": "reporting"},
     )
 
@@ -40,9 +56,14 @@ class Artifact(Base):
         ForeignKey("reporting.generations.id", ondelete="RESTRICT"),
         nullable=False,
     )
-    kind: Mapped[str] = mapped_column(Text, nullable=False)
-    name: Mapped[str] = mapped_column(Text, nullable=False)
-    format: Mapped[str] = mapped_column(Text, nullable=False)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    media_type: Mapped[str] = mapped_column(Text, nullable=False)
+    finalized_version_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    finalized_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("now()"), nullable=False
     )
@@ -55,15 +76,15 @@ class ArtifactVersion(Base):
             "id", "generation_id", name="uq_artifact_versions_id_generation"
         ),
         UniqueConstraint(
+            "id",
+            "artifact_id",
+            "generation_id",
+            name="uq_artifact_versions_id_artifact_generation",
+        ),
+        UniqueConstraint(
             "artifact_id",
             "revision_number",
             name="uq_artifact_versions_artifact_revision",
-        ),
-        Index(
-            "uq_artifact_versions_one_final",
-            "artifact_id",
-            unique=True,
-            postgresql_where=text("status = 'final'"),
         ),
         ForeignKeyConstraint(
             ["artifact_id", "generation_id"],
@@ -88,11 +109,6 @@ class ArtifactVersion(Base):
             "artifact_id",
             text("revision_number DESC"),
         ),
-        Index(
-            "ix_artifact_versions_final",
-            "artifact_id",
-            postgresql_where=text("status = 'final'"),
-        ),
         {"schema": "reporting"},
     )
 
@@ -110,7 +126,6 @@ class ArtifactVersion(Base):
     source_tool_call_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True), nullable=True
     )
-    status: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=text("now()"), nullable=False
     )

--- a/backend/migrations/versions/0008_reporting_artifact_contract.py
+++ b/backend/migrations/versions/0008_reporting_artifact_contract.py
@@ -1,0 +1,378 @@
+"""Align reporting artifacts with the file-like artifact contract.
+
+Revision ID: 0008
+Revises: 0007
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _drop_legacy_artifact_guard() -> None:
+    op.execute("DROP FUNCTION reporting.protect_artifact_version() CASCADE")
+
+
+def _create_artifact_guards() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION reporting.protect_artifact()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        DECLARE
+            selected_revision smallint;
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                RAISE EXCEPTION 'artifact identities cannot be deleted';
+            END IF;
+
+            IF ROW(
+                NEW.id, NEW.generation_id, NEW.path,
+                NEW.media_type, NEW.created_at
+            ) IS DISTINCT FROM ROW(
+                OLD.id, OLD.generation_id, OLD.path,
+                OLD.media_type, OLD.created_at
+            ) THEN
+                RAISE EXCEPTION 'artifact identity is immutable';
+            END IF;
+
+            IF OLD.finalized_version_id IS NOT NULL
+               AND ROW(NEW.finalized_version_id, NEW.finalized_at)
+                   IS DISTINCT FROM
+                   ROW(OLD.finalized_version_id, OLD.finalized_at) THEN
+                RAISE EXCEPTION 'artifact finalization is immutable';
+            END IF;
+
+            IF OLD.finalized_version_id IS NULL
+               AND NEW.finalized_version_id IS NOT NULL THEN
+                SELECT revision_number INTO selected_revision
+                FROM reporting.artifact_versions
+                WHERE id = NEW.finalized_version_id
+                  AND artifact_id = NEW.id
+                  AND generation_id = NEW.generation_id;
+
+                IF selected_revision IS NULL THEN
+                    RAISE EXCEPTION 'finalized version must belong to the artifact';
+                END IF;
+
+                IF EXISTS (
+                    SELECT 1
+                    FROM reporting.artifact_versions
+                    WHERE artifact_id = NEW.id
+                      AND revision_number > selected_revision
+                ) THEN
+                    RAISE EXCEPTION 'only the latest artifact version can be finalized';
+                END IF;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER artifacts_protect_identity_and_finalization
+        BEFORE UPDATE OR DELETE ON reporting.artifacts
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_artifact()
+        """
+    )
+    op.execute(
+        """
+        CREATE FUNCTION reporting.protect_artifact_version()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        DECLARE
+            artifact_finalized_version_id uuid;
+        BEGIN
+            IF TG_OP <> 'INSERT' THEN
+                RAISE EXCEPTION 'artifact versions are append-only';
+            END IF;
+
+            SELECT finalized_version_id INTO artifact_finalized_version_id
+            FROM reporting.artifacts
+            WHERE id = NEW.artifact_id
+              AND generation_id = NEW.generation_id
+            FOR UPDATE;
+
+            IF FOUND AND artifact_finalized_version_id IS NOT NULL THEN
+                RAISE EXCEPTION 'finalized artifacts cannot accept new versions';
+            END IF;
+
+            RETURN NEW;
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER artifact_versions_append_only
+        BEFORE INSERT OR UPDATE OR DELETE ON reporting.artifact_versions
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_artifact_version()
+        """
+    )
+
+
+def _drop_artifact_guards() -> None:
+    op.execute("DROP FUNCTION reporting.protect_artifact_version() CASCADE")
+    op.execute("DROP FUNCTION reporting.protect_artifact() CASCADE")
+
+
+def _create_legacy_artifact_guard() -> None:
+    op.execute(
+        """
+        CREATE FUNCTION reporting.protect_artifact_version()
+        RETURNS trigger LANGUAGE plpgsql AS $reporting$
+        BEGIN
+            RAISE EXCEPTION 'artifact versions are append-only';
+        END;
+        $reporting$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER artifact_versions_append_only
+        BEFORE UPDATE OR DELETE ON reporting.artifact_versions
+        FOR EACH ROW EXECUTE FUNCTION reporting.protect_artifact_version()
+        """
+    )
+
+
+def upgrade() -> None:
+    _drop_legacy_artifact_guard()
+
+    op.add_column(
+        "artifacts", sa.Column("path", sa.Text(), nullable=True), schema="reporting"
+    )
+    op.add_column(
+        "artifacts",
+        sa.Column("media_type", sa.Text(), nullable=True),
+        schema="reporting",
+    )
+    op.add_column(
+        "artifacts",
+        sa.Column("finalized_version_id", sa.UUID(), nullable=True),
+        schema="reporting",
+    )
+    op.add_column(
+        "artifacts",
+        sa.Column("finalized_at", sa.DateTime(timezone=True), nullable=True),
+        schema="reporting",
+    )
+    op.execute(
+        """
+        UPDATE reporting.artifacts
+        SET path = kind || '/' || name,
+            media_type = CASE lower(format)
+                WHEN 'markdown' THEN 'text/markdown'
+                WHEN 'json' THEN 'application/json'
+                WHEN 'text' THEN 'text/plain'
+                ELSE format
+            END
+        """
+    )
+    op.alter_column("artifacts", "path", nullable=False, schema="reporting")
+    op.alter_column("artifacts", "media_type", nullable=False, schema="reporting")
+
+    op.create_unique_constraint(
+        "uq_artifact_versions_id_artifact_generation",
+        "artifact_versions",
+        ["id", "artifact_id", "generation_id"],
+        schema="reporting",
+    )
+    op.execute(
+        """
+        UPDATE reporting.artifacts AS artifact
+        SET finalized_version_id = version.id,
+            finalized_at = version.created_at
+        FROM reporting.artifact_versions AS version
+        WHERE version.artifact_id = artifact.id
+          AND version.generation_id = artifact.generation_id
+          AND version.status = 'final'
+        """
+    )
+    op.create_check_constraint(
+        op.f("ck_artifacts_finalization_shape"),
+        "artifacts",
+        "(finalized_version_id IS NULL) = (finalized_at IS NULL)",
+        schema="reporting",
+    )
+    op.create_foreign_key(
+        "fk_artifacts_finalized_version_same_artifact",
+        "artifacts",
+        "artifact_versions",
+        ["finalized_version_id", "id", "generation_id"],
+        ["id", "artifact_id", "generation_id"],
+        source_schema="reporting",
+        referent_schema="reporting",
+        ondelete="RESTRICT",
+    )
+
+    op.drop_index(
+        "uq_artifact_versions_one_final",
+        table_name="artifact_versions",
+        schema="reporting",
+        postgresql_where=sa.text("status = 'final'"),
+    )
+    op.drop_index(
+        "ix_artifact_versions_final",
+        table_name="artifact_versions",
+        schema="reporting",
+        postgresql_where=sa.text("status = 'final'"),
+    )
+    op.drop_column("artifact_versions", "status", schema="reporting")
+
+    op.drop_index(
+        "ix_artifacts_generation_kind",
+        table_name="artifacts",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        "uq_artifacts_generation_kind_name",
+        "artifacts",
+        type_="unique",
+        schema="reporting",
+    )
+    op.create_unique_constraint(
+        "uq_artifacts_generation_path",
+        "artifacts",
+        ["generation_id", "path"],
+        schema="reporting",
+    )
+    op.create_index(
+        "ix_artifacts_generation_path",
+        "artifacts",
+        ["generation_id", "path"],
+        schema="reporting",
+    )
+    op.drop_column("artifacts", "format", schema="reporting")
+    op.drop_column("artifacts", "name", schema="reporting")
+    op.drop_column("artifacts", "kind", schema="reporting")
+
+    _create_artifact_guards()
+
+
+def downgrade() -> None:
+    _drop_artifact_guards()
+
+    op.add_column(
+        "artifacts", sa.Column("kind", sa.Text(), nullable=True), schema="reporting"
+    )
+    op.add_column(
+        "artifacts", sa.Column("name", sa.Text(), nullable=True), schema="reporting"
+    )
+    op.add_column(
+        "artifacts", sa.Column("format", sa.Text(), nullable=True), schema="reporting"
+    )
+    op.execute(
+        """
+        UPDATE reporting.artifacts
+        SET kind = CASE
+                WHEN strpos(path, '/') > 0 THEN split_part(path, '/', 1)
+                ELSE 'artifact'
+            END,
+            name = CASE
+                WHEN strpos(path, '/') > 0
+                    THEN substring(path FROM strpos(path, '/') + 1)
+                ELSE path
+            END,
+            format = CASE media_type
+                WHEN 'text/markdown' THEN 'markdown'
+                WHEN 'application/json' THEN 'json'
+                WHEN 'text/plain' THEN 'text'
+                ELSE media_type
+            END
+        """
+    )
+    op.alter_column("artifacts", "kind", nullable=False, schema="reporting")
+    op.alter_column("artifacts", "name", nullable=False, schema="reporting")
+    op.alter_column("artifacts", "format", nullable=False, schema="reporting")
+
+    op.add_column(
+        "artifact_versions",
+        sa.Column("status", sa.Text(), nullable=True),
+        schema="reporting",
+    )
+    op.execute("UPDATE reporting.artifact_versions SET status = 'working'")
+    op.execute(
+        """
+        UPDATE reporting.artifact_versions AS version
+        SET status = 'final'
+        FROM reporting.artifacts AS artifact
+        WHERE artifact.finalized_version_id = version.id
+          AND artifact.id = version.artifact_id
+          AND artifact.generation_id = version.generation_id
+        """
+    )
+    op.alter_column(
+        "artifact_versions", "status", nullable=False, schema="reporting"
+    )
+
+    op.drop_constraint(
+        "fk_artifacts_finalized_version_same_artifact",
+        "artifacts",
+        type_="foreignkey",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        op.f("ck_artifacts_finalization_shape"),
+        "artifacts",
+        type_="check",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        "uq_artifact_versions_id_artifact_generation",
+        "artifact_versions",
+        type_="unique",
+        schema="reporting",
+    )
+    op.drop_column("artifacts", "finalized_at", schema="reporting")
+    op.drop_column("artifacts", "finalized_version_id", schema="reporting")
+
+    op.drop_index(
+        "ix_artifacts_generation_path",
+        table_name="artifacts",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        "uq_artifacts_generation_path",
+        "artifacts",
+        type_="unique",
+        schema="reporting",
+    )
+    op.create_unique_constraint(
+        "uq_artifacts_generation_kind_name",
+        "artifacts",
+        ["generation_id", "kind", "name"],
+        schema="reporting",
+    )
+    op.create_index(
+        "ix_artifacts_generation_kind",
+        "artifacts",
+        ["generation_id", "kind"],
+        schema="reporting",
+    )
+    op.drop_column("artifacts", "media_type", schema="reporting")
+    op.drop_column("artifacts", "path", schema="reporting")
+
+    op.create_index(
+        "ix_artifact_versions_final",
+        "artifact_versions",
+        ["artifact_id"],
+        schema="reporting",
+        postgresql_where=sa.text("status = 'final'"),
+    )
+    op.create_index(
+        "uq_artifact_versions_one_final",
+        "artifact_versions",
+        ["artifact_id"],
+        unique=True,
+        schema="reporting",
+        postgresql_where=sa.text("status = 'final'"),
+    )
+
+    _create_legacy_artifact_guard()

--- a/backend/tests/database/constraints/test_cross_namespace_integrity.py
+++ b/backend/tests/database/constraints/test_cross_namespace_integrity.py
@@ -434,9 +434,8 @@ def test_artifact_memory_inputs_and_workspace_pointer_are_scope_safe(
             {
                 "id": artifact_id,
                 "generation_id": producer,
-                "kind": "memory",
-                "name": "memory",
-                "format": "json",
+                "path": "memory.json",
+                "media_type": "application/json",
             },
         )
         connection.execute(
@@ -448,7 +447,6 @@ def test_artifact_memory_inputs_and_workspace_pointer_are_scope_safe(
                 "revision_number": 1,
                 "content": "{}",
                 "content_hash": f"hash-{uuid4()}",
-                "status": "test",
             },
         )
         connection.execute(

--- a/backend/tests/database/constraints/test_reporting_constraints.py
+++ b/backend/tests/database/constraints/test_reporting_constraints.py
@@ -120,14 +120,13 @@ def _artifact_values(
     generation_id: UUID,
     *,
     artifact_id: UUID | None = None,
-    name: str = "article",
+    path: str = "article.md",
 ) -> dict[str, object]:
     return {
         "id": artifact_id or uuid4(),
         "generation_id": generation_id,
-        "kind": "article",
-        "name": name,
-        "format": "markdown",
+        "path": path,
+        "media_type": "text/markdown",
     }
 
 
@@ -137,7 +136,6 @@ def _artifact_version_values(
     *,
     version_id: UUID | None = None,
     revision_number: int = 1,
-    status: str = "working",
     source_ai_call_id: UUID | None = None,
     source_tool_call_id: UUID | None = None,
 ) -> dict[str, object]:
@@ -150,7 +148,6 @@ def _artifact_version_values(
         "content_hash": f"hash-{uuid4()}",
         "source_ai_call_id": source_ai_call_id,
         "source_tool_call_id": source_tool_call_id,
-        "status": status,
     }
 
 
@@ -176,13 +173,13 @@ def test_reporting_schema_has_only_structural_checks_and_history_guards(
         "artifact_versions",
     }
     expected_checks = {
+        "ck_artifacts_finalization_shape",
         "ck_generations_workspace_shape",
         "ck_generations_unambiguous_memory_input",
     }
     expected_partial_uniques = {
         "uq_evaluation_workspaces_one_active",
         "uq_ai_calls_one_success_per_turn",
-        "uq_artifact_versions_one_final",
     }
     expected_triggers = {
         "generations_protect_terminal",
@@ -191,6 +188,7 @@ def test_reporting_schema_has_only_structural_checks_and_history_guards(
         "ai_calls_protect_terminal",
         "tool_calls_protect_terminal",
         "artifact_versions_append_only",
+        "artifacts_protect_identity_and_finalization",
     }
 
     with database_engine.connect() as connection:
@@ -408,7 +406,6 @@ def test_partial_unique_indexes_and_natural_identity(
             _artifact_version_values(
                 artifact_id,
                 generation_id,
-                status="final",
                 revision_number=1,
             ),
         )
@@ -435,13 +432,8 @@ def test_partial_unique_indexes_and_natural_identity(
     )
     _assert_integrity_error(
         database_engine,
-        sa.insert(ArtifactVersion).values(
-            **_artifact_version_values(
-                artifact_id,
-                generation_id,
-                status="final",
-                revision_number=2,
-            )
+        sa.insert(Artifact).values(
+            **_artifact_values(generation_id, path="article.md")
         ),
     )
 
@@ -469,7 +461,6 @@ def test_partial_unique_indexes_and_natural_identity(
             _artifact_version_values(
                 artifact_id,
                 generation_id,
-                status="working",
                 revision_number=2,
             ),
         )
@@ -607,6 +598,151 @@ def test_artifact_versions_are_append_only(database_engine: Engine) -> None:
         database_engine,
         sa.delete(ArtifactVersion).where(ArtifactVersion.id == version_id),
     )
+
+
+def test_artifact_identity_and_finalization_are_immutable(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Finalized Artifact")
+        generation_id = uuid4()
+        artifact_id = uuid4()
+        version_id = uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(domain, generation_id=generation_id),
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            _artifact_values(generation_id, artifact_id=artifact_id),
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            _artifact_version_values(
+                artifact_id,
+                generation_id,
+                version_id=version_id,
+            ),
+        )
+        connection.execute(
+            sa.update(Artifact)
+            .where(Artifact.id == artifact_id)
+            .values(
+                finalized_version_id=version_id,
+                finalized_at=sa.func.now(),
+            )
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(Artifact)
+        .where(Artifact.id == artifact_id)
+        .values(path="renamed.md"),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(Artifact)
+        .where(Artifact.id == artifact_id)
+        .values(finalized_version_id=None, finalized_at=None),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.delete(Artifact).where(Artifact.id == artifact_id),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.insert(ArtifactVersion).values(
+            **_artifact_version_values(
+                artifact_id,
+                generation_id,
+                revision_number=2,
+            )
+        ),
+    )
+
+
+def test_artifact_finalization_requires_its_latest_version(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Finalization Scope")
+        generation_id = uuid4()
+        first_artifact_id = uuid4()
+        second_artifact_id = uuid4()
+        first_version_id = uuid4()
+        latest_version_id = uuid4()
+        other_version_id = uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            _generation_values(domain, generation_id=generation_id),
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            [
+                _artifact_values(
+                    generation_id,
+                    artifact_id=first_artifact_id,
+                    path="article.md",
+                ),
+                _artifact_values(
+                    generation_id,
+                    artifact_id=second_artifact_id,
+                    path="brief.md",
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            [
+                _artifact_version_values(
+                    first_artifact_id,
+                    generation_id,
+                    version_id=first_version_id,
+                    revision_number=1,
+                ),
+                _artifact_version_values(
+                    first_artifact_id,
+                    generation_id,
+                    version_id=latest_version_id,
+                    revision_number=2,
+                ),
+                _artifact_version_values(
+                    second_artifact_id,
+                    generation_id,
+                    version_id=other_version_id,
+                    revision_number=1,
+                ),
+            ],
+        )
+
+    _assert_database_error(
+        database_engine,
+        sa.update(Artifact)
+        .where(Artifact.id == first_artifact_id)
+        .values(
+            finalized_version_id=first_version_id,
+            finalized_at=sa.func.now(),
+        ),
+    )
+    _assert_database_error(
+        database_engine,
+        sa.update(Artifact)
+        .where(Artifact.id == first_artifact_id)
+        .values(
+            finalized_version_id=other_version_id,
+            finalized_at=sa.func.now(),
+        ),
+    )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(Artifact)
+            .where(Artifact.id == first_artifact_id)
+            .values(
+                finalized_version_id=latest_version_id,
+                finalized_at=sa.func.now(),
+            )
+        )
 
 
 def test_closed_workspace_and_generation_membership_are_immutable(

--- a/backend/tests/database/migrations/test_reporting_artifact_contract.py
+++ b/backend/tests/database/migrations/test_reporting_artifact_contract.py
@@ -1,0 +1,239 @@
+from io import StringIO
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, inspect, text
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.reporting import Generation
+
+
+def _config(database_url: str, *, output_buffer: StringIO | None = None) -> Config:
+    root = Path(__file__).resolve().parents[4]
+    config = Config(
+        str(root / "backend" / "migrations" / "alembic.ini"),
+        output_buffer=output_buffer,
+    )
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
+    return config
+
+
+def test_artifact_contract_upgrade_and_downgrade_compile_offline() -> None:
+    upgrade_sql = StringIO()
+    command.upgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=upgrade_sql,
+        ),
+        "0008",
+        sql=True,
+    )
+    upgrade = upgrade_sql.getvalue()
+    assert "ADD COLUMN path TEXT" in upgrade
+    assert "ADD COLUMN media_type TEXT" in upgrade
+    assert "finalized_version_id" in upgrade
+    assert "fk_artifacts_finalized_version_same_artifact" in upgrade
+    assert "artifacts_protect_identity_and_finalization" in upgrade
+
+    downgrade_sql = StringIO()
+    command.downgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=downgrade_sql,
+        ),
+        "0008:0007",
+        sql=True,
+    )
+    downgrade = downgrade_sql.getvalue()
+    assert "ADD COLUMN kind TEXT" in downgrade
+    assert "ADD COLUMN status TEXT" in downgrade
+    assert "uq_artifact_versions_one_final" in downgrade
+
+
+def test_artifact_contract_migrates_legacy_rows_and_reverses(
+    database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_MIGRATION_REQUIRE_TLS", "false")
+    monkeypatch.setenv("AIDAM_MIGRATION_ROLE", "aidam_owner")
+    config = _config(database_url)
+    command.upgrade(config, "0007")
+
+    competition_id = uuid4()
+    season_id = uuid4()
+    generation_id = uuid4()
+    article_id = uuid4()
+    brief_id = uuid4()
+    notes_id = uuid4()
+    working_version_id = uuid4()
+    final_version_id = uuid4()
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Artifact Migration League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "kind": "live",
+                "status": "succeeded",
+                "request_text": "write the report",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 1,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO reporting.artifacts (
+                    id, generation_id, kind, name, format
+                ) VALUES
+                    (:article_id, :generation_id, 'article', 'main', 'markdown'),
+                    (:brief_id, :generation_id, 'brief', 'main', 'json'),
+                    (:notes_id, :generation_id, 'notes', 'main', 'text')
+                """
+            ),
+            {
+                "article_id": article_id,
+                "brief_id": brief_id,
+                "notes_id": notes_id,
+                "generation_id": generation_id,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO reporting.artifact_versions (
+                    id, artifact_id, generation_id, revision_number,
+                    content, content_hash, status
+                ) VALUES
+                    (
+                        :working_id, :artifact_id, :generation_id, 1,
+                        '# Working', 'legacy-working-hash', 'working'
+                    ),
+                    (
+                        :final_id, :artifact_id, :generation_id, 2,
+                        '# Final', 'legacy-final-hash', 'final'
+                    )
+                """
+            ),
+            {
+                "working_id": working_version_id,
+                "final_id": final_version_id,
+                "artifact_id": article_id,
+                "generation_id": generation_id,
+            },
+        )
+
+    command.upgrade(config, "0008")
+    with engine.connect() as connection:
+        artifact_columns = {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "artifacts", schema="reporting"
+            )
+        }
+        version_columns = {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "artifact_versions", schema="reporting"
+            )
+        }
+        rows = connection.execute(
+            text(
+                """
+                SELECT id, path, media_type, finalized_version_id, finalized_at
+                FROM reporting.artifacts
+                WHERE generation_id = :generation_id
+                ORDER BY path
+                """
+            ),
+            {"generation_id": generation_id},
+        ).mappings()
+        artifacts = {row["id"]: row for row in rows}
+        versions = connection.execute(
+            text(
+                """
+                SELECT id, revision_number, content, content_hash
+                FROM reporting.artifact_versions
+                WHERE artifact_id = :artifact_id
+                ORDER BY revision_number
+                """
+            ),
+            {"artifact_id": article_id},
+        ).all()
+
+    assert {"path", "media_type", "finalized_version_id", "finalized_at"} <= (
+        artifact_columns
+    )
+    assert {"kind", "name", "format"}.isdisjoint(artifact_columns)
+    assert "status" not in version_columns
+    assert artifacts[article_id]["path"] == "article/main"
+    assert artifacts[article_id]["media_type"] == "text/markdown"
+    assert artifacts[article_id]["finalized_version_id"] == final_version_id
+    assert artifacts[article_id]["finalized_at"] is not None
+    assert artifacts[brief_id]["media_type"] == "application/json"
+    assert artifacts[notes_id]["media_type"] == "text/plain"
+    assert versions == [
+        (working_version_id, 1, "# Working", "legacy-working-hash"),
+        (final_version_id, 2, "# Final", "legacy-final-hash"),
+    ]
+
+    command.downgrade(config, "0007")
+    with engine.connect() as connection:
+        legacy_artifact = connection.execute(
+            text(
+                """
+                SELECT kind, name, format
+                FROM reporting.artifacts
+                WHERE id = :article_id
+                """
+            ),
+            {"article_id": article_id},
+        ).one()
+        legacy_version_statuses = connection.execute(
+            text(
+                """
+                SELECT id, revision_number, content, content_hash, status
+                FROM reporting.artifact_versions
+                WHERE artifact_id = :artifact_id
+                ORDER BY revision_number
+                """
+            ),
+            {"artifact_id": article_id},
+        ).all()
+
+    assert legacy_artifact == ("article", "main", "markdown")
+    assert legacy_version_statuses == [
+        (
+            working_version_id,
+            1,
+            "# Working",
+            "legacy-working-hash",
+            "working",
+        ),
+        (final_version_id, 2, "# Final", "legacy-final-hash", "final"),
+    ]
+
+    command.upgrade(config, "0008")
+    command.downgrade(config, "base")
+    engine.dispose()

--- a/docs/database/reporting.md
+++ b/docs/database/reporting.md
@@ -8,9 +8,10 @@
 
 DB-028 governs implementation. PostgreSQL enforces generation identity and
 scope, essential natural/partial uniqueness, exactly one resolved memory-input
-shape, and final/terminal history immutability. Pydantic objects and generation
-workflows validate status/type values, ranges, JSON shapes, timestamps, lifecycle
-transitions, snapshot readiness, article completion, and fast-forward promotion.
+shape, selected artifact-version finality, and terminal history immutability.
+Pydantic objects and generation workflows validate status/type values, ranges,
+JSON shapes, timestamps, lifecycle transitions, snapshot readiness, required
+reporter outputs, and fast-forward promotion.
 
 ## Purpose
 
@@ -88,7 +89,8 @@ by `rerun_of_generation_id`.
 There is deliberately no output-memory pointer on the generation. An accepted
 live mutation produces the unique next `memory.memory_revisions` row associated
 with that generation. An evaluation mutation produces a generic
-`memory_workspace` artifact version and advances only its workspace pointer.
+`memory/workspace.json` artifact version and advances only its workspace
+pointer.
 
 The frontend polls this row and then fetches newly created AI calls, tool calls,
 and artifact versions. No jobs, leases, heartbeat protocol, event stream, or SSE
@@ -201,26 +203,31 @@ duplicating today's nearly one-to-one tool history.
 
 ### `reporting.artifacts`
 
-A stable named artifact inside a generation:
+A stable path-addressed artifact inside a generation:
 
 - `id uuid` primary key;
 - `generation_id`;
-- `kind` and `name`;
-- `format`: initially `markdown`, `json`, or `text`;
-- `created_at`.
+- normalized relative `path`;
+- IANA `media_type` such as `text/markdown` or `application/json`;
+- nullable `finalized_version_id` selecting one existing immutable version;
+- `created_at` and nullable `finalized_at`.
 
-Unique `(generation_id, kind, name)`.
+Unique `(generation_id, path)`. Paths use `/` separators, cannot be absolute,
+cannot contain empty, `.` or `..` segments, and are the programmatic identity of
+an output rather than an operating-system filesystem location. `media_type`
+describes representation and is immutable after creation; semantic categories
+do not belong in a closed artifact-kind enum.
 
-The article is an artifact with `kind = 'article'`. Briefs, outlines, diagnostics,
-or future editorial products use the same table only when they are worth
-persisting. A separate article table is unnecessary while article identity is
-already one-to-one with an artifact; the API can expose an article-specific
-resource or view.
+The reporter's required Markdown artifacts are `research/brief.md` and
+`article.md`, both with `media_type = 'text/markdown'`. Outlines, diagnostics,
+or future editorial products use additional paths without requiring schema or
+enum changes. A separate article table is unnecessary; the API can expose the
+finalized `article.md` version as an article-specific resource or view.
 
-An evaluation memory checkpoint is an artifact with
-`kind = 'memory_workspace'` and `format = 'json'`. Its deterministic full content
-allows the next simulated week to resume without querying alternative versions
-from the canonical memory schema.
+An evaluation memory checkpoint uses `memory/workspace.json` with
+`media_type = 'application/json'`. Its deterministic full content allows the
+next simulated week to resume without querying alternative versions from the
+canonical memory schema.
 
 ### `reporting.artifact_versions`
 
@@ -232,21 +239,24 @@ One complete immutable artifact revision:
 - complete content text;
 - SHA-256 content hash;
 - nullable source AI call and tool call;
-- status: `working` or `final`;
 - `created_at`.
 
 Constraints:
 
 - unique `(artifact_id, revision_number)`;
-- at most one final version per artifact;
-- a generation succeeds only with a final article artifact version;
-- revisions are append-only.
+- revisions are append-only;
+- `finalized_version_id`, when present, belongs to the same artifact;
+- finalization selects the latest existing version and never duplicates or
+  mutates its content; and
+- no new version may be appended after an artifact is finalized.
 
-Persisting complete Markdown after each article mutation is intentionally simple
-and makes rendering, auditing, and comparison straightforward. The current
-structured brief can stay inside the reporter; its mutations are already visible
-through tool calls. If desired, its final form can be stored as a generic JSON or
-Markdown artifact.
+Persisting complete UTF-8 Markdown after each successful mutation is
+intentionally simple and makes rendering, auditing, and comparison
+straightforward. The reporter uses the same version model for
+`research/brief.md` and `article.md`. `submit_artifact` selects an existing
+revision of `article.md`; generation finalization pins that version and the
+current brief version supplied in `ReporterOutput` rather than appending
+content-identical final copies.
 
 ## Token Analytics, Not Stored Pricing
 
@@ -282,8 +292,8 @@ Baseline indexes support the actual product queries:
 - AI calls by `(generation_id, turn_number, attempt_number)` and
   `(actual_model, completed_at)`;
 - tool calls by generation/AI call/ordinal and by `(tool_name, started_at)`;
-- artifacts by generation/kind;
-- artifact versions by `(artifact_id, revision_number desc)` and final status.
+- artifacts by `(generation_id, path)` and finalized version;
+- artifact versions by `(artifact_id, revision_number desc)`.
 - evaluation workspaces by competition/status and base revision.
 
 These indexes support browsing history, live progress, model-token aggregation,

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -21,7 +21,8 @@ unchanged as a characterization baseline until the new path is proven and cut
 over. The target is a thin platform shell around that proven behavior:
 
 - `GenerationService` owns durable workflow and input policy;
-- the reporter owns model-facing prompts, tools, artifacts, and the agent loop;
+- the reporter owns model-facing prompts, generic artifact tools, path-addressed
+  Markdown artifacts, and the agent loop;
 - a frozen `FrozenLeagueData` instance supplies all factual reads;
 - one `GenerationMemoryContext` supplies pinned retrieval and buffered typed
   memory proposals;
@@ -46,9 +47,9 @@ identity changed the meaning of an operation.
 ## One-Sentence Model
 
 A generation seals one factual snapshot and one memory revision, runs the
-mostly unchanged reporter through instrumented model and tool boundaries, then
-persists its final article and applies its buffered memory proposals under the
-generation lifecycle.
+reporter through instrumented model and tool boundaries, then pins the submitted
+`article.md` version, retains `research/brief.md`, and applies its buffered memory
+proposals under the generation lifecycle.
 
 ```mermaid
 flowchart LR
@@ -70,9 +71,9 @@ flowchart LR
 
 ## Settled Direction
 
-- Keep `generate_article`, `Runner`, `CompletionClient`, `ToolRegistry`, the
-  typed brief/article state, prompts, procedures, and model-facing non-memory
-  tool contracts behaviorally intact.
+- Keep `generate_article`, `Runner`, `CompletionClient`, `ToolRegistry`, prompts,
+  procedures, and model-facing non-artifact/non-memory tool contracts
+  behaviorally intact.
 - Create a new reporter copy under `backend/services/reporter/` as the platform
   design already specifies. Copy and characterize first; do not retrofit the
   legacy `reporter_v2` package in place.
@@ -88,9 +89,13 @@ flowchart LR
   fallbacks each produce their own AI-call record and token usage.
 - Record tool execution at the runner boundary. Preserve `RunLog` for local
   diagnostics, but do not use its truncated summaries as durable audit data.
-- Preserve in-memory artifact editing. Mirror article mutations to immutable
-  artifact versions and persist a final brief JSON artifact without changing
-  model-facing artifact tools.
+- Replace section-specific brief/article state with one path-addressed in-memory
+  artifact store. The model-facing contract is `list_artifacts`,
+  `read_artifact`, `create_artifact`, exact-match `edit_artifact`, and
+  revision-checked `submit_artifact`.
+- Use raw UTF-8 Markdown at `research/brief.md` and `article.md`; mirror each
+  successful mutation to an immutable version and finalize by selecting existing
+  versions rather than writing final copies.
 - Keep every database transaction short. No database session stays open during
   Sleeper I/O, model calls, tool execution, or filesystem work.
 - Use the existing resource-manager pattern. Services orchestrate managers and
@@ -104,7 +109,7 @@ flowchart LR
 | Component | Meaning |
 | --- | --- |
 | Generation | Durable product execution: request, ownership/scope, input manifest, state, telemetry, artifacts, and finalization |
-| Reporter | In-process content engine: prompts, loop, tools, brief, article state, and model interaction |
+| Reporter | In-process content engine: prompts, loop, tools, path-addressed Markdown state, and model interaction |
 
 For that reason the design belongs in `docs/generation/`, while the code remains
 split between `services/generations/` and `services/reporter/`. Putting both
@@ -141,10 +146,10 @@ These are explicit design questions, not implied implementation details:
    adapter.
 4. **Cross-resource success atomicity is not yet settled.** The memory contract
    currently commits through `RevisionManager`, while reporting finalization
-   must also seal the final article and succeed the generation. The owner of a
-   single all-or-nothing finalization transaction, or the accepted recovery
-   semantics if it remains multi-transactional, must be decided before that
-   slice is implemented.
+   must also pin the selected reporter outputs and succeed the generation. The
+   owner of a single all-or-nothing finalization transaction, or the accepted
+   recovery semantics if it remains multi-transactional, must be decided before
+   that slice is implemented.
 5. **The closed reporter-adapter PR is prior art, not an upstream dependency.**
    It proved the 18 frozen-data handlers can delegate to `FrozenLeagueData`, but
    the new integration must recreate that adapter under the new backend reporter

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -75,7 +75,9 @@ shape depends on the unresolved cross-resource memory transaction decision. It
 must at minimum ensure that:
 
 - the generation is still running;
-- a final article version exists and belongs to the generation;
+- the selected `article.md` and `research/brief.md` versions exist and belong to
+  the generation;
+- finalization pins those existing versions without creating copies;
 - input identity remains unchanged;
 - completion timestamps/progress are coherent; and
 - a terminal generation cannot be reopened or modified.
@@ -91,13 +93,17 @@ must at minimum ensure that:
 - full tool result text is retained; structured JSON is additional.
 - artifact revisions are positive, append-only, hash-verified, and allocated
   under concurrency control.
+- artifact identity is unique by normalized `(generation_id, path)`, while
+  immutable `media_type` describes representation rather than semantic role.
+- finalizing an artifact selects its latest existing version and forbids later
+  appends.
 - expected lifecycle conflicts raise typed application errors, never leak
   constraint names.
 
 ## Reporter Generator Contract
 
-The target generator keeps the current entry point and output shape with narrow
-dependency substitutions:
+The target generator keeps the current entry point, adopts `ReporterOutput`,
+and makes the required dependency substitutions:
 
 ```python
 async def generate_article(
@@ -111,7 +117,7 @@ async def generate_article(
     recorder: ReporterExecutionRecorder | None = None,
     complete: CompletionFn | None = None,
     allow_memory_writes: bool = True,
-) -> ArticleOutput: ...
+) -> ReporterOutput: ...
 ```
 
 Changes from Reporter V2 are intentionally limited:
@@ -120,12 +126,37 @@ Changes from Reporter V2 are intentionally limited:
 - legacy `ContextStore` becomes an already-pinned
   `GenerationMemoryContext`;
 - durable execution recording is injected;
+- structured brief/article state becomes path-addressed Markdown artifacts;
 - filesystem log/output ownership leaves the production generator; and
 - legacy memory prepare/finalize calls leave the reporter and move to the
   generation workflow.
 
-The reporter continues to own registry construction, prompt building, brief
-seeding, runner construction, and `ArticleOutput` assembly.
+The reporter continues to own registry construction, prompt building,
+`research/brief.md` seeding, runner construction, and `ReporterOutput` assembly.
+
+The output selects the submitted artifact and returns one complete current
+snapshot for every artifact in deterministic path order:
+
+```python
+class ArtifactSnapshot(BaseModel, frozen=True):
+    path: str
+    media_type: Literal["text/markdown"]
+    content: str
+    revision: int
+    content_hash: str
+
+
+class ReporterOutput(BaseModel, frozen=True):
+    submitted_path: str | None
+    artifacts: tuple[ArtifactSnapshot, ...]
+```
+
+`ReporterOutput` can represent an unsubmitted diagnostic result, but generation
+success requires `submitted_path == "article.md"` plus both
+`research/brief.md` and `article.md`. The snapshot matching `submitted_path` is
+the exact revision selected by `submit_artifact`; the service does not infer a
+later revision. `content_hash` is lowercase SHA-256 over the exact UTF-8
+content.
 
 The production path always supplies a durable recorder. Tests may use an
 in-memory recorder, and a transitional standalone CLI may omit it.
@@ -151,11 +182,11 @@ connection, a source client, or the snapshot artifact path separately.
 
 ### Required metadata/identity seam
 
-Reporter V2 currently seeds brief league metadata and resolves roster keys via
-private SQLite access. That cannot continue. The new runtime already supplies
-league display data through curated snapshot results, but the exact non-tool
-metadata contract used to seed `BriefMeta` must be made public or supplied by
-`GenerationService`.
+Reporter V2 currently seeds structured brief league metadata and resolves
+roster keys via private SQLite access. That cannot continue. The new runtime
+already supplies league display data through curated snapshot results, but the
+exact non-tool metadata contract used to seed `research/brief.md` must be made
+public or supplied by `GenerationService`.
 
 Typed memory proposals involving a team require durable `franchise_id` or
 `season_roster_id`. The datalayer design promises stable core identity in frozen
@@ -240,7 +271,7 @@ messages or tool schemas.
 3. captures full string output plus structured JSON when valid;
 4. records duration and success/failure;
 5. returns the same tool-result content to the model; and
-6. sets local submission state only when `submit_article` returns `ok: true`.
+6. sets local submission state only when `submit_artifact` returns `ok: true`.
 
 Unknown tools and handler exceptions are durable failed tool calls. Sanitized
 error data is persisted, while the model receives the existing safe JSON error
@@ -253,25 +284,35 @@ tool-call row records the implementation version used by that handler.
 
 ## Artifact Contract
 
-Artifact tools retain their current model-facing signatures. Their internal
-context gains a recorder hook that receives complete serialized state after a
-successful mutation.
+The reporter replaces section-specific brief/article tools with one generic,
+path-addressed Markdown contract:
 
-Required mappings:
+```python
+list_artifacts()
+read_artifact(path)
+create_artifact(path, content)
+edit_artifact(path, old_text, new_text, expected_revision)
+submit_artifact(path, expected_revision)
+```
 
-| Tool event | Durable action |
-| --- | --- |
-| `write_section`, `rewrite_section`, `set_section_order` success | append complete `article/main` Markdown as `working` |
-| `submit_article` success | expose submitted content to generation finalization; do not independently succeed the generation |
-| brief mutation | keep in memory; optionally record working brief versions only if later justified |
-| generation finalization | append/finalize `article/main`; append final `brief/main` JSON |
+`research/brief.md` and `article.md` are the required paths and both use
+`text/markdown`. Paths are normalized relative logical names, not host
+filesystem paths. `create_artifact` rejects an existing path.
+`edit_artifact` succeeds only when `expected_revision` is current and
+`old_text` occurs exactly once; zero or multiple matches are typed tool errors.
+It performs one literal replacement and appends the resulting complete content
+as a new immutable version. There is deliberately no `replace_all` mode.
 
-Identical consecutive working mutations should not create meaningless versions.
-The manager may compare the new content hash and status to the current artifact
-version inside its short transaction and return the existing version for a
-working no-op. Finalization always appends a distinct `final` version when the
-latest identical content is only `working`; artifact versions are never promoted
-or mutated in place.
+`list_artifacts` and `read_artifact` never append versions. Failed mutations and
+content-identical edits do not append versions. Each successful create/edit
+passes its complete snapshot to the recorder with source AI/tool provenance.
+
+`submit_artifact` accepts only `article.md`, requires its expected current
+revision, records no content version, and ends the reporter loop. The resulting
+`ReporterOutput` contains `submitted_path` plus current snapshots of all
+artifacts. Generation finalization pins the submitted article version and the
+returned current `research/brief.md` version. It never appends a distinct final
+copy or mutates an artifact version in place.
 
 ## Manifest Contract
 
@@ -318,7 +359,7 @@ The initial API remains polling-oriented:
 - read generation detail and exact manifest;
 - list/read AI calls and token usage;
 - list/read tool calls and full results; and
-- list/read artifact versions and the final article.
+- list/read artifact versions and the finalized `article.md` version.
 
 Routes authenticate/authorize, build context, call manager reads or
 `GenerationService`, and translate typed errors. They do not run model loops,

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -6,7 +6,7 @@
 - Make one generation reproducible from immutable data, memory, prompt, tool,
   model, and runner inputs.
 - Persist every provider attempt, full tool execution, token category, and
-  versioned article mutation at the boundary where it occurs.
+  versioned artifact mutation at the boundary where it occurs.
 - Keep resource persistence, workflow policy, and reporter behavior in separate
   layers.
 - Make live generation, explicit reruns, and later evaluation workspaces use the
@@ -33,7 +33,7 @@ flowchart TB
         Runner["Runner"]
         Completion["CompletionClient"]
         Registry["ToolRegistry"]
-        ArtifactState["In-memory ArtifactStore"]
+        ArtifactState["Path-addressed ArtifactStore"]
         DataTools["Frozen-data tool adapter"]
         MemoryTools["Typed-memory tool adapter"]
     end
@@ -83,7 +83,7 @@ The generation service owns the durable application workflow:
 - construct one frozen data runtime, one generation memory context, one
   execution recorder, and one reporter call;
 - update progress through the generation manager;
-- coordinate article finalization, memory proposal handling, and terminal
+- coordinate selected-version finalization, memory proposal handling, and terminal
   generation state; and
 - translate expected workflow failures into sanitized durable failure metadata.
 
@@ -98,7 +98,7 @@ The reporter owns content generation:
 - prompt and user-message construction;
 - runner loop and procedure replacement behavior;
 - tool registration and model-facing schemas;
-- in-memory brief and article state;
+- path-addressed in-memory Markdown artifact state;
 - model retry/fallback adapter behavior; and
 - a local `RunLog` diagnostic view.
 
@@ -126,7 +126,8 @@ centralized reporting ORM models
 - progress and terminal transitions;
 - AI-call attempt start/finish;
 - tool-call start/finish;
-- stable artifact creation and append-only artifact versions; and
+- stable path-addressed artifact creation, append-only versions, and
+  selected-version finalization; and
 - generation detail/history reads.
 
 Separate public managers for AI calls, tool calls, and artifact versions are not
@@ -183,8 +184,7 @@ backend/
 │       │   └── tools/
 │       │       ├── registry.py
 │       │       ├── context.py
-│       │       ├── brief.py
-│       │       ├── article.py
+│       │       ├── artifacts.py
 │       │       ├── procedures.py
 │       │       ├── datalayer.py
 │       │       └── memory.py
@@ -247,23 +247,29 @@ The service opens the frozen snapshot with a context manager, creates
 
 The reporter:
 
-- registers brief, article, procedure, frozen-data, and typed-memory tools;
-- seeds the same brief/config shape where equivalent metadata is available;
+- registers generic artifact, procedure, frozen-data, and typed-memory tools;
+- seeds `research/brief.md` with equivalent league/config metadata;
 - runs the same turn loop and procedure replacement behavior;
 - records every provider attempt before/after network I/O;
 - records tool calls before/after handler execution;
-- appends working article artifact versions after successful mutations; and
-- returns only after `submit_article` succeeds, the loop ends, or a failure
-  escapes.
+- appends complete artifact versions after successful mutations; and
+- returns `ReporterOutput` with all current snapshots. `submitted_path` is
+  `article.md` only after `submit_artifact` succeeds and is otherwise `null`;
+  an unsubmitted output cannot succeed the generation.
 
 ### 5. Finalization
 
-`submit_article` remains a reporter-level signal, not the durable generation
-commit. After reporter success, `GenerationService`:
+`submit_artifact(path, expected_revision)` remains a reporter-level selection
+and stop signal, not the durable generation commit. It accepts only the current
+revision and `article.md` as the submitted output. `ReporterOutput` returns the
+nullable submitted path plus complete snapshots of every in-memory artifact.
+Only a submitted output is eligible for success. `GenerationService` then:
 
 - obtains the complete memory proposal bundle exactly once;
-- persists the final article artifact version;
-- persists the final brief JSON artifact;
+- verifies that the submitted `article.md` revision and current
+  `research/brief.md` revision already exist durably;
+- pins those existing versions as the generation's finalized outputs without
+  appending content-identical final copies;
 - applies or deliberately discards the memory bundle according to generation
   kind/policy; and
 - transitions the generation to succeeded only when its required final outputs
@@ -276,7 +282,7 @@ memory commit remains an explicit open decision.
 
 A pre-start failure leaves a terminal generation without pinned inputs and
 records the failure stage. A running failure preserves completed AI calls, tool
-calls, and working artifact versions, discards the uncommitted memory buffer,
+calls, and artifact versions, discards the uncommitted memory buffer,
 and marks the generation failed. A terminal generation never reopens; a retry
 creates a linked generation.
 
@@ -306,17 +312,31 @@ Dollar pricing remains an application-time analytic over recorded usage.
 
 ## Artifact Model
 
-The in-memory `ArtifactStore` remains the reporter's fast working state. Durable
-reporting artifacts mirror it at meaningful mutation boundaries:
+The in-memory `ArtifactStore` is the reporter's fast working state. It exposes
+one generic model-facing contract:
+
+- `list_artifacts()` lists paths, media types, and current revisions;
+- `read_artifact(path)` returns one current snapshot;
+- `create_artifact(path, content)` creates revision 1;
+- `edit_artifact(path, old_text, new_text, expected_revision)` requires the
+  expected current revision and exactly one occurrence of `old_text`; and
+- `submit_artifact(path, expected_revision)` selects the current `article.md`
+  revision and ends the reporter loop.
+
+All reporter artifacts are raw UTF-8 Markdown in the initial platform slice.
+Durable reporting artifacts mirror complete snapshots at successful mutation
+boundaries:
 
 | Artifact | Durable behavior |
 | --- | --- |
-| `article/main` Markdown | append a complete `working` version after each successful write/rewrite/order mutation; append one complete `final` version at successful finalization |
-| `brief/main` JSON | persist one complete final version; persisting every brief mutation is optional and not required by the database baseline |
+| `research/brief.md` (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
+| `article.md` (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
 Artifact versions use their source AI call/tool call when available. Reads do
-not append versions. Failed tool mutations do not append versions.
+not append versions. Failed and content-identical mutations do not append
+versions. Durable finalization pins the selected article version and current
+brief version; it does not create another artifact version.
 
 ## Dependency Rules
 

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -68,20 +68,53 @@ adapters, execution persistence, and finalization.
 unchanged, and new reporter code has no source/PostgreSQL/resource-manager
 imports.
 
-### `generation-2` — reporting resource contracts and manager
+### `generation-2` — reporting artifact storage contract
+
+- Replace reporting artifact `kind`/`name`/`format` identity with normalized
+  generation-scoped `path` plus immutable IANA `media_type`.
+- Replace artifact-version `working`/`final` status with selected-version
+  finalization; finalizing pins an existing version and forbids later appends.
+- Add the reversible legacy-row backfill, composite final-pointer integrity,
+  immutable identity/finalization guards, and post-finalization version guard.
+- Update the durable reporting and generation contracts for the new artifact
+  identity, version, and finalization model.
+
+**Exit gate:** migration upgrade/downgrade preserves legacy content and maps
+known formats to MIME types; live PostgreSQL tests prove selected versions stay
+within their artifact/generation and finalized artifacts cannot change.
+
+### `generation-3` — generic Markdown reporter artifacts
+
+- Refactor only the copied reporter from structured brief/section state to raw
+  UTF-8 Markdown at `research/brief.md` and `article.md`.
+- Replace specialized brief/article tools with `list_artifacts`,
+  `read_artifact(path)`, `create_artifact(path, content)`,
+  `edit_artifact(path, old_text, new_text, expected_revision)`, and
+  `submit_artifact(path, expected_revision)`.
+- Make edits revision-checked, literal, single-match replacements with no
+  `replace_all` mode.
+- Add `ReporterOutput` with `submitted_path` and complete current snapshots of
+  all artifacts; update prompts, procedures, and characterization tests.
+
+**Exit gate:** the copied reporter produces both required Markdown paths,
+rejects stale or ambiguous edits, submits an exact current `article.md`
+revision, and has no artifact-kind or section-specific persistence contract.
+
+### `generation-4` — reporting resource contracts and manager
 
 - Add resource objects for generation summary/detail, AI calls, tool calls,
   artifacts, and artifact versions.
 - Add `GenerationManager` with scoped pending/start/progress/fail/cancel/read
   operations.
-- Add child-call and append-only artifact operations under the same aggregate.
+- Add child-call, path-addressed artifact, append-only version, and
+  selected-version finalization operations under the same aggregate.
 - Add typed lifecycle/concurrency errors and ORM-to-resource conversion.
 - Prove existing reporting schema constraints through real manager behavior.
 
 **Exit gate:** pending-to-running input pinning is atomic, inputs are immutable,
 terminal rows cannot reopen, and concurrent call/artifact allocation is safe.
 
-### `generation-3` — manifest and model-call instrumentation
+### `generation-5` — manifest and model-call instrumentation
 
 - Add immutable manifest contracts, canonical serialization, versioning, and
   hash golden vectors.
@@ -95,7 +128,7 @@ terminal rows cannot reopen, and concurrent call/artifact allocation is safe.
 cancellation, missing usage, cached tokens, and reasoning tokens all produce
 the expected durable attempt rows without changing model-call behavior.
 
-### `generation-4` — tool-call and progress instrumentation
+### `generation-6` — tool-call and progress instrumentation
 
 - Add the generation execution recorder.
 - Instrument `Runner` around every tool handler, including unknown tools,
@@ -109,20 +142,20 @@ the expected durable attempt rows without changing model-call behavior.
 **Exit gate:** tool results sent to the model and persisted results are
 equivalent; provider order remains the tool ordinal under parallel completion.
 
-### `generation-5` — artifact persistence
+### `generation-7` — artifact persistence
 
 - Add artifact-recorder access to `ToolContext` without changing model-facing
   tool schemas.
-- Persist complete working article Markdown after successful article mutations.
-- Persist the final article and final brief JSON through generation
-  finalization.
+- Persist complete Markdown snapshots after successful creates and edits to
+  `research/brief.md` and `article.md`.
+- Return the existing version for content-identical mutations and create no
+  versions for reads, failed mutations, or submission.
 - Attach source AI/tool provenance and content hashes.
-- Avoid versions for reads, failed mutations, and identical consecutive content.
 
-**Exit gate:** article history can be reconstructed from artifact versions and
-one final article exists for a succeeded generation.
+**Exit gate:** both artifact histories can be reconstructed from immutable
+versions and the submitted article revision is represented exactly once.
 
-### `generation-6` — typed memory reporter adapter
+### `generation-8` — typed memory reporter adapter
 
 - Implement only the memory tool mappings settled in `generation-0`.
 - Register tools over `GenerationMemoryContext`, never over managers or legacy
@@ -136,7 +169,7 @@ one final article exists for a succeeded generation.
 **Exit gate:** a run cannot observe its own buffered proposals, invalid typed
 proposals return safe tool errors, and no legacy store is read or written.
 
-### `generation-7` — input lifecycle and reporter execution
+### `generation-9` — input lifecycle and reporter execution
 
 - Add `GenerationService.submit()` and `execute()`.
 - Implement generation-owned live/backtest cutoff policy.
@@ -151,12 +184,15 @@ proposals return safe tool errors, and no legacy store is read or written.
 **Exit gate:** no model call can occur before complete input pinning, and the run
 cannot switch data snapshot or memory revision mid-flight.
 
-### `generation-8` — finalization and failure recovery
+### `generation-10` — finalization and failure recovery
 
-- Implement the settled article/memory/generation finalization boundary.
+- Implement the settled selected-artifact/memory/generation finalization
+  boundary.
+- Pin the submitted `article.md` version and returned current
+  `research/brief.md` version without appending final copies.
 - Apply one completed memory bundle after successful reporter submission or
   discard it on failure/cancellation.
-- Preserve partial AI/tool/working-artifact telemetry on failure.
+- Preserve partial AI/tool/artifact telemetry on failure.
 - Add stale-running reconciliation and explicit rerun behavior.
 - Prove terminal immutability and sanitized failure metadata.
 
@@ -164,7 +200,7 @@ cannot switch data snapshot or memory revision mid-flight.
 does not leak an open resource, and cannot silently commit partial memory under
 the chosen contract.
 
-### `generation-9` — API, worker, and composition
+### `generation-11` — API, worker, and composition
 
 - Add typed generation dependencies to `backend/composition.py`.
 - Add submission, polling, history, call, token, tool-result, artifact, and
@@ -177,7 +213,7 @@ the chosen contract.
 **Exit gate:** API and worker tests prove scoping, polling, error translation,
 and one shared service path.
 
-### `generation-10` — cutover and legacy removal
+### `generation-12` — cutover and legacy removal
 
 - Switch all production entry points to the backend generation service.
 - Remove temporary compatibility imports and direct legacy CLI composition.
@@ -195,22 +231,25 @@ one canonical memory authority, and one reporting audit history.
 ```mermaid
 flowchart LR
     G0["G0 decisions"] --> G1["G1 reporter move"]
-    G0 --> G2["G2 reporting manager"]
-    G1 --> G3["G3 AI calls/tokens"]
-    G2 --> G3
-    G3 --> G4["G4 tool/progress"]
-    G4 --> G5["G5 artifacts"]
-    G1 --> G6["G6 memory adapter"]
-    Memory["Typed memory integration-ready"] --> G6
-    Data["Merged frozen datalayer"] --> G1
-    Data --> G7["G7 generation inputs"]
-    G2 --> G7
+    G1 --> G2["G2 artifact storage"]
+    G2 --> G3["G3 reporter artifacts"]
+    G2 --> G4["G4 reporting manager"]
+    G1 --> G5["G5 AI calls/tokens"]
+    G4 --> G5
+    G5 --> G6["G6 tool/progress"]
+    G6 --> G7["G7 artifact persistence"]
     G3 --> G7
-    G5 --> G7
-    G6 --> G7
-    G7 --> G8["G8 finalization"]
-    G8 --> G9["G9 API/worker"]
-    G9 --> G10["G10 cutover"]
+    G1 --> G8["G8 memory adapter"]
+    Memory["Typed memory integration-ready"] --> G8
+    Data["Merged frozen datalayer"] --> G1
+    Data --> G9["G9 generation inputs"]
+    G4 --> G9
+    G5 --> G9
+    G7 --> G9
+    G8 --> G9
+    G9 --> G10["G10 finalization"]
+    G10 --> G11["G11 API/worker"]
+    G11 --> G12["G12 cutover"]
 ```
 
 ## Decisions Required Before Implementation
@@ -260,12 +299,6 @@ The current memory service's transaction ownership means the first choice may
 require a narrow shared transaction helper or revised ownership contract. That
 change must be agreed with the memory design rather than bypassed.
 
-### 5. Brief artifact granularity
-
-This plan recommends one final JSON brief artifact and complete working article
-versions. Confirm whether working brief versions are valuable enough to store;
-the reporting database design explicitly leaves them optional.
-
 ## Required Acceptance Coverage
 
 The complete stack must prove:
@@ -280,8 +313,10 @@ The complete stack must prove:
 7. every tool call retains exact input, full output, status, timing, and
    provider ordinal;
 8. parallel tool completion does not corrupt ordering or provenance;
-9. article mutations create reconstructable immutable versions;
-10. one succeeded generation has one final article;
+9. `research/brief.md` and `article.md` mutations create reconstructable
+   immutable versions through the generic artifact contract;
+10. one succeeded generation pins the exact submitted article version and
+    returned current brief version without duplicate final copies;
 11. searches remain pinned and buffered memory proposals remain invisible;
 12. failed/cancelled generations discard buffered proposals;
 13. the chosen success finalization contract survives injected failure at each
@@ -293,13 +328,14 @@ The complete stack must prove:
 
 ## Test Layers
 
-- reporter characterization tests for prompt, tool schema, brief, article,
-  procedure, and runner compatibility;
+- reporter characterization tests for prompts, tool schemas, artifact
+  snapshots, procedures, and runner compatibility;
 - pure manifest and token-normalization golden tests;
 - completion adapter tests for retry/fallback/usage/error permutations;
 - runner tests with fake recorder and parallel tools;
 - generation-manager tests against disposable PostgreSQL;
-- artifact concurrency/hash/finality tests against PostgreSQL;
+- artifact path, concurrency, hash, and selected-version finalization tests
+  against PostgreSQL;
 - generation-service tests with fake managers and real fixture frozen SQLite;
 - typed-memory adapter tests with fake and real `GenerationMemoryContext`;
 - cross-resource failure-injection tests for finalization;

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -8,7 +8,8 @@ Reporter V2 already has the desired content engine:
 - one single-loop `Runner`;
 - a lightweight retry/fallback `CompletionClient`;
 - reporter-owned `ToolRegistry` and tool handlers;
-- typed in-memory brief/article artifacts;
+- typed in-memory brief/article state that the platform copy will replace with
+  path-addressed Markdown artifacts;
 - procedure replacement semantics;
 - a diagnostic `RunLog`; and
 - prompt/procedure files with broad test coverage.
@@ -38,11 +39,11 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 - `ToolRegistry` registration and context-tool pattern;
 - `CompletionSettings`, retry classification, delay, and fallback order;
 - message/tool-call normalization helpers;
-- `ReportConfig`, brief/article models, and `ArticleOutput`;
-- brief, article, and procedure tool names/schemas;
+- `ReportConfig` and non-artifact runner models;
+- procedure and other non-artifact tool names/schemas;
 - prompts and procedures;
 - procedure replacement versus append mode;
-- successful `submit_article` as the reporter stop signal; and
+- explicit artifact submission as the reporter stop signal; and
 - local `RunLog` for test/debug visibility.
 
 ### Modify internally
@@ -59,7 +60,8 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
   to the provider;
 - persist full tool results rather than relying on `RunLog` summaries;
 - persist provider token usage per attempt;
-- mirror article mutations to immutable reporting artifact versions; and
+- replace section-specific editing with generic path-addressed artifact tools;
+- mirror complete Markdown mutations to immutable reporting artifact versions;
 - move successful memory commit/discard out of the reporter and into
   `GenerationService`.
 
@@ -68,6 +70,7 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 - `SleeperLeagueData.load()` and source fetching during report generation;
 - private `_query_conn` access for metadata or roster resolution;
 - legacy `ContextStore` reads/writes and memory lifecycle helpers;
+- structured brief/section state and its specialized model-facing tools;
 - week-based article filenames as canonical output identity;
 - production dependence on `.output` run-log JSON files; and
 - CLI ownership of the durable generation lifecycle.
@@ -80,6 +83,7 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 - provider-attempt token/call recording;
 - full tool-call recording;
 - durable versioned artifacts;
+- raw Markdown `research/brief.md` and `article.md` plus `ReporterOutput`;
 - reporter adapters for frozen data and typed memory;
 - API polling/read surfaces; and
 - a thin worker/process entry point.
@@ -92,10 +96,11 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 | `reporter_v2/runner/runner.py` | new `backend/services/reporter/runner/runner.py` copy | Preserve loop; add execution recording calls only in the new package |
 | `reporter_v2/runner/completion.py` | reporter completion adapter | Preserve retry/fallback; instrument every actual attempt and normalize usage |
 | `reporter_v2/runner/models.py` | reporter runner models | Move with minimal changes |
-| `reporter_v2/runner/schemas.py` | reporter artifact schemas | Preserve; add serialization/version metadata only if artifact contract requires it |
-| `reporter_v2/runner/state.py` | reporter runner state | Preserve in-memory store; add recorder reference to tool context rather than database state |
+| `reporter_v2/runner/schemas.py` | reporter artifact schemas | Replace section/brief schemas with generic artifact snapshots and `ReporterOutput` in the artifact-refactor slice |
+| `reporter_v2/runner/state.py` | reporter runner state | Replace specialized state with the path-addressed `ArtifactStore`; add recorder reference to tool context rather than database state |
 | `reporter_v2/runner/run_log.py` | reporter diagnostics | Preserve as non-authoritative local view |
-| brief/article/procedure tools | reporter tools | Preserve model-facing contracts |
+| brief/article tools | generic reporter artifact tools | Replace after copy characterization with the settled path/revision contract |
+| procedure tools | reporter tools | Preserve model-facing contracts |
 | datalayer tools | reporter datalayer adapter | Already adapted to `FrozenLeagueData`; move mechanically |
 | persistent/memory tools | reporter memory adapter | Replace legacy backend; compatibility decided tool by tool below |
 | `reporter_v2/app/runner.py` | API/worker plus temporary CLI | Decompose; no canonical output filenames or direct loading in production |
@@ -103,36 +108,29 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 
 ## Non-Memory Tool Compatibility
 
-### Brief tools
+### Artifact tools
 
-Preserve the seven current interfaces:
+The copied reporter initially preserves its legacy tools only for
+characterization. The artifact-refactor slice then retires the specialized
+brief tools (`save_fact`, `save_memory_callback`, `save_storyline`,
+`set_outline`, `read_brief`, `set_style`, `set_bias`) and article tools
+(`write_section`, `read_article`, `read_section`, `rewrite_section`,
+`set_section_order`, `submit_article`). They are replaced by:
 
-- `save_fact`
-- `save_memory_callback`
-- `save_storyline`
-- `set_outline`
-- `read_brief`
-- `set_style`
-- `set_bias`
+- `list_artifacts()`;
+- `read_artifact(path)`;
+- `create_artifact(path, content)`;
+- `edit_artifact(path, old_text, new_text, expected_revision)`; and
+- `submit_artifact(path, expected_revision)`.
 
-These operate on the reporter's run-local verified brief, not canonical memory.
-Their names do not imply database persistence. Final brief persistence is a
-generation artifact concern.
-
-### Article tools
-
-Preserve the six current interfaces:
-
-- `write_section`
-- `read_article`
-- `read_section`
-- `rewrite_section`
-- `set_section_order`
-- `submit_article`
-
-Their internal mutation callbacks gain artifact recording. `submit_article`
-still ends the reporter loop but does not independently mark the generation
-succeeded.
+The required run-local artifacts are raw UTF-8 Markdown at
+`research/brief.md` and `article.md`. `edit_artifact` is a revision-checked
+literal find-and-replace: `old_text` must occur exactly once, and there is no
+`replace_all` mode. Successful creates and edits record complete immutable
+snapshots. Reads do not mutate state. `submit_artifact` accepts the current
+revision of `article.md`, ends the reporter loop, and produces
+`ReporterOutput(submitted_path, artifacts)`; it does not independently mark the
+generation succeeded or append a final copy.
 
 ### Procedure tool
 
@@ -220,7 +218,7 @@ Required additions are orthogonal:
 - pass turn identity to the completion adapter;
 - receive or resolve the successful AI-call identity for tool provenance;
 - begin/finish each tool call around the existing handler;
-- expose artifact recorder state through `ToolContext`; and
+- expose generic artifact state and recorder access through `ToolContext`; and
 - emit progress updates through the recorder.
 
 The runner must not learn about snapshots, memory revisions, SQLAlchemy,
@@ -236,8 +234,9 @@ production composition. Transition in two steps:
 2. switch the platform CLI/worker to submit/execute durable generations, then
    remove direct `SleeperLeagueData` and `ContextStore` composition.
 
-Generated files may remain a developer convenience, but generation ID plus
-reporting artifacts become the canonical address of an article.
+Generated files may remain a developer convenience, but generation ID plus the
+`article.md` artifact and selected version become the canonical address of an
+article.
 
 ## Exit Criteria
 
@@ -245,12 +244,12 @@ The transition is complete when:
 
 - production imports no `reporter_v2`, legacy datalayer facade, or
   `reporter_memory.ContextStore`;
-- the same fixture request produces compatible brief/article/tool behavior
-  through the moved reporter;
+- the same fixture request produces compatible reporting behavior through the
+  moved reporter before the explicit artifact-contract refactor;
 - the reporter can execute only against its pinned frozen snapshot and pinned
   memory context;
 - every provider attempt and tool call has complete durable telemetry;
-- token usage and final/working article artifacts are persisted;
+- token usage and immutable Markdown artifact versions are persisted;
 - failed runs discard typed memory proposals;
 - succeeded runs follow the settled finalization contract; and
 - the API/worker invoke the same `GenerationService` rather than duplicating


### PR DESCRIPTION
# PR: Align reporting artifact storage contract

Stack base: `codex/generation-1`

## Summary

- migrate reporting artifacts from kind/name/format and version status to
  path/media type and an artifact-level final-version pointer
- add deterministic legacy backfill, reversible downgrade, composite pointer
  integrity, and immutable/finalization database guards
- update durable database and generation contracts and split reporter runtime
  adoption into the following stacked PR

## Boundaries

- no `GenerationManager`, durable reporter writes, execution recording,
  generation success finalization, or API routes
- no reporter runtime, prompt, procedure, or tool changes

## Verification

- `21 passed` — live reporting migration and constraint tests
- compile checks and `git diff --check`
