### PR TITLE
fix(ci): repair database workflow bootstrap

### DIFF
--- a/.github/workflows/database-hosted-verify.yml
+++ b/.github/workflows/database-hosted-verify.yml
@@ -36,7 +36,7 @@ jobs:
       AIDAM_MIGRATION_REQUIRE_TLS: "true"
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
           python-version: "3.11"

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -6,8 +6,10 @@ on:
       - "backend/database/**"
       - "backend/migrations/**"
       - "backend/config.py"
+      - "backend/tests/database/**"
       - "infra/database/**"
       - "infra/postgres/**"
+      - "docs/database/runbooks/**"
       - ".github/workflows/database.yml"
       - ".github/workflows/database-hosted-verify.yml"
       - "compose.database.yml"
@@ -22,7 +24,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
           python-version: "3.11"


### PR DESCRIPTION
## Summary

- pin setup-uv to the official v10.0.1 commit in both database workflows
- restore database test and operational runbook path triggers
- keep the locked uv installation and command execution introduced by PR #148

## Why

The Database workflow cannot resolve the nonexistent floating setup-uv v10 tag, so main fails during job setup. The previous workflow update also removed two path filters required by the database operational-assets test.

## Testing

- uv sync --locked
- parsed both workflow files as YAML
- Alembic reports one head: 0007
- backend/tests/database: 19 passed, 52 PostgreSQL-only tests skipped without a database URL
- backend/tests/database/operations/test_assets.py: 7 passed
- git diff --check