### PR TITLE
Generation 4c — artifact resources

### DIFF
--- a/backend/resources/reporting/artifact_versions/__init__.py
+++ b/backend/resources/reporting/artifact_versions/__init__.py
@@ -1,0 +1,33 @@
+"""Public durable artifact-version resource contract."""
+
+from backend.resources.reporting.artifact_versions.errors import (
+    ArtifactVersionConcurrencyConflict,
+    ArtifactVersionLifecycleConflict,
+    ArtifactVersionProvenanceConflict,
+    ArtifactVersionResourceError,
+    ArtifactVersionResourceNotFound,
+)
+from backend.resources.reporting.artifact_versions.manager import (
+    ArtifactVersionManager,
+)
+from backend.resources.reporting.artifact_versions.objects import (
+    AppendArtifactVersion,
+    ArtifactVersion,
+    ArtifactVersionPage,
+    ArtifactVersionQuery,
+    ArtifactVersionSummary,
+)
+
+__all__ = [
+    "AppendArtifactVersion",
+    "ArtifactVersion",
+    "ArtifactVersionConcurrencyConflict",
+    "ArtifactVersionLifecycleConflict",
+    "ArtifactVersionManager",
+    "ArtifactVersionPage",
+    "ArtifactVersionProvenanceConflict",
+    "ArtifactVersionQuery",
+    "ArtifactVersionResourceError",
+    "ArtifactVersionResourceNotFound",
+    "ArtifactVersionSummary",
+]

--- a/backend/resources/reporting/artifact_versions/errors.py
+++ b/backend/resources/reporting/artifact_versions/errors.py
@@ -1,0 +1,45 @@
+"""Stable application failures for reporting artifact revisions."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+class ArtifactVersionResourceError(RuntimeError):
+    """Base class for artifact-version failures safe at service boundaries."""
+
+
+class ArtifactVersionResourceNotFound(ArtifactVersionResourceError):
+    def __init__(self, resource_kind: str, resource_id: UUID) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        super().__init__(f"{resource_kind} {resource_id} was not found")
+
+
+class ArtifactVersionLifecycleConflict(ArtifactVersionResourceError):
+    def __init__(self, resource_id: UUID, message: str, *, actual_status: str) -> None:
+        self.resource_id = resource_id
+        self.message = message
+        self.actual_status = actual_status
+        super().__init__(message)
+
+
+class ArtifactVersionConcurrencyConflict(ArtifactVersionResourceError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class ArtifactVersionProvenanceConflict(ArtifactVersionResourceError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+__all__ = [
+    "ArtifactVersionConcurrencyConflict",
+    "ArtifactVersionLifecycleConflict",
+    "ArtifactVersionProvenanceConflict",
+    "ArtifactVersionResourceError",
+    "ArtifactVersionResourceNotFound",
+]

--- a/backend/resources/reporting/artifact_versions/manager.py
+++ b/backend/resources/reporting/artifact_versions/manager.py
@@ -1,0 +1,251 @@
+"""Competition-scoped append manager for durable artifact revisions."""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.database.models.reporting import AICall as StoredAICall
+from backend.database.models.reporting import Artifact as StoredArtifact
+from backend.database.models.reporting import ArtifactVersion as StoredArtifactVersion
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.models.reporting import ToolCall as StoredToolCall
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.reporting.artifact_versions.errors import (
+    ArtifactVersionConcurrencyConflict,
+    ArtifactVersionLifecycleConflict,
+    ArtifactVersionProvenanceConflict,
+    ArtifactVersionResourceNotFound,
+)
+from backend.resources.reporting.artifact_versions.objects import (
+    AppendArtifactVersion,
+    ArtifactVersion,
+    ArtifactVersionPage,
+    ArtifactVersionQuery,
+    ArtifactVersionSummary,
+)
+
+
+class ArtifactVersionManager:
+    """Own hash-verified appends, revision allocation, and scoped reads."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def append_artifact_version(
+        self,
+        command: AppendArtifactVersion,
+    ) -> ArtifactVersion:
+        try:
+            with transaction_session(self._session_factory) as session:
+                artifact, generation = self._load_artifact_with_generation(
+                    session, command.artifact_id, lock=True
+                )
+                if generation.status != "running":
+                    raise ArtifactVersionLifecycleConflict(
+                        generation.id,
+                        "artifact versions can be appended only for a running generation",
+                        actual_status=generation.status,
+                    )
+                if artifact.finalized_version_id is not None:
+                    raise ArtifactVersionLifecycleConflict(
+                        artifact.id,
+                        "finalized artifacts cannot accept new versions",
+                        actual_status="finalized",
+                    )
+                latest = session.scalar(
+                    sa.select(StoredArtifactVersion)
+                    .where(StoredArtifactVersion.artifact_id == artifact.id)
+                    .order_by(StoredArtifactVersion.revision_number.desc())
+                    .limit(1)
+                )
+                self._validate_provenance(session, generation.id, command)
+                if (
+                    latest is not None
+                    and latest.content_hash == command.content_hash
+                    and latest.content == command.content
+                ):
+                    return _decode(latest)
+                stored = StoredArtifactVersion(
+                    id=uuid4(),
+                    artifact_id=artifact.id,
+                    generation_id=generation.id,
+                    revision_number=(
+                        latest.revision_number + 1 if latest is not None else 1
+                    ),
+                    content=command.content,
+                    content_hash=command.content_hash,
+                    source_ai_call_id=command.source_ai_call_id,
+                    source_tool_call_id=command.source_tool_call_id,
+                )
+                session.add(stored)
+                session.flush()
+                return _decode(stored)
+        except IntegrityError:
+            raise ArtifactVersionConcurrencyConflict(
+                "artifact revision identity is already allocated"
+            ) from None
+
+    def get(self, artifact_version_id: UUID) -> ArtifactVersion:
+        with read_only_session(self._session_factory) as session:
+            return _decode(self._load(session, artifact_version_id))
+
+    def list(self, query: ArtifactVersionQuery) -> ArtifactVersionPage:
+        with read_only_session(self._session_factory) as session:
+            artifact, _ = self._load_artifact_with_generation(
+                session, query.artifact_id
+            )
+            condition = StoredArtifactVersion.artifact_id == artifact.id
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredArtifactVersion)
+                    .where(condition)
+                ),
+            )
+            rows = session.scalars(
+                sa.select(StoredArtifactVersion)
+                .where(condition)
+                .order_by(StoredArtifactVersion.revision_number.asc())
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return ArtifactVersionPage(
+                items=tuple(_decode_summary(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def _validate_provenance(
+        self,
+        session: Session,
+        generation_id: UUID,
+        command: AppendArtifactVersion,
+    ) -> None:
+        ai_call: StoredAICall | None = None
+        if command.source_ai_call_id is not None:
+            ai_call = session.scalar(
+                sa.select(StoredAICall).where(
+                    StoredAICall.id == command.source_ai_call_id,
+                    StoredAICall.generation_id == generation_id,
+                )
+            )
+            if ai_call is None:
+                raise ArtifactVersionResourceNotFound(
+                    "ai_call", command.source_ai_call_id
+                )
+        if command.source_tool_call_id is None:
+            return
+        tool_call = session.scalar(
+            sa.select(StoredToolCall).where(
+                StoredToolCall.id == command.source_tool_call_id,
+                StoredToolCall.generation_id == generation_id,
+            )
+        )
+        if tool_call is None:
+            raise ArtifactVersionResourceNotFound(
+                "tool_call", command.source_tool_call_id
+            )
+        if ai_call is not None and tool_call.ai_call_id != ai_call.id:
+            raise ArtifactVersionProvenanceConflict(
+                "source tool call does not belong to the source AI call"
+            )
+
+    def _load(
+        self,
+        session: Session,
+        artifact_version_id: UUID,
+    ) -> StoredArtifactVersion:
+        stored = session.scalar(
+            sa.select(StoredArtifactVersion)
+            .join(
+                StoredGeneration,
+                StoredGeneration.id == StoredArtifactVersion.generation_id,
+            )
+            .where(
+                StoredArtifactVersion.id == artifact_version_id,
+                StoredGeneration.competition_id == self._competition_id,
+            )
+        )
+        if stored is None:
+            raise ArtifactVersionResourceNotFound(
+                "artifact_version", artifact_version_id
+            )
+        return stored
+
+    def _load_artifact_with_generation(
+        self,
+        session: Session,
+        artifact_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> tuple[StoredArtifact, StoredGeneration]:
+        statement = (
+            sa.select(StoredArtifact, StoredGeneration)
+            .join(
+                StoredGeneration,
+                StoredGeneration.id == StoredArtifact.generation_id,
+            )
+            .where(
+                StoredArtifact.id == artifact_id,
+                StoredGeneration.competition_id == self._competition_id,
+            )
+        )
+        if lock:
+            statement = statement.with_for_update(
+                of=(StoredGeneration, StoredArtifact)
+            )
+        row = session.execute(statement).one_or_none()
+        if row is None:
+            raise ArtifactVersionResourceNotFound("artifact", artifact_id)
+        return row._tuple()
+
+
+def _decode(stored: StoredArtifactVersion) -> ArtifactVersion:
+    return ArtifactVersion(
+        id=stored.id,
+        artifact_id=stored.artifact_id,
+        generation_id=stored.generation_id,
+        revision_number=stored.revision_number,
+        content=stored.content,
+        content_hash=stored.content_hash,
+        source_ai_call_id=stored.source_ai_call_id,
+        source_tool_call_id=stored.source_tool_call_id,
+        created_at=stored.created_at,
+    )
+
+
+def _decode_summary(stored: StoredArtifactVersion) -> ArtifactVersionSummary:
+    return ArtifactVersionSummary(
+        id=stored.id,
+        artifact_id=stored.artifact_id,
+        generation_id=stored.generation_id,
+        revision_number=stored.revision_number,
+        content_hash=stored.content_hash,
+        source_ai_call_id=stored.source_ai_call_id,
+        source_tool_call_id=stored.source_tool_call_id,
+        created_at=stored.created_at,
+    )
+
+
+__all__ = ["ArtifactVersionManager"]

--- a/backend/resources/reporting/artifact_versions/objects.py
+++ b/backend/resources/reporting/artifact_versions/objects.py
@@ -1,0 +1,77 @@
+"""Immutable commands and views for durable artifact revisions."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, model_validator
+
+from backend.resources._contracts import ContractModel
+
+
+PositiveRevision = Annotated[int, Field(strict=True, ge=1, le=32767)]
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+Sha256Hex = Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+
+
+class AppendArtifactVersion(ContractModel):
+    artifact_id: UUID
+    content: str
+    content_hash: Sha256Hex
+    source_ai_call_id: UUID | None = None
+    source_tool_call_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_content_hash(self) -> "AppendArtifactVersion":
+        actual = hashlib.sha256(self.content.encode("utf-8")).hexdigest()
+        if self.content_hash != actual:
+            raise ValueError("content_hash must match the exact UTF-8 content")
+        return self
+
+
+class ArtifactVersionQuery(ContractModel):
+    artifact_id: UUID
+    limit: PageLimit = 50
+    offset: NonNegativeInt = 0
+
+
+class ArtifactVersion(ContractModel):
+    id: UUID
+    artifact_id: UUID
+    generation_id: UUID
+    revision_number: PositiveRevision
+    content: str
+    content_hash: Sha256Hex
+    source_ai_call_id: UUID | None
+    source_tool_call_id: UUID | None
+    created_at: AwareDatetime
+
+
+class ArtifactVersionSummary(ContractModel):
+    id: UUID
+    artifact_id: UUID
+    generation_id: UUID
+    revision_number: PositiveRevision
+    content_hash: Sha256Hex
+    source_ai_call_id: UUID | None
+    source_tool_call_id: UUID | None
+    created_at: AwareDatetime
+
+
+class ArtifactVersionPage(ContractModel):
+    items: tuple[ArtifactVersionSummary, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+__all__ = [
+    "AppendArtifactVersion",
+    "ArtifactVersion",
+    "ArtifactVersionPage",
+    "ArtifactVersionQuery",
+    "ArtifactVersionSummary",
+]

--- a/backend/resources/reporting/artifacts/__init__.py
+++ b/backend/resources/reporting/artifacts/__init__.py
@@ -1,0 +1,33 @@
+"""Public durable artifact identity resource contract."""
+
+from backend.resources.reporting.artifacts.errors import (
+    ArtifactConcurrencyConflict,
+    ArtifactLifecycleConflict,
+    ArtifactMediaTypeConflict,
+    ArtifactResourceError,
+    ArtifactResourceNotFound,
+)
+from backend.resources.reporting.artifacts.manager import ArtifactManager
+from backend.resources.reporting.artifacts.objects import (
+    Artifact,
+    ArtifactPage,
+    ArtifactQuery,
+    ArtifactSummary,
+    CreateArtifact,
+    FinalizeArtifact,
+)
+
+__all__ = [
+    "Artifact",
+    "ArtifactConcurrencyConflict",
+    "ArtifactLifecycleConflict",
+    "ArtifactManager",
+    "ArtifactMediaTypeConflict",
+    "ArtifactPage",
+    "ArtifactQuery",
+    "ArtifactResourceError",
+    "ArtifactResourceNotFound",
+    "ArtifactSummary",
+    "CreateArtifact",
+    "FinalizeArtifact",
+]

--- a/backend/resources/reporting/artifacts/errors.py
+++ b/backend/resources/reporting/artifacts/errors.py
@@ -1,0 +1,53 @@
+"""Stable application failures for reporting artifact identities."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+class ArtifactResourceError(RuntimeError):
+    """Base class for artifact failures safe at service boundaries."""
+
+
+class ArtifactResourceNotFound(ArtifactResourceError):
+    def __init__(self, resource_kind: str, resource_id: UUID) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        super().__init__(f"{resource_kind} {resource_id} was not found")
+
+
+class ArtifactLifecycleConflict(ArtifactResourceError):
+    def __init__(self, resource_id: UUID, message: str, *, actual_status: str) -> None:
+        self.resource_id = resource_id
+        self.message = message
+        self.actual_status = actual_status
+        super().__init__(message)
+
+
+class ArtifactConcurrencyConflict(ArtifactResourceError):
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+class ArtifactMediaTypeConflict(ArtifactResourceError):
+    def __init__(
+        self,
+        path: str,
+        *,
+        requested_media_type: str,
+        actual_media_type: str,
+    ) -> None:
+        self.path = path
+        self.requested_media_type = requested_media_type
+        self.actual_media_type = actual_media_type
+        super().__init__(f"artifact {path} already uses media type {actual_media_type}")
+
+
+__all__ = [
+    "ArtifactConcurrencyConflict",
+    "ArtifactLifecycleConflict",
+    "ArtifactMediaTypeConflict",
+    "ArtifactResourceError",
+    "ArtifactResourceNotFound",
+]

--- a/backend/resources/reporting/artifacts/manager.py
+++ b/backend/resources/reporting/artifacts/manager.py
@@ -1,0 +1,235 @@
+"""Competition-scoped manager for durable artifact identities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.database.models.reporting import Artifact as StoredArtifact
+from backend.database.models.reporting import ArtifactVersion as StoredArtifactVersion
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.reporting.artifacts.errors import (
+    ArtifactConcurrencyConflict,
+    ArtifactLifecycleConflict,
+    ArtifactMediaTypeConflict,
+    ArtifactResourceNotFound,
+)
+from backend.resources.reporting.artifacts.objects import (
+    Artifact,
+    ArtifactPage,
+    ArtifactQuery,
+    ArtifactSummary,
+    CreateArtifact,
+    FinalizeArtifact,
+)
+
+
+class ArtifactManager:
+    """Own stable path identities, final selection, and scoped reads."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def create_artifact(self, command: CreateArtifact) -> Artifact:
+        try:
+            with transaction_session(self._session_factory) as session:
+                generation = self._load_generation(
+                    session, command.generation_id, lock=True
+                )
+                self._require_running(generation)
+                existing = session.scalar(
+                    sa.select(StoredArtifact).where(
+                        StoredArtifact.generation_id == generation.id,
+                        StoredArtifact.path == command.path,
+                    )
+                )
+                if existing is not None:
+                    if existing.media_type != command.media_type:
+                        raise ArtifactMediaTypeConflict(
+                            command.path,
+                            requested_media_type=command.media_type,
+                            actual_media_type=existing.media_type,
+                        )
+                    return _decode(existing)
+                stored = StoredArtifact(
+                    id=uuid4(),
+                    generation_id=generation.id,
+                    path=command.path,
+                    media_type=command.media_type,
+                )
+                session.add(stored)
+                session.flush()
+                return _decode(stored)
+        except IntegrityError:
+            raise ArtifactConcurrencyConflict(
+                "artifact path identity is already allocated"
+            ) from None
+
+    def finalize_artifact(self, command: FinalizeArtifact) -> Artifact:
+        with transaction_session(self._session_factory) as session:
+            stored, generation = self._load_with_generation(
+                session, command.artifact_id, lock=True
+            )
+            if stored.finalized_version_id is not None:
+                if stored.finalized_version_id == command.artifact_version_id:
+                    return _decode(stored)
+                raise ArtifactLifecycleConflict(
+                    stored.id,
+                    "artifact finalization is immutable",
+                    actual_status="finalized",
+                )
+            self._require_running(generation)
+            selected = session.scalar(
+                sa.select(StoredArtifactVersion).where(
+                    StoredArtifactVersion.id == command.artifact_version_id,
+                    StoredArtifactVersion.artifact_id == stored.id,
+                    StoredArtifactVersion.generation_id == stored.generation_id,
+                )
+            )
+            if selected is None:
+                raise ArtifactResourceNotFound(
+                    "artifact_version", command.artifact_version_id
+                )
+            latest_revision = session.scalar(
+                sa.select(sa.func.max(StoredArtifactVersion.revision_number)).where(
+                    StoredArtifactVersion.artifact_id == stored.id
+                )
+            )
+            if selected.revision_number != latest_revision:
+                raise ArtifactConcurrencyConflict(
+                    "only the latest artifact version can be finalized"
+                )
+            stored.finalized_version_id = selected.id
+            stored.finalized_at = datetime.now(UTC)
+            session.flush()
+            return _decode(stored)
+
+    def get(self, artifact_id: UUID) -> Artifact:
+        with read_only_session(self._session_factory) as session:
+            stored, _ = self._load_with_generation(session, artifact_id)
+            return _decode(stored)
+
+    def list(self, query: ArtifactQuery) -> ArtifactPage:
+        with read_only_session(self._session_factory) as session:
+            self._load_generation(session, query.generation_id)
+            conditions: list[sa.ColumnElement[bool]] = [
+                StoredArtifact.generation_id == query.generation_id
+            ]
+            if query.finalized is True:
+                conditions.append(StoredArtifact.finalized_version_id.is_not(None))
+            elif query.finalized is False:
+                conditions.append(StoredArtifact.finalized_version_id.is_(None))
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredArtifact)
+                    .where(*conditions)
+                ),
+            )
+            rows = session.scalars(
+                sa.select(StoredArtifact)
+                .where(*conditions)
+                .order_by(StoredArtifact.path.asc(), StoredArtifact.id.asc())
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return ArtifactPage(
+                items=tuple(_decode_summary(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def _load_with_generation(
+        self,
+        session: Session,
+        artifact_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> tuple[StoredArtifact, StoredGeneration]:
+        statement = (
+            sa.select(StoredArtifact, StoredGeneration)
+            .join(
+                StoredGeneration,
+                StoredGeneration.id == StoredArtifact.generation_id,
+            )
+            .where(
+                StoredArtifact.id == artifact_id,
+                StoredGeneration.competition_id == self._competition_id,
+            )
+        )
+        if lock:
+            statement = statement.with_for_update(
+                of=(StoredGeneration, StoredArtifact)
+            )
+        row = session.execute(statement).one_or_none()
+        if row is None:
+            raise ArtifactResourceNotFound("artifact", artifact_id)
+        return row._tuple()
+
+    def _load_generation(
+        self,
+        session: Session,
+        generation_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> StoredGeneration:
+        statement = sa.select(StoredGeneration).where(
+            StoredGeneration.id == generation_id,
+            StoredGeneration.competition_id == self._competition_id,
+        )
+        if lock:
+            statement = statement.with_for_update()
+        stored = session.scalar(statement)
+        if stored is None:
+            raise ArtifactResourceNotFound("generation", generation_id)
+        return stored
+
+    @staticmethod
+    def _require_running(generation: StoredGeneration) -> None:
+        if generation.status != "running":
+            raise ArtifactLifecycleConflict(
+                generation.id,
+                "artifacts can change only for a running generation",
+                actual_status=generation.status,
+            )
+
+
+def _decode(stored: StoredArtifact) -> Artifact:
+    return Artifact(
+        id=stored.id,
+        generation_id=stored.generation_id,
+        path=stored.path,
+        media_type=stored.media_type,
+        finalized_version_id=stored.finalized_version_id,
+        finalized_at=stored.finalized_at,
+        created_at=stored.created_at,
+    )
+
+
+def _decode_summary(stored: StoredArtifact) -> ArtifactSummary:
+    return ArtifactSummary.model_validate(_decode(stored).model_dump())
+
+
+__all__ = ["ArtifactManager"]

--- a/backend/resources/reporting/artifacts/objects.py
+++ b/backend/resources/reporting/artifacts/objects.py
@@ -1,0 +1,100 @@
+"""Immutable commands and views for durable artifact identities."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+import re
+from typing import Annotated, Any
+from uuid import UUID
+
+from pydantic import AwareDatetime, BeforeValidator, Field
+
+from backend.resources._contracts import ContractModel
+
+
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+_MEDIA_TYPE = re.compile(
+    r"^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$"
+)
+
+
+def _artifact_path(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    if not value or value != value.strip():
+        raise ValueError("artifact path must be a non-empty normalized string")
+    if "\x00" in value or "\\" in value:
+        raise ValueError("artifact path must use POSIX separators")
+    path = PurePosixPath(value)
+    if path.is_absolute() or path.as_posix() != value:
+        raise ValueError("artifact path must be a normalized relative path")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("artifact path cannot contain dot segments")
+    if not path.parts or ":" in path.parts[0]:
+        raise ValueError("artifact path must be relative to the artifact workspace")
+    return value
+
+
+def _media_type(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    value = value.strip().lower()
+    if _MEDIA_TYPE.fullmatch(value) is None:
+        raise ValueError("media_type must be a normalized IANA media type")
+    return value
+
+
+ArtifactPath = Annotated[str, BeforeValidator(_artifact_path)]
+MediaType = Annotated[str, BeforeValidator(_media_type)]
+
+
+class CreateArtifact(ContractModel):
+    generation_id: UUID
+    path: ArtifactPath
+    media_type: MediaType
+
+
+class FinalizeArtifact(ContractModel):
+    artifact_id: UUID
+    artifact_version_id: UUID
+
+
+class ArtifactQuery(ContractModel):
+    generation_id: UUID
+    finalized: bool | None = None
+    limit: PageLimit = 50
+    offset: NonNegativeInt = 0
+
+
+class Artifact(ContractModel):
+    id: UUID
+    generation_id: UUID
+    path: str
+    media_type: str
+    finalized_version_id: UUID | None
+    finalized_at: AwareDatetime | None
+    created_at: AwareDatetime
+
+
+class ArtifactSummary(Artifact):
+    pass
+
+
+class ArtifactPage(ContractModel):
+    items: tuple[ArtifactSummary, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+__all__ = [
+    "Artifact",
+    "ArtifactPage",
+    "ArtifactPath",
+    "ArtifactQuery",
+    "ArtifactSummary",
+    "CreateArtifact",
+    "FinalizeArtifact",
+    "MediaType",
+]

--- a/backend/tests/resources/reporting/artifact_versions/__init__.py
+++ b/backend/tests/resources/reporting/artifact_versions/__init__.py
@@ -1,0 +1,1 @@
+"""Artifact-version resource tests."""

--- a/backend/tests/resources/reporting/artifact_versions/conftest.py
+++ b/backend/tests/resources/reporting/artifact_versions/conftest.py
@@ -1,0 +1,47 @@
+"""Disposable PostgreSQL fixtures for artifact-version resource tests."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.reporting.artifact_versions import ArtifactVersionManager
+from backend.tests.database.conftest import database_engine, migrated_database
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+    seed_generation_domain,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_artifact_version_resources(request: pytest.FixtureRequest) -> None:
+    if "database_engine" not in request.fixturenames:
+        return
+    engine = request.getfixturevalue("database_engine")
+    with engine.begin() as connection:
+        connection.execute(sa.text("TRUNCATE TABLE core.competitions CASCADE"))
+
+
+@pytest.fixture
+def generation_domain(database_engine) -> GenerationDomain:
+    return seed_generation_domain(database_engine, label="Artifact Version Resource")
+
+
+@pytest.fixture
+def session_factory(database_engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+@pytest.fixture
+def artifact_version_manager(
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> ArtifactVersionManager:
+    return ArtifactVersionManager(
+        session_factory, generation_context(generation_domain)
+    )
+
+
+__all__ = ["database_engine", "migrated_database"]

--- a/backend/tests/resources/reporting/artifact_versions/test_manager.py
+++ b/backend/tests/resources/reporting/artifact_versions/test_manager.py
@@ -1,0 +1,299 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+import hashlib
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.reporting.ai_calls import (
+    AICallManager,
+    BeginAICall,
+    FinishAICall,
+)
+from backend.resources.reporting.artifact_versions import (
+    AppendArtifactVersion,
+    ArtifactVersionLifecycleConflict,
+    ArtifactVersionManager,
+    ArtifactVersionProvenanceConflict,
+    ArtifactVersionQuery,
+    ArtifactVersionResourceNotFound,
+)
+from backend.resources.reporting.artifacts import (
+    ArtifactManager,
+    CreateArtifact,
+    FinalizeArtifact,
+)
+from backend.resources.reporting.generations import (
+    CreateGeneration,
+    GenerationManager,
+    StartGeneration,
+)
+from backend.resources.reporting.tool_calls import BeginToolCall, ToolCallManager
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+    seed_generation_domain,
+)
+
+
+def _hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _create_running(
+    session_factory: SessionFactory,
+    domain: GenerationDomain,
+) -> UUID:
+    manager = GenerationManager(session_factory, generation_context(domain))
+    generation = manager.create_pending(
+        CreateGeneration(
+            generation_id=uuid4(),
+            competition_season_id=domain.season_id,
+            kind="live",
+            request_text="write the recap",
+            week_start=8,
+            week_end=8,
+            requested_primary_model="test-model",
+            settings={},
+        )
+    )
+    manager.start(
+        StartGeneration(
+            generation_id=generation.id,
+            data_snapshot_id=domain.snapshot_id,
+            input_memory_revision_id=domain.memory_revision_id,
+            knowledge_cutoff_at=datetime(2026, 10, 27, tzinfo=UTC),
+            input_manifest={"schema": 1},
+            manifest_schema_version=1,
+            manifest_hash="a" * 64,
+        )
+    )
+    return generation.id
+
+
+def _create_artifact(
+    session_factory: SessionFactory,
+    domain: GenerationDomain,
+    generation_id: UUID,
+):
+    manager = ArtifactManager(session_factory, generation_context(domain))
+    return manager.create_artifact(
+        CreateArtifact(
+            generation_id=generation_id,
+            path="article.md",
+            media_type="text/markdown",
+        )
+    )
+
+
+def _append(artifact_id: UUID, content: str) -> AppendArtifactVersion:
+    return AppendArtifactVersion(
+        artifact_id=artifact_id,
+        content=content,
+        content_hash=_hash(content),
+    )
+
+
+def _successful_ai_call(
+    session_factory: SessionFactory,
+    domain: GenerationDomain,
+    generation_id: UUID,
+):
+    manager = AICallManager(session_factory, generation_context(domain))
+    started = manager.begin_ai_call(
+        BeginAICall(
+            generation_id=generation_id,
+            turn_number=1,
+            requested_model="test-model",
+            input_messages=(),
+            tool_definitions=(),
+            request_parameters={},
+        )
+    )
+    return manager.finish_ai_call(
+        FinishAICall(
+            ai_call_id=started.id,
+            status="succeeded",
+            actual_model="test-model",
+            provider_response={"choices": []},
+        )
+    )
+
+
+def test_append_allocates_revisions_and_lists_without_full_content(
+    artifact_version_manager: ArtifactVersionManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create_artifact(
+        session_factory, generation_domain, generation_id
+    )
+    first = artifact_version_manager.append_artifact_version(
+        _append(artifact.id, "first")
+    )
+    second = artifact_version_manager.append_artifact_version(
+        _append(artifact.id, "second")
+    )
+    assert (first.revision_number, second.revision_number) == (1, 2)
+    assert artifact_version_manager.get(second.id).content == "second"
+    page = artifact_version_manager.list(
+        ArtifactVersionQuery(artifact_id=artifact.id)
+    )
+    assert page.total == 2
+    assert [item.revision_number for item in page.items] == [1, 2]
+    assert "content" not in page.items[0].model_fields_set
+
+
+def test_identical_writes_are_idempotent_including_under_concurrency(
+    artifact_version_manager: ArtifactVersionManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create_artifact(
+        session_factory, generation_domain, generation_id
+    )
+    command = _append(artifact.id, "same snapshot")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        versions = tuple(
+            pool.map(
+                lambda _: artifact_version_manager.append_artifact_version(command),
+                range(2),
+            )
+        )
+    assert versions[0] == versions[1]
+    assert versions[0].revision_number == 1
+
+
+def test_concurrent_distinct_writes_receive_sequential_revisions(
+    artifact_version_manager: ArtifactVersionManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create_artifact(
+        session_factory, generation_domain, generation_id
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        versions = tuple(
+            pool.map(
+                lambda content: artifact_version_manager.append_artifact_version(
+                    _append(artifact.id, content)
+                ),
+                ("alpha", "beta"),
+            )
+        )
+    assert sorted(version.revision_number for version in versions) == [1, 2]
+
+
+def test_provenance_must_belong_to_the_artifact_generation(
+    database_engine,
+    artifact_version_manager: ArtifactVersionManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create_artifact(
+        session_factory, generation_domain, generation_id
+    )
+    ai_call = _successful_ai_call(
+        session_factory, generation_domain, generation_id
+    )
+    tool_manager = ToolCallManager(
+        session_factory, generation_context(generation_domain)
+    )
+    tool_call = tool_manager.begin_tool_call(
+        BeginToolCall(
+            generation_id=generation_id,
+            ai_call_id=ai_call.id,
+            tool_ordinal=0,
+            tool_name="create_artifact",
+            implementation_version="v1",
+            arguments={},
+        )
+    )
+    recorded = artifact_version_manager.append_artifact_version(
+        AppendArtifactVersion(
+            **_append(artifact.id, "with provenance").model_dump(
+                exclude={"source_ai_call_id", "source_tool_call_id"}
+            ),
+            source_ai_call_id=ai_call.id,
+            source_tool_call_id=tool_call.id,
+        )
+    )
+    assert recorded.source_tool_call_id == tool_call.id
+
+    other_domain = seed_generation_domain(database_engine, label="Foreign Version")
+    other_factory = create_session_factory(database_engine)
+    other_generation_id = _create_running(other_factory, other_domain)
+    foreign_ai_call = _successful_ai_call(
+        other_factory, other_domain, other_generation_id
+    )
+    with pytest.raises(ArtifactVersionResourceNotFound, match="ai_call"):
+        artifact_version_manager.append_artifact_version(
+            AppendArtifactVersion(
+                **_append(artifact.id, "with provenance").model_dump(
+                    exclude={"source_ai_call_id", "source_tool_call_id"}
+                ),
+                source_ai_call_id=foreign_ai_call.id,
+            )
+        )
+
+    second_ai = AICallManager(
+        session_factory, generation_context(generation_domain)
+    ).begin_ai_call(
+        BeginAICall(
+            generation_id=generation_id,
+            turn_number=2,
+            requested_model="test-model",
+            input_messages=(),
+            tool_definitions=(),
+            request_parameters={},
+        )
+    )
+    with pytest.raises(ArtifactVersionProvenanceConflict, match="source AI"):
+        artifact_version_manager.append_artifact_version(
+            AppendArtifactVersion(
+                **_append(artifact.id, "mixed provenance").model_dump(
+                    exclude={"source_ai_call_id", "source_tool_call_id"}
+                ),
+                source_ai_call_id=second_ai.id,
+                source_tool_call_id=tool_call.id,
+            )
+        )
+
+
+def test_finalized_artifacts_reject_appends_and_scope_is_masked(
+    database_engine,
+    artifact_version_manager: ArtifactVersionManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create_artifact(
+        session_factory, generation_domain, generation_id
+    )
+    version = artifact_version_manager.append_artifact_version(
+        _append(artifact.id, "final")
+    )
+    ArtifactManager(
+        session_factory, generation_context(generation_domain)
+    ).finalize_artifact(
+        FinalizeArtifact(
+            artifact_id=artifact.id,
+            artifact_version_id=version.id,
+        )
+    )
+    with pytest.raises(ArtifactVersionLifecycleConflict, match="finalized"):
+        artifact_version_manager.append_artifact_version(
+            _append(artifact.id, "too late")
+        )
+
+    foreign_domain = seed_generation_domain(database_engine, label="Foreign Reader")
+    foreign = ArtifactVersionManager(
+        create_session_factory(database_engine), generation_context(foreign_domain)
+    )
+    with pytest.raises(ArtifactVersionResourceNotFound):
+        foreign.get(version.id)

--- a/backend/tests/resources/reporting/artifact_versions/test_objects.py
+++ b/backend/tests/resources/reporting/artifact_versions/test_objects.py
@@ -1,0 +1,33 @@
+import hashlib
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.reporting.artifact_versions import (
+    AppendArtifactVersion,
+    ArtifactVersionQuery,
+)
+
+
+def test_append_contract_verifies_exact_utf8_content_hash() -> None:
+    content = "touchdown — café"
+    command = AppendArtifactVersion(
+        artifact_id=uuid4(),
+        content=content,
+        content_hash=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    )
+    assert command.content == content
+    with pytest.raises(ValidationError, match="exact UTF-8"):
+        AppendArtifactVersion(
+            artifact_id=uuid4(),
+            content=content,
+            content_hash="0" * 64,
+        )
+
+
+def test_version_query_rejects_unsafe_pagination() -> None:
+    with pytest.raises(ValidationError):
+        ArtifactVersionQuery(artifact_id=uuid4(), limit=201)
+    with pytest.raises(ValidationError):
+        ArtifactVersionQuery(artifact_id=uuid4(), offset=-1)

--- a/backend/tests/resources/reporting/artifacts/__init__.py
+++ b/backend/tests/resources/reporting/artifacts/__init__.py
@@ -1,0 +1,1 @@
+"""Artifact resource tests."""

--- a/backend/tests/resources/reporting/artifacts/conftest.py
+++ b/backend/tests/resources/reporting/artifacts/conftest.py
@@ -1,0 +1,45 @@
+"""Disposable PostgreSQL fixtures for artifact resource tests."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.reporting.artifacts import ArtifactManager
+from backend.tests.database.conftest import database_engine, migrated_database
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+    seed_generation_domain,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_artifact_resources(request: pytest.FixtureRequest) -> None:
+    if "database_engine" not in request.fixturenames:
+        return
+    engine = request.getfixturevalue("database_engine")
+    with engine.begin() as connection:
+        connection.execute(sa.text("TRUNCATE TABLE core.competitions CASCADE"))
+
+
+@pytest.fixture
+def generation_domain(database_engine) -> GenerationDomain:
+    return seed_generation_domain(database_engine, label="Artifact Resource")
+
+
+@pytest.fixture
+def session_factory(database_engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+@pytest.fixture
+def artifact_manager(
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> ArtifactManager:
+    return ArtifactManager(session_factory, generation_context(generation_domain))
+
+
+__all__ = ["database_engine", "migrated_database"]

--- a/backend/tests/resources/reporting/artifacts/test_manager.py
+++ b/backend/tests/resources/reporting/artifacts/test_manager.py
@@ -1,0 +1,196 @@
+from datetime import UTC, datetime
+import hashlib
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.reporting.artifact_versions import (
+    AppendArtifactVersion,
+    ArtifactVersionManager,
+)
+from backend.resources.reporting.artifacts import (
+    ArtifactConcurrencyConflict,
+    ArtifactLifecycleConflict,
+    ArtifactManager,
+    ArtifactMediaTypeConflict,
+    ArtifactQuery,
+    ArtifactResourceNotFound,
+    CreateArtifact,
+    FinalizeArtifact,
+)
+from backend.resources.reporting.generations import (
+    CancelGeneration,
+    CreateGeneration,
+    GenerationManager,
+    StartGeneration,
+)
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+    seed_generation_domain,
+)
+
+
+def _hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _create_running(
+    session_factory: SessionFactory,
+    domain: GenerationDomain,
+) -> tuple[GenerationManager, UUID]:
+    manager = GenerationManager(session_factory, generation_context(domain))
+    generation = manager.create_pending(
+        CreateGeneration(
+            generation_id=uuid4(),
+            competition_season_id=domain.season_id,
+            kind="live",
+            request_text="write the recap",
+            week_start=8,
+            week_end=8,
+            requested_primary_model="test-model",
+            settings={},
+        )
+    )
+    manager.start(
+        StartGeneration(
+            generation_id=generation.id,
+            data_snapshot_id=domain.snapshot_id,
+            input_memory_revision_id=domain.memory_revision_id,
+            knowledge_cutoff_at=datetime(2026, 10, 27, tzinfo=UTC),
+            input_manifest={"schema": 1},
+            manifest_schema_version=1,
+            manifest_hash="a" * 64,
+        )
+    )
+    return manager, generation.id
+
+
+def _create(
+    manager: ArtifactManager,
+    generation_id: UUID,
+    *,
+    path: str = "article.md",
+    media_type: str = "text/markdown",
+):
+    return manager.create_artifact(
+        CreateArtifact(
+            generation_id=generation_id,
+            path=path,
+            media_type=media_type,
+        )
+    )
+
+
+def test_create_is_idempotent_and_media_type_is_immutable(
+    artifact_manager: ArtifactManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    _, generation_id = _create_running(session_factory, generation_domain)
+    created = _create(artifact_manager, generation_id)
+    repeated = _create(artifact_manager, generation_id)
+    assert repeated == created
+    with pytest.raises(ArtifactMediaTypeConflict, match="already uses"):
+        _create(
+            artifact_manager,
+            generation_id,
+            media_type="text/plain",
+        )
+
+
+def test_list_orders_paths_and_filters_finalized_artifacts(
+    artifact_manager: ArtifactManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    _, generation_id = _create_running(session_factory, generation_domain)
+    _create(artifact_manager, generation_id, path="research/brief.md")
+    article = _create(artifact_manager, generation_id)
+    version_manager = ArtifactVersionManager(
+        session_factory, generation_context(generation_domain)
+    )
+    version = version_manager.append_artifact_version(
+        AppendArtifactVersion(
+            artifact_id=article.id,
+            content="# Article",
+            content_hash=_hash("# Article"),
+        )
+    )
+    artifact_manager.finalize_artifact(
+        FinalizeArtifact(artifact_id=article.id, artifact_version_id=version.id)
+    )
+    page = artifact_manager.list(ArtifactQuery(generation_id=generation_id))
+    assert [item.path for item in page.items] == [
+        "article.md",
+        "research/brief.md",
+    ]
+    finalized = artifact_manager.list(
+        ArtifactQuery(generation_id=generation_id, finalized=True)
+    )
+    assert finalized.total == 1
+    assert finalized.items[0].id == article.id
+
+
+def test_finalization_selects_latest_version_and_is_idempotent(
+    artifact_manager: ArtifactManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    _, generation_id = _create_running(session_factory, generation_domain)
+    artifact = _create(artifact_manager, generation_id)
+    version_manager = ArtifactVersionManager(
+        session_factory, generation_context(generation_domain)
+    )
+    first = version_manager.append_artifact_version(
+        AppendArtifactVersion(
+            artifact_id=artifact.id,
+            content="first",
+            content_hash=_hash("first"),
+        )
+    )
+    second = version_manager.append_artifact_version(
+        AppendArtifactVersion(
+            artifact_id=artifact.id,
+            content="second",
+            content_hash=_hash("second"),
+        )
+    )
+    with pytest.raises(ArtifactConcurrencyConflict, match="latest"):
+        artifact_manager.finalize_artifact(
+            FinalizeArtifact(artifact_id=artifact.id, artifact_version_id=first.id)
+        )
+    finalized = artifact_manager.finalize_artifact(
+        FinalizeArtifact(artifact_id=artifact.id, artifact_version_id=second.id)
+    )
+    assert finalized.finalized_version_id == second.id
+    assert finalized.finalized_at is not None
+    assert (
+        artifact_manager.finalize_artifact(
+            FinalizeArtifact(artifact_id=artifact.id, artifact_version_id=second.id)
+        )
+        == finalized
+    )
+
+
+def test_generation_lifecycle_and_competition_scope_are_enforced(
+    database_engine,
+    artifact_manager: ArtifactManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_manager, generation_id = _create_running(
+        session_factory, generation_domain
+    )
+    artifact = _create(artifact_manager, generation_id)
+    generation_manager.cancel(CancelGeneration(generation_id=generation_id))
+    with pytest.raises(ArtifactLifecycleConflict, match="running generation"):
+        _create(artifact_manager, generation_id, path="late.md")
+
+    foreign_domain = seed_generation_domain(database_engine, label="Foreign Artifact")
+    foreign = ArtifactManager(
+        create_session_factory(database_engine), generation_context(foreign_domain)
+    )
+    with pytest.raises(ArtifactResourceNotFound):
+        foreign.get(artifact.id)

--- a/backend/tests/resources/reporting/artifacts/test_objects.py
+++ b/backend/tests/resources/reporting/artifacts/test_objects.py
@@ -1,0 +1,42 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.reporting.artifacts import ArtifactQuery, CreateArtifact
+
+
+def test_artifact_identity_normalizes_media_type() -> None:
+    command = CreateArtifact(
+        generation_id=uuid4(),
+        path="research/brief.md",
+        media_type=" Text/Markdown ",
+    )
+    assert command.path == "research/brief.md"
+    assert command.media_type == "text/markdown"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["", "/article.md", "../article.md", "research//brief.md", "C:/article.md"],
+)
+def test_artifact_identity_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(ValidationError):
+        CreateArtifact(
+            generation_id=uuid4(),
+            path=path,
+            media_type="text/markdown",
+        )
+
+
+def test_artifact_contracts_reject_invalid_media_and_paging() -> None:
+    with pytest.raises(ValidationError, match="IANA media type"):
+        CreateArtifact(
+            generation_id=uuid4(),
+            path="article.md",
+            media_type="markdown",
+        )
+    with pytest.raises(ValidationError):
+        ArtifactQuery(generation_id=uuid4(), limit=0)
+    with pytest.raises(ValidationError):
+        ArtifactQuery(generation_id=uuid4(), offset=-1)


### PR DESCRIPTION
# Generation 4c PR

## Scope

- immutable artifact and artifact-version commands, views, queries, paging, and
  typed resource failures;
- competition-scoped `ArtifactManager` idempotent path creation, immutable media
  type, selected-version finalization, get, and list;
- competition-scoped `ArtifactVersionManager` exact UTF-8 hash verification,
  append-only revision allocation, provenance validation, get, and list;
- lifecycle and concurrency handling for sequential competing revisions,
  idempotent identical writes, latest-version selection, and finalized-artifact
  append rejection.

## Deferred

- reporter execution recording and artifact-tool persistence (`generation-7`);
- generation-level success finalization and cross-resource memory commit;
- API routes and worker composition.

## Stack

- branch: `codex/generation-4c`
- base: `codex/generation-4b`
- commit: `5447611`

## Verification

- `38 passed`: artifact resources, generation lifecycle, and reporting
  constraints against disposable PostgreSQL;
- `188 passed`: complete backend resource suite plus reporting constraints
  against disposable PostgreSQL;
- resource and test modules compile through `uv run`;
- 99-column and `git diff --check` gates pass.
