### PR TITLE
fix(ci): run database checks with uv

### DIFF
--- a/.github/workflows/database-hosted-verify.yml
+++ b/.github/workflows/database-hosted-verify.yml
@@ -36,12 +36,13 @@ jobs:
       AIDAM_MIGRATION_REQUIRE_TLS: "true"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v10
         with:
+          version: "0.12.5"
           python-version: "3.11"
-          cache: pip
+          enable-cache: true
       - name: Install project
-        run: python -m pip install --editable '.[dev]'
+        run: uv sync --locked
       - name: Install trusted database CA
         env:
           DATABASE_CA_PEM: ${{ secrets.AIDAM_DATABASE_CA_PEM }}
@@ -51,37 +52,37 @@ jobs:
           chmod 600 "$RUNNER_TEMP/aidam-database/root.crt"
           echo "AIDAM_DATABASE_CA_FILE=$RUNNER_TEMP/aidam-database/root.crt" >> "$GITHUB_ENV"
       - name: Verify single Alembic head
-        run: test "$(alembic -c backend/migrations/alembic.ini heads | wc -l)" -eq 1
+        run: test "$(uv run --no-sync alembic -c backend/migrations/alembic.ini heads | wc -l)" -eq 1
       - name: Apply migration history
-        run: alembic -c backend/migrations/alembic.ini upgrade head
+        run: uv run --no-sync alembic -c backend/migrations/alembic.ini upgrade head
       - name: Verify database is at head
-        run: alembic -c backend/migrations/alembic.ini current --check-heads
+        run: uv run --no-sync alembic -c backend/migrations/alembic.ini current --check-heads
       - name: Verify migrator and hosted boundaries
         run: >-
-          python -m infra.database.verify_database
+          uv run --no-sync python -m infra.database.verify_database
           --url-environment AIDAM_MIGRATION_DATABASE_URL
           --expected-database "$AIDAM_EXPECTED_DATABASE"
           --expected-role aidam_migrator
           --profile migrator
       - name: Verify API role and TLS
         run: >-
-          python -m infra.database.verify_database
+          uv run --no-sync python -m infra.database.verify_database
           --url-environment AIDAM_DATABASE_URL
           --expected-database "$AIDAM_EXPECTED_DATABASE"
           --expected-role aidam_api
           --profile runtime
       - name: Verify worker role and TLS
         run: >-
-          python -m infra.database.verify_database
+          uv run --no-sync python -m infra.database.verify_database
           --url-environment AIDAM_WORKER_DATABASE_URL
           --expected-database "$AIDAM_EXPECTED_DATABASE"
           --expected-role aidam_worker
           --profile runtime
       - name: Check ORM and migration drift
-        run: alembic -c backend/migrations/alembic.ini check
+        run: uv run --no-sync alembic -c backend/migrations/alembic.ini check
       - name: Write credential-free schema report
         run: >-
-          python -m infra.database.schema_report
+          uv run --no-sync python -m infra.database.schema_report
           --url-environment AIDAM_MIGRATION_DATABASE_URL
           > "$RUNNER_TEMP/schema-report.json"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -5,13 +5,14 @@ on:
     paths:
       - "backend/database/**"
       - "backend/migrations/**"
-      - "backend/tests/database/**"
+      - "backend/config.py"
       - "infra/database/**"
       - "infra/postgres/**"
-      - "docs/database/runbooks/**"
+      - ".github/workflows/database.yml"
       - ".github/workflows/database-hosted-verify.yml"
       - "compose.database.yml"
       - "pyproject.toml"
+      - "uv.lock"
   push:
     branches: [main]
 
@@ -21,19 +22,20 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v10
         with:
+          version: "0.12.5"
           python-version: "3.11"
-          cache: pip
+          enable-cache: true
       - name: Start PostgreSQL
         run: docker compose -f compose.database.yml up --detach --wait
       - name: Install project
-        run: python -m pip install --editable '.[dev]'
+        run: uv sync --locked
       - name: Verify one migration head
         env:
           AIDAM_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:54329/aidam
           AIDAM_MIGRATION_REQUIRE_TLS: "false"
-        run: test "$(alembic -c backend/migrations/alembic.ini heads | wc -l)" -eq 1
+        run: test "$(uv run --no-sync alembic -c backend/migrations/alembic.ini heads | wc -l)" -eq 1
       - name: Record PostgreSQL version
         env:
           PGPASSWORD: postgres
@@ -43,15 +45,15 @@ jobs:
           AIDAM_MIGRATION_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:54329/aidam
           AIDAM_MIGRATION_REQUIRE_TLS: "false"
         run: |
-          alembic -c backend/migrations/alembic.ini upgrade head
-          alembic -c backend/migrations/alembic.ini current --check-heads
-          alembic -c backend/migrations/alembic.ini downgrade base
-          alembic -c backend/migrations/alembic.ini upgrade head
-          alembic -c backend/migrations/alembic.ini check
+          uv run --no-sync alembic -c backend/migrations/alembic.ini upgrade head
+          uv run --no-sync alembic -c backend/migrations/alembic.ini current --check-heads
+          uv run --no-sync alembic -c backend/migrations/alembic.ini downgrade base
+          uv run --no-sync alembic -c backend/migrations/alembic.ini upgrade head
+          uv run --no-sync alembic -c backend/migrations/alembic.ini check
       - name: Run PostgreSQL database tests
         env:
           AIDAM_TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@localhost:54329/aidam
-        run: pytest backend/tests/database
+        run: uv run --no-sync pytest backend/tests/database
       - name: PostgreSQL logs
         if: failure()
         run: docker compose -f compose.database.yml logs postgres


### PR DESCRIPTION
## Summary

- replace pip-based database CI setup with `astral-sh/setup-uv` and `uv sync --locked`
- run Alembic, Python modules, and pytest through `uv run --no-sync`
- apply the same locked uv workflow to hosted database verification
- trigger pull-request database CI for migrations, ORM metadata, database configuration and infrastructure, workflow files, and dependency manifests

## Why

PR #147 moved test tooling from the package `dev` extra to a uv dependency group. The database workflow still ran `pip install --editable '.[dev]'`, so pytest was not installed and the job failed with exit code 127.

## Testing

- `uv sync --locked`
- parsed both workflow files as YAML
- `uv run --no-sync pytest --version`
- `uv run --no-sync alembic -c backend/migrations/alembic.ini heads` — one head (`0007`)
- `uv run --no-sync pytest backend/tests/database -q` — 19 passed, 52 skipped without `AIDAM_TEST_DATABASE_URL`
