### PR TITLE
Generation 4d: attach submitted generation output

### DIFF
--- a/backend/database/models/reporting/artifacts.py
+++ b/backend/database/models/reporting/artifacts.py
@@ -29,6 +29,11 @@ class Artifact(Base):
         UniqueConstraint(
             "id", "generation_id", name="uq_artifacts_id_generation"
         ),
+        UniqueConstraint(
+            "finalized_version_id",
+            "generation_id",
+            name="uq_artifacts_finalized_version_generation",
+        ),
         CheckConstraint(
             "(finalized_version_id IS NULL) = (finalized_at IS NULL)",
             name="finalization_shape",

--- a/backend/database/models/reporting/generations.py
+++ b/backend/database/models/reporting/generations.py
@@ -93,6 +93,16 @@ class Generation(Base):
             use_alter=True,
         ),
         ForeignKeyConstraint(
+            ["submitted_artifact_version_id", "id"],
+            [
+                "reporting.artifacts.finalized_version_id",
+                "reporting.artifacts.generation_id",
+            ],
+            name="fk_generations_submitted_artifact_finalized",
+            ondelete="RESTRICT",
+            use_alter=True,
+        ),
+        ForeignKeyConstraint(
             [
                 "input_memory_artifact_generation_id",
                 "evaluation_workspace_id",
@@ -121,6 +131,10 @@ class Generation(Base):
             "evaluation_workspace_id IS NOT NULL))",
             name="unambiguous_memory_input",
         ),
+        CheckConstraint(
+            "submitted_artifact_version_id IS NULL OR status = 'succeeded'",
+            name="submitted_artifact_shape",
+        ),
         Index("ix_generations_competition_created", "competition_id", text("created_at DESC")),
         Index("ix_generations_status_progress", "status", "progress_updated_at"),
         Index("ix_generations_competition_season", "competition_season_id"),
@@ -147,6 +161,16 @@ class Generation(Base):
             "workspace_sequence_number",
         ),
         Index("ix_generations_requested_model", "requested_primary_model"),
+        Index(
+            "ix_generations_competition_submitted_completed",
+            "competition_id",
+            text("completed_at DESC"),
+            text("id DESC"),
+            postgresql_where=text(
+                "status = 'succeeded' "
+                "AND submitted_artifact_version_id IS NOT NULL"
+            ),
+        ),
         {"schema": "reporting"},
     )
 
@@ -176,6 +200,9 @@ class Generation(Base):
         BigInteger, nullable=True
     )
     rerun_of_generation_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    submitted_artifact_version_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True), nullable=True
     )
     kind: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/migrations/versions/0009_generation_submitted_artifact.py
+++ b/backend/migrations/versions/0009_generation_submitted_artifact.py
@@ -1,0 +1,94 @@
+"""Attach the reporter-selected finalized artifact version to its generation.
+
+Revision ID: 0009
+Revises: 0008
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_artifacts_finalized_version_generation",
+        "artifacts",
+        ["finalized_version_id", "generation_id"],
+        schema="reporting",
+    )
+    op.add_column(
+        "generations",
+        sa.Column("submitted_artifact_version_id", sa.UUID(), nullable=True),
+        schema="reporting",
+    )
+    op.create_check_constraint(
+        op.f("ck_generations_submitted_artifact_shape"),
+        "generations",
+        "submitted_artifact_version_id IS NULL OR status = 'succeeded'",
+        schema="reporting",
+    )
+    op.create_foreign_key(
+        "fk_generations_submitted_artifact_finalized",
+        "generations",
+        "artifacts",
+        ["submitted_artifact_version_id", "id"],
+        ["finalized_version_id", "generation_id"],
+        source_schema="reporting",
+        referent_schema="reporting",
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_generations_competition_submitted_completed",
+        "generations",
+        [
+            "competition_id",
+            sa.literal_column("completed_at DESC"),
+            sa.literal_column("id DESC"),
+        ],
+        schema="reporting",
+        postgresql_where=sa.text(
+            "status = 'succeeded' "
+            "AND submitted_artifact_version_id IS NOT NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_generations_competition_submitted_completed",
+        table_name="generations",
+        schema="reporting",
+        postgresql_where=sa.text(
+            "status = 'succeeded' "
+            "AND submitted_artifact_version_id IS NOT NULL"
+        ),
+    )
+    op.drop_constraint(
+        "fk_generations_submitted_artifact_finalized",
+        "generations",
+        type_="foreignkey",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        op.f("ck_generations_submitted_artifact_shape"),
+        "generations",
+        type_="check",
+        schema="reporting",
+    )
+    op.drop_column(
+        "generations",
+        "submitted_artifact_version_id",
+        schema="reporting",
+    )
+    op.drop_constraint(
+        "uq_artifacts_finalized_version_generation",
+        "artifacts",
+        type_="unique",
+        schema="reporting",
+    )

--- a/backend/resources/reporting/generations/__init__.py
+++ b/backend/resources/reporting/generations/__init__.py
@@ -19,6 +19,7 @@ from backend.resources.reporting.generations.objects import (
     GenerationStatus,
     GenerationSummary,
     StartGeneration,
+    SucceedGeneration,
     UpdateGenerationProgress,
 )
 
@@ -39,5 +40,6 @@ __all__ = [
     "GenerationStatus",
     "GenerationSummary",
     "StartGeneration",
+    "SucceedGeneration",
     "UpdateGenerationProgress",
 ]

--- a/backend/resources/reporting/generations/manager.py
+++ b/backend/resources/reporting/generations/manager.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from backend.database.models.core import CompetitionSeason
 from backend.database.models.memory import MemoryRevision
-from backend.database.models.reporting import EvaluationWorkspace
+from backend.database.models.reporting import Artifact, EvaluationWorkspace
 from backend.database.models.reporting import Generation as StoredGeneration
 from backend.database.models.sleeper import DataSnapshot
 from backend.database.sessions import (
@@ -37,6 +37,7 @@ from backend.resources.reporting.generations.objects import (
     GenerationStatus,
     GenerationSummary,
     StartGeneration,
+    SucceedGeneration,
     UpdateGenerationProgress,
 )
 
@@ -174,6 +175,36 @@ class GenerationManager:
             session.flush()
             return _decode(stored)
 
+    def succeed(self, command: SucceedGeneration) -> Generation:
+        with transaction_session(self._session_factory) as session:
+            stored = self._load(session, command.generation_id, lock=True)
+            self._require_status(stored, GenerationStatus.RUNNING)
+            submitted_artifact = session.scalar(
+                sa.select(Artifact.id).where(
+                    Artifact.generation_id == stored.id,
+                    Artifact.finalized_version_id
+                    == command.submitted_artifact_version_id,
+                )
+            )
+            if submitted_artifact is None:
+                raise GenerationLifecycleConflict(
+                    stored.id,
+                    "submitted output must be a finalized artifact version owned by "
+                    "the generation",
+                    expected_statuses=(GenerationStatus.RUNNING.value,),
+                    actual_status=stored.status,
+                )
+            now = datetime.now(UTC)
+            stored.submitted_artifact_version_id = (
+                command.submitted_artifact_version_id
+            )
+            stored.status = GenerationStatus.SUCCEEDED.value
+            stored.current_stage = "succeeded"
+            stored.progress_updated_at = now
+            stored.completed_at = now
+            session.flush()
+            return _decode(stored)
+
     def fail(self, command: FailGeneration) -> Generation:
         with transaction_session(self._session_factory) as session:
             stored = self._load(session, command.generation_id, lock=True)
@@ -230,6 +261,14 @@ class GenerationManager:
                     StoredGeneration.evaluation_workspace_id
                     == query.evaluation_workspace_id
                 )
+            if query.submitted_only:
+                conditions.extend(
+                    (
+                        StoredGeneration.status
+                        == GenerationStatus.SUCCEEDED.value,
+                        StoredGeneration.submitted_artifact_version_id.is_not(None),
+                    )
+                )
             total = cast(
                 int,
                 session.scalar(
@@ -238,13 +277,21 @@ class GenerationManager:
                     .where(*conditions)
                 ),
             )
-            rows = session.scalars(
-                sa.select(StoredGeneration)
-                .where(*conditions)
-                .order_by(
+            ordering = (
+                (
+                    StoredGeneration.completed_at.desc(),
+                    StoredGeneration.id.desc(),
+                )
+                if query.submitted_only
+                else (
                     StoredGeneration.created_at.desc(),
                     StoredGeneration.id.desc(),
                 )
+            )
+            rows = session.scalars(
+                sa.select(StoredGeneration)
+                .where(*conditions)
+                .order_by(*ordering)
                 .limit(query.limit)
                 .offset(query.offset)
             ).all()
@@ -412,6 +459,7 @@ def _generation_values(stored: StoredGeneration) -> dict[str, object]:
         "evaluation_workspace_id": stored.evaluation_workspace_id,
         "workspace_sequence_number": stored.workspace_sequence_number,
         "rerun_of_generation_id": stored.rerun_of_generation_id,
+        "submitted_artifact_version_id": stored.submitted_artifact_version_id,
         "kind": stored.kind,
         "status": stored.status,
         "request_text": stored.request_text,
@@ -452,6 +500,7 @@ def _decode_summary(stored: StoredGeneration) -> GenerationSummary:
         evaluation_workspace_id=stored.evaluation_workspace_id,
         workspace_sequence_number=stored.workspace_sequence_number,
         rerun_of_generation_id=stored.rerun_of_generation_id,
+        submitted_artifact_version_id=stored.submitted_artifact_version_id,
         kind=stored.kind,
         status=stored.status,
         request_text=stored.request_text,

--- a/backend/resources/reporting/generations/objects.py
+++ b/backend/resources/reporting/generations/objects.py
@@ -117,6 +117,11 @@ class UpdateGenerationProgress(ContractModel):
     current_stage: NonBlankStr
 
 
+class SucceedGeneration(ContractModel):
+    generation_id: UUID
+    submitted_artifact_version_id: UUID
+
+
 class FailGeneration(ContractModel):
     generation_id: UUID
     category: FailureCategory
@@ -134,8 +139,18 @@ class GenerationQuery(ContractModel):
     status: GenerationStatus | None = None
     rerun_of_generation_id: UUID | None = None
     evaluation_workspace_id: UUID | None = None
+    submitted_only: bool = False
     limit: PageLimit = 50
     offset: NonNegativeInt = 0
+
+    @model_validator(mode="after")
+    def validate_submitted_filter(self) -> "GenerationQuery":
+        if self.submitted_only and self.status not in (
+            None,
+            GenerationStatus.SUCCEEDED,
+        ):
+            raise ValueError("submitted_only is compatible only with succeeded status")
+        return self
 
 
 class Generation(ContractModel):
@@ -149,6 +164,7 @@ class Generation(ContractModel):
     evaluation_workspace_id: UUID | None
     workspace_sequence_number: int | None
     rerun_of_generation_id: UUID | None
+    submitted_artifact_version_id: UUID | None
     kind: GenerationKind
     status: GenerationStatus
     request_text: str
@@ -183,6 +199,7 @@ class GenerationSummary(ContractModel):
     evaluation_workspace_id: UUID | None
     workspace_sequence_number: int | None
     rerun_of_generation_id: UUID | None
+    submitted_artifact_version_id: UUID | None
     kind: GenerationKind
     status: GenerationStatus
     request_text: str

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -1,6 +1,6 @@
 # Drafting Procedure
 
-You are writing `article.md` from the brief artifact. Use `read_artifact(path="research/brief.md")`, then create or edit the article with artifact tools. Do not call datalayer tools while drafting unless you discover the brief is missing a required fact; if that happens, switch back to `research`.
+You are writing the publishable article from the brief artifact. Use `read_artifact(path="research/brief.md")`, then create or edit the article with artifact tools. Choose one stable normalized Markdown path for the draft; `article.md` is the default, not a requirement. Do not call datalayer tools while drafting unless you discover the brief is missing a required fact; if that happens, switch back to `research`.
 
 ## Operating Rules
 
@@ -9,7 +9,7 @@ You are writing `article.md` from the brief artifact. Use `read_artifact(path="r
 - Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
 - Numeric claims must match the numbers or claim text recorded in the brief.
 - Follow the outline unless later research made it incomplete. If it needs refreshing, switch to `storyline` before writing.
-- Draft with `create_artifact(path="article.md", content=...)` when the article does not exist. Use revision-checked `edit_artifact` calls for subsequent changes.
+- Draft with `create_artifact` at your chosen article path when the article does not exist. Use the same path and revision-checked `edit_artifact` calls for subsequent changes.
 - Do not submit the article from this procedure unless verification is explicitly skipped by the user or guardrails force wrap-up.
 
 ## Drafting Flow
@@ -17,8 +17,8 @@ You are writing `article.md` from the brief artifact. Use `read_artifact(path="r
 1. Read `research/brief.md`.
 2. Confirm its storylines and outline reflect the saved facts. If not, switch to `storyline` before writing.
 3. Identify the lead storyline and section order from the outline.
-4. Create a coherent Markdown draft in `article.md`, or read the existing article before continuing it.
-5. Read `article.md` after major additions to inspect flow and coverage.
+4. Create a coherent Markdown draft at one stable path, or read the existing draft before continuing it.
+5. Read the chosen draft artifact after major additions to inspect flow and coverage.
 6. Use exact `edit_artifact` replacements for local improvements. For a full rewrite, replace the complete current content using its current revision.
 7. Switch to `verification` when the draft is complete.
 

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,10 +1,10 @@
 # Verification Procedure
 
-You are checking `article.md` against `research/brief.md`. Your job is to find unsupported or incorrect claims, correct them with revision-checked exact edits, and submit only when the article is grounded.
+You are checking the chosen publishable draft artifact against `research/brief.md`. Your job is to find unsupported or incorrect claims, correct them with revision-checked exact edits, and submit only when the article is grounded.
 
 ## Operating Rules
 
-- Call `read_artifact` for both `article.md` and `research/brief.md` before judging the draft.
+- Use `list_artifacts` when needed to identify the draft path, then call `read_artifact` for both that draft and `research/brief.md` before judging it. Do not infer an application role from the filename.
 - Verify every numeric or factual claim against saved facts.
 - Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
 - If the brief is missing evidence for a necessary claim, switch to `research` instead of guessing.
@@ -39,7 +39,7 @@ For every callback paragraph:
 
 ## Verification Flow
 
-1. Read `article.md` and retain its current revision.
+1. Read the chosen publishable draft and retain its path and current revision.
 2. Read `research/brief.md`.
 3. Extract each factual claim from the article section by section.
 4. Match each claim to a fact ID and use the exact saved numbers.
@@ -50,7 +50,7 @@ For every callback paragraph:
 6. Correct `error` issues with exact, single-match `edit_artifact` calls.
 7. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
 8. After each edit, use its returned revision for the next edit. Read the article again after all corrections.
-9. Call `submit_artifact(path="article.md", expected_revision=<current>)` only after the draft passes verification.
+9. Call `submit_artifact(path=<draft_path>, expected_revision=<current>)` only after the draft passes verification.
 
 ## Correction Policy
 
@@ -74,4 +74,4 @@ Before `submit_artifact`, confirm:
 - Bias changes word choice and emphasis only, never facts.
 - The article is readable and close to the target length.
 
-Submission pins the current `article.md` snapshot and ends the reporter loop. A revision conflict requires another read and verification pass.
+Submission pins the current chosen draft snapshot and ends the reporter loop. A revision conflict requires another read and verification pass.

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -16,7 +16,8 @@ Artifact rules:
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` to work with them.
 - Before editing, read the artifact and pass its current revision. Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
 - Keep verified facts, callbacks, storylines, style, bias, and outline in `research/brief.md`.
-- Draft the publishable article at `article.md`.
+- Choose a stable normalized Markdown path for the publishable article.
+  `article.md` is the default convention, not a required application identity.
 
 Workflow:
 - Load procedures as needed with `load_procedure()`.
@@ -31,4 +32,5 @@ Available procedure names:
 - `drafting`
 - `verification`
 
-Do not end with a normal assistant message. Finish by calling `submit_artifact(path="article.md", expected_revision=...)`.
+Do not end with a normal assistant message. Finish by calling `submit_artifact`
+with the current revision of your chosen publishable artifact.

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -131,14 +131,6 @@ class ArtifactStore(BaseModel):
 
     def submit(self, path: str, *, expected_revision: int) -> ArtifactSnapshot:
         normalized = self._normalize_path(path)
-        if normalized != "article.md":
-            raise ArtifactStoreError(
-                "invalid_submission_path",
-                "Reporter submission must use article.md",
-                path=normalized,
-                required_path="article.md",
-            )
-
         artifact = self._get(normalized)
         self._check_revision(artifact, expected_revision)
         if artifact.finalized_revision is not None:
@@ -151,7 +143,7 @@ class ArtifactStore(BaseModel):
         if not artifact.current.content.strip():
             raise ArtifactStoreError(
                 "empty_submission",
-                "article.md must contain non-whitespace Markdown",
+                "submitted artifact must contain non-whitespace Markdown",
                 path=normalized,
                 current_revision=artifact.current.revision,
             )

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -95,16 +95,15 @@ ARTIFACT_TOOL_SPECS: list[ToolDef] = [
         "function": {
             "name": "submit_artifact",
             "description": (
-                "Submit article.md as the final reporter output. Submission pins the "
-                "existing revision and makes that artifact immutable."
+                "Submit a Markdown artifact as the final reporter output. Submission "
+                "pins the existing revision and makes that artifact immutable."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Must be article.md.",
-                        "enum": ["article.md"],
+                        "description": "Relative POSIX path of the publishable artifact.",
                     },
                     "expected_revision": {
                         "type": "integer",

--- a/backend/tests/database/constraints/test_reporting_constraints.py
+++ b/backend/tests/database/constraints/test_reporting_constraints.py
@@ -174,6 +174,7 @@ def test_reporting_schema_has_only_structural_checks_and_history_guards(
     }
     expected_checks = {
         "ck_artifacts_finalization_shape",
+        "ck_generations_submitted_artifact_shape",
         "ck_generations_workspace_shape",
         "ck_generations_unambiguous_memory_input",
     }
@@ -225,6 +226,14 @@ def test_reporting_schema_has_only_structural_checks_and_history_guards(
                 )
             ).scalars()
         )
+        indexes = set(
+            connection.execute(
+                sa.text(
+                    "SELECT indexname FROM pg_indexes "
+                    "WHERE schemaname = 'reporting'"
+                )
+            ).scalars()
+        )
         triggers = set(
             connection.execute(
                 sa.text(
@@ -266,6 +275,7 @@ def test_reporting_schema_has_only_structural_checks_and_history_guards(
     assert tables == expected_tables
     assert checks == expected_checks
     assert expected_partial_uniques <= partial_uniques
+    assert "ix_generations_competition_submitted_completed" in indexes
     assert expected_triggers <= triggers
     assert delete_rules == {"RESTRICT"}
     assert all(len(identifier) <= 63 for identifier in identifiers)
@@ -741,6 +751,83 @@ def test_artifact_finalization_requires_its_latest_version(
             .values(
                 finalized_version_id=latest_version_id,
                 finalized_at=sa.func.now(),
+            )
+        )
+
+
+def test_generation_submission_requires_its_own_finalized_artifact(
+    database_engine: Engine,
+) -> None:
+    with database_engine.begin() as connection:
+        domain = _seed_domain(connection, "Submitted Output")
+        source_generation_id = uuid4()
+        other_generation_id = uuid4()
+        artifact_id = uuid4()
+        version_id = uuid4()
+        connection.execute(
+            sa.insert(Generation),
+            [
+                _generation_values(
+                    domain,
+                    generation_id=source_generation_id,
+                    status="running",
+                ),
+                _generation_values(
+                    domain,
+                    generation_id=other_generation_id,
+                    status="running",
+                ),
+            ],
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            _artifact_values(
+                source_generation_id,
+                artifact_id=artifact_id,
+                path="drafts/custom-name.md",
+            ),
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            _artifact_version_values(
+                artifact_id,
+                source_generation_id,
+                version_id=version_id,
+            ),
+        )
+        connection.execute(
+            sa.update(Artifact)
+            .where(Artifact.id == artifact_id)
+            .values(
+                finalized_version_id=version_id,
+                finalized_at=sa.func.now(),
+            )
+        )
+
+    _assert_integrity_error(
+        database_engine,
+        sa.update(Generation)
+        .where(Generation.id == source_generation_id)
+        .values(submitted_artifact_version_id=version_id),
+    )
+    _assert_integrity_error(
+        database_engine,
+        sa.update(Generation)
+        .where(Generation.id == other_generation_id)
+        .values(
+            status="succeeded",
+            submitted_artifact_version_id=version_id,
+        ),
+    )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(Generation)
+            .where(Generation.id == source_generation_id)
+            .values(
+                status="succeeded",
+                submitted_artifact_version_id=version_id,
+                completed_at=sa.func.now(),
             )
         )
 

--- a/backend/tests/database/migrations/test_generation_submitted_artifact.py
+++ b/backend/tests/database/migrations/test_generation_submitted_artifact.py
@@ -1,0 +1,180 @@
+from io import StringIO
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.reporting import Artifact, ArtifactVersion, Generation
+
+
+def _config(database_url: str, *, output_buffer: StringIO | None = None) -> Config:
+    root = Path(__file__).resolve().parents[4]
+    config = Config(
+        str(root / "backend" / "migrations" / "alembic.ini"),
+        output_buffer=output_buffer,
+    )
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
+    return config
+
+
+def test_submitted_artifact_upgrade_and_downgrade_compile_offline() -> None:
+    upgrade_sql = StringIO()
+    command.upgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=upgrade_sql,
+        ),
+        "0009",
+        sql=True,
+    )
+    upgrade = upgrade_sql.getvalue()
+    assert "submitted_artifact_version_id" in upgrade
+    assert "fk_generations_submitted_artifact_finalized" in upgrade
+    assert "ix_generations_competition_submitted_completed" in upgrade
+
+    downgrade_sql = StringIO()
+    command.downgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=downgrade_sql,
+        ),
+        "0009:0008",
+        sql=True,
+    )
+    downgrade = downgrade_sql.getvalue()
+    assert "DROP COLUMN submitted_artifact_version_id" in downgrade
+    assert "DROP CONSTRAINT uq_artifacts_finalized_version_generation" in downgrade
+
+
+def test_submitted_artifact_migration_pins_only_a_finalized_owned_version(
+    database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_MIGRATION_REQUIRE_TLS", "false")
+    monkeypatch.setenv("AIDAM_MIGRATION_ROLE", "aidam_owner")
+    config = _config(database_url)
+    command.upgrade(config, "0008")
+
+    competition_id = uuid4()
+    season_id = uuid4()
+    generation_id = uuid4()
+    artifact_id = uuid4()
+    version_id = uuid4()
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Output Migration League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "kind": "live",
+                "status": "running",
+                "request_text": "write the recap",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 1,
+            },
+        )
+        connection.execute(
+            sa.insert(Artifact),
+            {
+                "id": artifact_id,
+                "generation_id": generation_id,
+                "path": "drafts/week-8-recap.md",
+                "media_type": "text/markdown",
+            },
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            {
+                "id": version_id,
+                "artifact_id": artifact_id,
+                "generation_id": generation_id,
+                "revision_number": 1,
+                "content": "# Week 8",
+                "content_hash": (
+                    "6322952fade5927c26fd1a800285fbfb80a0a87ae5191b7b1096a83c793b399e"
+                ),
+            },
+        )
+
+    command.upgrade(config, "0009")
+    generation_columns = {
+        column["name"]
+        for column in inspect(engine).get_columns(
+            "generations", schema="reporting"
+        )
+    }
+    assert "submitted_artifact_version_id" in generation_columns
+
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        connection.execute(
+            sa.update(Generation)
+            .where(Generation.id == generation_id)
+            .values(
+                status="succeeded",
+                submitted_artifact_version_id=version_id,
+                completed_at=sa.func.now(),
+            )
+        )
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.update(Artifact)
+            .where(Artifact.id == artifact_id)
+            .values(
+                finalized_version_id=version_id,
+                finalized_at=sa.func.now(),
+            )
+        )
+        connection.execute(
+            sa.update(Generation)
+            .where(Generation.id == generation_id)
+            .values(
+                status="succeeded",
+                submitted_artifact_version_id=version_id,
+                completed_at=sa.func.now(),
+            )
+        )
+
+    with engine.connect() as connection:
+        submitted = connection.scalar(
+            sa.select(Generation.submitted_artifact_version_id).where(
+                Generation.id == generation_id
+            )
+        )
+    assert submitted == version_id
+
+    command.downgrade(config, "0008")
+    downgraded_columns = {
+        column["name"]
+        for column in inspect(engine).get_columns(
+            "generations", schema="reporting"
+        )
+    }
+    assert "submitted_artifact_version_id" not in downgraded_columns
+
+    command.upgrade(config, "0009")
+    command.downgrade(config, "base")
+    engine.dispose()

--- a/backend/tests/resources/reporting/generations/test_manager.py
+++ b/backend/tests/resources/reporting/generations/test_manager.py
@@ -23,6 +23,7 @@ from backend.resources.reporting.generations import (
     GenerationQuery,
     GenerationResourceNotFound,
     StartGeneration,
+    SucceedGeneration,
     UpdateGenerationProgress,
 )
 from backend.tests.resources.reporting.generations.conftest import (
@@ -136,6 +137,93 @@ def test_failed_start_rolls_back_all_input_pinning(
     assert stored.status.value == "pending"
     assert stored.data_snapshot_id is None
     assert stored.input_manifest is None
+
+
+def test_success_pins_finalized_output_and_submitted_history_filters_by_it(
+    database_engine: Engine,
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    submitted = generation_manager.create_pending(_create_command(generation_domain))
+    omitted = generation_manager.create_pending(_create_command(generation_domain))
+    generation_manager.start(_start_command(generation_domain, submitted.id))
+    generation_manager.start(_start_command(generation_domain, omitted.id))
+    artifact_id = uuid4()
+    version_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Artifact),
+            {
+                "id": artifact_id,
+                "generation_id": submitted.id,
+                "path": "drafts/custom-name.md",
+                "media_type": "text/markdown",
+            },
+        )
+        connection.execute(
+            sa.insert(ArtifactVersion),
+            {
+                "id": version_id,
+                "artifact_id": artifact_id,
+                "generation_id": submitted.id,
+                "revision_number": 1,
+                "content": "# Submitted article\n",
+                "content_hash": (
+                    "503463bc8e496fecd2b0d9f2095f90a475f925ba2867715074b56621a3f1802a"
+                ),
+            },
+        )
+
+    with pytest.raises(GenerationLifecycleConflict, match="finalized artifact"):
+        generation_manager.succeed(
+            SucceedGeneration(
+                generation_id=submitted.id,
+                submitted_artifact_version_id=version_id,
+            )
+        )
+
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(Artifact)
+            .where(Artifact.id == artifact_id)
+            .values(
+                finalized_version_id=version_id,
+                finalized_at=sa.func.now(),
+            )
+        )
+
+    succeeded = generation_manager.succeed(
+        SucceedGeneration(
+            generation_id=submitted.id,
+            submitted_artifact_version_id=version_id,
+        )
+    )
+    assert succeeded.status.value == "succeeded"
+    assert succeeded.submitted_artifact_version_id == version_id
+    assert succeeded.completed_at is not None
+
+    with pytest.raises(GenerationLifecycleConflict, match="owned by the generation"):
+        generation_manager.succeed(
+            SucceedGeneration(
+                generation_id=omitted.id,
+                submitted_artifact_version_id=version_id,
+            )
+        )
+
+    generation_manager.fail(
+        FailGeneration(
+            generation_id=omitted.id,
+            category="test",
+            summary="not submitted",
+        )
+    )
+    page = generation_manager.list(GenerationQuery(submitted_only=True))
+    assert page.total == 1
+    assert page.items[0].id == submitted.id
+    assert page.items[0].submitted_artifact_version_id == version_id
+
+    with pytest.raises(ValueError, match="succeeded status"):
+        GenerationQuery(submitted_only=True, status="failed")
 
 
 def test_reads_reruns_and_history_are_competition_scoped(

--- a/backend/tests/services/reporter/test_artifact_tools.py
+++ b/backend/tests/services/reporter/test_artifact_tools.py
@@ -38,6 +38,12 @@ def test_tool_surface_is_generic() -> None:
         "edit_artifact",
         "submit_artifact",
     ]
+    submit_spec = next(
+        spec
+        for spec in ARTIFACT_TOOL_SPECS
+        if spec["function"]["name"] == "submit_artifact"
+    )
+    assert "enum" not in submit_spec["function"]["parameters"]["properties"]["path"]
 
 
 def test_create_list_and_read_artifacts() -> None:
@@ -194,18 +200,27 @@ def test_same_text_edit_is_noop_without_new_snapshot() -> None:
     assert len(ctx.artifacts.artifacts["article.md"].snapshots) == 1
 
 
-def test_submit_requires_article_path_current_revision_and_content() -> None:
-    ctx = make_ctx()
-    create_artifact(ctx, path="draft.md", content="# Draft")
-    create_artifact(ctx, path="article.md", content="   ")
-
-    wrong_path = decode(
-        submit_artifact(ctx, path="draft.md", expected_revision=1)
+def test_submit_accepts_any_artifact_path_and_checks_revision_and_content() -> None:
+    submitted_ctx = make_ctx()
+    create_artifact(submitted_ctx, path="drafts/week-8.md", content="# Draft")
+    submitted = decode(
+        submit_artifact(
+            submitted_ctx,
+            path="drafts/week-8.md",
+            expected_revision=1,
+        )
     )
-    stale = decode(submit_artifact(ctx, path="article.md", expected_revision=2))
-    empty = decode(submit_artifact(ctx, path="article.md", expected_revision=1))
 
-    assert wrong_path["error"]["code"] == "invalid_submission_path"
+    stale_ctx = make_ctx()
+    create_artifact(stale_ctx, path="article.md", content="# Article")
+    stale = decode(submit_artifact(stale_ctx, path="article.md", expected_revision=2))
+
+    empty_ctx = make_ctx()
+    create_artifact(empty_ctx, path="empty.md", content="   ")
+    empty = decode(submit_artifact(empty_ctx, path="empty.md", expected_revision=1))
+
+    assert submitted["ok"] is True
+    assert submitted_ctx.artifacts.submitted_path == "drafts/week-8.md"
     assert stale["error"]["code"] == "revision_conflict"
     assert empty["error"]["code"] == "empty_submission"
 

--- a/backend/tests/services/reporter/test_schemas.py
+++ b/backend/tests/services/reporter/test_schemas.py
@@ -137,19 +137,19 @@ def test_edit_reports_typed_conflicts(
 
 def test_submit_pins_existing_current_snapshot_without_new_revision() -> None:
     store = ArtifactStore()
-    current = store.create("article.md", "# Final article")
+    current = store.create("drafts/week-8.md", "# Final article")
 
-    submitted = store.submit("article.md", expected_revision=1)
+    submitted = store.submit("drafts/week-8.md", expected_revision=1)
 
-    working = store.artifacts["article.md"]
+    working = store.artifacts["drafts/week-8.md"]
     assert submitted is current
     assert working.final is current
     assert working.finalized_revision == 1
     assert len(working.snapshots) == 1
-    assert store.submitted_path == "article.md"
+    assert store.submitted_path == "drafts/week-8.md"
     with pytest.raises(ArtifactStoreError) as exc_info:
         store.edit(
-            "article.md",
+            "drafts/week-8.md",
             old_text="Final",
             new_text="Changed",
             expected_revision=1,

--- a/docs/database/reporting.md
+++ b/docs/database/reporting.md
@@ -39,6 +39,7 @@ erDiagram
     AI_CALLS ||--o{ TOOL_CALLS : requests
     GENERATIONS ||--o{ ARTIFACTS : owns
     ARTIFACTS ||--o{ ARTIFACT_VERSIONS : versions
+    GENERATIONS }o--o| ARTIFACT_VERSIONS : submitted_output
     EVALUATION_WORKSPACES ||--o{ GENERATIONS : contains
     EVALUATION_WORKSPACES }o--o| ARTIFACT_VERSIONS : current_memory
 ```
@@ -56,6 +57,7 @@ One row represents one submitted execution:
 - nullable `input_memory_artifact_version_id` for a continuing evaluation;
 - nullable `evaluation_workspace_id` and workspace sequence number;
 - nullable `rerun_of_generation_id` self-reference;
+- nullable `submitted_artifact_version_id` selecting the exact primary output;
 - `kind`: initially `live` or `backtest`;
 - `status`: `pending`, `running`, `succeeded`, `failed`, or `cancelled`;
 - original `request_text`;
@@ -85,6 +87,19 @@ Once running, the request, settings, input IDs, cutoffs, and manifest are
 immutable. The status and progress fields remain mutable. A terminal generation
 never reopens; a retry initiated by the user creates another generation linked
 by `rerun_of_generation_id`.
+
+`submitted_artifact_version_id` is null until successful finalization. When
+present, it must identify the finalized version of an artifact owned by that
+same generation and is set atomically with the transition to `succeeded`.
+Application article queries begin from this pointer; they never infer the
+primary output from an artifact path chosen inside the reporter loop.
+
+`GenerationQuery(submitted_only=True)` is the optimized article-history access
+path. It filters to successful generations with a non-null submitted pointer
+and orders by `completed_at DESC, id DESC`, matching
+`ix_generations_competition_submitted_completed`. The reporting manager remains
+competition-scoped; a later user-facing article feed can aggregate authorized
+competitions without changing artifact identity.
 
 There is deliberately no output-memory pointer on the generation. An accepted
 live mutation produces the unique next `memory.memory_revisions` row associated
@@ -218,11 +233,13 @@ an output rather than an operating-system filesystem location. `media_type`
 describes representation and is immutable after creation; semantic categories
 do not belong in a closed artifact-kind enum.
 
-The reporter's required Markdown artifacts are `research/brief.md` and
-`article.md`, both with `media_type = 'text/markdown'`. Outlines, diagnostics,
-or future editorial products use additional paths without requiring schema or
-enum changes. A separate article table is unnecessary; the API can expose the
-finalized `article.md` version as an article-specific resource or view.
+The reporter initially uses Markdown artifacts with `media_type =
+'text/markdown'`. Names such as `research/brief.md` and `article.md` are
+reporter-owned conventions. Outlines, diagnostics, or future editorial products
+use additional paths without requiring schema or enum changes. A separate
+article table is unnecessary while one successful generation represents one
+user-visible article: the API exposes the generation's explicitly submitted
+artifact version as an article-specific resource or view.
 
 An evaluation memory checkpoint uses `memory/workspace.json` with
 `media_type = 'application/json'`. Its deterministic full content allows the
@@ -252,11 +269,11 @@ Constraints:
 
 Persisting complete UTF-8 Markdown after each successful mutation is
 intentionally simple and makes rendering, auditing, and comparison
-straightforward. The reporter uses the same version model for
-`research/brief.md` and `article.md`. `submit_artifact` selects an existing
-revision of `article.md`; generation finalization pins that version and the
-current brief version supplied in `ReporterOutput` rather than appending
-content-identical final copies.
+straightforward. The reporter uses the same version model for every working
+artifact. `submit_artifact` selects an existing revision at any reporter-owned
+path; generation finalization finalizes that artifact and stores the same
+version in `generation.submitted_artifact_version_id` rather than appending a
+content-identical final copy.
 
 ## Token Analytics, Not Stored Pricing
 
@@ -286,6 +303,8 @@ Pub/Sub worker without building a DBOS-style scheduler now.
 Baseline indexes support the actual product queries:
 
 - generations by `(competition_id, created_at desc)`;
+- succeeded submitted outputs by `(competition_id, completed_at desc, id desc)`
+  for article history;
 - generations by `(status, progress_updated_at)` for polling/stale detection;
 - generations by competition season, data snapshot, canonical memory revision,
   evaluation workspace/sequence, and requested model;

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -47,8 +47,8 @@ identity changed the meaning of an operation.
 ## One-Sentence Model
 
 A generation seals one factual snapshot and one memory revision, runs the
-reporter through instrumented model and tool boundaries, then pins the submitted
-`article.md` version, retains `research/brief.md`, and applies its buffered memory
+reporter through instrumented model and tool boundaries, then pins the exact
+submitted artifact version on the generation and applies its buffered memory
 proposals under the generation lifecycle.
 
 ```mermaid
@@ -93,9 +93,13 @@ flowchart LR
   artifact store. The model-facing contract is `list_artifacts`,
   `read_artifact`, `create_artifact`, exact-match `edit_artifact`, and
   revision-checked `submit_artifact`.
-- Use raw UTF-8 Markdown at `research/brief.md` and `article.md`; mirror each
-  successful mutation to an immutable version and finalize by selecting existing
-  versions rather than writing final copies.
+- Use raw UTF-8 Markdown artifacts; mirror each successful mutation to an
+  immutable version and finalize by selecting existing versions rather than
+  writing final copies. Paths such as `research/brief.md` and `article.md` are
+  reporter-owned conventions, never application query keys.
+- Store the exact submitted finalized artifact version on the generation. The
+  application discovers generated articles through this pointer, independently
+  of the logical path chosen inside the reporter loop.
 - Keep every database transaction short. No database session stays open during
   Sleeper I/O, model calls, tool execution, or filesystem work.
 - Use the existing resource-manager pattern. Services orchestrate managers and

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -92,9 +92,10 @@ shape depends on the unresolved cross-resource memory transaction decision. It
 must at minimum ensure that:
 
 - the generation is still running;
-- the selected `article.md` and `research/brief.md` versions exist and belong to
-  the generation;
-- finalization pins those existing versions without creating copies;
+- the reporter-selected version exists, belongs to the generation, and is the
+  latest revision of its artifact;
+- finalization pins that existing version on both the artifact and generation
+  without creating a copy;
 - input identity remains unchanged;
 - completion timestamps/progress are coherent; and
 - a terminal generation cannot be reopened or modified.
@@ -115,6 +116,13 @@ must at minimum ensure that:
   immutable `media_type` describes representation rather than semantic role.
 - finalizing an artifact selects its latest existing version and forbids later
   appends.
+- a generation's nullable `submitted_artifact_version_id` identifies its exact
+  primary output, belongs to a finalized artifact from that same generation,
+  and may be set only as the generation succeeds.
+- `GenerationQuery(submitted_only=True)` returns only those successful outputs,
+  newest completion first, without inspecting artifact paths.
+- artifact paths are reporter-owned logical identity only; application queries
+  and output roles never depend on a particular path value.
 - expected lifecycle conflicts raise typed resource errors, never leak
   constraint names.
 
@@ -184,11 +192,10 @@ class ReporterOutput(BaseModel, frozen=True):
 ```
 
 `ReporterOutput` can represent an unsubmitted diagnostic result, but generation
-success requires `submitted_path == "article.md"` plus both
-`research/brief.md` and `article.md`. The snapshot matching `submitted_path` is
-the exact revision selected by `submit_artifact`; the service does not infer a
-later revision. `content_hash` is lowercase SHA-256 over the exact UTF-8
-content.
+success requires one non-null `submitted_path`. The snapshot matching that path
+is the exact revision selected by `submit_artifact`; the service does not infer
+a later revision or classify the output from its name. `content_hash` is
+lowercase SHA-256 over the exact UTF-8 content.
 
 The production path always supplies a durable recorder. Tests may use an
 in-memory recorder, and a transitional standalone CLI may omit it.
@@ -327,9 +334,10 @@ edit_artifact(path, old_text, new_text, expected_revision)
 submit_artifact(path, expected_revision)
 ```
 
-`research/brief.md` and `article.md` are the required paths and both use
-`text/markdown`. Paths are normalized relative logical names, not host
-filesystem paths. `create_artifact` rejects an existing path.
+Artifacts use `text/markdown`. Paths are normalized relative logical names, not
+host filesystem paths. The reporter may use defaults such as
+`research/brief.md` and `article.md`, but owns those names and may select another
+publishable path. `create_artifact` rejects an existing path.
 `edit_artifact` succeeds only when `expected_revision` is current and
 `old_text` occurs exactly once; zero or multiple matches are typed tool errors.
 It performs one literal replacement and appends the resulting complete content
@@ -339,12 +347,20 @@ as a new immutable version. There is deliberately no `replace_all` mode.
 content-identical edits do not append versions. Each successful create/edit
 passes its complete snapshot to the recorder with source AI/tool provenance.
 
-`submit_artifact` accepts only `article.md`, requires its expected current
+`submit_artifact` accepts any non-empty artifact, requires its expected current
 revision, records no content version, and ends the reporter loop. The resulting
 `ReporterOutput` contains `submitted_path` plus current snapshots of all
-artifacts. Generation finalization pins the submitted article version and the
-returned current `research/brief.md` version. It never appends a distinct final
-copy or mutates an artifact version in place.
+artifacts. Generation finalization finalizes that artifact and sets
+`generation.submitted_artifact_version_id` to the same existing version. It
+never appends a distinct final copy or mutates an artifact version in place.
+
+The reporting resource layer exposes this as
+`GenerationQuery(submitted_only=True)`. That query is the current article
+history read model: it is competition-scoped, orders by `completed_at DESC, id
+DESC`, and can fetch each exact article through the returned submitted version
+ID. A future user-facing API may aggregate competitions authorized for one
+user, but must preserve this explicit pointer contract rather than classify
+artifacts by path.
 
 ## Manifest Contract
 
@@ -391,7 +407,7 @@ The initial API remains polling-oriented:
 - read generation detail and exact manifest;
 - list/read AI calls and token usage;
 - list/read tool calls and full results; and
-- list/read artifact versions and the finalized `article.md` version.
+- list/read artifact versions and the generation's submitted output version.
 
 Routes authenticate/authorize, build context, call manager reads or
 `GenerationService`, and translate typed errors. They do not run model loops,

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -250,23 +250,24 @@ The reporter:
 - records every provider attempt before/after network I/O;
 - records tool calls before/after handler execution;
 - appends complete artifact versions after successful mutations; and
-- returns `ReporterOutput` with all current snapshots. `submitted_path` is
-  `article.md` only after `submit_artifact` succeeds and is otherwise `null`;
-  an unsubmitted output cannot succeed the generation.
+- returns `ReporterOutput` with all current snapshots. `submitted_path` names
+  the reporter-selected artifact only after `submit_artifact` succeeds and is
+  otherwise `null`; an unsubmitted output cannot succeed the generation.
 
 ### 5. Finalization
 
 `submit_artifact(path, expected_revision)` remains a reporter-level selection
-and stop signal, not the durable generation commit. It accepts only the current
-revision and `article.md` as the submitted output. `ReporterOutput` returns the
-nullable submitted path plus complete snapshots of every in-memory artifact.
-Only a submitted output is eligible for success. `GenerationService` then:
+and stop signal, not the durable generation commit. It accepts any current,
+non-empty Markdown artifact. `ReporterOutput` returns the nullable submitted
+path plus complete snapshots of every in-memory artifact. Artifact paths remain
+inside the reporter contract and carry no application-level role. Only a
+submitted output is eligible for success. `GenerationService` then:
 
 - obtains the complete memory proposal bundle exactly once;
-- verifies that the submitted `article.md` revision and current
-  `research/brief.md` revision already exist durably;
-- pins those existing versions as the generation's finalized outputs without
-  appending content-identical final copies;
+- verifies that the submitted revision already exists durably and belongs to
+  the generation;
+- finalizes that artifact without appending a content-identical copy and pins
+  its exact version in `generation.submitted_artifact_version_id`;
 - applies or deliberately discards the memory bundle according to generation
   kind/policy; and
 - transitions the generation to succeeded only when its required final outputs
@@ -317,23 +318,31 @@ one generic model-facing contract:
 - `create_artifact(path, content)` creates revision 1;
 - `edit_artifact(path, old_text, new_text, expected_revision)` requires the
   expected current revision and exactly one occurrence of `old_text`; and
-- `submit_artifact(path, expected_revision)` selects the current `article.md`
-  revision and ends the reporter loop.
+- `submit_artifact(path, expected_revision)` selects the current revision of
+  any non-empty artifact and ends the reporter loop.
 
 All reporter artifacts are raw UTF-8 Markdown in the initial platform slice.
-Durable reporting artifacts mirror complete snapshots at successful mutation
-boundaries:
+Their paths are reporter-owned logical names. `research/brief.md` and
+`article.md` remain useful defaults, but persistence and application queries do
+not infer semantic roles from either name. Durable reporting artifacts mirror
+complete snapshots at successful mutation boundaries:
 
 | Artifact | Durable behavior |
 | --- | --- |
-| `research/brief.md` (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
-| `article.md` (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision |
+| research or planning artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
+| publishable draft artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision regardless of path |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
 Artifact versions use their source AI call/tool call when available. Reads do
 not append versions. Failed and content-identical mutations do not append
-versions. Durable finalization pins the selected article version and current
-brief version; it does not create another artifact version.
+versions. Durable finalization pins the selected version both on its artifact
+and on the generation; it does not create another artifact version. The
+generation pointer is the application-level article output and supports article
+queries without inspecting reporter-controlled paths.
+The resource query `GenerationQuery(submitted_only=True)` uses that pointer,
+returns newest completed outputs first, and is backed by the partial
+competition/completion index. Product-user aggregation remains above this
+competition-scoped resource boundary until ownership is defined.
 
 ## Dependency Rules
 

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -96,9 +96,10 @@ within their artifact/generation and finalized artifacts cannot change.
 - Add `ReporterOutput` with `submitted_path` and complete current snapshots of
   all artifacts; update prompts, procedures, and characterization tests.
 
-**Exit gate:** the copied reporter produces both required Markdown paths,
-rejects stale or ambiguous edits, submits an exact current `article.md`
-revision, and has no artifact-kind or section-specific persistence contract.
+**Exit gate:** the copied reporter produces its two initial conventional
+Markdown paths, rejects stale or ambiguous edits, and submits an exact current
+draft revision. Generation 4d removes the initial `article.md` submission-path
+restriction while preserving the generic persistence contract.
 
 ### `generation-4a` — generation lifecycle resource
 
@@ -127,6 +128,24 @@ ordinals are typed conflicts, and terminal child telemetry cannot be stranded.
 
 **Exit gate:** concurrent revisions are sequential, identical writes are
 idempotent, media type is immutable, and finalized artifacts reject appends.
+
+### `generation-4d` — submitted generation output
+
+- Keep artifact paths under reporter control and remove the `article.md`
+  restriction from `submit_artifact`.
+- Add nullable `generation.submitted_artifact_version_id` with same-generation
+  finalized-artifact integrity and terminal shape constraints.
+- Add the competition/completion partial index used to list successful article
+  outputs without inspecting artifact paths.
+- Add atomic generation success attachment plus
+  `GenerationQuery(submitted_only=True)` so the resource query matches that
+  index and completion ordering.
+- Update reporter prompts, procedures, durable contracts, and output tests so
+  paths remain internal conventions rather than application roles.
+
+**Exit gate:** any current non-empty Markdown artifact can be submitted, a
+generation can pin only a finalized version that it owns as it succeeds, and
+article-history access begins from the explicit generation pointer.
 
 ### `generation-5` — manifest and model-call instrumentation
 
@@ -160,14 +179,14 @@ equivalent; provider order remains the tool ordinal under parallel completion.
 
 - Add artifact-recorder access to `ToolContext` without changing model-facing
   tool schemas.
-- Persist complete Markdown snapshots after successful creates and edits to
-  `research/brief.md` and `article.md`.
+- Persist complete Markdown snapshots after successful creates and edits at all
+  reporter-selected paths.
 - Return the existing version for content-identical mutations and create no
   versions for reads, failed mutations, or submission.
 - Attach source AI/tool provenance and content hashes.
 
-**Exit gate:** both artifact histories can be reconstructed from immutable
-versions and the submitted article revision is represented exactly once.
+**Exit gate:** all artifact histories can be reconstructed from immutable
+versions and the submitted output revision is represented exactly once.
 
 ### `generation-8` — typed memory reporter adapter
 
@@ -202,8 +221,8 @@ cannot switch data snapshot or memory revision mid-flight.
 
 - Implement the settled selected-artifact/memory/generation finalization
   boundary.
-- Pin the submitted `article.md` version and returned current
-  `research/brief.md` version without appending final copies.
+- Finalize the reporter-selected artifact and pin that exact version on the
+  generation without appending a final copy.
 - Apply one completed memory bundle after successful reporter submission or
   discard it on failure/cancellation.
 - Preserve partial AI/tool/artifact telemetry on failure.
@@ -250,12 +269,14 @@ flowchart LR
     G2 --> G4A["G4a generation lifecycle"]
     G4A --> G4B["G4b execution calls"]
     G4B --> G4C["G4c artifacts"]
+    G3 --> G4D["G4d submitted output"]
+    G4C --> G4D
     G1 --> G5["G5 AI calls/tokens"]
     G4B --> G5
     G5 --> G6["G6 tool/progress"]
     G6 --> G7["G7 artifact persistence"]
     G3 --> G7
-    G4C --> G7
+    G4D --> G7
     G1 --> G8["G8 memory adapter"]
     Memory["Typed memory integration-ready"] --> G8
     Data["Merged frozen datalayer"] --> G1
@@ -265,6 +286,7 @@ flowchart LR
     G7 --> G9
     G8 --> G9
     G9 --> G10["G10 finalization"]
+    G4D --> G10
     G10 --> G11["G11 API/worker"]
     G11 --> G12["G12 cutover"]
 ```
@@ -330,10 +352,10 @@ The complete stack must prove:
 7. every tool call retains exact input, full output, status, timing, and
    provider ordinal;
 8. parallel tool completion does not corrupt ordering or provenance;
-9. `research/brief.md` and `article.md` mutations create reconstructable
-   immutable versions through the generic artifact contract;
-10. one succeeded generation pins the exact submitted article version and
-    returned current brief version without duplicate final copies;
+9. reporter-selected artifact mutations create reconstructable immutable
+   versions through the generic artifact contract;
+10. one succeeded generation pins the exact submitted output version without
+    a duplicate final copy or path-based role inference;
 11. searches remain pinned and buffered memory proposals remain invisible;
 12. failed/cancelled generations discard buffered proposals;
 13. the chosen success finalization contract survives injected failure at each

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -83,7 +83,7 @@ Snapshot resolution and generation pinning remain outside the reporter adapter.
 - provider-attempt token/call recording;
 - full tool-call recording;
 - durable versioned artifacts;
-- raw Markdown `research/brief.md` and `article.md` plus `ReporterOutput`;
+- raw path-addressed Markdown artifacts plus `ReporterOutput`;
 - reporter adapters for frozen data and typed memory;
 - API polling/read surfaces; and
 - a thin worker/process entry point.
@@ -123,12 +123,13 @@ brief tools (`save_fact`, `save_memory_callback`, `save_storyline`,
 - `edit_artifact(path, old_text, new_text, expected_revision)`; and
 - `submit_artifact(path, expected_revision)`.
 
-The required run-local artifacts are raw UTF-8 Markdown at
-`research/brief.md` and `article.md`. `edit_artifact` is a revision-checked
-literal find-and-replace: `old_text` must occur exactly once, and there is no
+Run-local artifacts are raw UTF-8 Markdown at reporter-owned logical paths.
+`research/brief.md` and `article.md` remain useful prompt defaults, not durable
+application roles. `edit_artifact` is a revision-checked literal
+find-and-replace: `old_text` must occur exactly once, and there is no
 `replace_all` mode. Successful creates and edits record complete immutable
 snapshots. Reads do not mutate state. `submit_artifact` accepts the current
-revision of `article.md`, ends the reporter loop, and produces
+revision of any non-empty artifact, ends the reporter loop, and produces
 `ReporterOutput(submitted_path, artifacts)`; it does not independently mark the
 generation succeeded or append a final copy.
 
@@ -234,9 +235,9 @@ production composition. Transition in two steps:
 2. switch the platform CLI/worker to submit/execute durable generations, then
    remove direct `SleeperLeagueData` and `ContextStore` composition.
 
-Generated files may remain a developer convenience, but generation ID plus the
-`article.md` artifact and selected version become the canonical address of an
-article.
+Generated files may remain a developer convenience, but generation ID plus its
+explicit `submitted_artifact_version_id` become the canonical address of an
+article. No caller discovers articles by matching an artifact path.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary

- keep artifact naming inside the reporter loop and allow submission of any current non-empty Markdown artifact
- attach the exact finalized submitted artifact version directly to its successful generation
- add atomic success attachment and an indexed `submitted_only` generation query for article history without path matching
- update the durable generation/reporting design documents and migration plan

## Database contract

- adds nullable `reporting.generations.submitted_artifact_version_id`
- enforces same-generation finalized-version ownership with a composite foreign key
- permits the pointer only on succeeded generations
- adds a partial `(competition_id, completed_at DESC, id DESC)` index for submitted-output history

## Verification

- 53 focused reporter, migration, constraint, and generation-resource tests passed
- 304 tests passed in the broad resource/reporter run; 9 setup errors were caused only by an inaccessible default Windows pytest temp directory
- all 41 affected reporter tests passed when rerun with a workspace-local pytest temp root
- backend compile, 99-column, and `git diff --check` gates passed

## Stack

- base: `codex/generation-4c` / PR #149
- head: `codex/generation-4d`
