### PR TITLE
feat(reporter): record model provider attempts

### DIFF
--- a/backend/services/generations/__init__.py
+++ b/backend/services/generations/__init__.py
@@ -19,6 +19,7 @@ from backend.services.generations.manifest import (
     canonical_json_bytes,
     canonical_json_sha256,
 )
+from backend.services.generations.recorder import GenerationExecutionRecorder
 
 __all__ = [
     "MANIFEST_SCHEMA_VERSION",
@@ -28,6 +29,7 @@ __all__ = [
     "DataSnapshotInput",
     "EvaluationArtifactMemoryInput",
     "GenerationManifestInput",
+    "GenerationExecutionRecorder",
     "GenerationRequestInput",
     "ManifestCutoffs",
     "ModelExecutionInput",

--- a/backend/services/generations/recorder.py
+++ b/backend/services/generations/recorder.py
@@ -1,0 +1,78 @@
+"""Durable generation-scoped adapter for reporter completion attempts."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from backend.resources.reporting.ai_calls import (
+    AICallManager,
+    BeginAICall,
+    FinishAICall,
+    TokenUsage,
+)
+from backend.services.reporter.runner.recording import (
+    ModelAttemptFinish,
+    ModelAttemptStart,
+)
+
+
+class GenerationExecutionRecorder:
+    """Translate reporter completion events into durable AI-call resources."""
+
+    def __init__(self, generation_id: UUID, manager: AICallManager) -> None:
+        self._generation_id = generation_id
+        self._manager = manager
+        self._successful_by_turn: dict[int, UUID] = {}
+
+    @property
+    def generation_id(self) -> UUID:
+        return self._generation_id
+
+    def begin_model_attempt(self, attempt: ModelAttemptStart) -> UUID:
+        started = self._manager.begin_ai_call(
+            BeginAICall(
+                generation_id=self._generation_id,
+                turn_number=attempt.turn_number,
+                requested_provider=attempt.requested_provider,
+                requested_model=attempt.requested_model,
+                input_messages=attempt.input_messages,
+                tool_definitions=attempt.tool_definitions,
+                request_parameters=attempt.request_parameters,
+            )
+        )
+        return started.id
+
+    def finish_model_attempt(
+        self,
+        attempt_id: UUID,
+        result: ModelAttemptFinish,
+    ) -> None:
+        finished = self._manager.finish_ai_call(
+            FinishAICall(
+                ai_call_id=attempt_id,
+                status=result.status,
+                actual_provider=result.actual_provider,
+                actual_model=result.actual_model,
+                provider_response=result.provider_response,
+                error=result.error,
+                finish_reason=result.finish_reason,
+                provider_request_id=result.provider_request_id,
+                provider_response_id=result.provider_response_id,
+                usage=TokenUsage(
+                    input_tokens=result.usage.input_tokens,
+                    cached_input_tokens=result.usage.cached_input_tokens,
+                    output_tokens=result.usage.output_tokens,
+                    reasoning_tokens=result.usage.reasoning_tokens,
+                    total_tokens=result.usage.total_tokens,
+                    raw_provider_usage=result.usage.raw_provider_usage,
+                ),
+            )
+        )
+        if finished.status.value == "succeeded":
+            self._successful_by_turn[finished.turn_number] = finished.id
+
+    def successful_ai_call_id(self, turn_number: int) -> UUID | None:
+        return self._successful_by_turn.get(turn_number)
+
+
+__all__ = ["GenerationExecutionRecorder"]

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -25,6 +25,7 @@ from backend.services.reporter.runner.completion import (
     make_completion_client,
 )
 from backend.services.reporter.runner.memory_lifecycle import prepare_memory_run
+from backend.services.reporter.runner.recording import CompletionRecorder
 from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
@@ -49,6 +50,7 @@ async def generate_article(
     runner_config: RunnerConfig | None = None,
     log_path: Path | None = None,
     complete: CompletionFn | None = None,
+    recorder: CompletionRecorder | None = None,
     allow_memory_writes: bool = True,
 ) -> ReporterOutput:
     """Generate an article with the single-loop v2 runner.
@@ -62,6 +64,7 @@ async def generate_article(
         runner_config: Loop policy owned by Runner (max_turns, procedure mode).
         log_path: Optional streaming run-log path.
         complete: Injectable completion fn for tests. Mutually exclusive with client=.
+        recorder: Optional generation-scoped durable completion recorder.
         allow_memory_writes: When False (eval mode), skip memory mutations
             (lifecycle + in-run memory tools).
     """
@@ -82,6 +85,7 @@ async def generate_article(
         client=client,
         completion=completion,
         complete=complete,
+        recorder=recorder,
     )
 
     if log_path is not None:
@@ -136,16 +140,19 @@ def _resolve_client(
     client: CompletionClient | None,
     completion: CompletionSettings | None,
     complete: CompletionFn | None,
+    recorder: CompletionRecorder | None,
 ) -> CompletionClient:
     if client is not None and complete is not None:
         raise ValueError("Pass client= or complete=, not both.")
     if client is not None:
+        if recorder is not None and client.recorder is not recorder:
+            raise ValueError("A supplied client must already use the supplied recorder.")
         return client
 
     settings = completion or CompletionSettings()
     if complete is not None:
-        return CompletionClient(complete, settings)
-    return make_completion_client(settings)
+        return CompletionClient(complete, settings, recorder)
+    return make_completion_client(settings, recorder)
 
 
 def _build_system_prompt() -> str:

--- a/backend/services/reporter/runner/completion.py
+++ b/backend/services/reporter/runner/completion.py
@@ -3,11 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
+from datetime import date, datetime
+from enum import Enum
 import logging
+import math
 import random
 import re
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+from pydantic import JsonValue
+
+from backend.services.reporter.runner.recording import (
+    CompletionRecorder,
+    ModelAttemptFinish,
+    ModelAttemptStart,
+    RecordedTokenUsage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +67,27 @@ _RETRY_AFTER_RE = re.compile(
     re.IGNORECASE,
 )
 
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEYS = frozenset(
+    {
+        "authorization",
+        "proxyauthorization",
+        "apikey",
+        "xapikey",
+        "accesstoken",
+        "refreshtoken",
+        "clientsecret",
+        "cookie",
+        "setcookie",
+    }
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*")
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_ASSIGNED_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|client[_-]?secret)(\s*[=:]\s*)\S+"
+)
+_MAX_ERROR_MESSAGE_LENGTH = 2000
+
 
 class CompletionFn(Protocol):
     async def __call__(
@@ -63,6 +98,10 @@ class CompletionFn(Protocol):
         tools: list[Any] | None = None,
         **kwargs: Any,
     ) -> Any: ...
+
+
+class CompletionRecordingError(RuntimeError):
+    """Durable recording failed, so the provider operation cannot continue."""
 
 
 @dataclass(frozen=True)
@@ -107,17 +146,24 @@ class CompletionClient:
         self,
         complete: CompletionFn,
         settings: CompletionSettings,
+        recorder: CompletionRecorder | None = None,
     ) -> None:
         self._complete = complete
         self._settings = settings
+        self._recorder = recorder
 
     @property
     def settings(self) -> CompletionSettings:
         return self._settings
 
+    @property
+    def recorder(self) -> CompletionRecorder | None:
+        return self._recorder
+
     async def complete(
         self,
         *,
+        turn_number: int | None = None,
         messages: list[Any],
         tools: list[Any] | None = None,
         **kwargs: Any,
@@ -131,14 +177,24 @@ class CompletionClient:
         3. If that model is exhausted, move to the next fallback model.
         4. Non-retryable errors are raised immediately.
         """
+        if self._recorder is not None and (
+            isinstance(turn_number, bool)
+            or not isinstance(turn_number, int)
+            or turn_number < 1
+        ):
+            raise ValueError("recorded completions require a positive turn_number")
+
         models = self._settings.model_chain()
         if not models:
+            if self._recorder is not None:
+                raise ValueError("recorded completions require a configured model")
             # Preserve callers that inject fakes without configuring a model.
-            return await self._complete(
-                model=self._settings.model,
+            return await self._complete_once(
+                candidate=self._settings.model,
+                turn_number=turn_number,
                 messages=messages,
                 tools=tools,
-                **kwargs,
+                request_parameters=kwargs,
             )
 
         retry = self._settings.retry
@@ -146,11 +202,12 @@ class CompletionClient:
         for model_index, candidate in enumerate(models):
             for attempt in range(retry.max_retries + 1):
                 try:
-                    return await self._complete(
-                        model=candidate,
+                    return await self._complete_once(
+                        candidate=candidate,
+                        turn_number=turn_number,
                         messages=messages,
                         tools=tools,
-                        **kwargs,
+                        request_parameters=kwargs,
                     )
                 except Exception as exc:
                     if not is_retryable_error(exc):
@@ -194,10 +251,114 @@ class CompletionClient:
         assert last_error is not None
         raise last_error
 
+    async def _complete_once(
+        self,
+        *,
+        candidate: str | None,
+        turn_number: int | None,
+        messages: list[Any],
+        tools: list[Any] | None,
+        request_parameters: dict[str, Any],
+    ) -> Any:
+        parameters = dict(request_parameters)
+        if tools and _requires_none_reasoning_with_tools(candidate):
+            parameters.setdefault("reasoning_effort", "none")
 
-def make_completion_client(settings: CompletionSettings) -> CompletionClient:
+        requested_provider = _model_provider(candidate)
+        attempt_id: UUID | None = None
+        if self._recorder is not None:
+            assert candidate is not None
+            assert turn_number is not None
+            try:
+                attempt_id = self._recorder.begin_model_attempt(
+                    ModelAttemptStart(
+                        turn_number=turn_number,
+                        requested_provider=requested_provider,
+                        requested_model=candidate,
+                        input_messages=tuple(
+                            _json_object(message, redact_sensitive=False)
+                            for message in messages
+                        ),
+                        tool_definitions=tuple(
+                            _json_object(tool, redact_sensitive=False)
+                            for tool in tools or ()
+                        ),
+                        request_parameters=_json_object(parameters),
+                    )
+                )
+            except Exception as exc:
+                raise CompletionRecordingError(
+                    "model attempt recording failed before provider invocation"
+                ) from exc
+
+        try:
+            response = await self._complete(
+                model=candidate,
+                messages=messages,
+                tools=tools,
+                **parameters,
+            )
+        except asyncio.CancelledError as exc:
+            self._finish_recorded_attempt(
+                attempt_id,
+                ModelAttemptFinish(
+                    status="unknown_outcome",
+                    actual_provider=requested_provider,
+                    actual_model=candidate,
+                    error=sanitize_provider_error(exc, requested_provider),
+                ),
+            )
+            raise
+        except Exception as exc:
+            status = "retryable_error" if is_retryable_error(exc) else "fatal_error"
+            self._finish_recorded_attempt(
+                attempt_id,
+                ModelAttemptFinish(
+                    status=status,
+                    actual_provider=_error_provider(exc) or requested_provider,
+                    actual_model=candidate,
+                    error=sanitize_provider_error(exc, requested_provider),
+                    provider_request_id=_error_request_id(exc),
+                ),
+            )
+            raise
+
+        self._finish_recorded_attempt(
+            attempt_id,
+            ModelAttemptFinish(
+                status="succeeded",
+                actual_provider=_response_provider(response) or requested_provider,
+                actual_model=_non_blank(_read_attr(response, "model")) or candidate,
+                provider_response=sanitize_provider_response(response),
+                finish_reason=_response_finish_reason(response),
+                provider_request_id=_response_request_id(response),
+                provider_response_id=_non_blank(_read_attr(response, "id")),
+                usage=normalize_token_usage(response),
+            ),
+        )
+        return response
+
+    def _finish_recorded_attempt(
+        self,
+        attempt_id: UUID | None,
+        result: ModelAttemptFinish,
+    ) -> None:
+        if self._recorder is not None:
+            assert attempt_id is not None
+            try:
+                self._recorder.finish_model_attempt(attempt_id, result)
+            except Exception as exc:
+                raise CompletionRecordingError(
+                    "model attempt recording failed after provider invocation"
+                ) from exc
+
+
+def make_completion_client(
+    settings: CompletionSettings,
+    recorder: CompletionRecorder | None = None,
+) -> CompletionClient:
     """Build a CompletionClient with the default LiteLLM transport."""
-    return CompletionClient(make_litellm_completion(), settings)
+    return CompletionClient(make_litellm_completion(), settings, recorder)
 
 
 def is_retryable_error(exc: BaseException) -> bool:
@@ -285,9 +446,6 @@ def make_litellm_completion() -> CompletionFn:
     import litellm
 
     async def complete(**kwargs: Any) -> Any:
-        model = kwargs.get("model")
-        if kwargs.get("tools") and _requires_none_reasoning_with_tools(model):
-            kwargs.setdefault("reasoning_effort", "none")
         return await litellm.acompletion(**kwargs)
 
     return complete
@@ -316,3 +474,283 @@ def _requires_none_reasoning_with_tools(model: str | None) -> bool:
         )
     except Exception:
         return False
+
+
+def normalize_token_usage(response: Any) -> RecordedTokenUsage:
+    """Map only explicitly reported provider token categories."""
+    usage = _read_attr(response, "usage")
+    if usage is None:
+        return RecordedTokenUsage()
+
+    raw = _json_safe(usage)
+    raw_usage = raw if isinstance(raw, dict) else {"value": raw}
+    return RecordedTokenUsage(
+        input_tokens=_first_token(usage, "prompt_tokens", "input_tokens"),
+        cached_input_tokens=_first_present(
+            _nested_token(usage, "prompt_tokens_details", "cached_tokens"),
+            _nested_token(usage, "input_tokens_details", "cached_tokens"),
+            _first_token(usage, "cache_read_input_tokens", "cached_tokens"),
+        ),
+        output_tokens=_first_token(usage, "completion_tokens", "output_tokens"),
+        reasoning_tokens=_first_present(
+            _nested_token(usage, "completion_tokens_details", "reasoning_tokens"),
+            _nested_token(usage, "output_tokens_details", "reasoning_tokens"),
+            _first_token(usage, "reasoning_tokens"),
+        ),
+        total_tokens=_first_token(usage, "total_tokens"),
+        raw_provider_usage=cast(dict[str, JsonValue], raw_usage),
+    )
+
+
+def sanitize_provider_response(response: Any) -> dict[str, JsonValue]:
+    """Return complete JSON-safe provider output with secret fields redacted."""
+    value = _json_safe(response)
+    if isinstance(value, dict):
+        return cast(dict[str, JsonValue], value)
+    return {"value": cast(JsonValue, value)}
+
+
+def sanitize_provider_error(
+    exc: BaseException,
+    requested_provider: str | None = None,
+) -> dict[str, JsonValue]:
+    """Build a bounded error envelope without transport or credential objects."""
+    message = _redact_string(str(exc))[:_MAX_ERROR_MESSAGE_LENGTH]
+    error: dict[str, JsonValue] = {
+        "type": type(exc).__name__,
+        "message": message,
+    }
+    for output_name, attribute_names in (
+        ("status_code", ("status_code", "status")),
+        ("code", ("code",)),
+        ("request_id", ("request_id",)),
+    ):
+        value = _first_scalar(exc, *attribute_names)
+        if value is not None:
+            error[output_name] = value
+    provider = _error_provider(exc) or requested_provider
+    if provider is not None:
+        error["provider"] = provider
+    return error
+
+
+def _first_token(value: Any, *names: str) -> int | None:
+    for name in names:
+        token_count = _read_attr(value, name)
+        if (
+            isinstance(token_count, int)
+            and not isinstance(token_count, bool)
+            and token_count >= 0
+        ):
+            return token_count
+    return None
+
+
+def _nested_token(value: Any, parent: str, child: str) -> int | None:
+    nested = _read_attr(value, parent)
+    return _first_token(nested, child) if nested is not None else None
+
+
+def _first_present(*values: int | None) -> int | None:
+    return next((value for value in values if value is not None), None)
+
+
+def _response_finish_reason(response: Any) -> str | None:
+    choices = _read_attr(response, "choices", []) or []
+    try:
+        first_choice = choices[0]
+    except (IndexError, KeyError, TypeError):
+        return None
+    return _non_blank(_read_attr(first_choice, "finish_reason"))
+
+
+def _response_provider(response: Any) -> str | None:
+    direct = _non_blank(_read_attr(response, "provider"))
+    if direct is not None:
+        return direct
+    hidden = _read_attr(response, "_hidden_params", {}) or {}
+    return _non_blank(_read_attr(hidden, "custom_llm_provider"))
+
+
+def _response_request_id(response: Any) -> str | None:
+    direct = _non_blank(_read_attr(response, "request_id"))
+    if direct is not None:
+        return direct
+    hidden = _read_attr(response, "_hidden_params", {}) or {}
+    for container_name in ("additional_headers", "response_headers"):
+        headers = _read_attr(hidden, container_name, {}) or {}
+        for header_name in ("x-request-id", "request-id"):
+            value = _case_insensitive_mapping_value(headers, header_name)
+            if value is not None:
+                return _non_blank(value)
+    return None
+
+
+def _error_provider(exc: BaseException) -> str | None:
+    return _non_blank(
+        _read_attr(exc, "provider") or _read_attr(exc, "llm_provider")
+    )
+
+
+def _error_request_id(exc: BaseException) -> str | None:
+    return _non_blank(_read_attr(exc, "request_id"))
+
+
+def _model_provider(model: str | None) -> str | None:
+    if not model or "/" not in model:
+        return None
+    provider, _ = model.split("/", 1)
+    return provider or None
+
+
+def _first_scalar(value: Any, *names: str) -> JsonValue | None:
+    for name in names:
+        candidate = _read_attr(value, name)
+        if candidate is None or isinstance(candidate, (dict, list, tuple, set)):
+            continue
+        sanitized = _json_safe(candidate)
+        if isinstance(sanitized, (str, int, float, bool)):
+            return sanitized
+    return None
+
+
+def _json_object(
+    value: Any,
+    *,
+    redact_sensitive: bool = True,
+) -> dict[str, JsonValue]:
+    converted = _json_safe(value, redact_sensitive=redact_sensitive)
+    if isinstance(converted, dict):
+        return cast(dict[str, JsonValue], converted)
+    return {"value": cast(JsonValue, converted)}
+
+
+def _json_safe(
+    value: Any,
+    *,
+    redact_sensitive: bool = True,
+    depth: int = 0,
+) -> JsonValue:
+    if depth >= 20:
+        return "<maximum depth>"
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _redact_string(value) if redact_sensitive else value
+    if isinstance(value, Enum):
+        return _json_safe(
+            value.value,
+            redact_sensitive=redact_sensitive,
+            depth=depth + 1,
+        )
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return f"<bytes:{len(value)}>"
+
+    model_dump = _read_attr(value, "model_dump")
+    if callable(model_dump):
+        try:
+            dumped = model_dump(mode="json")
+        except Exception:
+            dumped = None
+        if dumped is not None and dumped is not value:
+            return _json_safe(
+                dumped,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+    if isinstance(value, Mapping):
+        converted: dict[str, JsonValue] = {}
+        for key, nested in value.items():
+            key_text = str(key)
+            if redact_sensitive and _is_sensitive_key(key_text):
+                converted[key_text] = _REDACTED
+            else:
+                converted[key_text] = _json_safe(
+                    nested,
+                    redact_sensitive=redact_sensitive,
+                    depth=depth + 1,
+                )
+        return converted
+    if isinstance(value, (list, tuple)):
+        return [
+            _json_safe(
+                nested,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+            for nested in value
+        ]
+    if isinstance(value, set):
+        return [
+            _json_safe(
+                nested,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+            for nested in sorted(value, key=str)
+        ]
+
+    public_attributes = _read_attr(value, "__dict__")
+    if isinstance(public_attributes, dict):
+        return _json_safe(
+            {
+                key: nested
+                for key, nested in public_attributes.items()
+                if not key.startswith("_")
+            },
+            redact_sensitive=redact_sensitive,
+            depth=depth + 1,
+        )
+    try:
+        text = str(value)
+    except Exception:
+        text = f"<{type(value).__name__}>"
+    return _redact_string(text) if redact_sensitive else text
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", key.casefold())
+    return normalized in _SENSITIVE_KEYS
+
+
+def _redact_string(value: str) -> str:
+    redacted = _BEARER_RE.sub(_REDACTED, value)
+    redacted = _OPENAI_KEY_RE.sub(_REDACTED, redacted)
+    return _ASSIGNED_SECRET_RE.sub(lambda match: f"{match.group(1)}={_REDACTED}", redacted)
+
+
+def _case_insensitive_mapping_value(value: Any, key: str) -> Any | None:
+    if not isinstance(value, Mapping):
+        return None
+    target = key.casefold()
+    return next(
+        (nested for name, nested in value.items() if str(name).casefold() == target),
+        None,
+    )
+
+
+def _non_blank(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    return text or None
+
+
+def _read_attr(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        if isinstance(value, Mapping):
+            return value.get(name, default)
+        return getattr(value, name, default)
+    except Exception:
+        return default

--- a/backend/services/reporter/runner/completion.py
+++ b/backend/services/reporter/runner/completion.py
@@ -3,24 +3,31 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
-from datetime import date, datetime
-from enum import Enum
 import logging
-import math
 import random
 import re
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 from uuid import UUID
 
-from pydantic import JsonValue
-
+from backend.services.reporter.runner.provider_telemetry import (
+    error_provider,
+    error_request_id,
+    json_object,
+    model_provider,
+    normalize_token_usage,
+    response_finish_reason,
+    response_id,
+    response_model,
+    response_provider,
+    response_request_id,
+    sanitize_provider_error,
+    sanitize_provider_response,
+)
 from backend.services.reporter.runner.recording import (
     CompletionRecorder,
     ModelAttemptFinish,
     ModelAttemptStart,
-    RecordedTokenUsage,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,28 +73,6 @@ _RETRY_AFTER_RE = re.compile(
     r"try again in\s+(\d+(?:\.\d+)?)\s*(ms|s|sec|secs|second|seconds)?",
     re.IGNORECASE,
 )
-
-_REDACTED = "[REDACTED]"
-_SENSITIVE_KEYS = frozenset(
-    {
-        "authorization",
-        "proxyauthorization",
-        "apikey",
-        "xapikey",
-        "accesstoken",
-        "refreshtoken",
-        "clientsecret",
-        "cookie",
-        "setcookie",
-    }
-)
-_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*")
-_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
-_ASSIGNED_SECRET_RE = re.compile(
-    r"(?i)\b(api[_-]?key|access[_-]?token|client[_-]?secret)(\s*[=:]\s*)\S+"
-)
-_MAX_ERROR_MESSAGE_LENGTH = 2000
-
 
 class CompletionFn(Protocol):
     async def __call__(
@@ -264,7 +249,7 @@ class CompletionClient:
         if tools and _requires_none_reasoning_with_tools(candidate):
             parameters.setdefault("reasoning_effort", "none")
 
-        requested_provider = _model_provider(candidate)
+        requested_provider = model_provider(candidate)
         attempt_id: UUID | None = None
         if self._recorder is not None:
             assert candidate is not None
@@ -276,14 +261,14 @@ class CompletionClient:
                         requested_provider=requested_provider,
                         requested_model=candidate,
                         input_messages=tuple(
-                            _json_object(message, redact_sensitive=False)
+                            json_object(message, redact_sensitive=False)
                             for message in messages
                         ),
                         tool_definitions=tuple(
-                            _json_object(tool, redact_sensitive=False)
+                            json_object(tool, redact_sensitive=False)
                             for tool in tools or ()
                         ),
-                        request_parameters=_json_object(parameters),
+                        request_parameters=json_object(parameters),
                     )
                 )
             except Exception as exc:
@@ -315,10 +300,10 @@ class CompletionClient:
                 attempt_id,
                 ModelAttemptFinish(
                     status=status,
-                    actual_provider=_error_provider(exc) or requested_provider,
+                    actual_provider=error_provider(exc) or requested_provider,
                     actual_model=candidate,
                     error=sanitize_provider_error(exc, requested_provider),
-                    provider_request_id=_error_request_id(exc),
+                    provider_request_id=error_request_id(exc),
                 ),
             )
             raise
@@ -327,12 +312,12 @@ class CompletionClient:
             attempt_id,
             ModelAttemptFinish(
                 status="succeeded",
-                actual_provider=_response_provider(response) or requested_provider,
-                actual_model=_non_blank(_read_attr(response, "model")) or candidate,
+                actual_provider=response_provider(response) or requested_provider,
+                actual_model=response_model(response) or candidate,
                 provider_response=sanitize_provider_response(response),
-                finish_reason=_response_finish_reason(response),
-                provider_request_id=_response_request_id(response),
-                provider_response_id=_non_blank(_read_attr(response, "id")),
+                finish_reason=response_finish_reason(response),
+                provider_request_id=response_request_id(response),
+                provider_response_id=response_id(response),
                 usage=normalize_token_usage(response),
             ),
         )
@@ -474,283 +459,3 @@ def _requires_none_reasoning_with_tools(model: str | None) -> bool:
         )
     except Exception:
         return False
-
-
-def normalize_token_usage(response: Any) -> RecordedTokenUsage:
-    """Map only explicitly reported provider token categories."""
-    usage = _read_attr(response, "usage")
-    if usage is None:
-        return RecordedTokenUsage()
-
-    raw = _json_safe(usage)
-    raw_usage = raw if isinstance(raw, dict) else {"value": raw}
-    return RecordedTokenUsage(
-        input_tokens=_first_token(usage, "prompt_tokens", "input_tokens"),
-        cached_input_tokens=_first_present(
-            _nested_token(usage, "prompt_tokens_details", "cached_tokens"),
-            _nested_token(usage, "input_tokens_details", "cached_tokens"),
-            _first_token(usage, "cache_read_input_tokens", "cached_tokens"),
-        ),
-        output_tokens=_first_token(usage, "completion_tokens", "output_tokens"),
-        reasoning_tokens=_first_present(
-            _nested_token(usage, "completion_tokens_details", "reasoning_tokens"),
-            _nested_token(usage, "output_tokens_details", "reasoning_tokens"),
-            _first_token(usage, "reasoning_tokens"),
-        ),
-        total_tokens=_first_token(usage, "total_tokens"),
-        raw_provider_usage=cast(dict[str, JsonValue], raw_usage),
-    )
-
-
-def sanitize_provider_response(response: Any) -> dict[str, JsonValue]:
-    """Return complete JSON-safe provider output with secret fields redacted."""
-    value = _json_safe(response)
-    if isinstance(value, dict):
-        return cast(dict[str, JsonValue], value)
-    return {"value": cast(JsonValue, value)}
-
-
-def sanitize_provider_error(
-    exc: BaseException,
-    requested_provider: str | None = None,
-) -> dict[str, JsonValue]:
-    """Build a bounded error envelope without transport or credential objects."""
-    message = _redact_string(str(exc))[:_MAX_ERROR_MESSAGE_LENGTH]
-    error: dict[str, JsonValue] = {
-        "type": type(exc).__name__,
-        "message": message,
-    }
-    for output_name, attribute_names in (
-        ("status_code", ("status_code", "status")),
-        ("code", ("code",)),
-        ("request_id", ("request_id",)),
-    ):
-        value = _first_scalar(exc, *attribute_names)
-        if value is not None:
-            error[output_name] = value
-    provider = _error_provider(exc) or requested_provider
-    if provider is not None:
-        error["provider"] = provider
-    return error
-
-
-def _first_token(value: Any, *names: str) -> int | None:
-    for name in names:
-        token_count = _read_attr(value, name)
-        if (
-            isinstance(token_count, int)
-            and not isinstance(token_count, bool)
-            and token_count >= 0
-        ):
-            return token_count
-    return None
-
-
-def _nested_token(value: Any, parent: str, child: str) -> int | None:
-    nested = _read_attr(value, parent)
-    return _first_token(nested, child) if nested is not None else None
-
-
-def _first_present(*values: int | None) -> int | None:
-    return next((value for value in values if value is not None), None)
-
-
-def _response_finish_reason(response: Any) -> str | None:
-    choices = _read_attr(response, "choices", []) or []
-    try:
-        first_choice = choices[0]
-    except (IndexError, KeyError, TypeError):
-        return None
-    return _non_blank(_read_attr(first_choice, "finish_reason"))
-
-
-def _response_provider(response: Any) -> str | None:
-    direct = _non_blank(_read_attr(response, "provider"))
-    if direct is not None:
-        return direct
-    hidden = _read_attr(response, "_hidden_params", {}) or {}
-    return _non_blank(_read_attr(hidden, "custom_llm_provider"))
-
-
-def _response_request_id(response: Any) -> str | None:
-    direct = _non_blank(_read_attr(response, "request_id"))
-    if direct is not None:
-        return direct
-    hidden = _read_attr(response, "_hidden_params", {}) or {}
-    for container_name in ("additional_headers", "response_headers"):
-        headers = _read_attr(hidden, container_name, {}) or {}
-        for header_name in ("x-request-id", "request-id"):
-            value = _case_insensitive_mapping_value(headers, header_name)
-            if value is not None:
-                return _non_blank(value)
-    return None
-
-
-def _error_provider(exc: BaseException) -> str | None:
-    return _non_blank(
-        _read_attr(exc, "provider") or _read_attr(exc, "llm_provider")
-    )
-
-
-def _error_request_id(exc: BaseException) -> str | None:
-    return _non_blank(_read_attr(exc, "request_id"))
-
-
-def _model_provider(model: str | None) -> str | None:
-    if not model or "/" not in model:
-        return None
-    provider, _ = model.split("/", 1)
-    return provider or None
-
-
-def _first_scalar(value: Any, *names: str) -> JsonValue | None:
-    for name in names:
-        candidate = _read_attr(value, name)
-        if candidate is None or isinstance(candidate, (dict, list, tuple, set)):
-            continue
-        sanitized = _json_safe(candidate)
-        if isinstance(sanitized, (str, int, float, bool)):
-            return sanitized
-    return None
-
-
-def _json_object(
-    value: Any,
-    *,
-    redact_sensitive: bool = True,
-) -> dict[str, JsonValue]:
-    converted = _json_safe(value, redact_sensitive=redact_sensitive)
-    if isinstance(converted, dict):
-        return cast(dict[str, JsonValue], converted)
-    return {"value": cast(JsonValue, converted)}
-
-
-def _json_safe(
-    value: Any,
-    *,
-    redact_sensitive: bool = True,
-    depth: int = 0,
-) -> JsonValue:
-    if depth >= 20:
-        return "<maximum depth>"
-    if value is None or isinstance(value, (bool, int)):
-        return value
-    if isinstance(value, float):
-        return value if math.isfinite(value) else None
-    if isinstance(value, str):
-        return _redact_string(value) if redact_sensitive else value
-    if isinstance(value, Enum):
-        return _json_safe(
-            value.value,
-            redact_sensitive=redact_sensitive,
-            depth=depth + 1,
-        )
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, date):
-        return value.isoformat()
-    if isinstance(value, bytes):
-        return f"<bytes:{len(value)}>"
-
-    model_dump = _read_attr(value, "model_dump")
-    if callable(model_dump):
-        try:
-            dumped = model_dump(mode="json")
-        except Exception:
-            dumped = None
-        if dumped is not None and dumped is not value:
-            return _json_safe(
-                dumped,
-                redact_sensitive=redact_sensitive,
-                depth=depth + 1,
-            )
-    if isinstance(value, Mapping):
-        converted: dict[str, JsonValue] = {}
-        for key, nested in value.items():
-            key_text = str(key)
-            if redact_sensitive and _is_sensitive_key(key_text):
-                converted[key_text] = _REDACTED
-            else:
-                converted[key_text] = _json_safe(
-                    nested,
-                    redact_sensitive=redact_sensitive,
-                    depth=depth + 1,
-                )
-        return converted
-    if isinstance(value, (list, tuple)):
-        return [
-            _json_safe(
-                nested,
-                redact_sensitive=redact_sensitive,
-                depth=depth + 1,
-            )
-            for nested in value
-        ]
-    if isinstance(value, set):
-        return [
-            _json_safe(
-                nested,
-                redact_sensitive=redact_sensitive,
-                depth=depth + 1,
-            )
-            for nested in sorted(value, key=str)
-        ]
-
-    public_attributes = _read_attr(value, "__dict__")
-    if isinstance(public_attributes, dict):
-        return _json_safe(
-            {
-                key: nested
-                for key, nested in public_attributes.items()
-                if not key.startswith("_")
-            },
-            redact_sensitive=redact_sensitive,
-            depth=depth + 1,
-        )
-    try:
-        text = str(value)
-    except Exception:
-        text = f"<{type(value).__name__}>"
-    return _redact_string(text) if redact_sensitive else text
-
-
-def _is_sensitive_key(key: str) -> bool:
-    normalized = re.sub(r"[^a-z0-9]", "", key.casefold())
-    return normalized in _SENSITIVE_KEYS
-
-
-def _redact_string(value: str) -> str:
-    redacted = _BEARER_RE.sub(_REDACTED, value)
-    redacted = _OPENAI_KEY_RE.sub(_REDACTED, redacted)
-    return _ASSIGNED_SECRET_RE.sub(lambda match: f"{match.group(1)}={_REDACTED}", redacted)
-
-
-def _case_insensitive_mapping_value(value: Any, key: str) -> Any | None:
-    if not isinstance(value, Mapping):
-        return None
-    target = key.casefold()
-    return next(
-        (nested for name, nested in value.items() if str(name).casefold() == target),
-        None,
-    )
-
-
-def _non_blank(value: Any) -> str | None:
-    if value is None:
-        return None
-    try:
-        text = str(value).strip()
-    except Exception:
-        return None
-    return text or None
-
-
-def _read_attr(value: Any, name: str, default: Any = None) -> Any:
-    try:
-        if isinstance(value, Mapping):
-            return value.get(name, default)
-        return getattr(value, name, default)
-    except Exception:
-        return default

--- a/backend/services/reporter/runner/provider_telemetry.py
+++ b/backend/services/reporter/runner/provider_telemetry.py
@@ -1,0 +1,344 @@
+"""Normalize and sanitize provider telemetry for durable model-call recording."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date, datetime
+from enum import Enum
+import math
+import re
+from typing import Any, cast
+from uuid import UUID
+
+from pydantic import JsonValue
+
+from backend.services.reporter.runner.recording import RecordedTokenUsage
+
+_REDACTED = "[REDACTED]"
+_SENSITIVE_KEYS = frozenset(
+    {
+        "authorization",
+        "proxyauthorization",
+        "apikey",
+        "xapikey",
+        "accesstoken",
+        "refreshtoken",
+        "clientsecret",
+        "cookie",
+        "setcookie",
+    }
+)
+_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*")
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_ASSIGNED_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|access[_-]?token|client[_-]?secret)(\s*[=:]\s*)\S+"
+)
+_MAX_ERROR_MESSAGE_LENGTH = 2000
+
+
+def normalize_token_usage(response: Any) -> RecordedTokenUsage:
+    """Map only explicitly reported provider token categories."""
+    usage = _read_attr(response, "usage")
+    if usage is None:
+        return RecordedTokenUsage()
+
+    raw = _json_safe(usage)
+    raw_usage = raw if isinstance(raw, dict) else {"value": raw}
+    return RecordedTokenUsage(
+        input_tokens=_first_token(usage, "prompt_tokens", "input_tokens"),
+        cached_input_tokens=_first_present(
+            _nested_token(usage, "prompt_tokens_details", "cached_tokens"),
+            _nested_token(usage, "input_tokens_details", "cached_tokens"),
+            _first_token(usage, "cache_read_input_tokens", "cached_tokens"),
+        ),
+        output_tokens=_first_token(usage, "completion_tokens", "output_tokens"),
+        reasoning_tokens=_first_present(
+            _nested_token(usage, "completion_tokens_details", "reasoning_tokens"),
+            _nested_token(usage, "output_tokens_details", "reasoning_tokens"),
+            _first_token(usage, "reasoning_tokens"),
+        ),
+        total_tokens=_first_token(usage, "total_tokens"),
+        raw_provider_usage=cast(dict[str, JsonValue], raw_usage),
+    )
+
+
+def sanitize_provider_response(response: Any) -> dict[str, JsonValue]:
+    """Return complete JSON-safe provider output with secret fields redacted."""
+    value = _json_safe(response)
+    if isinstance(value, dict):
+        return cast(dict[str, JsonValue], value)
+    return {"value": cast(JsonValue, value)}
+
+
+def sanitize_provider_error(
+    exc: BaseException,
+    requested_provider: str | None = None,
+) -> dict[str, JsonValue]:
+    """Build a bounded error envelope without transport or credential objects."""
+    message = _redact_string(str(exc))[:_MAX_ERROR_MESSAGE_LENGTH]
+    error: dict[str, JsonValue] = {
+        "type": type(exc).__name__,
+        "message": message,
+    }
+    for output_name, attribute_names in (
+        ("status_code", ("status_code", "status")),
+        ("code", ("code",)),
+        ("request_id", ("request_id",)),
+    ):
+        value = _first_scalar(exc, *attribute_names)
+        if value is not None:
+            error[output_name] = value
+    provider = error_provider(exc) or requested_provider
+    if provider is not None:
+        error["provider"] = provider
+    return error
+
+
+def json_object(
+    value: Any,
+    *,
+    redact_sensitive: bool = True,
+) -> dict[str, JsonValue]:
+    """Convert an arbitrary provider value into a JSON object."""
+    converted = _json_safe(value, redact_sensitive=redact_sensitive)
+    if isinstance(converted, dict):
+        return cast(dict[str, JsonValue], converted)
+    return {"value": cast(JsonValue, converted)}
+
+
+def response_finish_reason(response: Any) -> str | None:
+    choices = _read_attr(response, "choices", []) or []
+    try:
+        first_choice = choices[0]
+    except (IndexError, KeyError, TypeError):
+        return None
+    return _non_blank(_read_attr(first_choice, "finish_reason"))
+
+
+def response_provider(response: Any) -> str | None:
+    direct = _non_blank(_read_attr(response, "provider"))
+    if direct is not None:
+        return direct
+    hidden = _read_attr(response, "_hidden_params", {}) or {}
+    return _non_blank(_read_attr(hidden, "custom_llm_provider"))
+
+
+def response_request_id(response: Any) -> str | None:
+    direct = _non_blank(_read_attr(response, "request_id"))
+    if direct is not None:
+        return direct
+    hidden = _read_attr(response, "_hidden_params", {}) or {}
+    for container_name in ("additional_headers", "response_headers"):
+        headers = _read_attr(hidden, container_name, {}) or {}
+        for header_name in ("x-request-id", "request-id"):
+            value = _case_insensitive_mapping_value(headers, header_name)
+            if value is not None:
+                return _non_blank(value)
+    return None
+
+
+def response_model(response: Any) -> str | None:
+    return _non_blank(_read_attr(response, "model"))
+
+
+def response_id(response: Any) -> str | None:
+    return _non_blank(_read_attr(response, "id"))
+
+
+def error_provider(exc: BaseException) -> str | None:
+    return _non_blank(
+        _read_attr(exc, "provider") or _read_attr(exc, "llm_provider")
+    )
+
+
+def error_request_id(exc: BaseException) -> str | None:
+    return _non_blank(_read_attr(exc, "request_id"))
+
+
+def model_provider(model: str | None) -> str | None:
+    if not model or "/" not in model:
+        return None
+    provider, _ = model.split("/", 1)
+    return provider or None
+
+
+def _first_token(value: Any, *names: str) -> int | None:
+    for name in names:
+        token_count = _read_attr(value, name)
+        if (
+            isinstance(token_count, int)
+            and not isinstance(token_count, bool)
+            and token_count >= 0
+        ):
+            return token_count
+    return None
+
+
+def _nested_token(value: Any, parent: str, child: str) -> int | None:
+    nested = _read_attr(value, parent)
+    return _first_token(nested, child) if nested is not None else None
+
+
+def _first_present(*values: int | None) -> int | None:
+    return next((value for value in values if value is not None), None)
+
+
+def _first_scalar(value: Any, *names: str) -> JsonValue | None:
+    for name in names:
+        candidate = _read_attr(value, name)
+        if candidate is None or isinstance(candidate, (dict, list, tuple, set)):
+            continue
+        sanitized = _json_safe(candidate)
+        if isinstance(sanitized, (str, int, float, bool)):
+            return sanitized
+    return None
+
+
+def _json_safe(
+    value: Any,
+    *,
+    redact_sensitive: bool = True,
+    depth: int = 0,
+) -> JsonValue:
+    if depth >= 20:
+        return "<maximum depth>"
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _redact_string(value) if redact_sensitive else value
+    if isinstance(value, Enum):
+        return _json_safe(
+            value.value,
+            redact_sensitive=redact_sensitive,
+            depth=depth + 1,
+        )
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return f"<bytes:{len(value)}>"
+
+    model_dump = _read_attr(value, "model_dump")
+    if callable(model_dump):
+        try:
+            dumped = model_dump(mode="json")
+        except Exception:
+            dumped = None
+        if dumped is not None and dumped is not value:
+            return _json_safe(
+                dumped,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+    if isinstance(value, Mapping):
+        converted: dict[str, JsonValue] = {}
+        for key, nested in value.items():
+            key_text = str(key)
+            if redact_sensitive and _is_sensitive_key(key_text):
+                converted[key_text] = _REDACTED
+            else:
+                converted[key_text] = _json_safe(
+                    nested,
+                    redact_sensitive=redact_sensitive,
+                    depth=depth + 1,
+                )
+        return converted
+    if isinstance(value, (list, tuple)):
+        return [
+            _json_safe(
+                nested,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+            for nested in value
+        ]
+    if isinstance(value, set):
+        return [
+            _json_safe(
+                nested,
+                redact_sensitive=redact_sensitive,
+                depth=depth + 1,
+            )
+            for nested in sorted(value, key=str)
+        ]
+
+    public_attributes = _read_attr(value, "__dict__")
+    if isinstance(public_attributes, dict):
+        return _json_safe(
+            {
+                key: nested
+                for key, nested in public_attributes.items()
+                if not key.startswith("_")
+            },
+            redact_sensitive=redact_sensitive,
+            depth=depth + 1,
+        )
+    try:
+        text = str(value)
+    except Exception:
+        text = f"<{type(value).__name__}>"
+    return _redact_string(text) if redact_sensitive else text
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", key.casefold())
+    return normalized in _SENSITIVE_KEYS
+
+
+def _redact_string(value: str) -> str:
+    redacted = _BEARER_RE.sub(_REDACTED, value)
+    redacted = _OPENAI_KEY_RE.sub(_REDACTED, redacted)
+    return _ASSIGNED_SECRET_RE.sub(
+        lambda match: f"{match.group(1)}={_REDACTED}",
+        redacted,
+    )
+
+
+def _case_insensitive_mapping_value(value: Any, key: str) -> Any | None:
+    if not isinstance(value, Mapping):
+        return None
+    target = key.casefold()
+    return next(
+        (nested for name, nested in value.items() if str(name).casefold() == target),
+        None,
+    )
+
+
+def _non_blank(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    return text or None
+
+
+def _read_attr(value: Any, name: str, default: Any = None) -> Any:
+    try:
+        if isinstance(value, Mapping):
+            return value.get(name, default)
+        return getattr(value, name, default)
+    except Exception:
+        return default
+
+
+__all__ = [
+    "error_provider",
+    "error_request_id",
+    "json_object",
+    "model_provider",
+    "normalize_token_usage",
+    "response_finish_reason",
+    "response_id",
+    "response_model",
+    "response_provider",
+    "response_request_id",
+    "sanitize_provider_error",
+    "sanitize_provider_response",
+]

--- a/backend/services/reporter/runner/recording.py
+++ b/backend/services/reporter/runner/recording.py
@@ -1,0 +1,74 @@
+"""Reporter-facing contracts for generation-scoped completion recording."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+from uuid import UUID
+
+from pydantic import JsonValue
+
+
+ModelAttemptStatus = Literal[
+    "succeeded",
+    "retryable_error",
+    "fatal_error",
+    "cancelled",
+    "unknown_outcome",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedTokenUsage:
+    input_tokens: int | None = None
+    cached_input_tokens: int | None = None
+    output_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    total_tokens: int | None = None
+    raw_provider_usage: dict[str, JsonValue] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelAttemptStart:
+    turn_number: int
+    requested_provider: str | None
+    requested_model: str
+    input_messages: tuple[dict[str, JsonValue], ...]
+    tool_definitions: tuple[dict[str, JsonValue], ...]
+    request_parameters: dict[str, JsonValue]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelAttemptFinish:
+    status: ModelAttemptStatus
+    actual_provider: str | None = None
+    actual_model: str | None = None
+    provider_response: dict[str, JsonValue] | None = None
+    error: dict[str, JsonValue] | None = None
+    finish_reason: str | None = None
+    provider_request_id: str | None = None
+    provider_response_id: str | None = None
+    usage: RecordedTokenUsage = field(default_factory=RecordedTokenUsage)
+
+
+class CompletionRecorder(Protocol):
+    """Record provider attempts for exactly one durable generation."""
+
+    def begin_model_attempt(self, attempt: ModelAttemptStart) -> UUID: ...
+
+    def finish_model_attempt(
+        self,
+        attempt_id: UUID,
+        result: ModelAttemptFinish,
+    ) -> None: ...
+
+    def successful_ai_call_id(self, turn_number: int) -> UUID | None: ...
+
+
+__all__ = [
+    "CompletionRecorder",
+    "ModelAttemptFinish",
+    "ModelAttemptStart",
+    "ModelAttemptStatus",
+    "RecordedTokenUsage",
+]

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -14,7 +14,11 @@ import time
 from pathlib import Path
 from typing import Any
 
-from backend.services.reporter.runner.completion import CompletionClient, CompletionFn, CompletionSettings
+from backend.services.reporter.runner.completion import (
+    CompletionClient,
+    CompletionFn,
+    CompletionSettings,
+)
 from backend.services.reporter.runner.models import (
     ChatMessage,
     ToolCall,
@@ -92,6 +96,7 @@ class Runner:
             while turn < self.config.max_turns and not self._submitted:
                 turn += 1
                 response = await self._client.complete(
+                    turn_number=turn,
                     messages=list(messages),
                     tools=self.registry.tool_specs,
                 )

--- a/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
+++ b/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
@@ -1,0 +1,109 @@
+"""PostgreSQL integration for completion attempts through the durable recorder."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from backend.database.sessions import SessionFactory
+from backend.resources.reporting.ai_calls import AICallManager, AICallQuery
+from backend.resources.reporting.generations import (
+    CreateGeneration,
+    GenerationManager,
+    StartGeneration,
+)
+from backend.services.generations import GenerationExecutionRecorder
+from backend.services.reporter.runner.completion import (
+    CompletionClient,
+    CompletionSettings,
+    RetryPolicy,
+)
+from backend.tests.resources.reporting.generations.conftest import (
+    GenerationDomain,
+    generation_context,
+)
+
+
+class RateLimitError(Exception):
+    status_code = 429
+
+
+def _create_running_generation(
+    session_factory: SessionFactory,
+    domain: GenerationDomain,
+) -> UUID:
+    manager = GenerationManager(session_factory, generation_context(domain))
+    generation = manager.create_pending(
+        CreateGeneration(
+            generation_id=uuid4(),
+            competition_season_id=domain.season_id,
+            kind="live",
+            request_text="write the recap",
+            week_start=8,
+            week_end=8,
+            requested_primary_model="primary",
+            settings={},
+        )
+    )
+    manager.start(
+        StartGeneration(
+            generation_id=generation.id,
+            data_snapshot_id=domain.snapshot_id,
+            input_memory_revision_id=domain.memory_revision_id,
+            knowledge_cutoff_at=datetime(2026, 10, 27, tzinfo=UTC),
+            input_manifest={"schema": 1},
+            manifest_schema_version=1,
+            manifest_hash="a" * 64,
+        )
+    )
+    return generation.id
+
+
+def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
+    ai_call_manager: AICallManager,
+    session_factory: SessionFactory,
+    generation_domain: GenerationDomain,
+) -> None:
+    generation_id = _create_running_generation(session_factory, generation_domain)
+    outcomes: list[Any] = [
+        RateLimitError("primary unavailable"),
+        {
+            "id": "response-1",
+            "model": "fallback",
+            "provider": "test",
+            "choices": [{"finish_reason": "stop"}],
+            "usage": {"input_tokens": 9, "output_tokens": 4},
+        },
+    ]
+
+    async def complete(**_kwargs: Any) -> Any:
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    recorder = GenerationExecutionRecorder(generation_id, ai_call_manager)
+    client = CompletionClient(
+        complete,
+        CompletionSettings(
+            model="primary",
+            fallback_models=("fallback",),
+            retry=RetryPolicy(max_retries=0),
+        ),
+        recorder,
+    )
+
+    response = asyncio.run(client.complete(turn_number=1, messages=[]))
+
+    assert response["id"] == "response-1"
+    page = ai_call_manager.list(AICallQuery(generation_id=generation_id))
+    assert [item.attempt_number for item in page.items] == [0, 1]
+    assert [item.status.value for item in page.items] == [
+        "retryable_error",
+        "succeeded",
+    ]
+    assert page.items[1].usage.input_tokens == 9
+    assert page.items[1].usage.output_tokens == 4
+    assert recorder.successful_ai_call_id(1) == page.items[1].id

--- a/backend/tests/services/generations/test_recorder.py
+++ b/backend/tests/services/generations/test_recorder.py
@@ -1,0 +1,100 @@
+"""Tests for the durable generation AI-call recorder adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID, uuid4
+
+from backend.resources.reporting.ai_calls import AICallManager
+from backend.services.generations import GenerationExecutionRecorder
+from backend.services.reporter.runner.recording import (
+    ModelAttemptFinish,
+    ModelAttemptStart,
+    RecordedTokenUsage,
+)
+
+
+class FakeAICallManager:
+    def __init__(self) -> None:
+        self.begun = []
+        self.finished = []
+        self.turns: dict[UUID, int] = {}
+
+    def begin_ai_call(self, command):
+        call_id = uuid4()
+        self.begun.append(command)
+        self.turns[call_id] = command.turn_number
+        return SimpleNamespace(id=call_id)
+
+    def finish_ai_call(self, command):
+        self.finished.append(command)
+        return SimpleNamespace(
+            id=command.ai_call_id,
+            turn_number=self.turns[command.ai_call_id],
+            status=SimpleNamespace(value=command.status.value),
+        )
+
+
+def test_recorder_maps_reporter_events_and_retains_success_identity() -> None:
+    generation_id = uuid4()
+    manager = FakeAICallManager()
+    recorder = GenerationExecutionRecorder(
+        generation_id,
+        cast(AICallManager, manager),
+    )
+    attempt_id = recorder.begin_model_attempt(
+        ModelAttemptStart(
+            turn_number=2,
+            requested_provider="openai",
+            requested_model="openai/model",
+            input_messages=({"role": "user", "content": "hello"},),
+            tool_definitions=({"type": "function", "name": "lookup"},),
+            request_parameters={"temperature": 0.2},
+        )
+    )
+    recorder.finish_model_attempt(
+        attempt_id,
+        ModelAttemptFinish(
+            status="succeeded",
+            actual_provider="openai",
+            actual_model="model",
+            provider_response={"id": "response-1"},
+            usage=RecordedTokenUsage(
+                input_tokens=12,
+                output_tokens=5,
+                raw_provider_usage={"prompt_tokens": 12},
+            ),
+        ),
+    )
+
+    assert recorder.generation_id == generation_id
+    assert manager.begun[0].generation_id == generation_id
+    assert manager.begun[0].turn_number == 2
+    assert manager.finished[0].usage.input_tokens == 12
+    assert recorder.successful_ai_call_id(2) == attempt_id
+    assert recorder.successful_ai_call_id(3) is None
+
+
+def test_failed_attempt_does_not_become_successful_identity() -> None:
+    manager = FakeAICallManager()
+    recorder = GenerationExecutionRecorder(uuid4(), cast(AICallManager, manager))
+    attempt_id = recorder.begin_model_attempt(
+        ModelAttemptStart(
+            turn_number=1,
+            requested_provider=None,
+            requested_model="model",
+            input_messages=(),
+            tool_definitions=(),
+            request_parameters={},
+        )
+    )
+    recorder.finish_model_attempt(
+        attempt_id,
+        ModelAttemptFinish(
+            status="retryable_error",
+            error={"type": "TimeoutError", "message": "timeout"},
+        ),
+    )
+
+    assert recorder.successful_ai_call_id(1) is None

--- a/backend/tests/services/reporter/test_completion.py
+++ b/backend/tests/services/reporter/test_completion.py
@@ -2,16 +2,27 @@
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from typing import Any
+from uuid import UUID, uuid4
 
 import pytest
 
+from backend.services.reporter.generator import _resolve_client
 from backend.services.reporter.runner.completion import (
     CompletionClient,
     CompletionSettings,
     RetryPolicy,
     is_retryable_error,
+    normalize_token_usage,
     retry_delay_seconds,
+    sanitize_provider_error,
+    sanitize_provider_response,
+)
+from backend.services.reporter.runner.recording import (
+    ModelAttemptFinish,
+    ModelAttemptStart,
 )
 from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.tools.registry import ToolRegistry
@@ -43,12 +54,53 @@ class SequenceCompletion:
         return outcome
 
 
+class RecordingProbe:
+    def __init__(
+        self,
+        *,
+        fail_begin: bool = False,
+        fail_finish: bool = False,
+    ) -> None:
+        self.fail_begin = fail_begin
+        self.fail_finish = fail_finish
+        self.started: list[tuple[UUID, ModelAttemptStart]] = []
+        self.finished: list[tuple[UUID, ModelAttemptFinish]] = []
+        self.successful: dict[int, UUID] = {}
+
+    def begin_model_attempt(self, attempt: ModelAttemptStart) -> UUID:
+        if self.fail_begin:
+            raise RateLimitError("recorder timeout")
+        attempt_id = uuid4()
+        self.started.append((attempt_id, attempt))
+        return attempt_id
+
+    def finish_model_attempt(
+        self,
+        attempt_id: UUID,
+        result: ModelAttemptFinish,
+    ) -> None:
+        if self.fail_finish:
+            raise RateLimitError("recorder finish timeout")
+        self.finished.append((attempt_id, result))
+        if result.status == "succeeded":
+            turn = next(
+                attempt.turn_number
+                for started_id, attempt in self.started
+                if started_id == attempt_id
+            )
+            self.successful[turn] = attempt_id
+
+    def successful_ai_call_id(self, turn_number: int) -> UUID | None:
+        return self.successful.get(turn_number)
+
+
 def make_client(
     complete: SequenceCompletion,
     *,
     model: str | None = None,
     fallback_models: tuple[str, ...] = (),
     retry: RetryPolicy | None = None,
+    recorder: RecordingProbe | None = None,
 ) -> CompletionClient:
     return CompletionClient(
         complete,
@@ -57,6 +109,7 @@ def make_client(
             fallback_models=fallback_models,
             retry=retry or RetryPolicy(),
         ),
+        recorder,
     )
 
 
@@ -276,3 +329,296 @@ def test_runner_uses_fallback_model_on_rate_limits(monkeypatch) -> None:
         "gpt-primary",
         "gpt-fallback",
     ]
+
+
+def test_recorded_success_retains_exact_response_and_normalized_usage() -> None:
+    response = {
+        "id": "response-1",
+        "model": "actual-model",
+        "provider": "openai",
+        "choices": [{"finish_reason": "tool_calls", "message": {"content": None}}],
+        "usage": {
+            "prompt_tokens": 20,
+            "completion_tokens": 8,
+            "total_tokens": 28,
+            "prompt_tokens_details": {"cached_tokens": 3},
+            "completion_tokens_details": {"reasoning_tokens": 2},
+        },
+        "authorization": "Bearer provider-secret",
+    }
+    complete = SequenceCompletion([response])
+    recorder = RecordingProbe()
+    client = make_client(complete, model="openai/requested-model", recorder=recorder)
+
+    returned = run(
+        client.complete(
+            turn_number=3,
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+            temperature=0.25,
+        )
+    )
+
+    assert returned is response
+    assert len(recorder.started) == 1
+    _, started = recorder.started[0]
+    assert started.turn_number == 3
+    assert started.requested_provider == "openai"
+    assert started.requested_model == "openai/requested-model"
+    assert started.request_parameters == {"temperature": 0.25}
+    _, finished = recorder.finished[0]
+    assert finished.status == "succeeded"
+    assert finished.actual_model == "actual-model"
+    assert finished.provider_response["authorization"] == "[REDACTED]"
+    assert finished.usage.input_tokens == 20
+    assert finished.usage.cached_input_tokens == 3
+    assert finished.usage.output_tokens == 8
+    assert finished.usage.reasoning_tokens == 2
+    assert finished.usage.total_tokens == 28
+    assert recorder.successful_ai_call_id(3) is not None
+
+
+def test_every_retry_and_fallback_is_recorded_as_its_own_attempt(monkeypatch) -> None:
+    async def fake_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr("backend.services.reporter.runner.completion.asyncio.sleep", fake_sleep)
+    complete = SequenceCompletion(
+        [
+            RateLimitError("primary retry"),
+            RateLimitError("primary exhausted"),
+            {"model": "fallback", "choices": [{"finish_reason": "stop"}]},
+        ]
+    )
+    recorder = RecordingProbe()
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=1, base_delay=0.01, max_delay=0.01),
+        recorder=recorder,
+    )
+
+    run(client.complete(turn_number=1, messages=[]))
+
+    assert [attempt.requested_model for _, attempt in recorder.started] == [
+        "primary",
+        "primary",
+        "fallback",
+    ]
+    assert [result.status for _, result in recorder.finished] == [
+        "retryable_error",
+        "retryable_error",
+        "succeeded",
+    ]
+
+
+def test_retry_exhaustion_leaves_every_attempt_terminal() -> None:
+    complete = SequenceCompletion([RateLimitError("primary"), RateLimitError("fallback")])
+    recorder = RecordingProbe()
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=0),
+        recorder=recorder,
+    )
+
+    with pytest.raises(RateLimitError, match="fallback"):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert len(recorder.started) == 2
+    assert [result.status for _, result in recorder.finished] == [
+        "retryable_error",
+        "retryable_error",
+    ]
+
+
+def test_fatal_error_is_sanitized_and_recorded_once() -> None:
+    error = ValueError("invalid api_key=super-secret Bearer bearer-secret")
+    complete = SequenceCompletion([error])
+    recorder = RecordingProbe()
+    client = make_client(complete, model="primary", recorder=recorder)
+
+    with pytest.raises(ValueError, match="invalid"):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert len(recorder.started) == 1
+    result = recorder.finished[0][1]
+    assert result.status == "fatal_error"
+    assert "super-secret" not in result.error["message"]
+    assert "bearer-secret" not in result.error["message"]
+
+
+def test_inflight_cancellation_records_unknown_outcome() -> None:
+    class CancelledCompletion:
+        async def __call__(self, **_kwargs: Any) -> Any:
+            raise asyncio.CancelledError("caller cancelled")
+
+    recorder = RecordingProbe()
+    client = CompletionClient(
+        CancelledCompletion(),
+        CompletionSettings(model="primary"),
+        recorder,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert recorder.finished[0][1].status == "unknown_outcome"
+
+
+def test_recorder_begin_failure_prevents_provider_call() -> None:
+    complete = SequenceCompletion([{"model": "unused", "choices": []}])
+    client = make_client(
+        complete,
+        model="primary",
+        recorder=RecordingProbe(fail_begin=True),
+    )
+
+    with pytest.raises(RuntimeError, match="before provider invocation"):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert complete.requests == []
+
+
+def test_recorder_finish_failure_prevents_success_from_escaping() -> None:
+    response = {"model": "primary", "choices": [{"finish_reason": "stop"}]}
+    complete = SequenceCompletion([response])
+    client = make_client(
+        complete,
+        model="primary",
+        recorder=RecordingProbe(fail_finish=True),
+    )
+
+    with pytest.raises(RuntimeError, match="after provider invocation"):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert len(complete.requests) == 1
+
+
+def test_recording_requires_model_and_positive_turn() -> None:
+    complete = SequenceCompletion([])
+    recorder = RecordingProbe()
+
+    with pytest.raises(ValueError, match="configured model"):
+        run(make_client(complete, recorder=recorder).complete(turn_number=1, messages=[]))
+    with pytest.raises(ValueError, match="positive turn"):
+        run(
+            make_client(complete, model="primary", recorder=recorder).complete(
+                messages=[]
+            )
+        )
+    assert complete.requests == []
+
+
+def test_generator_client_resolution_preserves_recorder_identity() -> None:
+    complete = SequenceCompletion([])
+    recorder = RecordingProbe()
+    resolved = _resolve_client(
+        client=None,
+        completion=CompletionSettings(model="primary"),
+        complete=complete,
+        recorder=recorder,
+    )
+
+    assert resolved.recorder is recorder
+    with pytest.raises(ValueError, match="already use"):
+        _resolve_client(
+            client=CompletionClient(complete, CompletionSettings(model="primary")),
+            completion=None,
+            complete=None,
+            recorder=recorder,
+        )
+
+
+def test_token_normalization_preserves_zero_and_missing_categories() -> None:
+    usage = normalize_token_usage(
+        {
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 4,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            }
+        }
+    )
+
+    assert usage.input_tokens == 0
+    assert usage.cached_input_tokens == 0
+    assert usage.output_tokens == 4
+    assert usage.reasoning_tokens == 0
+    assert usage.total_tokens is None
+    assert normalize_token_usage({}).raw_provider_usage is None
+
+
+def test_litellm_style_object_metadata_and_usage_are_recorded() -> None:
+    response = SimpleNamespace(
+        id="response-object",
+        model="provider-model",
+        choices=[SimpleNamespace(finish_reason="stop")],
+        usage=SimpleNamespace(
+            prompt_tokens=11,
+            completion_tokens=6,
+            total_tokens=17,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=4),
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        ),
+        _hidden_params={
+            "custom_llm_provider": "azure",
+            "additional_headers": {"X-Request-ID": "request-object"},
+        },
+    )
+    recorder = RecordingProbe()
+    client = make_client(
+        SequenceCompletion([response]),
+        model="openai/requested",
+        recorder=recorder,
+    )
+
+    run(client.complete(turn_number=1, messages=[]))
+
+    result = recorder.finished[0][1]
+    assert result.actual_provider == "azure"
+    assert result.actual_model == "provider-model"
+    assert result.provider_request_id == "request-object"
+    assert result.provider_response_id == "response-object"
+    assert result.finish_reason == "stop"
+    assert result.usage.cached_input_tokens == 4
+    assert result.usage.reasoning_tokens == 2
+    assert result.usage.raw_provider_usage["prompt_tokens"] == 11
+
+
+def test_error_sanitizer_keeps_only_bounded_scalar_metadata() -> None:
+    error = RateLimitError("Bearer top-secret " + ("x" * 3000))
+    error.code = "rate_limit"
+    error.request_id = "request-7"
+    error.headers = {"authorization": "secret"}
+
+    sanitized = sanitize_provider_error(error, "openai")
+
+    assert sanitized["type"] == "RateLimitError"
+    assert sanitized["status_code"] == 429
+    assert sanitized["code"] == "rate_limit"
+    assert sanitized["request_id"] == "request-7"
+    assert sanitized["provider"] == "openai"
+    assert "top-secret" not in sanitized["message"]
+    assert len(sanitized["message"]) == 2000
+    assert "headers" not in sanitized
+
+
+def test_response_sanitizer_falls_back_when_provider_dump_fails() -> None:
+    class BrokenDump:
+        visible = "kept"
+
+        def __init__(self) -> None:
+            self.payload = {"api_key": "secret", "value": 7}
+
+        def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("provider serializer failed")
+
+    sanitized = sanitize_provider_response(BrokenDump())
+
+    assert sanitized == {
+        "payload": {"api_key": "[REDACTED]", "value": 7}
+    }

--- a/backend/tests/services/reporter/test_completion.py
+++ b/backend/tests/services/reporter/test_completion.py
@@ -15,10 +15,7 @@ from backend.services.reporter.runner.completion import (
     CompletionSettings,
     RetryPolicy,
     is_retryable_error,
-    normalize_token_usage,
     retry_delay_seconds,
-    sanitize_provider_error,
-    sanitize_provider_response,
 )
 from backend.services.reporter.runner.recording import (
     ModelAttemptFinish,
@@ -532,26 +529,6 @@ def test_generator_client_resolution_preserves_recorder_identity() -> None:
         )
 
 
-def test_token_normalization_preserves_zero_and_missing_categories() -> None:
-    usage = normalize_token_usage(
-        {
-            "usage": {
-                "input_tokens": 0,
-                "output_tokens": 4,
-                "input_tokens_details": {"cached_tokens": 0},
-                "output_tokens_details": {"reasoning_tokens": 0},
-            }
-        }
-    )
-
-    assert usage.input_tokens == 0
-    assert usage.cached_input_tokens == 0
-    assert usage.output_tokens == 4
-    assert usage.reasoning_tokens == 0
-    assert usage.total_tokens is None
-    assert normalize_token_usage({}).raw_provider_usage is None
-
-
 def test_litellm_style_object_metadata_and_usage_are_recorded() -> None:
     response = SimpleNamespace(
         id="response-object",
@@ -587,38 +564,3 @@ def test_litellm_style_object_metadata_and_usage_are_recorded() -> None:
     assert result.usage.cached_input_tokens == 4
     assert result.usage.reasoning_tokens == 2
     assert result.usage.raw_provider_usage["prompt_tokens"] == 11
-
-
-def test_error_sanitizer_keeps_only_bounded_scalar_metadata() -> None:
-    error = RateLimitError("Bearer top-secret " + ("x" * 3000))
-    error.code = "rate_limit"
-    error.request_id = "request-7"
-    error.headers = {"authorization": "secret"}
-
-    sanitized = sanitize_provider_error(error, "openai")
-
-    assert sanitized["type"] == "RateLimitError"
-    assert sanitized["status_code"] == 429
-    assert sanitized["code"] == "rate_limit"
-    assert sanitized["request_id"] == "request-7"
-    assert sanitized["provider"] == "openai"
-    assert "top-secret" not in sanitized["message"]
-    assert len(sanitized["message"]) == 2000
-    assert "headers" not in sanitized
-
-
-def test_response_sanitizer_falls_back_when_provider_dump_fails() -> None:
-    class BrokenDump:
-        visible = "kept"
-
-        def __init__(self) -> None:
-            self.payload = {"api_key": "secret", "value": 7}
-
-        def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
-            raise RuntimeError("provider serializer failed")
-
-    sanitized = sanitize_provider_response(BrokenDump())
-
-    assert sanitized == {
-        "payload": {"api_key": "[REDACTED]", "value": 7}
-    }

--- a/backend/tests/services/reporter/test_provider_telemetry.py
+++ b/backend/tests/services/reporter/test_provider_telemetry.py
@@ -1,0 +1,69 @@
+"""Tests for provider usage normalization and durable-payload sanitization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.reporter.runner.provider_telemetry import (
+    normalize_token_usage,
+    sanitize_provider_error,
+    sanitize_provider_response,
+)
+
+
+def test_token_normalization_preserves_zero_and_missing_categories() -> None:
+    usage = normalize_token_usage(
+        {
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 4,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            }
+        }
+    )
+
+    assert usage.input_tokens == 0
+    assert usage.cached_input_tokens == 0
+    assert usage.output_tokens == 4
+    assert usage.reasoning_tokens == 0
+    assert usage.total_tokens is None
+    assert normalize_token_usage({}).raw_provider_usage is None
+
+
+def test_error_sanitizer_keeps_only_bounded_scalar_metadata() -> None:
+    class ProviderError(Exception):
+        status_code = 429
+
+    error = ProviderError("Bearer top-secret " + ("x" * 3000))
+    error.code = "rate_limit"
+    error.request_id = "request-7"
+    error.headers = {"authorization": "secret"}
+
+    sanitized = sanitize_provider_error(error, "openai")
+
+    assert sanitized["type"] == "ProviderError"
+    assert sanitized["status_code"] == 429
+    assert sanitized["code"] == "rate_limit"
+    assert sanitized["request_id"] == "request-7"
+    assert sanitized["provider"] == "openai"
+    assert "top-secret" not in sanitized["message"]
+    assert len(sanitized["message"]) == 2000
+    assert "headers" not in sanitized
+
+
+def test_response_sanitizer_falls_back_when_provider_dump_fails() -> None:
+    class BrokenDump:
+        visible = "kept"
+
+        def __init__(self) -> None:
+            self.payload = {"api_key": "secret", "value": 7}
+
+        def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("provider serializer failed")
+
+    sanitized = sanitize_provider_response(BrokenDump())
+
+    assert sanitized == {
+        "payload": {"api_key": "[REDACTED]", "value": 7}
+    }

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -155,6 +155,7 @@ def test_runner_simple_text_response() -> None:
     assert complete.requests[0]["messages"][0]["role"] == "system"
     assert complete.requests[0]["messages"][1]["role"] == "user"
     assert complete.requests[0]["model"] is None
+    assert "turn_number" not in complete.requests[0]
 
 
 def test_runner_passes_explicit_model_override() -> None:


### PR DESCRIPTION
## Summary
- record every actual provider retry and fallback through one generation-scoped execution recorder
- normalize reported input, cached-input, output, reasoning, total, and raw usage without estimates
- persist JSON-safe redacted responses and bounded error envelopes while returning original provider responses unchanged
- retain the successful AI-call identity by turn for generation-6 tool provenance

## Verification
- 43 passed: final focused completion, runner, sanitization, and recorder tests
- 151 passed: complete generation-service and copied reporter suite
- 123 passed: untouched legacy reporter suite
- 31 passed: focused PostgreSQL AI-call, generation, submitted-output, migration, and constraint tests
- 178 passed: complete backend resource suite against disposable PostgreSQL
- compileall, 99-column, and git diff --check pass