### PR TITLE
Generation 6: record tool execution and progress

### DIFF
--- a/backend/services/generations/recorder.py
+++ b/backend/services/generations/recorder.py
@@ -1,4 +1,4 @@
-"""Durable generation-scoped adapter for reporter completion attempts."""
+"""Durable generation-scoped adapter for reporter execution events."""
 
 from __future__ import annotations
 
@@ -10,26 +10,47 @@ from backend.resources.reporting.ai_calls import (
     FinishAICall,
     TokenUsage,
 )
+from backend.resources.reporting.generations import (
+    GenerationManager,
+    UpdateGenerationProgress,
+)
+from backend.resources.reporting.tool_calls import (
+    BeginToolCall,
+    FinishToolCall,
+    ToolCallManager,
+)
 from backend.services.reporter.runner.recording import (
+    GenerationProgress,
     ModelAttemptFinish,
     ModelAttemptStart,
+    ToolExecutionFinish,
+    ToolExecutionStart,
 )
 
 
 class GenerationExecutionRecorder:
-    """Translate reporter completion events into durable AI-call resources."""
+    """Translate reporter execution events into durable reporting resources."""
 
-    def __init__(self, generation_id: UUID, manager: AICallManager) -> None:
+    def __init__(
+        self,
+        generation_id: UUID,
+        ai_call_manager: AICallManager,
+        tool_call_manager: ToolCallManager,
+        generation_manager: GenerationManager,
+    ) -> None:
         self._generation_id = generation_id
-        self._manager = manager
+        self._ai_call_manager = ai_call_manager
+        self._tool_call_manager = tool_call_manager
+        self._generation_manager = generation_manager
         self._successful_by_turn: dict[int, UUID] = {}
+        self._last_progress: tuple[int, str] | None = None
 
     @property
     def generation_id(self) -> UUID:
         return self._generation_id
 
     def begin_model_attempt(self, attempt: ModelAttemptStart) -> UUID:
-        started = self._manager.begin_ai_call(
+        started = self._ai_call_manager.begin_ai_call(
             BeginAICall(
                 generation_id=self._generation_id,
                 turn_number=attempt.turn_number,
@@ -47,7 +68,7 @@ class GenerationExecutionRecorder:
         attempt_id: UUID,
         result: ModelAttemptFinish,
     ) -> None:
-        finished = self._manager.finish_ai_call(
+        finished = self._ai_call_manager.finish_ai_call(
             FinishAICall(
                 ai_call_id=attempt_id,
                 status=result.status,
@@ -73,6 +94,55 @@ class GenerationExecutionRecorder:
 
     def successful_ai_call_id(self, turn_number: int) -> UUID | None:
         return self._successful_by_turn.get(turn_number)
+
+    def begin_tool_execution(self, execution: ToolExecutionStart) -> UUID:
+        ai_call_id = self.successful_ai_call_id(execution.turn_number)
+        if ai_call_id is None:
+            raise RuntimeError(
+                "tool execution requires a successful AI call for "
+                f"turn {execution.turn_number}"
+            )
+        started = self._tool_call_manager.begin_tool_call(
+            BeginToolCall(
+                generation_id=self._generation_id,
+                ai_call_id=ai_call_id,
+                tool_ordinal=execution.tool_ordinal,
+                provider_tool_call_id=execution.provider_tool_call_id,
+                tool_name=execution.tool_name,
+                implementation_version=execution.implementation_version,
+                arguments=execution.arguments,
+            )
+        )
+        return started.id
+
+    def finish_tool_execution(
+        self,
+        execution_id: UUID,
+        result: ToolExecutionFinish,
+    ) -> None:
+        self._tool_call_manager.finish_tool_call(
+            FinishToolCall(
+                tool_call_id=execution_id,
+                status=result.status,
+                full_result_text=result.full_result_text,
+                structured_result=result.structured_result,
+                error_text=result.error_text,
+                error=result.error,
+            )
+        )
+
+    def update_progress(self, progress: GenerationProgress) -> None:
+        checkpoint = (progress.current_turn, progress.current_stage)
+        if checkpoint == self._last_progress:
+            return
+        self._generation_manager.update_progress(
+            UpdateGenerationProgress(
+                generation_id=self._generation_id,
+                current_turn=progress.current_turn,
+                current_stage=progress.current_stage,
+            )
+        )
+        self._last_progress = checkpoint
 
 
 __all__ = ["GenerationExecutionRecorder"]

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from backend.services.reporter.config import ReportConfig
 from backend.services.reporter.runner.completion import (
@@ -25,7 +25,7 @@ from backend.services.reporter.runner.completion import (
     make_completion_client,
 )
 from backend.services.reporter.runner.memory_lifecycle import prepare_memory_run
-from backend.services.reporter.runner.recording import CompletionRecorder
+from backend.services.reporter.runner.recording import ExecutionRecorder
 from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
@@ -50,7 +50,7 @@ async def generate_article(
     runner_config: RunnerConfig | None = None,
     log_path: Path | None = None,
     complete: CompletionFn | None = None,
-    recorder: CompletionRecorder | None = None,
+    recorder: ExecutionRecorder | None = None,
     allow_memory_writes: bool = True,
 ) -> ReporterOutput:
     """Generate an article with the single-loop v2 runner.
@@ -64,7 +64,7 @@ async def generate_article(
         runner_config: Loop policy owned by Runner (max_turns, procedure mode).
         log_path: Optional streaming run-log path.
         complete: Injectable completion fn for tests. Mutually exclusive with client=.
-        recorder: Optional generation-scoped durable completion recorder.
+        recorder: Optional generation-scoped durable execution recorder.
         allow_memory_writes: When False (eval mode), skip memory mutations
             (lifecycle + in-run memory tools).
     """
@@ -81,11 +81,14 @@ async def generate_article(
         week=week,
         allow_memory_writes=allow_memory_writes,
     )
+    resolved_recorder = recorder
+    if resolved_recorder is None and client is not None:
+        resolved_recorder = cast(ExecutionRecorder | None, client.recorder)
     resolved_client = _resolve_client(
         client=client,
         completion=completion,
         complete=complete,
-        recorder=recorder,
+        recorder=resolved_recorder,
     )
 
     if log_path is not None:
@@ -108,6 +111,7 @@ async def generate_article(
         config=runner_config or RunnerConfig(),
         log_path=log_path,
         artifacts=artifacts,
+        recorder=resolved_recorder,
     )
 
     return await runner.run(_build_system_prompt(), _build_user_message(config))
@@ -140,7 +144,7 @@ def _resolve_client(
     client: CompletionClient | None,
     completion: CompletionSettings | None,
     complete: CompletionFn | None,
-    recorder: CompletionRecorder | None,
+    recorder: ExecutionRecorder | None,
 ) -> CompletionClient:
     if client is not None and complete is not None:
         raise ValueError("Pass client= or complete=, not both.")

--- a/backend/services/reporter/runner/recording.py
+++ b/backend/services/reporter/runner/recording.py
@@ -16,6 +16,7 @@ ModelAttemptStatus = Literal[
     "cancelled",
     "unknown_outcome",
 ]
+ToolExecutionStatus = Literal["succeeded", "failed", "cancelled"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +52,31 @@ class ModelAttemptFinish:
     usage: RecordedTokenUsage = field(default_factory=RecordedTokenUsage)
 
 
+@dataclass(frozen=True, slots=True)
+class ToolExecutionStart:
+    turn_number: int
+    tool_ordinal: int
+    provider_tool_call_id: str | None
+    tool_name: str
+    implementation_version: str
+    arguments: dict[str, JsonValue]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionFinish:
+    status: ToolExecutionStatus
+    full_result_text: str | None = None
+    structured_result: dict[str, JsonValue] | list[JsonValue] | None = None
+    error_text: str | None = None
+    error: dict[str, JsonValue] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationProgress:
+    current_turn: int
+    current_stage: str
+
+
 class CompletionRecorder(Protocol):
     """Record provider attempts for exactly one durable generation."""
 
@@ -65,10 +91,34 @@ class CompletionRecorder(Protocol):
     def successful_ai_call_id(self, turn_number: int) -> UUID | None: ...
 
 
+class RunnerRecorder(Protocol):
+    """Record tool execution and bounded progress for one reporter run."""
+
+    def begin_tool_execution(self, execution: ToolExecutionStart) -> UUID: ...
+
+    def finish_tool_execution(
+        self,
+        execution_id: UUID,
+        result: ToolExecutionFinish,
+    ) -> None: ...
+
+    def update_progress(self, progress: GenerationProgress) -> None: ...
+
+
+class ExecutionRecorder(CompletionRecorder, RunnerRecorder, Protocol):
+    """Complete durable recorder contract used by a generation run."""
+
+
 __all__ = [
     "CompletionRecorder",
+    "ExecutionRecorder",
+    "GenerationProgress",
     "ModelAttemptFinish",
     "ModelAttemptStart",
     "ModelAttemptStatus",
     "RecordedTokenUsage",
+    "RunnerRecorder",
+    "ToolExecutionFinish",
+    "ToolExecutionStart",
+    "ToolExecutionStatus",
 ]

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -12,7 +12,10 @@ import asyncio
 import json
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from uuid import UUID
+
+from pydantic import JsonValue
 
 from backend.services.reporter.runner.completion import (
     CompletionClient,
@@ -27,6 +30,13 @@ from backend.services.reporter.runner.models import (
     extract_tool_calls,
     tool_result_message,
 )
+from backend.services.reporter.runner.provider_telemetry import sanitize_provider_error
+from backend.services.reporter.runner.recording import (
+    GenerationProgress,
+    RunnerRecorder,
+    ToolExecutionFinish,
+    ToolExecutionStart,
+)
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import (
@@ -38,7 +48,14 @@ from backend.services.reporter.runner.state import (
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
-__all__ = ["CompletionFn", "Runner"]
+__all__ = ["CompletionFn", "Runner", "RunnerRecordingError"]
+
+
+_UNKNOWN_TOOL_IMPLEMENTATION_VERSION = "unregistered-v1"
+
+
+class RunnerRecordingError(RuntimeError):
+    """Durable runner recording failed, so execution cannot continue."""
 
 
 class Runner:
@@ -53,6 +70,7 @@ class Runner:
         config: RunnerConfig | None = None,
         log_path: Path | None = None,
         artifacts: ArtifactStore | None = None,
+        recorder: RunnerRecorder | None = None,
     ) -> None:
         if client is not None and complete is not None:
             raise ValueError("Pass client= or complete=, not both.")
@@ -65,6 +83,7 @@ class Runner:
             raise TypeError("Runner requires client= (or complete= for tests).")
 
         self.registry = registry
+        self._recorder = recorder
         self.config = config or RunnerConfig()
         self.artifacts = artifacts or ArtifactStore()
         self.procedures = ProcedureState()
@@ -95,6 +114,7 @@ class Runner:
         try:
             while turn < self.config.max_turns and not self._submitted:
                 turn += 1
+                self._record_progress(turn, self.procedures.active or "running")
                 response = await self._client.complete(
                     turn_number=turn,
                     messages=list(messages),
@@ -105,7 +125,13 @@ class Runner:
                 if calls:
                     self.registry.set_turn(turn)
                     messages.append(assistant_tool_call_message(calls, response))
+                    previous_stage = self.procedures.active
                     results = await self._execute_tool_batch(calls, turn)
+                    if (
+                        self.procedures.active is not None
+                        and self.procedures.active != previous_stage
+                    ):
+                        self._record_progress(turn, self.procedures.active)
                     for call, result_content in zip(calls, results):
                         if call.name == "load_procedure":
                             self._append_procedure_message(messages, call, result_content)
@@ -156,27 +182,84 @@ class Runner:
         turn: int,
     ) -> list[str]:
         executed = await asyncio.gather(
-            *[self._execute_tool(call, turn) for call in calls]
+            *[
+                self._execute_tool(call, turn, ordinal)
+                for ordinal, call in enumerate(calls)
+            ]
         )
         return list(executed)
 
-    async def _execute_tool(self, call: ToolCall, turn: int) -> str:
+    async def _execute_tool(
+        self,
+        call: ToolCall,
+        turn: int,
+        ordinal: int,
+    ) -> str:
         handler = self.registry.get_handler(call.name)
+        implementation_version = (
+            self.registry.get_implementation_version(call.name)
+            or _UNKNOWN_TOOL_IMPLEMENTATION_VERSION
+        )
+        execution_id = self._begin_tool_execution(
+            ToolExecutionStart(
+                turn_number=turn,
+                tool_ordinal=ordinal,
+                provider_tool_call_id=call.id or None,
+                tool_name=call.name,
+                implementation_version=implementation_version,
+                arguments=cast(dict[str, JsonValue], call.arguments),
+            )
+        )
+        start = time.time()
         if handler is None:
-            result: Any = {"error": f"Unknown tool: {call.name}"}
+            message = f"Unknown tool: {call.name}"
+            error: dict[str, JsonValue] = {
+                "type": "UnknownToolError",
+                "message": message,
+            }
+            result: Any = {"error": message}
             result_content = self._as_tool_result_content(result)
-            self.log.add_tool_call(call.name, call.arguments, result_content, 0, turn=turn)
+            duration_ms = self._duration_ms(start)
+            self.log.add_tool_call(
+                call.name,
+                call.arguments,
+                result_content,
+                duration_ms,
+                turn=turn,
+            )
+            self._finish_tool_execution(
+                execution_id,
+                ToolExecutionFinish(
+                    status="failed",
+                    full_result_text=result_content,
+                    structured_result=cast(dict[str, JsonValue], result),
+                    error_text=message,
+                    error=error,
+                ),
+            )
             return result_content
 
-        start = time.time()
         try:
             result = handler(**call.arguments)
             if asyncio.iscoroutine(result):
                 result = await result
+        except asyncio.CancelledError:
+            self._finish_tool_execution(
+                execution_id,
+                ToolExecutionFinish(status="cancelled"),
+            )
+            raise
         except Exception as exc:
-            result = {"error": str(exc)}
+            error = sanitize_provider_error(exc)
+            error_text = str(error.get("message") or type(exc).__name__)
+            result = {"error": error_text}
+            status = "failed"
+        else:
+            error = None
+            error_text = None
+            status = "succeeded"
 
-        duration_ms = int((time.time() - start) * 1000)
+        duration_ms = self._duration_ms(start)
         result_content = self._as_tool_result_content(result)
         self.log.add_tool_call(
             call.name,
@@ -185,11 +268,59 @@ class Runner:
             duration_ms,
             turn=turn,
         )
+        self._finish_tool_execution(
+            execution_id,
+            ToolExecutionFinish(
+                status=status,
+                full_result_text=result_content,
+                structured_result=self._structured_result(result_content),
+                error_text=error_text,
+                error=error,
+            ),
+        )
 
         if call.name == "submit_artifact" and self._is_successful_submit(result_content):
             self._submitted = True
 
         return result_content
+
+    def _begin_tool_execution(self, execution: ToolExecutionStart) -> UUID | None:
+        if self._recorder is None:
+            return None
+        try:
+            return self._recorder.begin_tool_execution(execution)
+        except Exception as exc:
+            raise RunnerRecordingError(
+                f"Could not begin durable tool execution for {execution.tool_name}"
+            ) from exc
+
+    def _finish_tool_execution(
+        self,
+        execution_id: UUID | None,
+        result: ToolExecutionFinish,
+    ) -> None:
+        if self._recorder is None:
+            return
+        if execution_id is None:
+            raise RunnerRecordingError("Durable tool execution ID is missing")
+        try:
+            self._recorder.finish_tool_execution(execution_id, result)
+        except Exception as exc:
+            raise RunnerRecordingError(
+                "Could not finish durable tool execution"
+            ) from exc
+
+    def _record_progress(self, turn: int, stage: str) -> None:
+        if self._recorder is None:
+            return
+        try:
+            self._recorder.update_progress(
+                GenerationProgress(current_turn=turn, current_stage=stage)
+            )
+        except Exception as exc:
+            raise RunnerRecordingError(
+                f"Could not record generation progress for turn {turn}"
+            ) from exc
 
     def _append_procedure_message(
         self,
@@ -221,6 +352,24 @@ class Runner:
         except json.JSONDecodeError:
             return False
         return isinstance(data, dict) and data.get("ok") is True
+
+    @staticmethod
+    def _structured_result(
+        result: str,
+    ) -> dict[str, JsonValue] | list[JsonValue] | None:
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if isinstance(parsed, dict):
+            return cast(dict[str, JsonValue], parsed)
+        if isinstance(parsed, list):
+            return cast(list[JsonValue], parsed)
+        return None
+
+    @staticmethod
+    def _duration_ms(start: float) -> int:
+        return max(0, int((time.time() - start) * 1000))
 
     @staticmethod
     def _summarize_result(result: str) -> str:

--- a/backend/services/reporter/runner/tools/registry.py
+++ b/backend/services/reporter/runner/tools/registry.py
@@ -54,6 +54,9 @@ class ToolRegistry:
     def get_handler(self, name: str) -> Callable[..., Any] | None:
         return self._handlers.get(name)
 
+    def get_implementation_version(self, name: str) -> str | None:
+        return self._implementation_versions.get(name)
+
     def set_turn(self, turn: int) -> None:
         if self._context is not None:
             self._context.turn = turn

--- a/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
+++ b/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
@@ -14,11 +14,17 @@ from backend.resources.reporting.generations import (
     GenerationManager,
     StartGeneration,
 )
+from backend.resources.reporting.tool_calls import ToolCallManager, ToolCallQuery
 from backend.services.generations import GenerationExecutionRecorder
 from backend.services.reporter.runner.completion import (
     CompletionClient,
     CompletionSettings,
     RetryPolicy,
+)
+from backend.services.reporter.runner.recording import (
+    GenerationProgress,
+    ToolExecutionFinish,
+    ToolExecutionStart,
 )
 from backend.tests.resources.reporting.generations.conftest import (
     GenerationDomain,
@@ -84,7 +90,15 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
             raise outcome
         return outcome
 
-    recorder = GenerationExecutionRecorder(generation_id, ai_call_manager)
+    context = generation_context(generation_domain)
+    generation_manager = GenerationManager(session_factory, context)
+    tool_call_manager = ToolCallManager(session_factory, context)
+    recorder = GenerationExecutionRecorder(
+        generation_id,
+        ai_call_manager,
+        tool_call_manager,
+        generation_manager,
+    )
     client = CompletionClient(
         complete,
         CompletionSettings(
@@ -107,3 +121,36 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     assert page.items[1].usage.input_tokens == 9
     assert page.items[1].usage.output_tokens == 4
     assert recorder.successful_ai_call_id(1) == page.items[1].id
+
+    recorder.update_progress(
+        GenerationProgress(current_turn=1, current_stage="research")
+    )
+    execution_id = recorder.begin_tool_execution(
+        ToolExecutionStart(
+            turn_number=1,
+            tool_ordinal=0,
+            provider_tool_call_id="provider-tool-1",
+            tool_name="lookup",
+            implementation_version="lookup-v1",
+            arguments={"week": 8},
+        )
+    )
+    recorder.finish_tool_execution(
+        execution_id,
+        ToolExecutionFinish(
+            status="succeeded",
+            full_result_text='{"ok": false}',
+            structured_result={"ok": False},
+        ),
+    )
+
+    generation = generation_manager.get(generation_id)
+    assert (generation.current_turn, generation.current_stage) == (1, "research")
+    tools = tool_call_manager.list(ToolCallQuery(generation_id=generation_id))
+    assert tools.total == 1
+    stored_tool = tool_call_manager.get(tools.items[0].id)
+    assert stored_tool.ai_call_id == page.items[1].id
+    assert stored_tool.tool_ordinal == 0
+    assert stored_tool.status.value == "succeeded"
+    assert stored_tool.full_result_text == '{"ok": false}'
+    assert stored_tool.structured_result == {"ok": False}

--- a/backend/tests/services/generations/test_recorder.py
+++ b/backend/tests/services/generations/test_recorder.py
@@ -6,12 +6,19 @@ from types import SimpleNamespace
 from typing import cast
 from uuid import UUID, uuid4
 
+import pytest
+
 from backend.resources.reporting.ai_calls import AICallManager
+from backend.resources.reporting.generations import GenerationManager
+from backend.resources.reporting.tool_calls import ToolCallManager
 from backend.services.generations import GenerationExecutionRecorder
 from backend.services.reporter.runner.recording import (
+    GenerationProgress,
     ModelAttemptFinish,
     ModelAttemptStart,
     RecordedTokenUsage,
+    ToolExecutionFinish,
+    ToolExecutionStart,
 )
 
 
@@ -36,13 +43,52 @@ class FakeAICallManager:
         )
 
 
+class FakeToolCallManager:
+    def __init__(self) -> None:
+        self.begun = []
+        self.finished = []
+
+    def begin_tool_call(self, command):
+        self.begun.append(command)
+        return SimpleNamespace(id=uuid4())
+
+    def finish_tool_call(self, command):
+        self.finished.append(command)
+        return SimpleNamespace(id=command.tool_call_id)
+
+
+class FakeGenerationManager:
+    def __init__(self) -> None:
+        self.progress = []
+
+    def update_progress(self, command):
+        self.progress.append(command)
+        return SimpleNamespace(id=command.generation_id)
+
+
+def make_recorder(
+    generation_id: UUID | None = None,
+) -> tuple[
+    GenerationExecutionRecorder,
+    FakeAICallManager,
+    FakeToolCallManager,
+    FakeGenerationManager,
+]:
+    ai_calls = FakeAICallManager()
+    tool_calls = FakeToolCallManager()
+    generations = FakeGenerationManager()
+    recorder = GenerationExecutionRecorder(
+        generation_id or uuid4(),
+        cast(AICallManager, ai_calls),
+        cast(ToolCallManager, tool_calls),
+        cast(GenerationManager, generations),
+    )
+    return recorder, ai_calls, tool_calls, generations
+
+
 def test_recorder_maps_reporter_events_and_retains_success_identity() -> None:
     generation_id = uuid4()
-    manager = FakeAICallManager()
-    recorder = GenerationExecutionRecorder(
-        generation_id,
-        cast(AICallManager, manager),
-    )
+    recorder, manager, _, _ = make_recorder(generation_id)
     attempt_id = recorder.begin_model_attempt(
         ModelAttemptStart(
             turn_number=2,
@@ -77,8 +123,7 @@ def test_recorder_maps_reporter_events_and_retains_success_identity() -> None:
 
 
 def test_failed_attempt_does_not_become_successful_identity() -> None:
-    manager = FakeAICallManager()
-    recorder = GenerationExecutionRecorder(uuid4(), cast(AICallManager, manager))
+    recorder, _, _, _ = make_recorder()
     attempt_id = recorder.begin_model_attempt(
         ModelAttemptStart(
             turn_number=1,
@@ -98,3 +143,100 @@ def test_failed_attempt_does_not_become_successful_identity() -> None:
     )
 
     assert recorder.successful_ai_call_id(1) is None
+
+
+def test_recorder_maps_tool_execution_to_successful_turn_provenance() -> None:
+    generation_id = uuid4()
+    recorder, _, tool_calls, _ = make_recorder(generation_id)
+    attempt_id = recorder.begin_model_attempt(
+        ModelAttemptStart(
+            turn_number=4,
+            requested_provider="openai",
+            requested_model="model",
+            input_messages=(),
+            tool_definitions=(),
+            request_parameters={},
+        )
+    )
+    recorder.finish_model_attempt(
+        attempt_id,
+        ModelAttemptFinish(
+            status="succeeded",
+            actual_model="model",
+            provider_response={"choices": []},
+        ),
+    )
+
+    execution_id = recorder.begin_tool_execution(
+        ToolExecutionStart(
+            turn_number=4,
+            tool_ordinal=2,
+            provider_tool_call_id="provider-call-2",
+            tool_name="lookup",
+            implementation_version="lookup-v3",
+            arguments={"week": 8},
+        )
+    )
+    recorder.finish_tool_execution(
+        execution_id,
+        ToolExecutionFinish(
+            status="succeeded",
+            full_result_text='{"found": true}',
+            structured_result={"found": True},
+        ),
+    )
+
+    begun = tool_calls.begun[0]
+    assert begun.generation_id == generation_id
+    assert begun.ai_call_id == attempt_id
+    assert begun.tool_ordinal == 2
+    assert begun.provider_tool_call_id == "provider-call-2"
+    assert begun.tool_name == "lookup"
+    assert begun.implementation_version == "lookup-v3"
+    assert begun.arguments == {"week": 8}
+    finished = tool_calls.finished[0]
+    assert finished.tool_call_id == execution_id
+    assert finished.status.value == "succeeded"
+    assert finished.full_result_text == '{"found": true}'
+    assert finished.structured_result == {"found": True}
+
+
+def test_recorder_rejects_tools_without_a_successful_turn() -> None:
+    recorder, _, tool_calls, _ = make_recorder()
+
+    with pytest.raises(RuntimeError, match="successful AI call"):
+        recorder.begin_tool_execution(
+            ToolExecutionStart(
+                turn_number=1,
+                tool_ordinal=0,
+                provider_tool_call_id=None,
+                tool_name="lookup",
+                implementation_version="v1",
+                arguments={},
+            )
+        )
+
+    assert tool_calls.begun == []
+
+
+def test_recorder_deduplicates_identical_progress_checkpoints() -> None:
+    generation_id = uuid4()
+    recorder, _, _, generations = make_recorder(generation_id)
+
+    recorder.update_progress(
+        GenerationProgress(current_turn=1, current_stage="running")
+    )
+    recorder.update_progress(
+        GenerationProgress(current_turn=1, current_stage="running")
+    )
+    recorder.update_progress(
+        GenerationProgress(current_turn=1, current_stage="research")
+    )
+
+    assert [
+        (command.generation_id, command.current_turn, command.current_stage)
+        for command in generations.progress
+    ] == [
+        (generation_id, 1, "running"),
+        (generation_id, 1, "research"),
+    ]

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -7,12 +7,18 @@ import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
+from uuid import UUID, uuid4
 
 import pytest
 
 from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
 from backend.services.reporter.runner.models import ToolCall
-from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.recording import (
+    GenerationProgress,
+    ToolExecutionFinish,
+    ToolExecutionStart,
+)
+from backend.services.reporter.runner.runner import Runner, RunnerRecordingError
 from backend.services.reporter.runner.state import (
     ArtifactStore,
     ProcedureHistoryMode,
@@ -20,7 +26,47 @@ from backend.services.reporter.runner.state import (
 )
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
 from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.procedure_tools import (
+    register_procedure_tools,
+)
 from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+class RecordingProbe:
+    def __init__(
+        self,
+        *,
+        fail_begin: bool = False,
+        fail_finish: bool = False,
+        fail_progress: bool = False,
+    ) -> None:
+        self.fail_begin = fail_begin
+        self.fail_finish = fail_finish
+        self.fail_progress = fail_progress
+        self.started: list[tuple[UUID, ToolExecutionStart]] = []
+        self.finished: list[tuple[UUID, ToolExecutionFinish]] = []
+        self.progress: list[GenerationProgress] = []
+
+    def begin_tool_execution(self, execution: ToolExecutionStart) -> UUID:
+        if self.fail_begin:
+            raise RuntimeError("database unavailable")
+        execution_id = uuid4()
+        self.started.append((execution_id, execution))
+        return execution_id
+
+    def finish_tool_execution(
+        self,
+        execution_id: UUID,
+        result: ToolExecutionFinish,
+    ) -> None:
+        if self.fail_finish:
+            raise RuntimeError("database unavailable")
+        self.finished.append((execution_id, result))
+
+    def update_progress(self, progress: GenerationProgress) -> None:
+        if self.fail_progress:
+            raise RuntimeError("database unavailable")
+        self.progress.append(progress)
 
 
 class FakeCompletion:
@@ -99,6 +145,8 @@ def test_tool_registry_exposes_specs_and_names() -> None:
     assert registry.tool_names == ["lookup"]
     assert registry.tool_specs == [tool_def("lookup")]
     assert registry.tool_implementation_versions == [("lookup", "test-v1")]
+    assert registry.get_implementation_version("lookup") == "test-v1"
+    assert registry.get_implementation_version("missing") is None
     assert registry.get_handler("lookup") is not None
     assert registry.get_handler("missing") is None
 
@@ -200,6 +248,187 @@ def test_runner_tool_call_dispatch() -> None:
     assert result_message["role"] == "tool"
     assert result_message["tool_call_id"] == "call_1"
     assert result_message["content"] == '{"ok": true, "value": 7}'
+
+
+def test_runner_records_parallel_tools_in_provider_order_with_exact_results() -> None:
+    async def handler(*, value: int, delay: float) -> dict[str, Any]:
+        await asyncio.sleep(delay)
+        return {"ok": value != 2, "value": value}
+
+    calls = [
+        tool_call("lookup", {"value": 1, "delay": 0.02}, "call_1"),
+        tool_call("lookup", {"value": 2, "delay": 0.0}, "call_2"),
+    ]
+    complete = FakeCompletion(
+        [make_response(tool_calls=calls), make_response(text="Done.")]
+    )
+    recorder = RecordingProbe()
+    runner = Runner(
+        registry_with("lookup", handler),
+        complete=complete,
+        recorder=recorder,
+    )
+
+    run(runner.run("system", "user"))
+
+    assert [event.tool_ordinal for _, event in recorder.started] == [0, 1]
+    assert [event.provider_tool_call_id for _, event in recorder.started] == [
+        "call_1",
+        "call_2",
+    ]
+    assert [result.status for _, result in recorder.finished] == [
+        "succeeded",
+        "succeeded",
+    ]
+    persisted_by_id = {
+        execution_id: result.full_result_text
+        for execution_id, result in recorder.finished
+    }
+    persisted_in_provider_order = [
+        persisted_by_id[execution_id] for execution_id, _ in recorder.started
+    ]
+    sent_results = [
+        message["content"]
+        for message in complete.requests[1]["messages"]
+        if message["role"] == "tool"
+    ]
+    assert persisted_in_provider_order == sent_results
+    assert json.loads(sent_results[1]) == {"ok": False, "value": 2}
+
+
+def test_runner_records_unknown_tools_and_sanitized_handler_exceptions() -> None:
+    def explode() -> None:
+        raise RuntimeError("Bearer secret-token api_key=top-secret")
+
+    registry = registry_with("explode", explode)
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("missing"), tool_call("explode", call_id="call_2")]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner = Runner(registry, complete=complete, recorder=recorder)
+
+    run(runner.run("system", "user"))
+
+    starts = [event for _, event in recorder.started]
+    assert starts[0].implementation_version == "unregistered-v1"
+    assert starts[1].implementation_version == "test-v1"
+    results = [result for _, result in recorder.finished]
+    assert [result.status for result in results] == ["failed", "failed"]
+    assert results[0].error == {
+        "type": "UnknownToolError",
+        "message": "Unknown tool: missing",
+    }
+    assert results[1].error is not None
+    assert results[1].error["type"] == "RuntimeError"
+    assert "secret-token" not in str(results[1].error)
+    assert "top-secret" not in str(results[1].error)
+    sent = [
+        message["content"]
+        for message in complete.requests[1]["messages"]
+        if message["role"] == "tool"
+    ]
+    assert sent == [result.full_result_text for result in results]
+
+
+def test_runner_records_tool_cancellation_and_reraises() -> None:
+    started = asyncio.Event()
+
+    async def wait_forever() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    async def scenario() -> None:
+        recorder = RecordingProbe()
+        runner = Runner(
+            registry_with("wait", wait_forever),
+            complete=FakeCompletion([]),
+            recorder=recorder,
+        )
+        task = asyncio.create_task(runner._execute_tool(tool_call("wait"), 1, 0))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert recorder.finished[0][1] == ToolExecutionFinish(status="cancelled")
+
+    run(scenario())
+
+
+def test_runner_records_bounded_turn_and_phase_progress() -> None:
+    registry = ToolRegistry()
+    register_artifact_tools(registry)
+    register_procedure_tools(registry)
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("load_procedure", {"name": "research"})]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner = Runner(registry, complete=complete, recorder=recorder)
+
+    run(runner.run("system", "user"))
+
+    assert recorder.progress == [
+        GenerationProgress(current_turn=1, current_stage="running"),
+        GenerationProgress(current_turn=1, current_stage="research"),
+        GenerationProgress(current_turn=2, current_stage="research"),
+    ]
+
+
+def test_runner_progress_recording_fails_closed_before_provider_call() -> None:
+    complete = FakeCompletion([make_response(text="Done.")])
+    runner = Runner(
+        ToolRegistry(),
+        complete=complete,
+        recorder=RecordingProbe(fail_progress=True),
+    )
+
+    with pytest.raises(RunnerRecordingError, match="progress"):
+        run(runner.run("system", "user"))
+
+    assert complete.requests == []
+
+
+def test_runner_tool_recording_fails_closed_around_handler() -> None:
+    calls: list[str] = []
+
+    def handler() -> str:
+        calls.append("called")
+        return "result"
+
+    responses = [
+        make_response(tool_calls=[tool_call("lookup")]),
+        make_response(text="Done."),
+    ]
+    begin_complete = FakeCompletion(list(responses))
+    begin_runner = Runner(
+        registry_with("lookup", handler),
+        complete=begin_complete,
+        recorder=RecordingProbe(fail_begin=True),
+    )
+    with pytest.raises(RunnerRecordingError, match="begin"):
+        run(begin_runner.run("system", "user"))
+    assert calls == []
+    assert len(begin_complete.requests) == 1
+
+    finish_complete = FakeCompletion(list(responses))
+    finish_runner = Runner(
+        registry_with("lookup", handler),
+        complete=finish_complete,
+        recorder=RecordingProbe(fail_finish=True),
+    )
+    with pytest.raises(RunnerRecordingError, match="finish"):
+        run(finish_runner.run("system", "user"))
+    assert calls == ["called"]
+    assert len(finish_complete.requests) == 1
 
 
 def test_runner_carries_tool_call_history_after_tool_call() -> None:


### PR DESCRIPTION
## Summary
- add composite reporter execution recording contracts
- persist every tool invocation with provider-order provenance and exact model-visible results
- emit deduplicated turn and procedure progress through the generation manager
- preserve local RunLog behavior and fail closed on durable recording errors

## Behavior
- normal handler returns, including domain error payloads, are successful invocations
- unknown tools and handler exceptions are failed with sanitized structured errors
- cancellations are recorded and re-raised
- parallel tool ordinals retain provider order
- progress writes are capped at turn start plus one phase change per batch

## Verification
- 51 focused reporter, completion, integration, and generation-recorder tests passed
- 11 focused PostgreSQL AI-call, tool-call, and generation lifecycle tests passed
- targeted compile, 99-column, and git diff checks passed

No database migration or legacy reporter_v2 changes.