### PR TITLE
feat(generation): add deterministic input manifests

### DIFF
--- a/backend/services/generations/__init__.py
+++ b/backend/services/generations/__init__.py
@@ -1,0 +1,41 @@
+"""Generation workflow helpers that do not own resource persistence."""
+
+from backend.services.generations.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    BuiltGenerationManifest,
+    CanonicalMemoryInput,
+    CodeRevisionInput,
+    DataSnapshotInput,
+    EvaluationArtifactMemoryInput,
+    GenerationManifestInput,
+    GenerationRequestInput,
+    ManifestCutoffs,
+    ModelExecutionInput,
+    ProcedureInput,
+    RetryPolicyInput,
+    RunnerExecutionInput,
+    ToolInput,
+    build_generation_manifest,
+    canonical_json_bytes,
+    canonical_json_sha256,
+)
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "BuiltGenerationManifest",
+    "CanonicalMemoryInput",
+    "CodeRevisionInput",
+    "DataSnapshotInput",
+    "EvaluationArtifactMemoryInput",
+    "GenerationManifestInput",
+    "GenerationRequestInput",
+    "ManifestCutoffs",
+    "ModelExecutionInput",
+    "ProcedureInput",
+    "RetryPolicyInput",
+    "RunnerExecutionInput",
+    "ToolInput",
+    "build_generation_manifest",
+    "canonical_json_bytes",
+    "canonical_json_sha256",
+]

--- a/backend/services/generations/manifest.py
+++ b/backend/services/generations/manifest.py
@@ -1,0 +1,260 @@
+"""Immutable generation input manifest construction and identity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+from typing import Annotated, Any, Literal, TypeAlias, cast
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field, JsonValue, StringConstraints, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+from backend.resources.reporting.generations import GenerationKind
+
+
+MANIFEST_SCHEMA_VERSION = 1
+
+Sha256 = Annotated[str, StringConstraints(pattern=r"^[a-f0-9]{64}$")]
+PositiveInt = Annotated[int, Field(strict=True, ge=1)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+PositiveWeek = Annotated[int, Field(strict=True, ge=1, le=18)]
+SafeName = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=200,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:/-]*$",
+    ),
+]
+
+
+class GenerationRequestInput(ContractModel):
+    kind: GenerationKind
+    request_text: NonBlankStr
+    resolved_settings: dict[str, JsonValue]
+
+
+class DataSnapshotInput(ContractModel):
+    data_snapshot_id: UUID
+    snapshot_projection_version: NonBlankStr
+    artifact_sha256: Sha256
+
+
+class CanonicalMemoryInput(ContractModel):
+    kind: Literal["canonical_revision"] = "canonical_revision"
+    revision_id: UUID
+
+
+class EvaluationArtifactMemoryInput(ContractModel):
+    kind: Literal["evaluation_artifact"] = "evaluation_artifact"
+    artifact_version_id: UUID
+    source_generation_id: UUID
+
+
+MemoryInput: TypeAlias = Annotated[
+    CanonicalMemoryInput | EvaluationArtifactMemoryInput,
+    Field(discriminator="kind"),
+]
+
+
+class ManifestCutoffs(ContractModel):
+    domain_cutoff_week: PositiveWeek
+    domain_cutoff_at: AwareDatetime
+    knowledge_cutoff_at: AwareDatetime
+
+
+class RetryPolicyInput(ContractModel):
+    max_retries: NonNegativeInt
+    base_delay_seconds: float = Field(gt=0)
+    max_delay_seconds: float = Field(gt=0)
+
+    @model_validator(mode="after")
+    def validate_delays(self) -> "RetryPolicyInput":
+        if self.max_delay_seconds < self.base_delay_seconds:
+            raise ValueError("max delay must be greater than or equal to base delay")
+        return self
+
+
+class ModelExecutionInput(ContractModel):
+    requested_provider: NonBlankStr | None = None
+    requested_model: NonBlankStr
+    fallback_models: tuple[NonBlankStr, ...] = ()
+    retry: RetryPolicyInput
+    request_parameters: dict[str, JsonValue]
+
+    @model_validator(mode="after")
+    def validate_model_chain(self) -> "ModelExecutionInput":
+        chain = (self.requested_model, *self.fallback_models)
+        if len(chain) != len(set(chain)):
+            raise ValueError("resolved model chain must not contain duplicates")
+        return self
+
+
+class RunnerExecutionInput(ContractModel):
+    max_turns: PositiveInt
+    procedure_history_mode: Literal["replace", "append"]
+
+
+class ProcedureInput(ContractModel):
+    name: SafeName
+    content_sha256: Sha256
+
+
+class ToolInput(ContractModel):
+    name: SafeName
+    definition: dict[str, JsonValue]
+    implementation_version: SafeName
+
+    @model_validator(mode="after")
+    def validate_definition_name(self) -> "ToolInput":
+        function = self.definition.get("function")
+        definition_name = function.get("name") if isinstance(function, dict) else None
+        if definition_name != self.name:
+            raise ValueError("tool definition name must match tool input name")
+        return self
+
+
+class CodeRevisionInput(ContractModel):
+    reporter_revision: NonBlankStr
+    generation_revision: NonBlankStr
+
+
+class GenerationManifestInput(ContractModel):
+    generation: GenerationRequestInput
+    data_snapshot: DataSnapshotInput
+    memory_input: MemoryInput
+    cutoffs: ManifestCutoffs
+    model: ModelExecutionInput
+    runner: RunnerExecutionInput
+    system_prompt_sha256: Sha256
+    procedures: tuple[ProcedureInput, ...]
+    tools: tuple[ToolInput, ...]
+    code: CodeRevisionInput
+
+    @model_validator(mode="after")
+    def validate_named_inputs(self) -> "GenerationManifestInput":
+        procedure_names = [procedure.name for procedure in self.procedures]
+        if not procedure_names:
+            raise ValueError("generation manifest requires at least one procedure")
+        if len(procedure_names) != len(set(procedure_names)):
+            raise ValueError("procedure names must be unique")
+        tool_names = [tool.name for tool in self.tools]
+        if not tool_names:
+            raise ValueError("generation manifest requires at least one tool")
+        if len(tool_names) != len(set(tool_names)):
+            raise ValueError("tool names must be unique")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltGenerationManifest:
+    manifest: dict[str, JsonValue]
+    schema_version: int
+    canonical_bytes: bytes
+    manifest_hash: str
+
+
+def build_generation_manifest(
+    inputs: GenerationManifestInput,
+) -> BuiltGenerationManifest:
+    """Build the complete immutable input seal for one generation."""
+    procedures = sorted(inputs.procedures, key=lambda procedure: procedure.name)
+    tool_definitions = [tool.definition for tool in inputs.tools]
+    manifest = cast(
+        dict[str, JsonValue],
+        {
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "generation": inputs.generation.model_dump(mode="json"),
+            "data_snapshot": inputs.data_snapshot.model_dump(mode="json"),
+            "memory_input": inputs.memory_input.model_dump(mode="json"),
+            "cutoffs": inputs.cutoffs.model_dump(mode="json"),
+            "model": inputs.model.model_dump(mode="json"),
+            "runner": inputs.runner.model_dump(mode="json"),
+            "assets": {
+                "system_prompt_sha256": inputs.system_prompt_sha256,
+                "procedures": [
+                    procedure.model_dump(mode="json") for procedure in procedures
+                ],
+            },
+            "tools": {
+                "schema_bundle_sha256": canonical_json_sha256(tool_definitions),
+                "implementations": [
+                    {
+                        "name": tool.name,
+                        "version": tool.implementation_version,
+                    }
+                    for tool in inputs.tools
+                ],
+            },
+            "code": inputs.code.model_dump(mode="json"),
+        },
+    )
+    encoded = canonical_json_bytes(manifest)
+    return BuiltGenerationManifest(
+        manifest=manifest,
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        canonical_bytes=encoded,
+        manifest_hash=hashlib.sha256(encoded).hexdigest(),
+    )
+
+
+def canonical_json_bytes(value: JsonValue) -> bytes:
+    """Encode a JSON value with the generation manifest's stable rules."""
+    _validate_json_value(value)
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_json_sha256(value: JsonValue) -> str:
+    """Return the lowercase SHA-256 of canonical generation JSON."""
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _validate_json_value(value: Any) -> None:
+    if value is None or isinstance(value, (bool, int, str)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("canonical JSON numbers must be finite")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_json_value(item)
+        return
+    if isinstance(value, dict):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("canonical JSON object keys must be strings")
+        for item in value.values():
+            _validate_json_value(item)
+        return
+    raise TypeError(f"unsupported canonical JSON value: {type(value).__name__}")
+
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "BuiltGenerationManifest",
+    "CanonicalMemoryInput",
+    "CodeRevisionInput",
+    "DataSnapshotInput",
+    "EvaluationArtifactMemoryInput",
+    "GenerationManifestInput",
+    "GenerationRequestInput",
+    "ManifestCutoffs",
+    "ModelExecutionInput",
+    "ProcedureInput",
+    "RetryPolicyInput",
+    "RunnerExecutionInput",
+    "ToolInput",
+    "build_generation_manifest",
+    "canonical_json_bytes",
+    "canonical_json_sha256",
+]

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -13,6 +13,9 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 
+ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "1"
+
+
 ARTIFACT_TOOL_SPECS: list[ToolDef] = [
     {
         "type": "function",
@@ -128,7 +131,12 @@ def register_artifact_tools(registry: ToolRegistry) -> None:
     }
     for spec in ARTIFACT_TOOL_SPECS:
         name = spec["function"]["name"]
-        registry.register_context_tool(name, handlers[name], spec)
+        registry.register_context_tool(
+            name,
+            handlers[name],
+            spec,
+            ARTIFACT_TOOL_IMPLEMENTATION_VERSION,
+        )
 
 
 def list_artifacts(ctx: ToolContext) -> str:

--- a/backend/services/reporter/runner/tools/datalayer_tools.py
+++ b/backend/services/reporter/runner/tools/datalayer_tools.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from backend.services.datalayer import FrozenLeagueData
 
 
+DATALAYER_TOOL_IMPLEMENTATION_VERSION = "1"
+
+
 def _week_property(description: str = "Week number (1-18).") -> dict[str, str]:
     return {"type": "integer", "description": description}
 
@@ -262,7 +265,12 @@ def register_datalayer_tools(
     handlers = _create_tool_handlers(data)
     for spec in DATALAYER_TOOL_SPECS:
         name = spec["function"]["name"]
-        registry.register(name, _json_handler(handlers[name]), spec)
+        registry.register(
+            name,
+            _json_handler(handlers[name]),
+            spec,
+            DATALAYER_TOOL_IMPLEMENTATION_VERSION,
+        )
 
 
 def _create_tool_handlers(

--- a/backend/services/reporter/runner/tools/memory_tools.py
+++ b/backend/services/reporter/runner/tools/memory_tools.py
@@ -18,6 +18,9 @@ from backend.services.reporter.runner.models import ToolDef
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
+
+MEMORY_TOOL_IMPLEMENTATION_VERSION = "1"
+
 if TYPE_CHECKING:
     from reporter_memory.context_store import ContextStore
 
@@ -786,10 +789,18 @@ def register_memory_tools(
         name = spec["function"]["name"]
         if name == "record_memory_verification":
             registry.register_context_tool(
-                name, record_memory_verification, spec
+                name,
+                record_memory_verification,
+                spec,
+                MEMORY_TOOL_IMPLEMENTATION_VERSION,
             )
             continue
-        registry.register(name, handlers[name], spec)
+        registry.register(
+            name,
+            handlers[name],
+            spec,
+            MEMORY_TOOL_IMPLEMENTATION_VERSION,
+        )
 
 
 def _resolve_team_keys(

--- a/backend/services/reporter/runner/tools/persistent_tools.py
+++ b/backend/services/reporter/runner/tools/persistent_tools.py
@@ -18,6 +18,9 @@ from backend.services.reporter.runner.tools.memory_tools import (
 )
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
+
+PERSISTENT_TOOL_IMPLEMENTATION_VERSION = "1"
+
 if TYPE_CHECKING:
     from reporter_memory.context_store import ContextStore
 
@@ -249,7 +252,12 @@ def register_persistent_tools(
     }
     for spec in LEGACY_PERSISTENT_TOOLS:
         name = spec["function"]["name"]
-        registry.register(name, handlers[name], spec)
+        registry.register(
+            name,
+            handlers[name],
+            spec,
+            PERSISTENT_TOOL_IMPLEMENTATION_VERSION,
+        )
 
     register_memory_tools(
         registry,

--- a/backend/services/reporter/runner/tools/procedure_tools.py
+++ b/backend/services/reporter/runner/tools/procedure_tools.py
@@ -12,6 +12,7 @@ from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
 VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
+PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "1"
 
 PROCEDURE_TOOL_SPECS: list[ToolDef] = [
     {
@@ -43,6 +44,7 @@ def register_procedure_tools(registry: ToolRegistry) -> None:
         "load_procedure",
         load_procedure,
         PROCEDURE_TOOL_SPECS[0],
+        PROCEDURE_TOOL_IMPLEMENTATION_VERSION,
     )
 
 

--- a/backend/services/reporter/runner/tools/registry.py
+++ b/backend/services/reporter/runner/tools/registry.py
@@ -15,6 +15,7 @@ class ToolRegistry:
     def __init__(self) -> None:
         self._handlers: dict[str, Callable[..., Any]] = {}
         self._specs: dict[str, ToolDef] = {}
+        self._implementation_versions: dict[str, str] = {}
         self._context: ToolContext | None = None
 
     def set_context(self, context: ToolContext) -> None:
@@ -25,22 +26,30 @@ class ToolRegistry:
         name: str,
         handler: Callable[..., Any],
         spec: ToolDef,
+        implementation_version: str,
     ) -> None:
+        if (
+            not implementation_version
+            or implementation_version.strip() != implementation_version
+        ):
+            raise ValueError("tool implementation version must be non-blank and trimmed")
         self._handlers[name] = handler
         self._specs[name] = spec
+        self._implementation_versions[name] = implementation_version
 
     def register_context_tool(
         self,
         name: str,
         handler: Callable[..., Any],
         spec: ToolDef,
+        implementation_version: str,
     ) -> None:
         def bound_handler(**kwargs: Any) -> Any:
             if self._context is None:
                 raise RuntimeError("ToolRegistry context has not been set.")
             return handler(self._context, **kwargs)
 
-        self.register(name, bound_handler, spec)
+        self.register(name, bound_handler, spec, implementation_version)
 
     def get_handler(self, name: str) -> Callable[..., Any] | None:
         return self._handlers.get(name)
@@ -56,3 +65,7 @@ class ToolRegistry:
     @property
     def tool_names(self) -> list[str]:
         return list(self._handlers.keys())
+
+    @property
+    def tool_implementation_versions(self) -> list[tuple[str, str]]:
+        return list(self._implementation_versions.items())

--- a/backend/tests/services/generations/__init__.py
+++ b/backend/tests/services/generations/__init__.py
@@ -1,0 +1,1 @@
+"""Generation service tests."""

--- a/backend/tests/services/generations/test_manifest.py
+++ b/backend/tests/services/generations/test_manifest.py
@@ -1,0 +1,246 @@
+"""Golden tests for immutable generation input manifests."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+
+from backend.resources.reporting.generations import GenerationKind
+from backend.services.generations import (
+    CanonicalMemoryInput,
+    CodeRevisionInput,
+    DataSnapshotInput,
+    EvaluationArtifactMemoryInput,
+    GenerationManifestInput,
+    GenerationRequestInput,
+    ManifestCutoffs,
+    ModelExecutionInput,
+    ProcedureInput,
+    RetryPolicyInput,
+    RunnerExecutionInput,
+    ToolInput,
+    build_generation_manifest,
+    canonical_json_bytes,
+)
+from backend.services.reporter.runner.tools.artifact_tools import (
+    ARTIFACT_TOOL_IMPLEMENTATION_VERSION,
+    ARTIFACT_TOOL_SPECS,
+)
+
+
+def _uuid(value: int) -> UUID:
+    return UUID(int=value)
+
+
+def _submit_tool() -> ToolInput:
+    spec = next(
+        spec
+        for spec in ARTIFACT_TOOL_SPECS
+        if spec["function"]["name"] == "submit_artifact"
+    )
+    return ToolInput(
+        name="submit_artifact",
+        definition=spec,
+        implementation_version=ARTIFACT_TOOL_IMPLEMENTATION_VERSION,
+    )
+
+
+def _lookup_tool() -> ToolInput:
+    return ToolInput(
+        name="lookup",
+        definition={
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Look up café facts.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        implementation_version="lookup-v1",
+    )
+
+
+def _inputs(
+    *,
+    memory_input: CanonicalMemoryInput | EvaluationArtifactMemoryInput | None = None,
+) -> GenerationManifestInput:
+    return GenerationManifestInput(
+        generation=GenerationRequestInput(
+            kind=GenerationKind.LIVE,
+            request_text="Write a lively recap.",
+            resolved_settings={"temperature": 0.25, "weeks": [7, 8]},
+        ),
+        data_snapshot=DataSnapshotInput(
+            data_snapshot_id=_uuid(1),
+            snapshot_projection_version="snapshot-v3",
+            artifact_sha256="a" * 64,
+        ),
+        memory_input=memory_input or CanonicalMemoryInput(revision_id=_uuid(2)),
+        cutoffs=ManifestCutoffs(
+            domain_cutoff_week=8,
+            domain_cutoff_at=datetime(2026, 10, 28, 7, tzinfo=UTC),
+            knowledge_cutoff_at=datetime(2026, 10, 29, 19, 30, tzinfo=UTC),
+        ),
+        model=ModelExecutionInput(
+            requested_provider="openai",
+            requested_model="gpt-primary",
+            fallback_models=("gpt-fallback",),
+            retry=RetryPolicyInput(
+                max_retries=2,
+                base_delay_seconds=0.5,
+                max_delay_seconds=4.0,
+            ),
+            request_parameters={"reasoning_effort": "none"},
+        ),
+        runner=RunnerExecutionInput(
+            max_turns=60,
+            procedure_history_mode="replace",
+        ),
+        system_prompt_sha256="b" * 64,
+        procedures=(
+            ProcedureInput(name="verification", content_sha256="d" * 64),
+            ProcedureInput(name="research", content_sha256="c" * 64),
+        ),
+        tools=(_submit_tool(), _lookup_tool()),
+        code=CodeRevisionInput(
+            reporter_revision="reporter-5a",
+            generation_revision="generation-5a",
+        ),
+    )
+
+
+def test_canonical_json_has_a_locked_utf8_vector() -> None:
+    value = {"z": [3, 2, 1], "a": {"café": True, "n": 1.0}}
+
+    assert canonical_json_bytes(value) == (
+        b'{"a":{"caf\xc3\xa9":true,"n":1.0},"z":[3,2,1]}'
+    )
+
+
+def test_manifest_has_a_locked_schema_and_hash() -> None:
+    built = build_generation_manifest(_inputs())
+
+    assert built.schema_version == 1
+    assert built.manifest["schema_version"] == 1
+    assert built.manifest_hash == (
+        "6c8f715099f5421247c7bff04a01b103cbfb007ec391b292920b09a5c5cbb3a3"
+    )
+    assert built.canonical_bytes.decode("utf-8").startswith(
+        '{"assets":{"procedures":[{"content_sha256":"'
+    )
+    procedure_names = [
+        procedure["name"] for procedure in built.manifest["assets"]["procedures"]
+    ]
+    assert procedure_names == ["research", "verification"]
+
+
+def test_mapping_order_does_not_change_manifest_identity() -> None:
+    inputs = _inputs()
+    reversed_settings = dict(reversed(inputs.generation.resolved_settings.items()))
+    reordered = inputs.model_copy(
+        update={
+            "generation": inputs.generation.model_copy(
+                update={"resolved_settings": reversed_settings}
+            )
+        }
+    )
+
+    assert build_generation_manifest(inputs) == build_generation_manifest(reordered)
+
+
+def test_ordered_tool_bundle_changes_manifest_identity() -> None:
+    inputs = _inputs()
+    reordered = inputs.model_copy(update={"tools": tuple(reversed(inputs.tools))})
+
+    original = build_generation_manifest(inputs)
+    changed = build_generation_manifest(reordered)
+
+    assert original.manifest_hash != changed.manifest_hash
+    assert original.manifest["tools"]["schema_bundle_sha256"] != (
+        changed.manifest["tools"]["schema_bundle_sha256"]
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["settings", "prompt", "procedure", "tool_schema", "tool_version", "code"],
+)
+def test_every_versioned_input_changes_manifest_identity(field: str) -> None:
+    inputs = _inputs()
+    if field == "settings":
+        generation = inputs.generation.model_copy(
+            update={"resolved_settings": {"temperature": 0.5, "weeks": [7, 8]}}
+        )
+        changed = inputs.model_copy(update={"generation": generation})
+    elif field == "prompt":
+        changed = inputs.model_copy(update={"system_prompt_sha256": "e" * 64})
+    elif field == "procedure":
+        procedures = list(inputs.procedures)
+        procedures[0] = procedures[0].model_copy(
+            update={"content_sha256": "e" * 64}
+        )
+        changed = inputs.model_copy(update={"procedures": tuple(procedures)})
+    elif field == "tool_schema":
+        definition = deepcopy(inputs.tools[0].definition)
+        definition["function"]["description"] = "Changed submission contract."
+        tool = inputs.tools[0].model_copy(update={"definition": definition})
+        changed = inputs.model_copy(update={"tools": (tool, *inputs.tools[1:])})
+    elif field == "tool_version":
+        tool = inputs.tools[0].model_copy(update={"implementation_version": "2"})
+        changed = inputs.model_copy(update={"tools": (tool, *inputs.tools[1:])})
+    else:
+        code = inputs.code.model_copy(update={"reporter_revision": "reporter-next"})
+        changed = inputs.model_copy(update={"code": code})
+
+    assert build_generation_manifest(inputs).manifest_hash != (
+        build_generation_manifest(changed).manifest_hash
+    )
+
+
+def test_memory_input_variants_are_explicit() -> None:
+    live = build_generation_manifest(_inputs())
+    evaluation = build_generation_manifest(
+        _inputs(
+            memory_input=EvaluationArtifactMemoryInput(
+                artifact_version_id=_uuid(3),
+                source_generation_id=_uuid(4),
+            )
+        )
+    )
+
+    assert live.manifest["memory_input"]["kind"] == "canonical_revision"
+    assert evaluation.manifest["memory_input"]["kind"] == "evaluation_artifact"
+    assert live.manifest_hash != evaluation.manifest_hash
+
+
+def test_manifest_is_input_only_and_submit_schema_is_path_generic() -> None:
+    inputs = _inputs()
+    built = build_generation_manifest(inputs)
+    serialized = built.canonical_bytes.decode("utf-8")
+    submit_parameters = inputs.tools[0].definition["function"]["parameters"]
+
+    assert "enum" not in submit_parameters["properties"]["path"]
+    assert "submitted_artifact_version_id" not in serialized
+    assert "submitted_path" not in serialized
+    assert "article.md" not in serialized
+
+    fixed_path_definition = deepcopy(inputs.tools[0].definition)
+    fixed_path_definition["function"]["parameters"]["properties"]["path"][
+        "enum"
+    ] = ["article.md"]
+    fixed_path_tool = inputs.tools[0].model_copy(
+        update={"definition": fixed_path_definition}
+    )
+    fixed_path = inputs.model_copy(
+        update={"tools": (fixed_path_tool, *inputs.tools[1:])}
+    )
+    assert built.manifest_hash != build_generation_manifest(fixed_path).manifest_hash
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_canonical_json_rejects_non_finite_numbers(value: float) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        canonical_json_bytes({"value": value})

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
 from backend.services.reporter.runner.models import ToolCall
 from backend.services.reporter.runner.runner import Runner
@@ -79,7 +81,7 @@ def registry_with(
     description: str = "Test tool",
 ) -> ToolRegistry:
     registry = ToolRegistry()
-    registry.register(name, handler, tool_def(name, description))
+    registry.register(name, handler, tool_def(name, description), "test-v1")
     return registry
 
 
@@ -96,8 +98,17 @@ def test_tool_registry_exposes_specs_and_names() -> None:
 
     assert registry.tool_names == ["lookup"]
     assert registry.tool_specs == [tool_def("lookup")]
+    assert registry.tool_implementation_versions == [("lookup", "test-v1")]
     assert registry.get_handler("lookup") is not None
     assert registry.get_handler("missing") is None
+
+
+def test_tool_registry_requires_an_explicit_implementation_version() -> None:
+    registry = ToolRegistry()
+
+    for invalid in ("", " untrimmed"):
+        with pytest.raises(ValueError, match="implementation version"):
+            registry.register("lookup", lambda: "{}", tool_def("lookup"), invalid)
 
 
 def test_runner_context_tool_dispatch_updates_turn() -> None:
@@ -108,7 +119,12 @@ def test_runner_context_tool_dispatch_updates_turn() -> None:
         return "{}"
 
     registry = ToolRegistry()
-    registry.register_context_tool("context_tool", context_tool, tool_def("context_tool"))
+    registry.register_context_tool(
+        "context_tool",
+        context_tool,
+        tool_def("context_tool"),
+        "test-v1",
+    )
     complete = FakeCompletion(
         [
             make_response(tool_calls=[tool_call("context_tool")]),

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -147,10 +147,21 @@ idempotent, media type is immutable, and finalized artifacts reject appends.
 generation can pin only a finalized version that it owns as it succeeds, and
 article-history access begins from the explicit generation pointer.
 
-### `generation-5` — manifest and model-call instrumentation
+### `generation-5a` — generation manifest
 
 - Add immutable manifest contracts, canonical serialization, versioning, and
   hash golden vectors.
+- Add ordered, explicit implementation versions to every registered reporter
+  tool so the manifest seals both schemas and implementations.
+- Keep the manifest input-only: reporter-selected paths and the eventual
+  submitted artifact-version pointer are execution outputs, not sealed inputs.
+
+**Exit gate:** mapping order cannot change manifest identity, ordered tool or
+version changes do, both memory-input variants are explicit, and the generic
+submission schema introduces no path-based output role.
+
+### `generation-5b` — model-call instrumentation
+
 - Extend `CompletionClient` with generation-scoped attempt recording.
 - Record retries and fallbacks as distinct AI calls.
 - Normalize LiteLLM/provider usage into the existing token columns while
@@ -271,9 +282,10 @@ flowchart LR
     G4B --> G4C["G4c artifacts"]
     G3 --> G4D["G4d submitted output"]
     G4C --> G4D
-    G1 --> G5["G5 AI calls/tokens"]
-    G4B --> G5
-    G5 --> G6["G6 tool/progress"]
+    G4D --> G5A["G5a manifest"]
+    G5A --> G5B["G5b AI calls/tokens"]
+    G4B --> G5B
+    G5B --> G6["G6 tool/progress"]
     G6 --> G7["G7 artifact persistence"]
     G3 --> G7
     G4D --> G7
@@ -282,7 +294,7 @@ flowchart LR
     Data["Merged frozen datalayer"] --> G1
     Data --> G9["G9 generation inputs"]
     G4A --> G9
-    G5 --> G9
+    G5B --> G9
     G7 --> G9
     G8 --> G9
     G9 --> G10["G10 finalization"]


### PR DESCRIPTION
## Summary
- add immutable generation manifest v1 contracts and deterministic canonical JSON hashing
- seal snapshot, memory, cutoff, model, runner, prompt, procedure, ordered tool, and code inputs
- assign explicit implementation versions to every reporter tool without encoding submitted output paths

## Verification
- 136 passed: manifest and copied reporter suite
- 123 passed: untouched legacy reporter suite
- 30 passed: final focused manifest and registry checks
- reporting constraint selection: 4 passed, 20 skipped because AIDAM_TEST_DATABASE_URL is unavailable
- compileall, 99-column, and git diff --check pass