### PR TITLE
Generation 4a — generation lifecycle resource

### DIFF
--- a/backend/resources/reporting/__init__.py
+++ b/backend/resources/reporting/__init__.py
@@ -1,0 +1,41 @@
+"""Typed reporting resources grouped by resource kind."""
+
+from backend.resources.reporting.generations import (
+    CancelGeneration,
+    CreateGeneration,
+    FailGeneration,
+    Generation,
+    GenerationConcurrencyConflict,
+    GenerationDetail,
+    GenerationKind,
+    GenerationLifecycleConflict,
+    GenerationManager,
+    GenerationPage,
+    GenerationQuery,
+    GenerationResourceError,
+    GenerationResourceNotFound,
+    GenerationStatus,
+    GenerationSummary,
+    StartGeneration,
+    UpdateGenerationProgress,
+)
+
+__all__ = [
+    "CancelGeneration",
+    "CreateGeneration",
+    "FailGeneration",
+    "Generation",
+    "GenerationConcurrencyConflict",
+    "GenerationDetail",
+    "GenerationKind",
+    "GenerationLifecycleConflict",
+    "GenerationManager",
+    "GenerationPage",
+    "GenerationQuery",
+    "GenerationResourceError",
+    "GenerationResourceNotFound",
+    "GenerationStatus",
+    "GenerationSummary",
+    "StartGeneration",
+    "UpdateGenerationProgress",
+]

--- a/backend/resources/reporting/generations/__init__.py
+++ b/backend/resources/reporting/generations/__init__.py
@@ -1,0 +1,43 @@
+"""Public durable generation resource contract."""
+
+from backend.resources.reporting.generations.errors import (
+    GenerationConcurrencyConflict,
+    GenerationLifecycleConflict,
+    GenerationResourceError,
+    GenerationResourceNotFound,
+)
+from backend.resources.reporting.generations.manager import GenerationManager
+from backend.resources.reporting.generations.objects import (
+    CancelGeneration,
+    CreateGeneration,
+    FailGeneration,
+    Generation,
+    GenerationDetail,
+    GenerationKind,
+    GenerationPage,
+    GenerationQuery,
+    GenerationStatus,
+    GenerationSummary,
+    StartGeneration,
+    UpdateGenerationProgress,
+)
+
+__all__ = [
+    "CancelGeneration",
+    "CreateGeneration",
+    "FailGeneration",
+    "Generation",
+    "GenerationConcurrencyConflict",
+    "GenerationDetail",
+    "GenerationKind",
+    "GenerationLifecycleConflict",
+    "GenerationManager",
+    "GenerationPage",
+    "GenerationQuery",
+    "GenerationResourceError",
+    "GenerationResourceNotFound",
+    "GenerationStatus",
+    "GenerationSummary",
+    "StartGeneration",
+    "UpdateGenerationProgress",
+]

--- a/backend/resources/reporting/generations/errors.py
+++ b/backend/resources/reporting/generations/errors.py
@@ -1,0 +1,47 @@
+"""Stable application failures for generation lifecycle persistence."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+
+class GenerationResourceError(RuntimeError):
+    """Base class for generation resource failures safe at service boundaries."""
+
+
+class GenerationResourceNotFound(GenerationResourceError):
+    def __init__(self, resource_kind: str, resource_id: UUID) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        super().__init__(f"{resource_kind} {resource_id} was not found")
+
+
+class GenerationLifecycleConflict(GenerationResourceError):
+    def __init__(
+        self,
+        generation_id: UUID,
+        message: str,
+        *,
+        expected_statuses: Iterable[str] = (),
+        actual_status: str | None = None,
+    ) -> None:
+        self.generation_id = generation_id
+        self.message = message
+        self.expected_statuses = tuple(expected_statuses)
+        self.actual_status = actual_status
+        super().__init__(message)
+
+
+class GenerationConcurrencyConflict(GenerationResourceError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+__all__ = [
+    "GenerationConcurrencyConflict",
+    "GenerationLifecycleConflict",
+    "GenerationResourceError",
+    "GenerationResourceNotFound",
+]

--- a/backend/resources/reporting/generations/manager.py
+++ b/backend/resources/reporting/generations/manager.py
@@ -1,0 +1,472 @@
+"""Competition-scoped lifecycle manager for durable generations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import CompetitionSeason
+from backend.database.models.memory import MemoryRevision
+from backend.database.models.reporting import EvaluationWorkspace
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.models.sleeper import DataSnapshot
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.reporting.generations.errors import (
+    GenerationConcurrencyConflict,
+    GenerationLifecycleConflict,
+    GenerationResourceNotFound,
+)
+from backend.resources.reporting.generations.objects import (
+    CancelGeneration,
+    CreateGeneration,
+    FailGeneration,
+    Generation,
+    GenerationDetail,
+    GenerationPage,
+    GenerationQuery,
+    GenerationStatus,
+    GenerationSummary,
+    StartGeneration,
+    UpdateGenerationProgress,
+)
+
+
+_TERMINAL_STATUSES = {
+    GenerationStatus.SUCCEEDED.value,
+    GenerationStatus.FAILED.value,
+    GenerationStatus.CANCELLED.value,
+}
+
+
+class GenerationManager:
+    """Own pending creation, input pinning, progress, and terminal transitions."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def create_pending(self, command: CreateGeneration) -> Generation:
+        try:
+            with transaction_session(self._session_factory) as session:
+                self._require_season(session, command.competition_season_id)
+                if command.rerun_of_generation_id is not None:
+                    original = self._load(session, command.rerun_of_generation_id)
+                    if original.status not in _TERMINAL_STATUSES:
+                        raise _lifecycle(
+                            original,
+                            "reruns require a terminal source generation",
+                            _TERMINAL_STATUSES,
+                        )
+                if command.evaluation_workspace_id is not None:
+                    workspace = self._load_workspace(
+                        session, command.evaluation_workspace_id
+                    )
+                    if workspace.status != "active":
+                        raise GenerationLifecycleConflict(
+                            command.generation_id,
+                            "new generations require an active evaluation workspace",
+                            expected_statuses=("active",),
+                            actual_status=workspace.status,
+                        )
+
+                stored = StoredGeneration(
+                    id=command.generation_id,
+                    competition_id=self._competition_id,
+                    competition_season_id=command.competition_season_id,
+                    evaluation_workspace_id=command.evaluation_workspace_id,
+                    workspace_sequence_number=command.workspace_sequence_number,
+                    rerun_of_generation_id=command.rerun_of_generation_id,
+                    kind=command.kind.value,
+                    status=GenerationStatus.PENDING.value,
+                    request_text=command.request_text,
+                    week_start=command.week_start,
+                    week_end=command.week_end,
+                    requested_primary_model=command.requested_primary_model,
+                    settings_jsonb=command.settings,
+                    current_turn=0,
+                )
+                session.add(stored)
+                session.flush()
+                return _decode(stored)
+        except IntegrityError:
+            raise GenerationConcurrencyConflict(
+                "generation identity or workspace sequence is already allocated"
+            ) from None
+
+    def start(self, command: StartGeneration) -> Generation:
+        with transaction_session(self._session_factory) as session:
+            stored = self._load(session, command.generation_id, lock=True)
+            self._require_status(stored, GenerationStatus.PENDING)
+            snapshot = session.scalar(
+                sa.select(DataSnapshot).where(
+                    DataSnapshot.id == command.data_snapshot_id,
+                    DataSnapshot.competition_id == self._competition_id,
+                    DataSnapshot.primary_competition_season_id
+                    == stored.competition_season_id,
+                )
+            )
+            if snapshot is None:
+                raise GenerationResourceNotFound(
+                    "data_snapshot", command.data_snapshot_id
+                )
+            if snapshot.status != "ready":
+                raise GenerationLifecycleConflict(
+                    stored.id,
+                    "generation inputs require a ready data snapshot",
+                    expected_statuses=("ready",),
+                    actual_status=snapshot.status,
+                )
+            self._validate_memory_input(session, stored, command)
+
+            now = datetime.now(UTC)
+            stored.data_snapshot_id = snapshot.id
+            stored.input_memory_revision_id = command.input_memory_revision_id
+            stored.input_memory_artifact_version_id = (
+                command.input_memory_artifact_version_id
+            )
+            stored.input_memory_artifact_generation_id = (
+                command.input_memory_artifact_generation_id
+            )
+            stored.domain_cutoff_week = snapshot.domain_cutoff_week
+            stored.domain_cutoff_at = snapshot.domain_cutoff_at
+            stored.knowledge_cutoff_at = command.knowledge_cutoff_at
+            stored.input_manifest_jsonb = command.input_manifest
+            stored.manifest_schema_version = command.manifest_schema_version
+            stored.manifest_hash = command.manifest_hash
+            stored.status = GenerationStatus.RUNNING.value
+            stored.current_stage = command.initial_stage
+            stored.progress_updated_at = now
+            stored.started_at = now
+            session.flush()
+            return _decode(stored)
+
+    def update_progress(self, command: UpdateGenerationProgress) -> Generation:
+        with transaction_session(self._session_factory) as session:
+            stored = self._load(session, command.generation_id, lock=True)
+            self._require_status(stored, GenerationStatus.RUNNING)
+            if command.current_turn < stored.current_turn:
+                raise GenerationLifecycleConflict(
+                    stored.id,
+                    "generation progress cannot move to an earlier turn",
+                    actual_status=stored.status,
+                )
+            stored.current_turn = command.current_turn
+            stored.current_stage = command.current_stage
+            stored.progress_updated_at = datetime.now(UTC)
+            session.flush()
+            return _decode(stored)
+
+    def fail(self, command: FailGeneration) -> Generation:
+        with transaction_session(self._session_factory) as session:
+            stored = self._load(session, command.generation_id, lock=True)
+            self._require_active(stored)
+            now = datetime.now(UTC)
+            stored.status = GenerationStatus.FAILED.value
+            stored.current_stage = "failed"
+            stored.failure_category = command.category
+            stored.failure_summary = command.summary
+            stored.progress_updated_at = now
+            stored.completed_at = now
+            session.flush()
+            return _decode(stored)
+
+    def cancel(self, command: CancelGeneration) -> Generation:
+        with transaction_session(self._session_factory) as session:
+            stored = self._load(session, command.generation_id, lock=True)
+            self._require_active(stored)
+            now = datetime.now(UTC)
+            stored.status = GenerationStatus.CANCELLED.value
+            stored.current_stage = "cancelled"
+            stored.failure_category = "cancelled"
+            stored.failure_summary = command.summary or "Generation was cancelled"
+            stored.progress_updated_at = now
+            stored.completed_at = now
+            session.flush()
+            return _decode(stored)
+
+    def get(self, generation_id: UUID) -> GenerationDetail:
+        with read_only_session(self._session_factory) as session:
+            return _decode_detail(self._load(session, generation_id))
+
+    def list(self, query: GenerationQuery) -> GenerationPage:
+        with read_only_session(self._session_factory) as session:
+            conditions: list[sa.ColumnElement[bool]] = [
+                StoredGeneration.competition_id == self._competition_id
+            ]
+            if query.competition_season_id is not None:
+                conditions.append(
+                    StoredGeneration.competition_season_id
+                    == query.competition_season_id
+                )
+            if query.kind is not None:
+                conditions.append(StoredGeneration.kind == query.kind.value)
+            if query.status is not None:
+                conditions.append(StoredGeneration.status == query.status.value)
+            if query.rerun_of_generation_id is not None:
+                conditions.append(
+                    StoredGeneration.rerun_of_generation_id
+                    == query.rerun_of_generation_id
+                )
+            if query.evaluation_workspace_id is not None:
+                conditions.append(
+                    StoredGeneration.evaluation_workspace_id
+                    == query.evaluation_workspace_id
+                )
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredGeneration)
+                    .where(*conditions)
+                ),
+            )
+            rows = session.scalars(
+                sa.select(StoredGeneration)
+                .where(*conditions)
+                .order_by(
+                    StoredGeneration.created_at.desc(),
+                    StoredGeneration.id.desc(),
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return GenerationPage(
+                items=tuple(_decode_summary(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def _validate_memory_input(
+        self,
+        session: Session,
+        generation: StoredGeneration,
+        command: StartGeneration,
+    ) -> None:
+        if command.input_memory_revision_id is not None:
+            revision = session.scalar(
+                sa.select(MemoryRevision.id).where(
+                    MemoryRevision.id == command.input_memory_revision_id,
+                    MemoryRevision.competition_id == self._competition_id,
+                )
+            )
+            if revision is None:
+                raise GenerationResourceNotFound(
+                    "memory_revision", command.input_memory_revision_id
+                )
+            return
+
+        workspace_id = generation.evaluation_workspace_id
+        if workspace_id is None:
+            raise GenerationLifecycleConflict(
+                generation.id,
+                "workspace memory input requires workspace generation membership",
+            )
+        workspace = self._load_workspace(session, workspace_id, lock=True)
+        if workspace.status != "active":
+            raise GenerationLifecycleConflict(
+                generation.id,
+                "workspace memory input requires an active workspace",
+                expected_statuses=("active",),
+                actual_status=workspace.status,
+            )
+        if (
+            workspace.current_memory_artifact_version_id
+            != command.input_memory_artifact_version_id
+            or workspace.current_memory_artifact_generation_id
+            != command.input_memory_artifact_generation_id
+        ):
+            raise GenerationConcurrencyConflict(
+                "workspace memory input is not the current workspace artifact"
+            )
+        source = session.scalar(
+            sa.select(StoredGeneration).where(
+                StoredGeneration.id == command.input_memory_artifact_generation_id,
+                StoredGeneration.competition_id == self._competition_id,
+                StoredGeneration.evaluation_workspace_id == workspace.id,
+            )
+        )
+        if source is None:
+            raise GenerationResourceNotFound(
+                "generation", cast(UUID, command.input_memory_artifact_generation_id)
+            )
+        if source.status != GenerationStatus.SUCCEEDED.value:
+            raise GenerationLifecycleConflict(
+                generation.id,
+                "workspace memory input must come from a succeeded generation",
+                expected_statuses=(GenerationStatus.SUCCEEDED.value,),
+                actual_status=source.status,
+            )
+
+    def _load(
+        self,
+        session: Session,
+        generation_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> StoredGeneration:
+        statement = sa.select(StoredGeneration).where(
+            StoredGeneration.id == generation_id,
+            StoredGeneration.competition_id == self._competition_id,
+        )
+        if lock:
+            statement = statement.with_for_update()
+        stored = session.scalar(statement)
+        if stored is None:
+            raise GenerationResourceNotFound("generation", generation_id)
+        return stored
+
+    def _load_workspace(
+        self,
+        session: Session,
+        workspace_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> EvaluationWorkspace:
+        statement = sa.select(EvaluationWorkspace).where(
+            EvaluationWorkspace.id == workspace_id,
+            EvaluationWorkspace.competition_id == self._competition_id,
+        )
+        if lock:
+            statement = statement.with_for_update()
+        workspace = session.scalar(statement)
+        if workspace is None:
+            raise GenerationResourceNotFound("evaluation_workspace", workspace_id)
+        return workspace
+
+    def _require_season(self, session: Session, season_id: UUID) -> None:
+        season = session.scalar(
+            sa.select(CompetitionSeason.id).where(
+                CompetitionSeason.id == season_id,
+                CompetitionSeason.competition_id == self._competition_id,
+            )
+        )
+        if season is None:
+            raise GenerationResourceNotFound("competition_season", season_id)
+
+    @staticmethod
+    def _require_status(
+        stored: StoredGeneration,
+        expected: GenerationStatus,
+    ) -> None:
+        if stored.status != expected.value:
+            raise _lifecycle(
+                stored,
+                f"generation must be {expected.value} for this operation",
+                (expected.value,),
+            )
+
+    @staticmethod
+    def _require_active(stored: StoredGeneration) -> None:
+        active = (GenerationStatus.PENDING.value, GenerationStatus.RUNNING.value)
+        if stored.status not in active:
+            raise _lifecycle(
+                stored,
+                "only a pending or running generation can become terminal",
+                active,
+            )
+
+
+def _lifecycle(
+    stored: StoredGeneration,
+    message: str,
+    expected_statuses: set[str] | tuple[str, ...],
+) -> GenerationLifecycleConflict:
+    return GenerationLifecycleConflict(
+        stored.id,
+        message,
+        expected_statuses=expected_statuses,
+        actual_status=stored.status,
+    )
+
+
+def _generation_values(stored: StoredGeneration) -> dict[str, object]:
+    return {
+        "id": stored.id,
+        "competition_id": stored.competition_id,
+        "competition_season_id": stored.competition_season_id,
+        "data_snapshot_id": stored.data_snapshot_id,
+        "input_memory_revision_id": stored.input_memory_revision_id,
+        "input_memory_artifact_version_id": stored.input_memory_artifact_version_id,
+        "input_memory_artifact_generation_id": (
+            stored.input_memory_artifact_generation_id
+        ),
+        "evaluation_workspace_id": stored.evaluation_workspace_id,
+        "workspace_sequence_number": stored.workspace_sequence_number,
+        "rerun_of_generation_id": stored.rerun_of_generation_id,
+        "kind": stored.kind,
+        "status": stored.status,
+        "request_text": stored.request_text,
+        "week_start": stored.week_start,
+        "week_end": stored.week_end,
+        "domain_cutoff_week": stored.domain_cutoff_week,
+        "domain_cutoff_at": stored.domain_cutoff_at,
+        "knowledge_cutoff_at": stored.knowledge_cutoff_at,
+        "requested_primary_model": stored.requested_primary_model,
+        "settings": stored.settings_jsonb,
+        "input_manifest": stored.input_manifest_jsonb,
+        "manifest_schema_version": stored.manifest_schema_version,
+        "manifest_hash": stored.manifest_hash,
+        "current_turn": stored.current_turn,
+        "current_stage": stored.current_stage,
+        "progress_updated_at": stored.progress_updated_at,
+        "failure_category": stored.failure_category,
+        "failure_summary": stored.failure_summary,
+        "created_at": stored.created_at,
+        "started_at": stored.started_at,
+        "completed_at": stored.completed_at,
+    }
+
+
+def _decode(stored: StoredGeneration) -> Generation:
+    return Generation.model_validate(_generation_values(stored))
+
+
+def _decode_detail(stored: StoredGeneration) -> GenerationDetail:
+    return GenerationDetail.model_validate(_generation_values(stored))
+
+
+def _decode_summary(stored: StoredGeneration) -> GenerationSummary:
+    return GenerationSummary(
+        id=stored.id,
+        competition_id=stored.competition_id,
+        competition_season_id=stored.competition_season_id,
+        evaluation_workspace_id=stored.evaluation_workspace_id,
+        workspace_sequence_number=stored.workspace_sequence_number,
+        rerun_of_generation_id=stored.rerun_of_generation_id,
+        kind=stored.kind,
+        status=stored.status,
+        request_text=stored.request_text,
+        week_start=stored.week_start,
+        week_end=stored.week_end,
+        requested_primary_model=stored.requested_primary_model,
+        current_turn=stored.current_turn,
+        current_stage=stored.current_stage,
+        progress_updated_at=stored.progress_updated_at,
+        failure_category=stored.failure_category,
+        failure_summary=stored.failure_summary,
+        created_at=stored.created_at,
+        started_at=stored.started_at,
+        completed_at=stored.completed_at,
+    )
+
+
+__all__ = ["GenerationManager"]

--- a/backend/resources/reporting/generations/objects.py
+++ b/backend/resources/reporting/generations/objects.py
@@ -1,0 +1,222 @@
+"""Immutable commands and views for one durable generation resource."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import (
+    AwareDatetime,
+    Field,
+    JsonValue,
+    StringConstraints,
+    model_validator,
+)
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+PositiveWeek = Annotated[int, Field(strict=True, ge=1, le=18)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+PositiveInt = Annotated[int, Field(strict=True, ge=1)]
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{64}$")]
+FailureCategory = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=100,
+        pattern=r"^[a-z0-9][a-z0-9_.-]*$",
+    ),
+]
+FailureSummary = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1, max_length=500),
+]
+
+
+class GenerationKind(StrEnum):
+    LIVE = "live"
+    BACKTEST = "backtest"
+
+
+class GenerationStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class CreateGeneration(ContractModel):
+    generation_id: UUID
+    competition_season_id: UUID
+    kind: GenerationKind
+    request_text: NonBlankStr
+    week_start: PositiveWeek | None = None
+    week_end: PositiveWeek | None = None
+    requested_primary_model: NonBlankStr
+    settings: dict[str, JsonValue]
+    rerun_of_generation_id: UUID | None = None
+    evaluation_workspace_id: UUID | None = None
+    workspace_sequence_number: PositiveInt | None = None
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> "CreateGeneration":
+        if (self.week_start is None) != (self.week_end is None):
+            raise ValueError("week_start and week_end must be provided together")
+        if (
+            self.week_start is not None
+            and self.week_end is not None
+            and self.week_start > self.week_end
+        ):
+            raise ValueError("week_start cannot be after week_end")
+        if (self.evaluation_workspace_id is None) != (
+            self.workspace_sequence_number is None
+        ):
+            raise ValueError(
+                "evaluation workspace ID and sequence number must be provided together"
+            )
+        return self
+
+
+class StartGeneration(ContractModel):
+    generation_id: UUID
+    data_snapshot_id: UUID
+    input_memory_revision_id: UUID | None = None
+    input_memory_artifact_version_id: UUID | None = None
+    input_memory_artifact_generation_id: UUID | None = None
+    knowledge_cutoff_at: AwareDatetime
+    input_manifest: dict[str, JsonValue]
+    manifest_schema_version: PositiveInt
+    manifest_hash: Sha256
+    initial_stage: NonBlankStr = "starting"
+
+    @model_validator(mode="after")
+    def validate_memory_input(self) -> "StartGeneration":
+        artifact_shape = (
+            self.input_memory_artifact_version_id is not None
+            and self.input_memory_artifact_generation_id is not None
+        )
+        if (self.input_memory_artifact_version_id is None) != (
+            self.input_memory_artifact_generation_id is None
+        ):
+            raise ValueError("workspace memory input requires both artifact IDs")
+        if (self.input_memory_revision_id is not None) == artifact_shape:
+            raise ValueError("start requires exactly one resolved memory input")
+        if not self.input_manifest:
+            raise ValueError("start requires a non-empty input manifest")
+        return self
+
+
+class UpdateGenerationProgress(ContractModel):
+    generation_id: UUID
+    current_turn: NonNegativeInt
+    current_stage: NonBlankStr
+
+
+class FailGeneration(ContractModel):
+    generation_id: UUID
+    category: FailureCategory
+    summary: FailureSummary
+
+
+class CancelGeneration(ContractModel):
+    generation_id: UUID
+    summary: FailureSummary | None = None
+
+
+class GenerationQuery(ContractModel):
+    competition_season_id: UUID | None = None
+    kind: GenerationKind | None = None
+    status: GenerationStatus | None = None
+    rerun_of_generation_id: UUID | None = None
+    evaluation_workspace_id: UUID | None = None
+    limit: PageLimit = 50
+    offset: NonNegativeInt = 0
+
+
+class Generation(ContractModel):
+    id: UUID
+    competition_id: UUID
+    competition_season_id: UUID
+    data_snapshot_id: UUID | None
+    input_memory_revision_id: UUID | None
+    input_memory_artifact_version_id: UUID | None
+    input_memory_artifact_generation_id: UUID | None
+    evaluation_workspace_id: UUID | None
+    workspace_sequence_number: int | None
+    rerun_of_generation_id: UUID | None
+    kind: GenerationKind
+    status: GenerationStatus
+    request_text: str
+    week_start: int | None
+    week_end: int | None
+    domain_cutoff_week: int | None
+    domain_cutoff_at: AwareDatetime | None
+    knowledge_cutoff_at: AwareDatetime | None
+    requested_primary_model: str
+    settings: dict[str, JsonValue]
+    input_manifest: dict[str, JsonValue] | None
+    manifest_schema_version: int | None
+    manifest_hash: str | None
+    current_turn: int
+    current_stage: str | None
+    progress_updated_at: AwareDatetime | None
+    failure_category: str | None
+    failure_summary: str | None
+    created_at: AwareDatetime
+    started_at: AwareDatetime | None
+    completed_at: AwareDatetime | None
+
+
+class GenerationDetail(Generation):
+    """Complete generation row without child-resource payloads."""
+
+
+class GenerationSummary(ContractModel):
+    id: UUID
+    competition_id: UUID
+    competition_season_id: UUID
+    evaluation_workspace_id: UUID | None
+    workspace_sequence_number: int | None
+    rerun_of_generation_id: UUID | None
+    kind: GenerationKind
+    status: GenerationStatus
+    request_text: str
+    week_start: int | None
+    week_end: int | None
+    requested_primary_model: str
+    current_turn: int
+    current_stage: str | None
+    progress_updated_at: AwareDatetime | None
+    failure_category: str | None
+    failure_summary: str | None
+    created_at: AwareDatetime
+    started_at: AwareDatetime | None
+    completed_at: AwareDatetime | None
+
+
+class GenerationPage(ContractModel):
+    items: tuple[GenerationSummary, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+__all__ = [
+    "CancelGeneration",
+    "CreateGeneration",
+    "FailGeneration",
+    "Generation",
+    "GenerationDetail",
+    "GenerationKind",
+    "GenerationPage",
+    "GenerationQuery",
+    "GenerationStatus",
+    "GenerationSummary",
+    "StartGeneration",
+    "UpdateGenerationProgress",
+]

--- a/backend/tests/resources/reporting/__init__.py
+++ b/backend/tests/resources/reporting/__init__.py
@@ -1,0 +1,1 @@
+"""Reporting resource tests."""

--- a/backend/tests/resources/reporting/generations/__init__.py
+++ b/backend/tests/resources/reporting/generations/__init__.py
@@ -1,0 +1,1 @@
+"""Generation lifecycle resource tests."""

--- a/backend/tests/resources/reporting/generations/conftest.py
+++ b/backend/tests/resources/reporting/generations/conftest.py
@@ -1,0 +1,128 @@
+"""Disposable PostgreSQL fixtures for generation lifecycle tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.memory import MemoryRevision
+from backend.database.models.sleeper import DataSnapshot
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.context import (
+    CompetitionScope,
+    ManagerContext,
+    SystemProcessActor,
+)
+from backend.resources.reporting.generations import GenerationManager
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@dataclass(frozen=True)
+class GenerationDomain:
+    competition_id: UUID
+    season_id: UUID
+    memory_revision_id: UUID
+    snapshot_id: UUID
+
+
+@pytest.fixture(autouse=True)
+def clean_generation_resources(request: pytest.FixtureRequest) -> None:
+    if "database_engine" not in request.fixturenames:
+        return
+    engine = request.getfixturevalue("database_engine")
+    with engine.begin() as connection:
+        connection.execute(sa.text("TRUNCATE TABLE core.competitions CASCADE"))
+
+
+def seed_generation_domain(
+    database_engine: Engine,
+    *,
+    label: str = "Generation Resource",
+    snapshot_status: str = "ready",
+) -> GenerationDomain:
+    competition_id = uuid4()
+    season_id = uuid4()
+    memory_revision_id = uuid4()
+    snapshot_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": label},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": memory_revision_id,
+                "competition_id": competition_id,
+                "sequence_number": 0,
+                "competition_season_id": season_id,
+                "state_content_hash": "root-state",
+            },
+        )
+        connection.execute(
+            sa.insert(DataSnapshot),
+            {
+                "id": snapshot_id,
+                "competition_id": competition_id,
+                "primary_competition_season_id": season_id,
+                "build_key": uuid4().hex + uuid4().hex,
+                "domain_cutoff_week": 8,
+                "domain_cutoff_at": None,
+                "as_of_date": date(2026, 10, 27),
+                "status": snapshot_status,
+                "snapshot_projection_version": "1",
+                "code_version": "test",
+                "completeness_warnings": [],
+                "sqlite_artifact_sha256": "a" * 64,
+                "sqlite_artifact_byte_length": 10,
+                "sqlite_artifact_storage_key": "snapshots/test.sqlite",
+            },
+        )
+    return GenerationDomain(
+        competition_id=competition_id,
+        season_id=season_id,
+        memory_revision_id=memory_revision_id,
+        snapshot_id=snapshot_id,
+    )
+
+
+def generation_context(domain: GenerationDomain) -> ManagerContext[CompetitionScope]:
+    return ManagerContext[CompetitionScope](
+        actor=SystemProcessActor(process_name="generation-test"),
+        scope=CompetitionScope(competition_id=domain.competition_id),
+        correlation_id=uuid4(),
+    )
+
+
+@pytest.fixture
+def generation_domain(database_engine: Engine) -> GenerationDomain:
+    return seed_generation_domain(database_engine)
+
+
+@pytest.fixture
+def session_factory(database_engine: Engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+@pytest.fixture
+def generation_manager(
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> GenerationManager:
+    return GenerationManager(session_factory, generation_context(generation_domain))

--- a/backend/tests/resources/reporting/generations/test_manager.py
+++ b/backend/tests/resources/reporting/generations/test_manager.py
@@ -1,0 +1,283 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.reporting import (
+    Artifact,
+    ArtifactVersion,
+    EvaluationWorkspace,
+    Generation as StoredGeneration,
+)
+from backend.database.sessions import create_session_factory
+from backend.resources.reporting.generations import (
+    CancelGeneration,
+    CreateGeneration,
+    FailGeneration,
+    GenerationConcurrencyConflict,
+    GenerationLifecycleConflict,
+    GenerationManager,
+    GenerationQuery,
+    GenerationResourceNotFound,
+    StartGeneration,
+    UpdateGenerationProgress,
+)
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+    seed_generation_domain,
+)
+
+
+def _create_command(
+    domain: GenerationDomain,
+    *,
+    generation_id: UUID | None = None,
+    **overrides: object,
+) -> CreateGeneration:
+    values: dict[str, object] = {
+        "generation_id": generation_id or uuid4(),
+        "competition_season_id": domain.season_id,
+        "kind": "live",
+        "request_text": "write a weekly recap",
+        "week_start": 8,
+        "week_end": 8,
+        "requested_primary_model": "test-model",
+        "settings": {"fallbacks": ["backup-model"]},
+    }
+    values.update(overrides)
+    return CreateGeneration.model_validate(values)
+
+
+def _start_command(
+    domain: GenerationDomain,
+    generation_id: UUID,
+) -> StartGeneration:
+    return StartGeneration(
+        generation_id=generation_id,
+        data_snapshot_id=domain.snapshot_id,
+        input_memory_revision_id=domain.memory_revision_id,
+        knowledge_cutoff_at=datetime(2026, 10, 27, tzinfo=UTC),
+        input_manifest={"prompt_hash": "b" * 64},
+        manifest_schema_version=1,
+        manifest_hash="c" * 64,
+    )
+
+
+def test_pending_start_progress_and_terminal_lifecycle_are_atomic(
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    pending = generation_manager.create_pending(_create_command(generation_domain))
+    assert pending.status.value == "pending"
+    assert pending.data_snapshot_id is None
+    assert pending.settings == {"fallbacks": ["backup-model"]}
+
+    running = generation_manager.start(_start_command(generation_domain, pending.id))
+    assert running.status.value == "running"
+    assert running.data_snapshot_id == generation_domain.snapshot_id
+    assert running.domain_cutoff_week == 8
+    assert running.domain_cutoff_at is None
+    assert running.input_memory_revision_id == generation_domain.memory_revision_id
+    assert running.input_manifest == {"prompt_hash": "b" * 64}
+    assert running.manifest_hash == "c" * 64
+
+    with pytest.raises(GenerationLifecycleConflict):
+        generation_manager.start(_start_command(generation_domain, pending.id))
+    progressed = generation_manager.update_progress(
+        UpdateGenerationProgress(
+            generation_id=pending.id,
+            current_turn=3,
+            current_stage="drafting",
+        )
+    )
+    assert progressed.current_turn == 3
+    with pytest.raises(GenerationLifecycleConflict, match="earlier turn"):
+        generation_manager.update_progress(
+            UpdateGenerationProgress(
+                generation_id=pending.id,
+                current_turn=2,
+                current_stage="research",
+            )
+        )
+    failed = generation_manager.fail(
+        FailGeneration(
+            generation_id=pending.id,
+            category="provider_error",
+            summary="Provider failed after retries",
+        )
+    )
+    assert failed.status.value == "failed"
+    assert failed.completed_at is not None
+    with pytest.raises(GenerationLifecycleConflict):
+        generation_manager.cancel(CancelGeneration(generation_id=pending.id))
+    assert (
+        generation_manager.get(pending.id).data_snapshot_id
+        == running.data_snapshot_id
+    )
+
+
+def test_failed_start_rolls_back_all_input_pinning(
+    database_engine: Engine,
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    other = seed_generation_domain(database_engine, label="Foreign input")
+    pending = generation_manager.create_pending(_create_command(generation_domain))
+    command = _start_command(generation_domain, pending.id).model_copy(
+        update={"input_memory_revision_id": other.memory_revision_id}
+    )
+    with pytest.raises(GenerationResourceNotFound, match="memory_revision"):
+        generation_manager.start(command)
+    stored = generation_manager.get(pending.id)
+    assert stored.status.value == "pending"
+    assert stored.data_snapshot_id is None
+    assert stored.input_manifest is None
+
+
+def test_reads_reruns_and_history_are_competition_scoped(
+    database_engine: Engine,
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    original = generation_manager.create_pending(_create_command(generation_domain))
+    rerun_command = _create_command(
+        generation_domain,
+        rerun_of_generation_id=original.id,
+    )
+    with pytest.raises(GenerationLifecycleConflict, match="terminal source"):
+        generation_manager.create_pending(rerun_command)
+    generation_manager.cancel(CancelGeneration(generation_id=original.id))
+    rerun = generation_manager.create_pending(rerun_command)
+    page = generation_manager.list(
+        GenerationQuery(rerun_of_generation_id=original.id, limit=1)
+    )
+    assert page.total == 1
+    assert page.items[0].id == rerun.id
+    history = generation_manager.list(GenerationQuery(limit=1))
+    assert history.total == 2
+    assert history.items[0].id == rerun.id
+    assert generation_manager.list(GenerationQuery(limit=1, offset=1)).items[
+        0
+    ].id == original.id
+
+    other = seed_generation_domain(database_engine, label="Other competition")
+    other_manager = GenerationManager(
+        create_session_factory(database_engine), generation_context(other)
+    )
+    with pytest.raises(GenerationResourceNotFound):
+        other_manager.get(original.id)
+    with pytest.raises(GenerationResourceNotFound):
+        other_manager.create_pending(
+            _create_command(other, rerun_of_generation_id=original.id)
+        )
+
+
+def test_concurrent_pending_identity_has_one_typed_winner(
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    command = _create_command(generation_domain)
+
+    def create(_: int):
+        try:
+            return generation_manager.create_pending(command)
+        except GenerationConcurrencyConflict as error:
+            return error
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = tuple(pool.map(create, range(2)))
+    assert sum(not isinstance(result, Exception) for result in results) == 1
+    assert (
+        sum(isinstance(result, GenerationConcurrencyConflict) for result in results)
+        == 1
+    )
+
+
+def test_workspace_generation_pins_only_the_current_succeeded_artifact(
+    database_engine: Engine,
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    workspace_id = uuid4()
+    source_generation_id = uuid4()
+    artifact_id = uuid4()
+    version_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(EvaluationWorkspace),
+            {
+                "id": workspace_id,
+                "competition_id": generation_domain.competition_id,
+                "base_memory_revision_id": generation_domain.memory_revision_id,
+                "status": "active",
+            },
+        )
+        connection.execute(
+            sa.insert(StoredGeneration),
+            {
+                "id": source_generation_id,
+                "competition_id": generation_domain.competition_id,
+                "competition_season_id": generation_domain.season_id,
+                "evaluation_workspace_id": workspace_id,
+                "workspace_sequence_number": 1,
+                "kind": "backtest",
+                "status": "succeeded",
+                "request_text": "source",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 1,
+            },
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            {
+                "id": artifact_id,
+                "generation_id": source_generation_id,
+                "path": "memory/workspace.json",
+                "media_type": "application/json",
+            },
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            {
+                "id": version_id,
+                "artifact_id": artifact_id,
+                "generation_id": source_generation_id,
+                "revision_number": 1,
+                "content": "{}",
+                "content_hash": (
+                    "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+                ),
+            },
+        )
+        connection.execute(
+            sa.update(EvaluationWorkspace)
+            .where(EvaluationWorkspace.id == workspace_id)
+            .values(
+                current_memory_artifact_version_id=version_id,
+                current_memory_artifact_generation_id=source_generation_id,
+            )
+        )
+
+    pending = generation_manager.create_pending(
+        _create_command(
+            generation_domain,
+            kind="backtest",
+            evaluation_workspace_id=workspace_id,
+            workspace_sequence_number=2,
+        )
+    )
+    start = _start_command(generation_domain, pending.id).model_copy(
+        update={
+            "input_memory_revision_id": None,
+            "input_memory_artifact_version_id": version_id,
+            "input_memory_artifact_generation_id": source_generation_id,
+        }
+    )
+    running = generation_manager.start(start)
+    assert running.input_memory_revision_id is None
+    assert running.input_memory_artifact_version_id == version_id

--- a/backend/tests/resources/reporting/generations/test_objects.py
+++ b/backend/tests/resources/reporting/generations/test_objects.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.reporting.generations import (
+    CreateGeneration,
+    GenerationKind,
+    GenerationQuery,
+    StartGeneration,
+)
+
+
+def _create_values() -> dict[str, object]:
+    return {
+        "generation_id": uuid4(),
+        "competition_season_id": uuid4(),
+        "kind": GenerationKind.LIVE,
+        "request_text": "write the recap",
+        "week_start": 4,
+        "week_end": 8,
+        "requested_primary_model": "test-model",
+        "settings": {"temperature": 0.2, "enabled": True},
+    }
+
+
+def test_create_contract_validates_coverage_and_workspace_shape() -> None:
+    command = CreateGeneration.model_validate(_create_values())
+    assert command.week_start == 4
+    with pytest.raises(ValidationError, match="provided together"):
+        CreateGeneration.model_validate({**_create_values(), "week_end": None})
+    with pytest.raises(ValidationError, match="cannot be after"):
+        CreateGeneration.model_validate(
+            {**_create_values(), "week_start": 9, "week_end": 8}
+        )
+    with pytest.raises(ValidationError, match="sequence number"):
+        CreateGeneration.model_validate(
+            {**_create_values(), "evaluation_workspace_id": uuid4()}
+        )
+
+
+def test_start_contract_requires_one_complete_memory_input_and_manifest() -> None:
+    values = {
+        "generation_id": uuid4(),
+        "data_snapshot_id": uuid4(),
+        "knowledge_cutoff_at": datetime.now(UTC),
+        "input_manifest": {"schema": 1},
+        "manifest_schema_version": 1,
+        "manifest_hash": "a" * 64,
+    }
+    canonical = StartGeneration.model_validate(
+        {**values, "input_memory_revision_id": uuid4()}
+    )
+    assert canonical.input_memory_artifact_version_id is None
+    with pytest.raises(ValidationError, match="exactly one"):
+        StartGeneration.model_validate(values)
+    with pytest.raises(ValidationError, match="both artifact IDs"):
+        StartGeneration.model_validate(
+            {**values, "input_memory_artifact_version_id": uuid4()}
+        )
+    with pytest.raises(ValidationError, match="non-empty"):
+        StartGeneration.model_validate(
+            {**values, "input_manifest": {}, "input_memory_revision_id": uuid4()}
+        )
+
+
+def test_generation_query_rejects_unsafe_pagination() -> None:
+    assert GenerationQuery().limit == 50
+    with pytest.raises(ValidationError):
+        GenerationQuery(limit=0)
+    with pytest.raises(ValidationError):
+        GenerationQuery(offset=-1)

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -3,8 +3,8 @@
 **Status:** Proposed architecture contract for the generation implementation stack
 
 **Scope:** `backend/services/generations`, `backend/services/reporter`, the
-reporting resource aggregate, generation API/worker boundaries, and the adapters
-to frozen datalayer and typed memory
+reporting resource layer, generation API/worker boundaries, and the adapters to
+frozen datalayer and typed memory
 
 **Authoritative persistence baseline:**
 [`docs/database/reporting.md`](../database/reporting.md)

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | API | generation request/response schemas | authentication, authorization, transport validation, polling |
 | Worker/process | `GenerationService` | execute one durable generation and reconcile stale runs |
-| Generation service | generation manager | scoped lifecycle, call telemetry, artifacts, and terminal state |
+| Generation service | reporting resource managers | scoped lifecycle, call telemetry, artifacts, and terminal state |
 | Generation service | datalayer services | optional refresh and ready snapshot resolution |
 | Generation service | memory services | revision pin, generation context, and proposal finalization |
 | Generation service | reporter generator | produce one article from already-resolved capabilities |
@@ -44,10 +44,10 @@ The exact live-versus-backtest mapping to `SnapshotRequest.as_of_date` and
 knowledge cutoff is owned by generation policy. It must be specified with
 golden tests rather than inferred inside the datalayer.
 
-## Generation Manager Contract
+## Reporting Resource Manager Contracts
 
 The generation manager is competition-scoped through `ManagerContext`. Its
-public operations are aggregate operations, not generic table CRUD.
+public operations own only generation lifecycle state, not generic table CRUD.
 
 Required semantic operations:
 
@@ -59,18 +59,31 @@ class GenerationManager:
     def fail(self, command: FailGeneration) -> Generation: ...
     def cancel(self, command: CancelGeneration) -> Generation: ...
     def get(self, generation_id: UUID) -> GenerationDetail: ...
-    def list(self, query: GenerationQuery) -> Page[GenerationSummary]: ...
+    def list(self, query: GenerationQuery) -> GenerationPage: ...
+```
 
+Child reporting resources use the same competition scope through independent
+manager boundaries:
+
+```python
+class AICallManager:
     def begin_ai_call(self, command: BeginAICall) -> AICall: ...
     def finish_ai_call(self, command: FinishAICall) -> AICall: ...
+
+class ToolCallManager:
     def begin_tool_call(self, command: BeginToolCall) -> ToolCall: ...
     def finish_tool_call(self, command: FinishToolCall) -> ToolCall: ...
+
+class ArtifactManager:
+    def finalize_artifact(self, command: FinalizeArtifact) -> Artifact: ...
+
+class ArtifactVersionManager:
     def append_artifact_version(
         self, command: AppendArtifactVersion
     ) -> ArtifactVersion: ...
 ```
 
-Successful finalization requires one additional aggregate operation whose exact
+Successful finalization requires one additional service operation whose exact
 shape depends on the unresolved cross-resource memory transaction decision. It
 must at minimum ensure that:
 
@@ -82,13 +95,14 @@ must at minimum ensure that:
 - completion timestamps/progress are coherent; and
 - a terminal generation cannot be reopened or modified.
 
-### Manager invariants
+### Cross-manager invariants
 
 - Every ID belongs to the manager's competition scope.
 - `create_pending` durably captures the original request before external work.
 - `start` atomically pins all required inputs and manifest fields.
 - input fields are immutable after start.
-- AI-call `(turn, attempt)` and tool ordinal identity are manager-controlled.
+- AI-call `(turn, attempt)` and tool ordinal identity are controlled by their
+  resource managers.
 - a tool call references the successful AI call for its turn.
 - full tool result text is retained; structured JSON is additional.
 - artifact revisions are positive, append-only, hash-verified, and allocated
@@ -97,7 +111,7 @@ must at minimum ensure that:
   immutable `media_type` describes representation rather than semantic role.
 - finalizing an artifact selects its latest existing version and forbids later
   appends.
-- expected lifecycle conflicts raise typed application errors, never leak
+- expected lifecycle conflicts raise typed resource errors, never leak
   constraint names.
 
 ## Reporter Generator Contract

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -39,7 +39,7 @@ flowchart TB
     end
 
     subgraph Resources["backend/resources"]
-        GenerationManager["GenerationManager aggregate"]
+        ReportingManagers["Reporting resource managers"]
         MemoryManagers["Memory managers"]
         SnapshotManager["Datalayer managers"]
     end
@@ -58,8 +58,8 @@ flowchart TB
     Completion --> Recorder
     Runner --> Recorder
     ArtifactState --> Recorder
-    Recorder --> GenerationManager
-    Service --> GenerationManager
+    Recorder --> ReportingManagers
+    Service --> ReportingManagers
     SnapshotService --> SnapshotManager
     MemoryContext --> MemoryManagers
 ```
@@ -106,39 +106,35 @@ It receives capabilities; it does not discover platform state. Specifically, it
 must not import snapshot or refresh services, memory managers, generation ORM
 models, session factories, API dependencies, or worker code.
 
-### Generation resource aggregate
+### Reporting resource managers
 
-The platform architecture permits one manager to own the generation aggregate,
-including its child AI calls, tool calls, artifacts, and versions. That is the
-simplest baseline:
+Reporting persistence follows the resource-per-manager convention used by the
+rest of the backend:
 
 ```text
 centralized reporting ORM models
     -> reporting resource objects
-    -> GenerationManager
+    -> per-resource reporting managers
     -> GenerationService / execution recorder
 ```
 
-`GenerationManager` owns short, scope-checked operations for:
+`GenerationManager` owns short, scope-checked operations for pending creation,
+atomic input pin/start, progress, terminal transitions, and generation reads.
+Child persistence belongs to separate managers:
 
-- pending creation and reads;
-- atomic input pin/start;
-- progress and terminal transitions;
-- AI-call attempt start/finish;
-- tool-call start/finish;
-- stable path-addressed artifact creation, append-only versions, and
-  selected-version finalization; and
-- generation detail/history reads.
+- `AICallManager` owns attempt start/finish and allocation;
+- `ToolCallManager` owns provider-call start/finish and ordinal identity;
+- `ArtifactManager` owns stable path identity and finalization; and
+- `ArtifactVersionManager` owns append-only content revisions.
 
-Separate public managers for AI calls, tool calls, and artifact versions are not
-required while those rows have no lifecycle outside a generation. Internal
-modules may split the SQL by child type without creating public repositories.
+Application services compose these narrow operations when workflow policy spans
+multiple resources.
 
 ### Execution recorder
 
 The execution recorder is a generation-scoped application adapter between the
-reporter execution boundaries and `GenerationManager`. It is not a generic event
-bus and does not own workflow policy.
+reporter execution boundaries and the reporting resource managers. It is not a
+generic event bus and does not own workflow policy.
 
 It is needed in three places:
 
@@ -157,11 +153,12 @@ production generation path always uses the durable recorder.
 ```text
 backend/
 ├── resources/
-│   └── generations/
-│       ├── __init__.py
-│       ├── objects.py          # generation aggregate and child resource objects
-│       ├── manager.py          # scoped lifecycle and aggregate persistence
-│       └── shared.py           # only if cross-resource finalization needs it
+│   └── reporting/
+│       ├── generations/        # lifecycle contracts and GenerationManager
+│       ├── ai_calls/           # AI-call contracts and AICallManager
+│       ├── tool_calls/         # tool-call contracts and ToolCallManager
+│       ├── artifacts/          # artifact contracts and ArtifactManager
+│       └── artifact_versions/  # version contracts and ArtifactVersionManager
 ├── services/
 │   ├── generations/
 │   │   ├── __init__.py
@@ -344,13 +341,13 @@ Allowed:
 
 ```text
 api / worker -> GenerationService
-GenerationService -> generation manager, datalayer services, memory services,
-                     reporter service
+GenerationService -> reporting resource managers, datalayer services,
+                     memory services, reporter service
 reporter generator -> Runner and reporter-owned tool adapters
 reporter data adapter -> FrozenLeagueData
 reporter memory adapter -> GenerationMemoryContext
-execution recorder -> GenerationManager
-GenerationManager -> reporting ORM models and database infrastructure
+execution recorder -> reporting resource managers
+reporting resource managers -> reporting ORM models and database infrastructure
 ```
 
 Forbidden:

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -24,7 +24,7 @@ adopted:
   of the generation service and the frozen reporter adapter in the new package;
 - this generation stack supplies reporting resources, reporter execution,
   observability, artifacts, memory lifecycle, API, and worker integration; and
-- neither stack introduces a second generation manager or alternate start path.
+- neither stack introduces an alternate generation start path.
 
 Memory's reporter-retrieval and reporter-mutation tail likewise lands through
 the single reporter memory adapter and `GenerationService` finalization path.
@@ -100,19 +100,33 @@ within their artifact/generation and finalized artifacts cannot change.
 rejects stale or ambiguous edits, submits an exact current `article.md`
 revision, and has no artifact-kind or section-specific persistence contract.
 
-### `generation-4` — reporting resource contracts and manager
+### `generation-4a` — generation lifecycle resource
 
-- Add resource objects for generation summary/detail, AI calls, tool calls,
-  artifacts, and artifact versions.
-- Add `GenerationManager` with scoped pending/start/progress/fail/cancel/read
-  operations.
-- Add child-call, path-addressed artifact, append-only version, and
-  selected-version finalization operations under the same aggregate.
+- Add immutable generation summary/detail, command, query, and paging contracts.
+- Add a competition-scoped `GenerationManager` for pending creation,
+  atomic start/input pinning, progress, failure, cancellation, and reads.
 - Add typed lifecycle/concurrency errors and ORM-to-resource conversion.
-- Prove existing reporting schema constraints through real manager behavior.
 
-**Exit gate:** pending-to-running input pinning is atomic, inputs are immutable,
-terminal rows cannot reopen, and concurrent call/artifact allocation is safe.
+**Exit gate:** pending-to-running input pinning is atomic, request and input
+fields are immutable, scope is masked on reads, and terminal rows cannot reopen.
+
+### `generation-4b` — execution-call resources
+
+- Add AI-call and tool-call contracts in resource-specific packages.
+- Add separate `AICallManager` and `ToolCallManager` boundaries for start/finish
+  operations, attempt allocation, provider ordinals, and provenance checks.
+
+**Exit gate:** concurrent attempt allocation is sequential, duplicate tool
+ordinals are typed conflicts, and terminal child telemetry cannot be stranded.
+
+### `generation-4c` — artifact resources
+
+- Add artifact and artifact-version contracts in resource-specific packages.
+- Add separate `ArtifactManager` and `ArtifactVersionManager` boundaries for
+  stable paths, append-only versions, and selected-version finalization.
+
+**Exit gate:** concurrent revisions are sequential, identical writes are
+idempotent, media type is immutable, and finalized artifacts reject appends.
 
 ### `generation-5` — manifest and model-call instrumentation
 
@@ -233,17 +247,20 @@ flowchart LR
     G0["G0 decisions"] --> G1["G1 reporter move"]
     G1 --> G2["G2 artifact storage"]
     G2 --> G3["G3 reporter artifacts"]
-    G2 --> G4["G4 reporting manager"]
+    G2 --> G4A["G4a generation lifecycle"]
+    G4A --> G4B["G4b execution calls"]
+    G4B --> G4C["G4c artifacts"]
     G1 --> G5["G5 AI calls/tokens"]
-    G4 --> G5
+    G4B --> G5
     G5 --> G6["G6 tool/progress"]
     G6 --> G7["G7 artifact persistence"]
     G3 --> G7
+    G4C --> G7
     G1 --> G8["G8 memory adapter"]
     Memory["Typed memory integration-ready"] --> G8
     Data["Merged frozen datalayer"] --> G1
     Data --> G9["G9 generation inputs"]
-    G4 --> G9
+    G4A --> G9
     G5 --> G9
     G7 --> G9
     G8 --> G9

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -77,7 +77,7 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 
 ### Add
 
-- reporting resource objects and `GenerationManager`;
+- per-resource reporting objects and managers;
 - deterministic manifest construction and hashing;
 - `GenerationService` submission/start/execute/finalize/fail workflow;
 - provider-attempt token/call recording;


### PR DESCRIPTION
# Generation 4a PR

## Scope

- immutable generation lifecycle commands, views, paging, and typed errors;
- competition-scoped `GenerationManager` pending/start/progress/fail/cancel/get/list;
- atomic snapshot and memory-input pinning against the existing reporting schema;
- focused pure and disposable-PostgreSQL lifecycle tests.

## Deferred

- AI-call and tool-call resources and managers (`generation-4b`);
- artifact and artifact-version resources and managers (`generation-4c`);
- successful cross-resource finalization, reporter instrumentation, API, and worker composition.

## Stack

- branch: `codex/generation-4a`
- base: `codex/generation-3`
- commit: `8edcb69`

## Verification

- `20 passed`: generation lifecycle resources plus existing reporting constraints;
- reporting resource/test modules compile;
- `git diff --check` passes.
