### PR TITLE
feat(reporter): persist artifact mutations

### DIFF
--- a/backend/services/generations/recorder.py
+++ b/backend/services/generations/recorder.py
@@ -10,6 +10,11 @@ from backend.resources.reporting.ai_calls import (
     FinishAICall,
     TokenUsage,
 )
+from backend.resources.reporting.artifact_versions import (
+    AppendArtifactVersion,
+    ArtifactVersionManager,
+)
+from backend.resources.reporting.artifacts import ArtifactManager, CreateArtifact
 from backend.resources.reporting.generations import (
     GenerationManager,
     UpdateGenerationProgress,
@@ -20,6 +25,7 @@ from backend.resources.reporting.tool_calls import (
     ToolCallManager,
 )
 from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
     GenerationProgress,
     ModelAttemptFinish,
     ModelAttemptStart,
@@ -37,12 +43,17 @@ class GenerationExecutionRecorder:
         ai_call_manager: AICallManager,
         tool_call_manager: ToolCallManager,
         generation_manager: GenerationManager,
+        artifact_manager: ArtifactManager,
+        artifact_version_manager: ArtifactVersionManager,
     ) -> None:
         self._generation_id = generation_id
         self._ai_call_manager = ai_call_manager
         self._tool_call_manager = tool_call_manager
         self._generation_manager = generation_manager
+        self._artifact_manager = artifact_manager
+        self._artifact_version_manager = artifact_version_manager
         self._successful_by_turn: dict[int, UUID] = {}
+        self._tool_ai_calls: dict[UUID, UUID] = {}
         self._last_progress: tuple[int, str] | None = None
 
     @property
@@ -113,6 +124,7 @@ class GenerationExecutionRecorder:
                 arguments=execution.arguments,
             )
         )
+        self._tool_ai_calls[started.id] = ai_call_id
         return started.id
 
     def finish_tool_execution(
@@ -143,6 +155,50 @@ class GenerationExecutionRecorder:
             )
         )
         self._last_progress = checkpoint
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID:
+        source_ai_call_id: UUID | None = None
+        if mutation.source_tool_call_id is not None:
+            source_ai_call_id = self._tool_ai_calls.get(
+                mutation.source_tool_call_id
+            )
+            if source_ai_call_id is None:
+                raise RuntimeError(
+                    "artifact mutation requires a tool call begun by this recorder"
+                )
+
+        artifact = self._artifact_manager.create_artifact(
+            CreateArtifact(
+                generation_id=self._generation_id,
+                path=mutation.path,
+                media_type=mutation.media_type,
+            )
+        )
+        if (
+            artifact.generation_id != self._generation_id
+            or artifact.path != mutation.path
+            or artifact.media_type != mutation.media_type
+        ):
+            raise RuntimeError("durable artifact identity does not match mutation")
+
+        version = self._artifact_version_manager.append_artifact_version(
+            AppendArtifactVersion(
+                artifact_id=artifact.id,
+                content=mutation.content,
+                content_hash=mutation.content_hash,
+                source_ai_call_id=source_ai_call_id,
+                source_tool_call_id=mutation.source_tool_call_id,
+            )
+        )
+        if (
+            version.artifact_id != artifact.id
+            or version.generation_id != self._generation_id
+            or version.revision_number != mutation.revision
+            or version.content != mutation.content
+            or version.content_hash != mutation.content_hash
+        ):
+            raise RuntimeError("durable artifact version does not match mutation")
+        return version.id
 
 
 __all__ = ["GenerationExecutionRecorder"]

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -25,9 +25,13 @@ from backend.services.reporter.runner.completion import (
     make_completion_client,
 )
 from backend.services.reporter.runner.memory_lifecycle import prepare_memory_run
-from backend.services.reporter.runner.recording import ExecutionRecorder
+from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
+    ArtifactRecordingError,
+    ExecutionRecorder,
+)
 from backend.services.reporter.runner.runner import Runner
-from backend.services.reporter.runner.schemas import ReporterOutput
+from backend.services.reporter.runner.schemas import ArtifactSnapshot, ReporterOutput
 from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
 from backend.services.reporter.runner.tools.datalayer_tools import register_datalayer_tools
@@ -103,6 +107,11 @@ async def generate_article(
             league_id=league_id,
             league_name=league_name,
         ),
+        on_change=(
+            _seed_artifact_recorder(resolved_recorder)
+            if resolved_recorder is not None
+            else None
+        ),
     )
 
     runner = Runner(
@@ -115,6 +124,28 @@ async def generate_article(
     )
 
     return await runner.run(_build_system_prompt(), _build_user_message(config))
+
+
+def _seed_artifact_recorder(
+    recorder: ExecutionRecorder,
+) -> Callable[[ArtifactSnapshot], None]:
+    def record(snapshot: ArtifactSnapshot) -> None:
+        try:
+            recorder.record_artifact_mutation(
+                ArtifactMutation(
+                    path=snapshot.path,
+                    media_type=snapshot.media_type,
+                    content=snapshot.content,
+                    revision=snapshot.revision,
+                    content_hash=snapshot.content_hash,
+                )
+            )
+        except Exception as exc:
+            raise ArtifactRecordingError(
+                f"Could not record seeded artifact {snapshot.path}"
+            ) from exc
+
+    return record
 
 
 def _build_registry(

--- a/backend/services/reporter/runner/recording.py
+++ b/backend/services/reporter/runner/recording.py
@@ -19,6 +19,10 @@ ModelAttemptStatus = Literal[
 ToolExecutionStatus = Literal["succeeded", "failed", "cancelled"]
 
 
+class ArtifactRecordingError(RuntimeError):
+    """Durable artifact recording failed, so reporter execution must stop."""
+
+
 @dataclass(frozen=True, slots=True)
 class RecordedTokenUsage:
     input_tokens: int | None = None
@@ -72,6 +76,16 @@ class ToolExecutionFinish:
 
 
 @dataclass(frozen=True, slots=True)
+class ArtifactMutation:
+    path: str
+    media_type: Literal["text/markdown"]
+    content: str
+    revision: int
+    content_hash: str
+    source_tool_call_id: UUID | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class GenerationProgress:
     current_turn: int
     current_stage: str
@@ -105,11 +119,25 @@ class RunnerRecorder(Protocol):
     def update_progress(self, progress: GenerationProgress) -> None: ...
 
 
-class ExecutionRecorder(CompletionRecorder, RunnerRecorder, Protocol):
+class ArtifactRecorder(Protocol):
+    """Record complete immutable snapshots for one generation."""
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID: ...
+
+
+class ExecutionRecorder(
+    CompletionRecorder,
+    RunnerRecorder,
+    ArtifactRecorder,
+    Protocol,
+):
     """Complete durable recorder contract used by a generation run."""
 
 
 __all__ = [
+    "ArtifactMutation",
+    "ArtifactRecorder",
+    "ArtifactRecordingError",
     "CompletionRecorder",
     "ExecutionRecorder",
     "GenerationProgress",

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -32,6 +32,8 @@ from backend.services.reporter.runner.models import (
 )
 from backend.services.reporter.runner.provider_telemetry import sanitize_provider_error
 from backend.services.reporter.runner.recording import (
+    ArtifactRecorder,
+    ArtifactRecordingError,
     GenerationProgress,
     RunnerRecorder,
     ToolExecutionFinish,
@@ -92,6 +94,7 @@ class Runner:
             artifacts=self.artifacts,
             procedures=self.procedures,
             log=self.log,
+            artifact_recorder=self._artifact_recorder(recorder),
         )
         self.registry.set_context(self.tool_context)
         self._procedure_message_idx: int | None = None
@@ -239,16 +242,24 @@ class Runner:
             )
             return result_content
 
+        artifact_recording_error: ArtifactRecordingError | None = None
         try:
-            result = handler(**call.arguments)
-            if asyncio.iscoroutine(result):
-                result = await result
+            with self.tool_context.bind_tool_execution(execution_id):
+                result = handler(**call.arguments)
+                if asyncio.iscoroutine(result):
+                    result = await result
         except asyncio.CancelledError:
             self._finish_tool_execution(
                 execution_id,
                 ToolExecutionFinish(status="cancelled"),
             )
             raise
+        except ArtifactRecordingError as exc:
+            artifact_recording_error = exc
+            error = sanitize_provider_error(exc)
+            error_text = str(error.get("message") or type(exc).__name__)
+            result = {"error": error_text}
+            status = "failed"
         except Exception as exc:
             error = sanitize_provider_error(exc)
             error_text = str(error.get("message") or type(exc).__name__)
@@ -278,6 +289,11 @@ class Runner:
                 error=error,
             ),
         )
+
+        if artifact_recording_error is not None:
+            raise RunnerRecordingError(
+                "Could not record durable artifact mutation"
+            ) from artifact_recording_error
 
         if call.name == "submit_artifact" and self._is_successful_submit(result_content):
             self._submitted = True
@@ -321,6 +337,15 @@ class Runner:
             raise RunnerRecordingError(
                 f"Could not record generation progress for turn {turn}"
             ) from exc
+
+    @staticmethod
+    def _artifact_recorder(
+        recorder: RunnerRecorder | None,
+    ) -> ArtifactRecorder | None:
+        if recorder is None:
+            return None
+        method = getattr(recorder, "record_artifact_mutation", None)
+        return cast(ArtifactRecorder, recorder) if callable(method) else None
 
     def _append_procedure_message(
         self,

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
@@ -66,7 +67,13 @@ class ArtifactStore(BaseModel):
         normalized = self._normalize_path(path)
         return self._get(normalized).current
 
-    def create(self, path: str, content: str) -> ArtifactSnapshot:
+    def create(
+        self,
+        path: str,
+        content: str,
+        *,
+        on_change: Callable[[ArtifactSnapshot], None] | None = None,
+    ) -> ArtifactSnapshot:
         normalized = self._normalize_path(path)
         collision = self._casefold_collision(normalized)
         if collision is not None:
@@ -79,6 +86,12 @@ class ArtifactStore(BaseModel):
 
         artifact = WorkingArtifact.create(path=normalized, content=content)
         self.artifacts[normalized] = artifact
+        try:
+            if on_change is not None:
+                on_change(artifact.current)
+        except Exception:
+            del self.artifacts[normalized]
+            raise
         return artifact.current
 
     def edit(
@@ -88,6 +101,7 @@ class ArtifactStore(BaseModel):
         old_text: str,
         new_text: str,
         expected_revision: int,
+        on_change: Callable[[ArtifactSnapshot], None] | None = None,
     ) -> tuple[ArtifactSnapshot, bool]:
         normalized = self._normalize_path(path)
         artifact = self._get(normalized)
@@ -127,7 +141,15 @@ class ArtifactStore(BaseModel):
         if updated == artifact.current.content:
             return artifact.current, False
 
-        return artifact.append(updated), True
+        previous_snapshots = artifact.snapshots
+        snapshot = artifact.append(updated)
+        try:
+            if on_change is not None:
+                on_change(snapshot)
+        except Exception:
+            artifact.snapshots = previous_snapshots
+            raise
+        return snapshot, True
 
     def submit(self, path: str, *, expected_revision: int) -> ArtifactSnapshot:
         normalized = self._normalize_path(path)

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 
-ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "1"
+ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "2"
 
 
 ARTIFACT_TOOL_SPECS: list[ToolDef] = [
@@ -80,7 +80,10 @@ ARTIFACT_TOOL_SPECS: list[ToolDef] = [
                     "path": {"type": "string"},
                     "old_text": {
                         "type": "string",
-                        "description": "Exact non-empty text expected once, including whitespace.",
+                        "description": (
+                            "Exact non-empty text expected once, including "
+                            "whitespace."
+                        ),
                     },
                     "new_text": {"type": "string"},
                     "expected_revision": {
@@ -171,7 +174,11 @@ def read_artifact(ctx: ToolContext, *, path: str) -> str:
 
 def create_artifact(ctx: ToolContext, *, path: str, content: str) -> str:
     def operation() -> str:
-        artifact = ctx.artifacts.create(path, content)
+        artifact = ctx.artifacts.create(
+            path,
+            content,
+            on_change=ctx.record_artifact_mutation,
+        )
         ctx.log.add_artifact_write(
             artifact.path,
             "create_artifact",
@@ -200,6 +207,7 @@ def edit_artifact(
             old_text=old_text,
             new_text=new_text,
             expected_revision=expected_revision,
+            on_change=ctx.record_artifact_mutation,
         )
         if changed:
             ctx.log.add_artifact_write(

--- a/backend/services/reporter/runner/tools/context.py
+++ b/backend/services/reporter/runner/tools/context.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
+from uuid import UUID
 
+from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
+    ArtifactRecorder,
+    ArtifactRecordingError,
+)
 from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.schemas import ArtifactSnapshot
 from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
 
 
@@ -14,3 +24,40 @@ class ToolContext:
     procedures: ProcedureState
     log: RunLog
     turn: int = 0
+    artifact_recorder: ArtifactRecorder | None = None
+
+    def __post_init__(self) -> None:
+        self._source_tool_call_id: ContextVar[UUID | None] = ContextVar(
+            f"reporter_source_tool_call_id_{id(self)}",
+            default=None,
+        )
+
+    @contextmanager
+    def bind_tool_execution(
+        self,
+        tool_call_id: UUID | None,
+    ) -> Iterator[None]:
+        token: Token[UUID | None] = self._source_tool_call_id.set(tool_call_id)
+        try:
+            yield
+        finally:
+            self._source_tool_call_id.reset(token)
+
+    def record_artifact_mutation(self, snapshot: ArtifactSnapshot) -> None:
+        if self.artifact_recorder is None:
+            return
+        try:
+            self.artifact_recorder.record_artifact_mutation(
+                ArtifactMutation(
+                    path=snapshot.path,
+                    media_type=snapshot.media_type,
+                    content=snapshot.content,
+                    revision=snapshot.revision,
+                    content_hash=snapshot.content_hash,
+                    source_tool_call_id=self._source_tool_call_id.get(),
+                )
+            )
+        except Exception as exc:
+            raise ArtifactRecordingError(
+                f"Could not record artifact mutation for {snapshot.path}"
+            ) from exc

--- a/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
+++ b/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+import hashlib
 from typing import Any
 from uuid import UUID, uuid4
 
 from backend.database.sessions import SessionFactory
 from backend.resources.reporting.ai_calls import AICallManager, AICallQuery
+from backend.resources.reporting.artifact_versions import (
+    ArtifactVersionManager,
+    ArtifactVersionQuery,
+)
+from backend.resources.reporting.artifacts import (
+    ArtifactManager,
+    ArtifactQuery,
+)
 from backend.resources.reporting.generations import (
     CreateGeneration,
     GenerationManager,
@@ -22,6 +31,7 @@ from backend.services.reporter.runner.completion import (
     RetryPolicy,
 )
 from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
     GenerationProgress,
     ToolExecutionFinish,
     ToolExecutionStart,
@@ -93,11 +103,27 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     context = generation_context(generation_domain)
     generation_manager = GenerationManager(session_factory, context)
     tool_call_manager = ToolCallManager(session_factory, context)
+    artifact_manager = ArtifactManager(session_factory, context)
+    artifact_version_manager = ArtifactVersionManager(session_factory, context)
     recorder = GenerationExecutionRecorder(
         generation_id,
         ai_call_manager,
         tool_call_manager,
         generation_manager,
+        artifact_manager,
+        artifact_version_manager,
+    )
+    seed_content = "# Brief"
+    seed_version_id = recorder.record_artifact_mutation(
+        ArtifactMutation(
+            path="research/brief.md",
+            media_type="text/markdown",
+            content=seed_content,
+            revision=1,
+            content_hash=hashlib.sha256(
+                seed_content.encode("utf-8")
+            ).hexdigest(),
+        )
     )
     client = CompletionClient(
         complete,
@@ -135,6 +161,19 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
             arguments={"week": 8},
         )
     )
+    edited_content = "# Brief\n\nVerified fact."
+    edited_version_id = recorder.record_artifact_mutation(
+        ArtifactMutation(
+            path="research/brief.md",
+            media_type="text/markdown",
+            content=edited_content,
+            revision=2,
+            content_hash=hashlib.sha256(
+                edited_content.encode("utf-8")
+            ).hexdigest(),
+            source_tool_call_id=execution_id,
+        )
+    )
     recorder.finish_tool_execution(
         execution_id,
         ToolExecutionFinish(
@@ -154,3 +193,17 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     assert stored_tool.status.value == "succeeded"
     assert stored_tool.full_result_text == '{"ok": false}'
     assert stored_tool.structured_result == {"ok": False}
+
+    artifacts = artifact_manager.list(ArtifactQuery(generation_id=generation_id))
+    assert artifacts.total == 1
+    versions = artifact_version_manager.list(
+        ArtifactVersionQuery(artifact_id=artifacts.items[0].id)
+    )
+    assert [item.revision_number for item in versions.items] == [1, 2]
+    seed_version = artifact_version_manager.get(seed_version_id)
+    edited_version = artifact_version_manager.get(edited_version_id)
+    assert seed_version.source_ai_call_id is None
+    assert seed_version.source_tool_call_id is None
+    assert edited_version.source_ai_call_id == page.items[1].id
+    assert edited_version.source_tool_call_id == execution_id
+    assert edited_version.content == edited_content

--- a/backend/tests/services/generations/test_manifest.py
+++ b/backend/tests/services/generations/test_manifest.py
@@ -126,7 +126,7 @@ def test_manifest_has_a_locked_schema_and_hash() -> None:
     assert built.schema_version == 1
     assert built.manifest["schema_version"] == 1
     assert built.manifest_hash == (
-        "6c8f715099f5421247c7bff04a01b103cbfb007ec391b292920b09a5c5cbb3a3"
+        "7990c2c3dfa07301b107b8091e66f21b601acb76a501492f9fb4d2a059e9bf3d"
     )
     assert built.canonical_bytes.decode("utf-8").startswith(
         '{"assets":{"procedures":[{"content_sha256":"'
@@ -189,7 +189,7 @@ def test_every_versioned_input_changes_manifest_identity(field: str) -> None:
         tool = inputs.tools[0].model_copy(update={"definition": definition})
         changed = inputs.model_copy(update={"tools": (tool, *inputs.tools[1:])})
     elif field == "tool_version":
-        tool = inputs.tools[0].model_copy(update={"implementation_version": "2"})
+        tool = inputs.tools[0].model_copy(update={"implementation_version": "3"})
         changed = inputs.model_copy(update={"tools": (tool, *inputs.tools[1:])})
     else:
         code = inputs.code.model_copy(update={"reporter_revision": "reporter-next"})

--- a/backend/tests/services/generations/test_recorder.py
+++ b/backend/tests/services/generations/test_recorder.py
@@ -9,10 +9,13 @@ from uuid import UUID, uuid4
 import pytest
 
 from backend.resources.reporting.ai_calls import AICallManager
+from backend.resources.reporting.artifact_versions import ArtifactVersionManager
+from backend.resources.reporting.artifacts import ArtifactManager
 from backend.resources.reporting.generations import GenerationManager
 from backend.resources.reporting.tool_calls import ToolCallManager
 from backend.services.generations import GenerationExecutionRecorder
 from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
     GenerationProgress,
     ModelAttemptFinish,
     ModelAttemptStart,
@@ -66,6 +69,51 @@ class FakeGenerationManager:
         return SimpleNamespace(id=command.generation_id)
 
 
+class FakeArtifactManager:
+    def __init__(self) -> None:
+        self.created = []
+        self.ids: dict[str, UUID] = {}
+
+    def create_artifact(self, command):
+        self.created.append(command)
+        artifact_id = self.ids.setdefault(command.path, uuid4())
+        return SimpleNamespace(
+            id=artifact_id,
+            generation_id=command.generation_id,
+            path=command.path,
+            media_type=command.media_type,
+        )
+
+
+class FakeArtifactVersionManager:
+    def __init__(self, generation_id: UUID) -> None:
+        self.generation_id = generation_id
+        self.appended = []
+        self.versions: dict[UUID, list[SimpleNamespace]] = {}
+
+    def append_artifact_version(self, command):
+        self.appended.append(command)
+        versions = self.versions.setdefault(command.artifact_id, [])
+        if (
+            versions
+            and versions[-1].content == command.content
+            and versions[-1].content_hash == command.content_hash
+        ):
+            return versions[-1]
+        version = SimpleNamespace(
+            id=uuid4(),
+            artifact_id=command.artifact_id,
+            generation_id=self.generation_id,
+            revision_number=len(versions) + 1,
+            content=command.content,
+            content_hash=command.content_hash,
+            source_ai_call_id=command.source_ai_call_id,
+            source_tool_call_id=command.source_tool_call_id,
+        )
+        versions.append(version)
+        return version
+
+
 def make_recorder(
     generation_id: UUID | None = None,
 ) -> tuple[
@@ -73,22 +121,36 @@ def make_recorder(
     FakeAICallManager,
     FakeToolCallManager,
     FakeGenerationManager,
+    FakeArtifactManager,
+    FakeArtifactVersionManager,
 ]:
+    resolved_generation_id = generation_id or uuid4()
     ai_calls = FakeAICallManager()
     tool_calls = FakeToolCallManager()
     generations = FakeGenerationManager()
+    artifacts = FakeArtifactManager()
+    artifact_versions = FakeArtifactVersionManager(resolved_generation_id)
     recorder = GenerationExecutionRecorder(
-        generation_id or uuid4(),
+        resolved_generation_id,
         cast(AICallManager, ai_calls),
         cast(ToolCallManager, tool_calls),
         cast(GenerationManager, generations),
+        cast(ArtifactManager, artifacts),
+        cast(ArtifactVersionManager, artifact_versions),
     )
-    return recorder, ai_calls, tool_calls, generations
+    return (
+        recorder,
+        ai_calls,
+        tool_calls,
+        generations,
+        artifacts,
+        artifact_versions,
+    )
 
 
 def test_recorder_maps_reporter_events_and_retains_success_identity() -> None:
     generation_id = uuid4()
-    recorder, manager, _, _ = make_recorder(generation_id)
+    recorder, manager, _, _, _, _ = make_recorder(generation_id)
     attempt_id = recorder.begin_model_attempt(
         ModelAttemptStart(
             turn_number=2,
@@ -123,7 +185,7 @@ def test_recorder_maps_reporter_events_and_retains_success_identity() -> None:
 
 
 def test_failed_attempt_does_not_become_successful_identity() -> None:
-    recorder, _, _, _ = make_recorder()
+    recorder, _, _, _, _, _ = make_recorder()
     attempt_id = recorder.begin_model_attempt(
         ModelAttemptStart(
             turn_number=1,
@@ -147,7 +209,7 @@ def test_failed_attempt_does_not_become_successful_identity() -> None:
 
 def test_recorder_maps_tool_execution_to_successful_turn_provenance() -> None:
     generation_id = uuid4()
-    recorder, _, tool_calls, _ = make_recorder(generation_id)
+    recorder, _, tool_calls, _, _, _ = make_recorder(generation_id)
     attempt_id = recorder.begin_model_attempt(
         ModelAttemptStart(
             turn_number=4,
@@ -202,7 +264,7 @@ def test_recorder_maps_tool_execution_to_successful_turn_provenance() -> None:
 
 
 def test_recorder_rejects_tools_without_a_successful_turn() -> None:
-    recorder, _, tool_calls, _ = make_recorder()
+    recorder, _, tool_calls, _, _, _ = make_recorder()
 
     with pytest.raises(RuntimeError, match="successful AI call"):
         recorder.begin_tool_execution(
@@ -221,7 +283,7 @@ def test_recorder_rejects_tools_without_a_successful_turn() -> None:
 
 def test_recorder_deduplicates_identical_progress_checkpoints() -> None:
     generation_id = uuid4()
-    recorder, _, _, generations = make_recorder(generation_id)
+    recorder, _, _, generations, _, _ = make_recorder(generation_id)
 
     recorder.update_progress(
         GenerationProgress(current_turn=1, current_stage="running")
@@ -240,3 +302,89 @@ def test_recorder_deduplicates_identical_progress_checkpoints() -> None:
         (generation_id, 1, "running"),
         (generation_id, 1, "research"),
     ]
+
+
+def test_recorder_persists_seed_and_tool_mutations_with_exact_provenance() -> None:
+    generation_id = uuid4()
+    recorder, _, _, _, artifacts, versions = make_recorder(generation_id)
+    seed = ArtifactMutation(
+        path="research/brief.md",
+        media_type="text/markdown",
+        content="# Brief",
+        revision=1,
+        content_hash="fd55350669a978d5a8cde0218d92baa5d6f8e1c9102f40cc42301a56543cc99d",
+    )
+    recorder.record_artifact_mutation(seed)
+
+    attempt_id = recorder.begin_model_attempt(
+        ModelAttemptStart(
+            turn_number=1,
+            requested_provider=None,
+            requested_model="model",
+            input_messages=(),
+            tool_definitions=(),
+            request_parameters={},
+        )
+    )
+    recorder.finish_model_attempt(
+        attempt_id,
+        ModelAttemptFinish(
+            status="succeeded",
+            actual_model="model",
+            provider_response={"choices": []},
+        ),
+    )
+    execution_id = recorder.begin_tool_execution(
+        ToolExecutionStart(
+            turn_number=1,
+            tool_ordinal=0,
+            provider_tool_call_id="call-1",
+            tool_name="edit_artifact",
+            implementation_version="2",
+            arguments={},
+        )
+    )
+    edited = ArtifactMutation(
+        path="research/brief.md",
+        media_type="text/markdown",
+        content="# Brief\n\nFact",
+        revision=2,
+        content_hash="08808033cd0b39693b096ed7cf4553f0186b76aae404c125b8ddb66b88680862",
+        source_tool_call_id=execution_id,
+    )
+    version_id = recorder.record_artifact_mutation(edited)
+
+    assert len(artifacts.created) == 2
+    seed_command, edit_command = versions.appended
+    assert seed_command.source_ai_call_id is None
+    assert seed_command.source_tool_call_id is None
+    assert edit_command.source_ai_call_id == attempt_id
+    assert edit_command.source_tool_call_id == execution_id
+    assert version_id == next(iter(versions.versions.values()))[-1].id
+
+
+def test_recorder_returns_identical_version_and_rejects_revision_drift() -> None:
+    recorder, _, _, _, _, versions = make_recorder()
+    mutation = ArtifactMutation(
+        path="article.md",
+        media_type="text/markdown",
+        content="same",
+        revision=1,
+        content_hash="0967115f2813a3541eaef77de9d9d5773f1c0c04314b0bbfe4ff3b3b1c55b5d5",
+    )
+
+    first = recorder.record_artifact_mutation(mutation)
+    repeated = recorder.record_artifact_mutation(mutation)
+
+    assert repeated == first
+    assert len(next(iter(versions.versions.values()))) == 1
+
+    drifted = ArtifactMutation(
+        path="article.md",
+        media_type="text/markdown",
+        content="different",
+        revision=3,
+        content_hash="9d6f965ac832e40a5df6c06afe983e3b449c07b843ff51ce76204de05c690d11",
+    )
+    with pytest.raises(RuntimeError, match="does not match mutation"):
+        recorder.record_artifact_mutation(drifted)

--- a/backend/tests/services/reporter/test_artifact_tools.py
+++ b/backend/tests/services/reporter/test_artifact_tools.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 import json
+from uuid import UUID, uuid4
 
+import pytest
+
+from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
+    ArtifactRecordingError,
+)
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
 from backend.services.reporter.runner.tools.artifact_tools import (
@@ -17,12 +24,27 @@ from backend.services.reporter.runner.tools.artifact_tools import (
 from backend.services.reporter.runner.tools.context import ToolContext
 
 
-def make_ctx() -> ToolContext:
+class ArtifactRecordingProbe:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.mutations: list[ArtifactMutation] = []
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID:
+        if self.fail:
+            raise RuntimeError("database unavailable")
+        self.mutations.append(mutation)
+        return uuid4()
+
+
+def make_ctx(
+    recorder: ArtifactRecordingProbe | None = None,
+) -> ToolContext:
     return ToolContext(
         artifacts=ArtifactStore(),
         procedures=ProcedureState(),
         log=RunLog(session_id="testlog"),
         turn=3,
+        artifact_recorder=recorder,
     )
 
 
@@ -256,3 +278,60 @@ def test_submit_pins_existing_snapshot_and_final_artifact_is_immutable() -> None
     assert rejected_edit["error"]["code"] == "artifact_finalized"
     assert ctx.log.entries[-2].data["operation"] == "submit_artifact"
     assert ctx.log.entries[-1].event_type == "completion"
+
+
+def test_only_changed_mutations_are_recorded_with_bound_tool_provenance() -> None:
+    recorder = ArtifactRecordingProbe()
+    ctx = make_ctx(recorder)
+    create_call_id = uuid4()
+    edit_call_id = uuid4()
+
+    with ctx.bind_tool_execution(create_call_id):
+        create_artifact(ctx, path="article.md", content="Stable")
+    read_artifact(ctx, path="article.md")
+    with ctx.bind_tool_execution(uuid4()):
+        edit_artifact(
+            ctx,
+            path="article.md",
+            old_text="Stable",
+            new_text="Stable",
+            expected_revision=1,
+        )
+    with ctx.bind_tool_execution(edit_call_id):
+        edit_artifact(
+            ctx,
+            path="article.md",
+            old_text="Stable",
+            new_text="Changed",
+            expected_revision=1,
+        )
+    submit_artifact(ctx, path="article.md", expected_revision=2)
+
+    assert [mutation.revision for mutation in recorder.mutations] == [1, 2]
+    assert [
+        mutation.source_tool_call_id for mutation in recorder.mutations
+    ] == [create_call_id, edit_call_id]
+    assert recorder.mutations[-1].content == "Changed"
+
+
+def test_recording_failure_rolls_back_create_and_edit() -> None:
+    create_ctx = make_ctx(ArtifactRecordingProbe(fail=True))
+    with pytest.raises(ArtifactRecordingError, match="article.md"):
+        create_artifact(create_ctx, path="article.md", content="Draft")
+    assert create_ctx.artifacts.list() == ()
+
+    edit_ctx = make_ctx()
+    create_artifact(edit_ctx, path="article.md", content="Draft")
+    edit_ctx.artifact_recorder = ArtifactRecordingProbe(fail=True)
+    with pytest.raises(ArtifactRecordingError, match="article.md"):
+        edit_artifact(
+            edit_ctx,
+            path="article.md",
+            old_text="Draft",
+            new_text="Changed",
+            expected_revision=1,
+        )
+
+    snapshot = edit_ctx.artifacts.read("article.md")
+    assert snapshot.revision == 1
+    assert snapshot.content == "Draft"

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -6,11 +6,13 @@ import asyncio
 import json
 from types import SimpleNamespace
 from typing import Any
+from uuid import UUID, uuid4
 
 from backend.services.reporter.config import ReportConfig, TimeRange
 from backend.services.reporter.generator import generate_article
 from backend.services.reporter.runner.completion import CompletionSettings
 from backend.services.reporter.runner.models import ToolCall
+from backend.services.reporter.runner.recording import ArtifactMutation
 
 
 class FakeCompletion:
@@ -23,6 +25,43 @@ class FakeCompletion:
         if not self.responses:
             return make_response(text="Done.")
         return self.responses.pop(0)
+
+
+class ExecutionRecordingProbe:
+    def __init__(self) -> None:
+        self.attempt_turns: dict[UUID, int] = {}
+        self.successful_turns: dict[int, UUID] = {}
+        self.tool_ai_calls: dict[UUID, UUID] = {}
+        self.artifact_mutations: list[ArtifactMutation] = []
+
+    def begin_model_attempt(self, attempt):
+        attempt_id = uuid4()
+        self.attempt_turns[attempt_id] = attempt.turn_number
+        return attempt_id
+
+    def finish_model_attempt(self, attempt_id, result):
+        if result.status == "succeeded":
+            self.successful_turns[self.attempt_turns[attempt_id]] = attempt_id
+
+    def successful_ai_call_id(self, turn_number):
+        return self.successful_turns.get(turn_number)
+
+    def begin_tool_execution(self, execution):
+        execution_id = uuid4()
+        self.tool_ai_calls[execution_id] = self.successful_turns[
+            execution.turn_number
+        ]
+        return execution_id
+
+    def finish_tool_execution(self, execution_id, result):
+        del execution_id, result
+
+    def update_progress(self, progress):
+        del progress
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID:
+        self.artifact_mutations.append(mutation)
+        return uuid4()
 
 
 class FakeFrozenLeagueData:
@@ -96,6 +135,7 @@ def run(coro: Any) -> Any:
 
 
 def test_generate_article_end_to_end_tool_loop() -> None:
+    recorder = ExecutionRecordingProbe()
     complete = FakeCompletion(
         [
             make_response(
@@ -239,6 +279,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
             ),
             completion=CompletionSettings(model="test-model"),
             complete=complete,
+            recorder=recorder,
         )
     )
 
@@ -286,6 +327,21 @@ def test_generate_article_end_to_end_tool_loop() -> None:
         tool_names
     )
     assert "league_snapshot" in tool_names
+    histories = {
+        path: [
+            mutation
+            for mutation in recorder.artifact_mutations
+            if mutation.path == path
+        ]
+        for path in ("research/brief.md", "article.md")
+    }
+    assert [item.revision for item in histories["research/brief.md"]] == [1, 2, 3]
+    assert histories["research/brief.md"][0].source_tool_call_id is None
+    assert [item.revision for item in histories["article.md"]] == [1, 2]
+    tool_mutations = (
+        histories["research/brief.md"][1:] + histories["article.md"]
+    )
+    assert all(item.source_tool_call_id is not None for item in tool_mutations)
 
 
 def test_generate_article_allows_backtracking_from_drafting_to_research() -> None:

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -14,6 +14,7 @@ import pytest
 from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
 from backend.services.reporter.runner.models import ToolCall
 from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
     GenerationProgress,
     ToolExecutionFinish,
     ToolExecutionStart,
@@ -39,13 +40,16 @@ class RecordingProbe:
         fail_begin: bool = False,
         fail_finish: bool = False,
         fail_progress: bool = False,
+        fail_artifact: bool = False,
     ) -> None:
         self.fail_begin = fail_begin
         self.fail_finish = fail_finish
         self.fail_progress = fail_progress
+        self.fail_artifact = fail_artifact
         self.started: list[tuple[UUID, ToolExecutionStart]] = []
         self.finished: list[tuple[UUID, ToolExecutionFinish]] = []
         self.progress: list[GenerationProgress] = []
+        self.artifact_mutations: list[ArtifactMutation] = []
 
     def begin_tool_execution(self, execution: ToolExecutionStart) -> UUID:
         if self.fail_begin:
@@ -67,6 +71,12 @@ class RecordingProbe:
         if self.fail_progress:
             raise RuntimeError("database unavailable")
         self.progress.append(progress)
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID:
+        if self.fail_artifact:
+            raise RuntimeError("database unavailable")
+        self.artifact_mutations.append(mutation)
+        return uuid4()
 
 
 class FakeCompletion:
@@ -429,6 +439,64 @@ def test_runner_tool_recording_fails_closed_around_handler() -> None:
         run(finish_runner.run("system", "user"))
     assert calls == ["called"]
     assert len(finish_complete.requests) == 1
+
+
+def test_runner_artifact_recording_fails_closed_and_rolls_back() -> None:
+    registry = ToolRegistry()
+    register_artifact_tools(registry)
+    recorder = RecordingProbe(fail_artifact=True)
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "create_artifact",
+                        {"path": "article.md", "content": "Draft"},
+                    )
+                ]
+            )
+        ]
+    )
+    runner = Runner(registry, complete=complete, recorder=recorder)
+
+    with pytest.raises(RunnerRecordingError, match="artifact"):
+        run(runner.run("system", "user"))
+
+    assert runner.artifacts.list() == ()
+    assert recorder.finished[-1][1].status == "failed"
+
+
+def test_runner_parallel_artifact_provenance_is_invocation_local() -> None:
+    registry = ToolRegistry()
+    register_artifact_tools(registry)
+    recorder = RecordingProbe()
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "create_artifact",
+                        {"path": "one.md", "content": "One"},
+                        "create_1",
+                    ),
+                    tool_call(
+                        "create_artifact",
+                        {"path": "two.md", "content": "Two"},
+                        "create_2",
+                    ),
+                ]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry, complete=complete, recorder=recorder)
+
+    run(runner.run("system", "user"))
+
+    started_ids = [execution_id for execution_id, _ in recorder.started]
+    assert [
+        mutation.source_tool_call_id for mutation in recorder.artifact_mutations
+    ] == started_ids
 
 
 def test_runner_carries_tool_call_history_after_tool_call() -> None:

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -346,6 +346,8 @@ as a new immutable version. There is deliberately no `replace_all` mode.
 `list_artifacts` and `read_artifact` never append versions. Failed mutations and
 content-identical edits do not append versions. Each successful create/edit
 passes its complete snapshot to the recorder with source AI/tool provenance.
+The generator records its seeded `research/brief.md` snapshot as revision 1
+before the first model call, with no source AI call or tool call.
 
 `submit_artifact` accepts any non-empty artifact, requires its expected current
 revision, records no content version, and ends the reporter loop. The resulting

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -333,6 +333,11 @@ complete snapshots at successful mutation boundaries:
 | publishable draft artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision regardless of path |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
+The reporter-owned `research/brief.md` seed is persisted as revision 1 before
+the first provider call, without AI-call or tool-call provenance. Subsequent
+reporter edits therefore retain the same revision numbers in memory and in
+durable storage.
+
 Artifact versions use their source AI call/tool call when available. Reads do
 not append versions. Failed and content-identical mutations do not append
 versions. Durable finalization pins the selected version both on its artifact


### PR DESCRIPTION
## Summary
- persist seeded, created, and edited Markdown snapshots as immutable reporting artifact versions
- preserve exact AI/tool provenance through invocation-local bindings and fail closed with in-memory rollback
- keep reads, no-op/failed mutations, and submission version-free while retaining exact revision alignment

## Verification
- 59 focused reporter/generation tests passed
- 6 focused PostgreSQL artifact/provenance tests passed
- 6 reporter characterization/import-boundary tests passed
- compile, 99-column, and git diff checks passed