### PR TITLE
feat(datalayer): add frozen roster identities

### DIFF
--- a/backend/composition.py
+++ b/backend/composition.py
@@ -24,6 +24,7 @@ from backend.resources.sleeper_data import (
     LeagueSeasonManager,
     NormalizedScopeManager,
     RefreshRunManager,
+    RosterManager,
 )
 from backend.services.datalayer import (
     DatalayerSnapshotService,
@@ -185,9 +186,11 @@ def build_datalayer_snapshot_dependencies(
 
     resolved = settings or DatalayerSettings.from_environment()
     files = LocalDatalayerFileStore(resolved.data_root)
+    planning = LeagueSeasonManager(session_factory, context)
     return DatalayerSnapshotDependencies(
         snapshot=DatalayerSnapshotService(
-            planning=LeagueSeasonManager(session_factory, context),
+            planning=planning,
+            roster_identities=RosterManager(session_factory, context),
             requests=ApiRequestManager(session_factory, context),
             snapshots=DataSnapshotManager(session_factory, context),
             materializer=SQLiteSnapshotMaterializer(

--- a/backend/resources/sleeper_data/__init__.py
+++ b/backend/resources/sleeper_data/__init__.py
@@ -38,6 +38,7 @@ from backend.resources.sleeper_data.rosters import (
     RosterManager,
     RosterManagerAssignment,
     RosterPlayer,
+    SeasonRosterIdentity,
     SeasonRosterState,
 )
 from backend.resources.sleeper_data.snapshots import (
@@ -95,6 +96,7 @@ __all__ = [
     "RosterPlayer",
     "SealSnapshot",
     "SeasonRosterState",
+    "SeasonRosterIdentity",
     "SnapshotCandidateQuery",
     "SnapshotBuildState",
     "SnapshotFailure",

--- a/backend/resources/sleeper_data/rosters/__init__.py
+++ b/backend/resources/sleeper_data/rosters/__init__.py
@@ -2,6 +2,7 @@ from backend.resources.sleeper_data.rosters.manager import RosterManager
 from backend.resources.sleeper_data.rosters.objects import (
     RosterManagerAssignment,
     RosterPlayer,
+    SeasonRosterIdentity,
     SeasonRosterState,
 )
 
@@ -9,5 +10,6 @@ __all__ = [
     "RosterManager",
     "RosterManagerAssignment",
     "RosterPlayer",
+    "SeasonRosterIdentity",
     "SeasonRosterState",
 ]

--- a/backend/resources/sleeper_data/rosters/manager.py
+++ b/backend/resources/sleeper_data/rosters/manager.py
@@ -20,6 +20,7 @@ from backend.resources.sleeper_data.players.codec import decode_player
 from backend.resources.sleeper_data.rosters.objects import (
     RosterManagerAssignment,
     RosterPlayer,
+    SeasonRosterIdentity,
     SeasonRosterState,
 )
 from backend.services.datalayer.errors import DatalayerResourceNotFound
@@ -35,6 +36,32 @@ class RosterManager:
     ) -> None:
         self._session_factory = session_factory
         self._competition_id = context.scope.competition_id
+
+    def list_roster_identities(
+        self,
+        competition_season_id: UUID,
+    ) -> tuple[SeasonRosterIdentity, ...]:
+        """Return stable identities for every roster in one scoped season."""
+
+        with read_only_session(self._session_factory) as session:
+            rows = session.execute(
+                sa.select(SeasonRoster)
+                .where(
+                    SeasonRoster.competition_season_id == competition_season_id,
+                    SeasonRoster.competition_id == self._competition_id,
+                )
+                .order_by(SeasonRoster.sleeper_roster_id, SeasonRoster.id)
+            ).scalars()
+            return tuple(
+                SeasonRosterIdentity(
+                    competition_id=identity.competition_id,
+                    competition_season_id=identity.competition_season_id,
+                    season_roster_id=identity.id,
+                    franchise_id=identity.franchise_id,
+                    sleeper_roster_id=identity.sleeper_roster_id,
+                )
+                for identity in rows
+            )
 
     def get_roster(self, season_roster_id: UUID) -> SeasonRosterState:
         with read_only_session(self._session_factory) as session:

--- a/backend/resources/sleeper_data/rosters/objects.py
+++ b/backend/resources/sleeper_data/rosters/objects.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from pydantic import Field
 
-from backend.resources._contracts import ContractModel
+from backend.resources._contracts import ContractModel, NonBlankStr
 from backend.resources.sleeper_data.players.objects import Player
 from backend.services.datalayer.canonical_json import JsonValue
 
@@ -23,6 +23,16 @@ class RosterManagerAssignment(ContractModel):
 class RosterPlayer(ContractModel):
     player: Player
     role: Literal["starter", "bench", "taxi", "reserve", "ir", "unknown"]
+
+
+class SeasonRosterIdentity(ContractModel):
+    """Stable core identity for one provider roster in a competition season."""
+
+    competition_id: UUID
+    competition_season_id: UUID
+    season_roster_id: UUID
+    franchise_id: UUID
+    sleeper_roster_id: NonBlankStr
 
 
 class SeasonRosterState(ContractModel):

--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -110,6 +110,7 @@ from backend.services.datalayer.versions import (
 )
 
 __all__ = [
+    "AmbiguousRosterIdentity",
     "ApplyDisposition",
     "BracketMatchupRecord",
     "CompletenessWarning",
@@ -126,6 +127,7 @@ __all__ = [
     "EndpointPayloadRejected",
     "FailedSourceAttempt",
     "FrozenLeagueData",
+    "FrozenRosterIdentity",
     "FrozenSnapshotInvalid",
     "INGESTION_NORMALIZER_VERSION",
     "InternalDatalayerFailure",
@@ -153,6 +155,9 @@ __all__ = [
     "RefreshRequest",
     "RefreshStatus",
     "RefreshTrigger",
+    "ResolvedRosterIdentity",
+    "RosterIdentityNotFound",
+    "RosterIdentityResolution",
     "RosterManagerRecord",
     "RosterPlayerRecord",
     "RosterRecord",
@@ -245,17 +250,40 @@ def __getattr__(name: str) -> Any:
         "select_snapshot_requests",
         "SQLiteSnapshotMaterializer",
         "FrozenLeagueData",
+        "FrozenRosterIdentity",
         "FrozenSnapshotInvalid",
+        "AmbiguousRosterIdentity",
+        "ResolvedRosterIdentity",
+        "RosterIdentityNotFound",
+        "RosterIdentityResolution",
     }:
-        if name in {"FrozenLeagueData", "FrozenSnapshotInvalid"}:
+        if name in {
+            "AmbiguousRosterIdentity",
+            "FrozenLeagueData",
+            "FrozenRosterIdentity",
+            "FrozenSnapshotInvalid",
+            "ResolvedRosterIdentity",
+            "RosterIdentityNotFound",
+            "RosterIdentityResolution",
+        }:
             from backend.services.datalayer.query import (
+                AmbiguousRosterIdentity,
                 FrozenLeagueData,
+                FrozenRosterIdentity,
                 FrozenSnapshotInvalid,
+                ResolvedRosterIdentity,
+                RosterIdentityNotFound,
+                RosterIdentityResolution,
             )
 
             return {
+                "AmbiguousRosterIdentity": AmbiguousRosterIdentity,
                 "FrozenLeagueData": FrozenLeagueData,
+                "FrozenRosterIdentity": FrozenRosterIdentity,
                 "FrozenSnapshotInvalid": FrozenSnapshotInvalid,
+                "ResolvedRosterIdentity": ResolvedRosterIdentity,
+                "RosterIdentityNotFound": RosterIdentityNotFound,
+                "RosterIdentityResolution": RosterIdentityResolution,
             }[name]
         if name == "SQLiteSnapshotMaterializer":
             from backend.services.datalayer.snapshot_sqlite import (

--- a/backend/services/datalayer/query/__init__.py
+++ b/backend/services/datalayer/query/__init__.py
@@ -1,8 +1,23 @@
 """Frozen SQLite reporter query runtime."""
 
+from backend.services.datalayer.query.identity import (
+    AmbiguousRosterIdentity,
+    FrozenRosterIdentity,
+    ResolvedRosterIdentity,
+    RosterIdentityNotFound,
+    RosterIdentityResolution,
+)
 from backend.services.datalayer.query.runtime import (
     FrozenLeagueData,
     FrozenSnapshotInvalid,
 )
 
-__all__ = ["FrozenLeagueData", "FrozenSnapshotInvalid"]
+__all__ = [
+    "AmbiguousRosterIdentity",
+    "FrozenLeagueData",
+    "FrozenRosterIdentity",
+    "FrozenSnapshotInvalid",
+    "ResolvedRosterIdentity",
+    "RosterIdentityNotFound",
+    "RosterIdentityResolution",
+]

--- a/backend/services/datalayer/query/identity.py
+++ b/backend/services/datalayer/query/identity.py
@@ -1,0 +1,107 @@
+"""Typed stable roster identity resolution over one frozen snapshot."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Literal, TypeAlias
+from uuid import UUID
+
+from backend.resources._contracts import ContractModel, DisplayName, NonBlankStr
+
+
+class FrozenRosterIdentity(ContractModel):
+    competition_id: UUID
+    competition_season_id: UUID
+    season_roster_id: UUID
+    franchise_id: UUID
+    sleeper_roster_id: NonBlankStr
+    team_name: DisplayName = None
+    manager_name: DisplayName = None
+
+
+class ResolvedRosterIdentity(ContractModel):
+    status: Literal["resolved"] = "resolved"
+    roster_key: str
+    identity: FrozenRosterIdentity
+
+
+class AmbiguousRosterIdentity(ContractModel):
+    status: Literal["ambiguous"] = "ambiguous"
+    roster_key: str
+    matches: tuple[FrozenRosterIdentity, ...]
+
+
+class RosterIdentityNotFound(ContractModel):
+    status: Literal["not_found"] = "not_found"
+    roster_key: str
+
+
+RosterIdentityResolution: TypeAlias = (
+    ResolvedRosterIdentity | AmbiguousRosterIdentity | RosterIdentityNotFound
+)
+
+
+def resolve_roster_identity(
+    connection: sqlite3.Connection,
+    *,
+    competition_id: UUID,
+    competition_season_id: UUID,
+    league_id: str,
+    roster_key: str | int,
+) -> RosterIdentityResolution:
+    key = "" if roster_key is None else str(roster_key).strip()
+    if not key:
+        return RosterIdentityNotFound(roster_key=key)
+
+    params: dict[str, Any] = {"league_id": league_id}
+    if key.isdigit():
+        roster_id = int(key)
+        if roster_id < 1 or str(roster_id) != key:
+            return RosterIdentityNotFound(roster_key=key)
+        predicate = "ri.roster_id = :roster_id"
+        params["roster_id"] = roster_id
+    else:
+        predicate = """
+            (tp.team_name IS NOT NULL AND lower(tp.team_name) = lower(:roster_key))
+            OR
+            (tp.manager_name IS NOT NULL AND lower(tp.manager_name) = lower(:roster_key))
+        """
+        params["roster_key"] = key
+
+    rows = connection.execute(
+        f"""
+        SELECT
+            ri.competition_id,
+            ri.competition_season_id,
+            ri.season_roster_id,
+            ri.franchise_id,
+            ri.roster_id,
+            tp.team_name,
+            tp.manager_name
+        FROM roster_identities AS ri
+        LEFT JOIN team_profiles AS tp
+          ON tp.league_id = ri.league_id
+         AND tp.roster_id = ri.roster_id
+        WHERE ri.league_id = :league_id
+          AND ({predicate})
+        ORDER BY ri.roster_id
+        """,
+        params,
+    ).fetchall()
+    matches = tuple(
+        FrozenRosterIdentity(
+            competition_id=competition_id,
+            competition_season_id=competition_season_id,
+            season_roster_id=UUID(row["season_roster_id"]),
+            franchise_id=UUID(row["franchise_id"]),
+            sleeper_roster_id=str(row["roster_id"]),
+            team_name=row["team_name"],
+            manager_name=row["manager_name"],
+        )
+        for row in rows
+    )
+    if not matches:
+        return RosterIdentityNotFound(roster_key=key)
+    if len(matches) > 1:
+        return AmbiguousRosterIdentity(roster_key=key, matches=matches)
+    return ResolvedRosterIdentity(roster_key=key, identity=matches[0])

--- a/backend/services/datalayer/query/runtime.py
+++ b/backend/services/datalayer/query/runtime.py
@@ -12,6 +12,10 @@ from uuid import UUID
 
 from backend.services.datalayer.canonical_json import canonical_json_bytes, parse_json_bytes
 from backend.services.datalayer.contracts import ReadyDataSnapshot
+from backend.services.datalayer.query.identity import (
+    RosterIdentityResolution,
+    resolve_roster_identity,
+)
 from backend.services.datalayer.query.curated import (
     get_bench_analysis,
     get_league_snapshot,
@@ -59,6 +63,8 @@ class FrozenLeagueData:
         self._connection: sqlite3.Connection | None = None
         self._league_id = ""
         self._season = ""
+        self._competition_id: UUID | None = None
+        self._competition_season_id: UUID | None = None
         self._through_week = 0
         self._allowed_tables: frozenset[str] = frozenset()
 
@@ -76,6 +82,10 @@ class FrozenLeagueData:
             instance._connection = connection
             instance._league_id = metadata["sleeper_league_id"]
             instance._season = str(metadata["season_year"])
+            instance._competition_id = UUID(metadata["competition_id"])
+            instance._competition_season_id = UUID(
+                metadata["primary_competition_season_id"]
+            )
             instance._through_week = int(metadata["through_week"])
             instance._allowed_tables = frozenset(schema.tables)
             return instance
@@ -286,6 +296,21 @@ class FrozenLeagueData:
     def get_roster_at_cutoff(self, roster_key: Any) -> dict[str, Any]:
         return get_roster_at_cutoff(self._conn(), self._league_id, roster_key)
 
+    def resolve_roster_identity(
+        self,
+        roster_key: str | int,
+    ) -> RosterIdentityResolution:
+        connection = self._conn()
+        if self._competition_id is None or self._competition_season_id is None:
+            raise RuntimeError("FrozenLeagueData identity scope is unavailable")
+        return resolve_roster_identity(
+            connection,
+            competition_id=self._competition_id,
+            competition_season_id=self._competition_season_id,
+            league_id=self._league_id,
+            roster_key=roster_key,
+        )
+
     def get_roster_snapshot(self, roster_key: Any, week: int) -> dict[str, Any]:
         return get_roster_snapshot(
             self._conn(),
@@ -408,7 +433,59 @@ def _validate_artifact(
         raise FrozenSnapshotInvalid("snapshot league metadata is inconsistent")
     if context[0]["effective_week"] != metadata["through_week"]:
         raise FrozenSnapshotInvalid("snapshot cutoff metadata is inconsistent")
+    _validate_roster_identities(connection, metadata)
     return metadata
+
+
+def _validate_roster_identities(
+    connection: sqlite3.Connection,
+    metadata: dict[str, Any],
+) -> None:
+    try:
+        roster_ids = {
+            row[0]
+            for row in connection.execute("SELECT roster_id FROM rosters").fetchall()
+        }
+        identities = connection.execute(
+            "SELECT * FROM roster_identities ORDER BY roster_id"
+        ).fetchall()
+    except sqlite3.Error as error:
+        raise FrozenSnapshotInvalid(
+            "snapshot roster identities are unreadable"
+        ) from error
+    if {row["roster_id"] for row in identities} != roster_ids:
+        raise FrozenSnapshotInvalid(
+            "snapshot roster identities do not match snapshot rosters"
+        )
+    expected_scope = (
+        metadata["sleeper_league_id"],
+        metadata["competition_id"],
+        metadata["primary_competition_season_id"],
+    )
+    if any(
+        (
+            row["league_id"],
+            row["competition_id"],
+            row["competition_season_id"],
+        )
+        != expected_scope
+        for row in identities
+    ):
+        raise FrozenSnapshotInvalid(
+            "snapshot roster identities are outside the snapshot scope"
+        )
+    for field in ("season_roster_id", "franchise_id"):
+        values = [row[field] for row in identities]
+        try:
+            canonical = [str(UUID(value)) for value in values]
+        except (AttributeError, TypeError, ValueError) as error:
+            raise FrozenSnapshotInvalid(
+                f"snapshot roster identity {field} is invalid"
+            ) from error
+        if values != canonical or len(values) != len(set(values)):
+            raise FrozenSnapshotInvalid(
+                f"snapshot roster identity {field} is invalid"
+            )
 
 
 def _validate_canonical_json(value: Any, *, expected_list: bool) -> Any:

--- a/backend/services/datalayer/snapshot_service.py
+++ b/backend/services/datalayer/snapshot_service.py
@@ -21,6 +21,7 @@ from backend.resources.sleeper_data.requests import (
     SnapshotCandidateQuery,
     VerifiedPayload,
 )
+from backend.resources.sleeper_data.rosters import SeasonRosterIdentity
 from backend.resources.sleeper_data.snapshots import (
     ArtifactFailure,
     BeginSnapshotBuild,
@@ -63,6 +64,7 @@ from backend.services.datalayer.snapshot_selection import (
 )
 from backend.services.datalayer.sleeper.endpoints import (
     EndpointRecords,
+    LeagueRostersEndpointRecords,
     normalize_league,
     normalize_league_rosters,
     normalize_league_users,
@@ -99,6 +101,13 @@ class SnapshotRequestReader(Protocol):
         self,
         request_ids: Collection[UUID],
     ) -> tuple[VerifiedPayload, ...]: ...
+
+
+class SnapshotRosterIdentityReader(Protocol):
+    def list_roster_identities(
+        self,
+        competition_season_id: UUID,
+    ) -> tuple[SeasonRosterIdentity, ...]: ...
 
 
 class SnapshotLifecycle(Protocol):
@@ -151,6 +160,7 @@ class SnapshotMaterializationInput(ContractModel):
     snapshot_projection_version: str
     manifest: SelectedRequestManifest
     endpoint_records: tuple[SnapshotEndpointRecords, ...]
+    roster_identities: tuple[SeasonRosterIdentity, ...]
 
     @model_validator(mode="after")
     def validate_records(self) -> "SnapshotMaterializationInput":
@@ -160,6 +170,45 @@ class SnapshotMaterializationInput(ContractModel):
         ]
         if record_ids != manifest_ids:
             raise ValueError("snapshot endpoint records must follow manifest order")
+        expected_scope = (
+            self.planning_context.competition_id,
+            self.planning_context.competition_season_id,
+        )
+        if any(
+            (
+                identity.competition_id,
+                identity.competition_season_id,
+            )
+            != expected_scope
+            for identity in self.roster_identities
+        ):
+            raise ValueError("snapshot roster identities must match the planning scope")
+        _require_distinct(
+            [identity.sleeper_roster_id for identity in self.roster_identities],
+            "Sleeper roster IDs",
+        )
+        _require_distinct(
+            [identity.season_roster_id for identity in self.roster_identities],
+            "season-roster IDs",
+        )
+        _require_distinct(
+            [identity.franchise_id for identity in self.roster_identities],
+            "franchise IDs",
+        )
+        selected_roster_ids = tuple(
+            roster.sleeper_roster_id
+            for endpoint in self.endpoint_records
+            if isinstance(endpoint.records, LeagueRostersEndpointRecords)
+            for roster in endpoint.records.rosters
+        )
+        if (
+            len(selected_roster_ids) != len(set(selected_roster_ids))
+            or set(selected_roster_ids)
+            != {identity.sleeper_roster_id for identity in self.roster_identities}
+        ):
+            raise ValueError(
+                "snapshot roster identities must exactly match selected rosters"
+            )
         return self
 
 
@@ -190,6 +239,7 @@ class DatalayerSnapshotService:
         self,
         *,
         planning: SnapshotPlanningReader,
+        roster_identities: SnapshotRosterIdentityReader,
         requests: SnapshotRequestReader,
         snapshots: SnapshotLifecycle,
         materializer: SnapshotMaterializer,
@@ -218,6 +268,7 @@ class DatalayerSnapshotService:
             poll_interval_seconds, "poll_interval_seconds"
         )
         self._planning = planning
+        self._roster_identities = roster_identities
         self._requests = requests
         self._snapshots = snapshots
         self._materializer = materializer
@@ -265,6 +316,9 @@ class DatalayerSnapshotService:
             context = self._planning.get_snapshot_planning_context(
                 request.competition_season_id
             )
+            roster_identities = self._roster_identities.list_roster_identities(
+                request.competition_season_id
+            )
             requirements = plan_snapshot_requirements(request, context)
             candidates = self._requests.list_snapshot_candidates(
                 SnapshotCandidateQuery(
@@ -286,6 +340,7 @@ class DatalayerSnapshotService:
                     snapshot_projection_version=self._projection_version,
                     manifest=manifest,
                     endpoint_records=records,
+                    roster_identities=roster_identities,
                 )
             )
             receipt = self._files.store_file(
@@ -499,3 +554,8 @@ def _positive_number(value: float, name: str) -> float:
     ):
         raise ValueError(f"{name} must be positive")
     return float(value)
+
+
+def _require_distinct(values: list[object], label: str) -> None:
+    if len(values) != len(set(values)):
+        raise ValueError(f"snapshot roster identities contain duplicate {label}")

--- a/backend/services/datalayer/snapshot_sqlite/derivations.py
+++ b/backend/services/datalayer/snapshot_sqlite/derivations.py
@@ -28,6 +28,7 @@ _DERIVED_TABLES = {
     "team_profiles",
     "draft_picks",
     "season_context",
+    "roster_identities",
 }
 
 
@@ -52,6 +53,7 @@ def derive_snapshot_rows(
     rows["standings"] = standings
     warnings.extend(standing_warnings)
     rows["team_profiles"] = _derive_profiles(materialization, source)
+    rows["roster_identities"] = _derive_roster_identities(materialization)
     rows["draft_picks"] = _derive_draft_picks(materialization, source)
     rows["season_context"] = [
         {
@@ -78,6 +80,26 @@ def derive_snapshot_rows(
         )
     )
     return SnapshotProjection(frozen_rows, ordered_warnings, source.provenance)
+
+
+def _derive_roster_identities(
+    materialization: SnapshotMaterializationInput,
+) -> list[dict[str, Any]]:
+    context = materialization.planning_context
+    return [
+        {
+            "league_id": context.sleeper_league_id,
+            "roster_id": _numeric_roster_id(identity.sleeper_roster_id),
+            "competition_id": str(identity.competition_id),
+            "competition_season_id": str(identity.competition_season_id),
+            "season_roster_id": str(identity.season_roster_id),
+            "franchise_id": str(identity.franchise_id),
+        }
+        for identity in sorted(
+            materialization.roster_identities,
+            key=lambda item: _numeric_roster_id(item.sleeper_roster_id),
+        )
+    ]
 
 
 def _derive_games(

--- a/backend/services/datalayer/snapshot_sqlite/materializer.py
+++ b/backend/services/datalayer/snapshot_sqlite/materializer.py
@@ -6,7 +6,8 @@ import hashlib
 from pathlib import Path
 import sqlite3
 import tempfile
-from typing import Any
+from typing import Any, Mapping
+from uuid import UUID
 
 from sqlalchemy import create_engine
 
@@ -40,6 +41,7 @@ _DERIVED_TABLES = {
     "team_profiles",
     "draft_picks",
     "season_context",
+    "roster_identities",
 }
 
 
@@ -185,6 +187,17 @@ def verify_snapshot_file(
                 raise SnapshotArtifactInvalid(
                     "snapshot contains post-cutoff bracket facts"
                 )
+        identity_rows = [
+            dict(row)
+            for row in connection.execute(
+                "SELECT * FROM roster_identities ORDER BY roster_id"
+            ).fetchall()
+        ]
+        roster_ids = {
+            row[0]
+            for row in connection.execute("SELECT roster_id FROM rosters").fetchall()
+        }
+        _validate_roster_identities(materialization, identity_rows, roster_ids)
     except sqlite3.Error as error:
         raise SnapshotArtifactInvalid("snapshot SQLite verification failed") from error
     finally:
@@ -227,6 +240,11 @@ def _validate_projection(
     if seasons - {str(context.season_year)}:
         raise SnapshotArtifactInvalid("snapshot combines multiple competition seasons")
     roster_ids = {row["roster_id"] for row in projection.rows_for("rosters")}
+    _validate_roster_identities(
+        materialization,
+        projection.rows_for("roster_identities"),
+        roster_ids,
+    )
     roster_tables = (
         "matchups",
         "player_performances",
@@ -240,6 +258,47 @@ def _validate_projection(
         ):
             raise SnapshotArtifactInvalid(
                 "snapshot contains an unknown roster reference"
+            )
+
+
+def _validate_roster_identities(
+    materialization: SnapshotMaterializationInput,
+    rows: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]],
+    roster_ids: set[int],
+) -> None:
+    context = materialization.planning_context
+    if {row["roster_id"] for row in rows} != roster_ids:
+        raise SnapshotArtifactInvalid(
+            "snapshot roster identities do not match snapshot rosters"
+        )
+    expected_scope = (
+        context.sleeper_league_id,
+        str(context.competition_id),
+        str(context.competition_season_id),
+    )
+    if any(
+        (
+            row["league_id"],
+            row["competition_id"],
+            row["competition_season_id"],
+        )
+        != expected_scope
+        for row in rows
+    ):
+        raise SnapshotArtifactInvalid(
+            "snapshot roster identities are outside the snapshot scope"
+        )
+    for field in ("season_roster_id", "franchise_id"):
+        values = [row[field] for row in rows]
+        try:
+            canonical = [str(UUID(value)) for value in values]
+        except (AttributeError, TypeError, ValueError) as error:
+            raise SnapshotArtifactInvalid(
+                f"snapshot roster identity {field} is invalid"
+            ) from error
+        if values != canonical or len(values) != len(set(values)):
+            raise SnapshotArtifactInvalid(
+                f"snapshot roster identity {field} is invalid"
             )
 
 

--- a/backend/services/datalayer/snapshot_sqlite/schema.py
+++ b/backend/services/datalayer/snapshot_sqlite/schema.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
 
 
 SQLITE_APPLICATION_ID = 0x41494441
-SQLITE_USER_VERSION = 1
+SQLITE_USER_VERSION = 2
 
 
 SNAPSHOT_TABLE_ORDER = (
@@ -28,6 +28,7 @@ SNAPSHOT_TABLE_ORDER = (
     "season_context",
     "users",
     "rosters",
+    "roster_identities",
     "team_profiles",
     "draft_picks",
     "players",
@@ -51,7 +52,7 @@ class SnapshotSchema:
     table_order: tuple[str, ...]
 
 
-def _build_v1() -> SnapshotSchema:
+def _build_v2() -> SnapshotSchema:
     metadata = MetaData()
 
     Table(
@@ -95,6 +96,18 @@ def _build_v1() -> SnapshotSchema:
         Column("record_string", Text),
         PrimaryKeyConstraint("league_id", "roster_id"),
         Index("idx_rosters_league_roster", "league_id", "roster_id"),
+    )
+    Table(
+        "roster_identities",
+        metadata,
+        Column("league_id", Text, nullable=False),
+        Column("roster_id", Integer, nullable=False),
+        Column("competition_id", Text, nullable=False),
+        Column("competition_season_id", Text, nullable=False),
+        Column("season_roster_id", Text, nullable=False, unique=True),
+        Column("franchise_id", Text, nullable=False, unique=True),
+        PrimaryKeyConstraint("league_id", "roster_id"),
+        Index("idx_roster_identities_franchise", "franchise_id"),
     )
     Table(
         "team_profiles",
@@ -290,17 +303,17 @@ def _build_v1() -> SnapshotSchema:
         CheckConstraint("singleton_id = 1", name="ck_snapshot_metadata_singleton"),
     )
     tables = MappingProxyType(dict(metadata.tables))
-    return SnapshotSchema("1", metadata, tables, SNAPSHOT_TABLE_ORDER)
+    return SnapshotSchema("2", metadata, tables, SNAPSHOT_TABLE_ORDER)
 
 
-_V1 = _build_v1()
+_V2 = _build_v2()
 
 
 def get_snapshot_schema(projection_version: str) -> SnapshotSchema:
     """Return the exact schema owned by a supported projection version."""
 
-    if projection_version != "1":
+    if projection_version != "2":
         raise ValueError(
             f"unsupported snapshot projection version: {projection_version!r}"
         )
-    return _V1
+    return _V2

--- a/backend/services/datalayer/versions.py
+++ b/backend/services/datalayer/versions.py
@@ -1,4 +1,4 @@
 """Compatibility versions for normalized facts and frozen projections."""
 
 INGESTION_NORMALIZER_VERSION = "1"
-SNAPSHOT_PROJECTION_VERSION = "1"
+SNAPSHOT_PROJECTION_VERSION = "2"

--- a/backend/tests/resources/sleeper_data/test_roster_manager.py
+++ b/backend/tests/resources/sleeper_data/test_roster_manager.py
@@ -11,6 +11,7 @@ from backend.resources.sleeper_data.rosters import (
     RosterManager,
     RosterManagerAssignment,
     RosterPlayer,
+    SeasonRosterIdentity,
     SeasonRosterState,
 )
 from backend.services.datalayer.errors import DatalayerResourceNotFound
@@ -98,3 +99,31 @@ def test_roster_read_reports_not_found_and_enforces_competition_scope(
         manager.get_roster(uuid4())
     with pytest.raises(DatalayerResourceNotFound, match="season_roster"):
         other_manager.get_roster(projected_season.domain.roster_ids[0])
+
+
+def test_roster_identity_list_is_stable_ordered_and_competition_scoped(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    projected_season: ProjectedSeason,
+) -> None:
+    domain = projected_season.domain
+    manager = RosterManager(session_factory, manager_context(domain))
+
+    identities = manager.list_roster_identities(domain.season_id)
+
+    assert identities == tuple(
+        SeasonRosterIdentity(
+            competition_id=domain.competition_id,
+            competition_season_id=domain.season_id,
+            season_roster_id=domain.roster_ids[index],
+            franchise_id=domain.franchise_ids[index],
+            sleeper_roster_id=str(index + 1),
+        )
+        for index in range(2)
+    )
+    other = seed_domain(database_engine, label="Identity Scope")
+    other_manager = RosterManager(
+        create_session_factory(database_engine),
+        manager_context(other),
+    )
+    assert other_manager.list_roster_identities(domain.season_id) == ()

--- a/backend/tests/services/datalayer/test_frozen_query_runtime.py
+++ b/backend/tests/services/datalayer/test_frozen_query_runtime.py
@@ -12,9 +12,12 @@ from uuid import UUID
 import pytest
 
 from backend.services.datalayer import (
+    AmbiguousRosterIdentity,
     FrozenLeagueData,
     FrozenSnapshotInvalid,
     ReadyDataSnapshot,
+    ResolvedRosterIdentity,
+    RosterIdentityNotFound,
     SnapshotRequest,
     VerifiedLocalArtifact,
 )
@@ -46,6 +49,7 @@ from backend.tests.services.datalayer.test_snapshot_source_projection import (
     FIXTURES,
     _context,
     _fixture_input,
+    _roster_identities,
 )
 
 
@@ -264,6 +268,87 @@ def test_name_resolvers_preserve_ambiguity_results(
     assert len(player["matches"]) == 2
 
 
+def test_typed_roster_identity_resolution_uses_only_frozen_snapshot(
+    ready_snapshot: ReadyDataSnapshot,
+) -> None:
+    with FrozenLeagueData.open(ready_snapshot) as data:
+        by_id = data.resolve_roster_identity(1)
+        by_team = data.resolve_roster_identity(" alpha ")
+        by_manager = data.resolve_roster_identity("ALICE")
+        missing = data.resolve_roster_identity("missing")
+        invalid = data.resolve_roster_identity("01")
+
+    assert isinstance(by_id, ResolvedRosterIdentity)
+    assert by_team == by_id.model_copy(update={"roster_key": "alpha"})
+    assert by_manager == by_id.model_copy(update={"roster_key": "ALICE"})
+    assert by_id.identity.model_dump(mode="json") == {
+        "competition_id": "22222222-2222-2222-2222-222222222222",
+        "competition_season_id": "11111111-1111-1111-1111-111111111111",
+        "season_roster_id": "00000000-0000-0000-0000-000000000065",
+        "franchise_id": "00000000-0000-0000-0000-0000000000c9",
+        "sleeper_roster_id": "1",
+        "team_name": "Alpha",
+        "manager_name": "Alice",
+    }
+    assert missing == RosterIdentityNotFound(roster_key="missing")
+    assert invalid == RosterIdentityNotFound(roster_key="01")
+
+
+def test_typed_roster_identity_resolution_preserves_name_ambiguity(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+) -> None:
+    ambiguous = _mutated_copy(
+        ready_snapshot.artifact.path,
+        tmp_path / "ambiguous-identity.sqlite",
+        "UPDATE team_profiles SET team_name = 'Alpha' WHERE roster_id = 2",
+    )
+    with FrozenLeagueData.open(
+        ready_snapshot.model_copy(update={"artifact": ambiguous})
+    ) as data:
+        resolution = data.resolve_roster_identity("Alpha")
+
+    assert isinstance(resolution, AmbiguousRosterIdentity)
+    assert [match.sleeper_roster_id for match in resolution.matches] == ["1", "2"]
+
+
+@pytest.mark.parametrize(
+    ("statement", "message"),
+    [
+        (
+            "UPDATE roster_identities SET season_roster_id = 'not-a-uuid' "
+            "WHERE roster_id = 1",
+            "season_roster_id",
+        ),
+        (
+            "UPDATE roster_identities SET competition_id = "
+            "'33333333-3333-3333-3333-333333333333' WHERE roster_id = 1",
+            "scope",
+        ),
+        (
+            "DELETE FROM roster_identities WHERE roster_id = 1",
+            "match snapshot rosters",
+        ),
+    ],
+)
+def test_invalid_frozen_roster_identity_rows_fail_closed(
+    ready_snapshot: ReadyDataSnapshot,
+    tmp_path: Path,
+    statement: str,
+    message: str,
+) -> None:
+    changed = _mutated_copy(
+        ready_snapshot.artifact.path,
+        tmp_path / f"invalid-identity-{message}.sqlite",
+        statement,
+    )
+
+    with pytest.raises(FrozenSnapshotInvalid, match=message):
+        FrozenLeagueData.open(
+            ready_snapshot.model_copy(update={"artifact": changed})
+        )
+
+
 def test_context_exit_closes_runtime_deterministically(
     ready_snapshot: ReadyDataSnapshot,
 ) -> None:
@@ -273,6 +358,8 @@ def test_context_exit_closes_runtime_deterministically(
 
     with pytest.raises(RuntimeError, match="closed"):
         data.get_league_snapshot()
+    with pytest.raises(RuntimeError, match="closed"):
+        data.resolve_roster_identity("Alpha")
 
 
 @pytest.mark.parametrize(
@@ -283,7 +370,7 @@ def test_context_exit_closes_runtime_deterministically(
         ("primary_competition_season_id", "44444444-4444-4444-4444-444444444444"),
         ("through_week", 1),
         ("as_of_date", "2024-09-18"),
-        ("snapshot_projection_version", "2"),
+        ("snapshot_projection_version", "1"),
     ],
 )
 def test_internal_identity_mismatches_fail_closed(
@@ -346,7 +433,7 @@ def test_unavailable_and_unsupported_snapshots_fail_before_querying(
         FrozenLeagueData.open(ready_snapshot.model_copy(update={"artifact": missing}))
     with pytest.raises(FrozenSnapshotInvalid, match="unsupported"):
         FrozenLeagueData.open(
-            ready_snapshot.model_copy(update={"snapshot_projection_version": "2"})
+            ready_snapshot.model_copy(update={"snapshot_projection_version": "1"})
         )
 
 
@@ -441,9 +528,10 @@ def _fixture_input_for_week(through_week: int) -> SnapshotMaterializationInput:
         request=request,
         planning_context=context,
         build_key="c" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         manifest=SelectedRequestManifest(entries=tuple(manifest)),
         endpoint_records=tuple(endpoints),
+        roster_identities=_roster_identities(),
     )
 
 

--- a/backend/tests/services/datalayer/test_snapshot_derivations.py
+++ b/backend/tests/services/datalayer/test_snapshot_derivations.py
@@ -66,6 +66,24 @@ def test_derives_profiles_picks_and_deterministic_season_context() -> None:
             "generated_at": None,
         },
     )
+    assert projection.rows_for("roster_identities") == (
+        {
+            "league_id": "123",
+            "roster_id": 1,
+            "competition_id": "22222222-2222-2222-2222-222222222222",
+            "competition_season_id": "11111111-1111-1111-1111-111111111111",
+            "season_roster_id": "00000000-0000-0000-0000-000000000065",
+            "franchise_id": "00000000-0000-0000-0000-0000000000c9",
+        },
+        {
+            "league_id": "123",
+            "roster_id": 2,
+            "competition_id": "22222222-2222-2222-2222-222222222222",
+            "competition_season_id": "11111111-1111-1111-1111-111111111111",
+            "season_roster_id": "00000000-0000-0000-0000-000000000066",
+            "franchise_id": "00000000-0000-0000-0000-0000000000ca",
+        },
+    )
 
 
 def test_malformed_matchup_group_is_omitted_with_warning() -> None:

--- a/backend/tests/services/datalayer/test_snapshot_materializer_integration.py
+++ b/backend/tests/services/datalayer/test_snapshot_materializer_integration.py
@@ -10,6 +10,7 @@ from backend.resources.sleeper_data import (
     LeagueSeasonManager,
     NormalizedScopeManager,
     RefreshRunManager,
+    RosterManager,
 )
 from backend.services.datalayer import (
     DatalayerSnapshotService,
@@ -60,6 +61,7 @@ def test_refresh_to_materialization_and_atomic_seal(
     )
     service = DatalayerSnapshotService(
         planning=planning,
+        roster_identities=RosterManager(sessions, context),
         requests=requests,
         snapshots=snapshots,
         materializer=SQLiteSnapshotMaterializer(tmp_path / "staging"),

--- a/backend/tests/services/datalayer/test_snapshot_service.py
+++ b/backend/tests/services/datalayer/test_snapshot_service.py
@@ -23,6 +23,7 @@ from backend.resources.sleeper_data import (
     SnapshotCandidateQuery,
     SnapshotFailure,
     SnapshotPlanningContext,
+    SeasonRosterIdentity,
 )
 from backend.services.datalayer import (
     DatalayerSnapshotService,
@@ -71,6 +72,33 @@ class FakePlanning:
             draft_rounds=0,
             league_average_match=0,
         )
+
+
+class FakeRosterIdentities:
+    def __init__(
+        self,
+        *,
+        roster_ids: tuple[int, ...] = (1, 2),
+        competition_id: UUID = COMPETITION_ID,
+    ) -> None:
+        self.calls: list[UUID] = []
+        self.identities = tuple(
+            SeasonRosterIdentity(
+                competition_id=competition_id,
+                competition_season_id=SEASON_ID,
+                season_roster_id=UUID(int=100 + roster_id),
+                franchise_id=UUID(int=200 + roster_id),
+                sleeper_roster_id=str(roster_id),
+            )
+            for roster_id in roster_ids
+        )
+
+    def list_roster_identities(
+        self,
+        competition_season_id: UUID,
+    ) -> tuple[SeasonRosterIdentity, ...]:
+        self.calls.append(competition_season_id)
+        return self.identities
 
 
 class FakeRequests:
@@ -265,6 +293,7 @@ def _service(
     *,
     snapshots: FakeSnapshots | None = None,
     requests: FakeRequests | None = None,
+    roster_identities: FakeRosterIdentities | None = None,
     monotonic_clock=lambda: 0.0,
     delay=lambda _: None,
 ) -> tuple[
@@ -280,6 +309,7 @@ def _service(
     return (
         DatalayerSnapshotService(
             planning=FakePlanning(),
+            roster_identities=roster_identities or FakeRosterIdentities(),
             requests=reader,
             snapshots=lifecycle,
             materializer=materializer,
@@ -325,6 +355,32 @@ def test_claimed_build_replays_inline_and_object_payloads_then_seals(
     ]
 
 
+@pytest.mark.parametrize(
+    "roster_identities",
+    [
+        FakeRosterIdentities(roster_ids=(1,)),
+        FakeRosterIdentities(
+            competition_id=UUID("33333333-3333-3333-3333-333333333333")
+        ),
+    ],
+)
+def test_invalid_roster_identity_input_fails_the_claim(
+    tmp_path: Path,
+    roster_identities: FakeRosterIdentities,
+) -> None:
+    service, snapshots, materializer, _ = _service(
+        tmp_path,
+        roster_identities=roster_identities,
+    )
+
+    with pytest.raises(InternalDatalayerFailure):
+        service.get_or_create(_request())
+
+    assert snapshots.failed[0].code == "snapshot_build_failed"
+    assert snapshots.sealed is None
+    assert materializer.calls == []
+
+
 def test_healthy_ready_snapshot_is_verified_without_rebuilding(tmp_path: Path) -> None:
     files = LocalDatalayerFileStore(tmp_path / "data")
     receipt = files.store_bytes(LocalArtifactKind.SNAPSHOT, b"ready")
@@ -333,7 +389,7 @@ def test_healthy_ready_snapshot_is_verified_without_rebuilding(tmp_path: Path) -
         through_week=1,
         as_of_date=date(2026, 10, 27),
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         code_version="test",
     )
     stored = _snapshot_from_command(
@@ -363,7 +419,7 @@ def test_corrupt_ready_snapshot_is_expired_before_replacement(tmp_path: Path) ->
         through_week=1,
         as_of_date=date(2026, 10, 27),
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         code_version="test",
     )
     stored = _snapshot_from_command(
@@ -417,7 +473,7 @@ def test_existing_build_times_out_without_stealing_a_healthy_claim(
         through_week=1,
         as_of_date=date(2026, 10, 27),
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         code_version="test",
     )
     building = _snapshot_from_command(command)
@@ -441,7 +497,7 @@ def test_existing_build_waits_for_and_reuses_ready_result(tmp_path: Path) -> Non
         through_week=1,
         as_of_date=date(2026, 10, 27),
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         code_version="test",
     )
     building = _snapshot_from_command(command)
@@ -470,7 +526,7 @@ def test_stale_existing_build_is_failed_before_reclaim(tmp_path: Path) -> None:
         through_week=1,
         as_of_date=date(2026, 10, 27),
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         code_version="test",
     )
     building = _snapshot_from_command(command)

--- a/backend/tests/services/datalayer/test_snapshot_source_projection.py
+++ b/backend/tests/services/datalayer/test_snapshot_source_projection.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import pytest
 
-from backend.resources.sleeper_data import SnapshotPlanningContext
+from backend.resources.sleeper_data import SeasonRosterIdentity, SnapshotPlanningContext
 from backend.services.datalayer import SnapshotRequest
 from backend.services.datalayer.canonical_json import parse_json_bytes
 from backend.services.datalayer.snapshot_selection import (
@@ -35,6 +35,19 @@ from backend.services.datalayer.sleeper.scope import EndpointKind
 SEASON_ID = UUID("11111111-1111-1111-1111-111111111111")
 COMPETITION_ID = UUID("22222222-2222-2222-2222-222222222222")
 FIXTURES = Path(__file__).parents[4] / "datalayer" / "tests" / "fixtures" / "sleeper"
+
+
+def _roster_identities() -> tuple[SeasonRosterIdentity, ...]:
+    return tuple(
+        SeasonRosterIdentity(
+            competition_id=COMPETITION_ID,
+            competition_season_id=SEASON_ID,
+            season_roster_id=UUID(int=100 + roster_id),
+            franchise_id=UUID(int=200 + roster_id),
+            sleeper_roster_id=str(roster_id),
+        )
+        for roster_id in (1, 2)
+    )
 
 
 def _context(*, playoff_start_week: int | None = 15) -> SnapshotPlanningContext:
@@ -106,9 +119,10 @@ def _fixture_input() -> SnapshotMaterializationInput:
         request=request,
         planning_context=context,
         build_key="a" * 64,
-        snapshot_projection_version="1",
+        snapshot_projection_version="2",
         manifest=SelectedRequestManifest(entries=tuple(manifest)),
         endpoint_records=tuple(endpoints),
+        roster_identities=_roster_identities(),
     )
 
 
@@ -196,3 +210,17 @@ def test_non_numeric_roster_ids_fail_closed() -> None:
         project_source_records(
             materialization.model_copy(update={"endpoint_records": tuple(endpoints)})
         )
+
+
+def test_duplicate_stable_roster_identities_are_rejected() -> None:
+    materialization = _fixture_input()
+    duplicate = materialization.roster_identities[1].model_copy(
+        update={
+            "season_roster_id": materialization.roster_identities[0].season_roster_id
+        }
+    )
+    payload = materialization.model_dump()
+    payload["roster_identities"] = (materialization.roster_identities[0], duplicate)
+
+    with pytest.raises(ValueError, match="duplicate season-roster IDs"):
+        SnapshotMaterializationInput.model_validate(payload)

--- a/backend/tests/services/datalayer/test_snapshot_sqlite_materializer.py
+++ b/backend/tests/services/datalayer/test_snapshot_sqlite_materializer.py
@@ -17,6 +17,7 @@ from backend.services.datalayer import (
 from backend.tests.services.datalayer.test_snapshot_service import (
     FakePlanning,
     FakeRequests,
+    FakeRosterIdentities,
     FakeSnapshots,
     _request,
 )
@@ -55,6 +56,13 @@ def test_artifact_contains_manifest_warnings_and_no_volatile_state(
         )
         player = dict(connection.execute("SELECT * FROM players LIMIT 1").fetchone())
         context = dict(connection.execute("SELECT * FROM season_context").fetchone())
+        identities = [
+            dict(row)
+            for row in connection.execute(
+                "SELECT * FROM roster_identities ORDER BY roster_id"
+            ).fetchall()
+        ]
+        user_version = connection.execute("PRAGMA user_version").fetchone()[0]
         connection.close()
 
         assert metadata["build_key"] == materialization.build_key
@@ -65,6 +73,11 @@ def test_artifact_contains_manifest_warnings_and_no_volatile_state(
         ]
         assert player["nfl_team"] is None
         assert player["status"] is None
+        assert user_version == 2
+        assert [row["roster_id"] for row in identities] == [1, 2]
+        assert identities[0]["season_roster_id"] == (
+            "00000000-0000-0000-0000-000000000065"
+        )
         assert context == {
             "league_id": "123",
             "computed_week": 2,
@@ -104,7 +117,7 @@ def test_corrupt_or_incomplete_sqlite_fails_closed(tmp_path: Path) -> None:
 
 def test_unsupported_projection_version_removes_staged_file(tmp_path: Path) -> None:
     materialization = _fixture_input().model_copy(
-        update={"snapshot_projection_version": "2"}
+        update={"snapshot_projection_version": "1"}
     )
     staging = tmp_path / "staging"
     materializer = SQLiteSnapshotMaterializer(staging)
@@ -127,6 +140,7 @@ def test_real_materializer_runs_through_storage_and_sealing(tmp_path: Path) -> N
     staging = tmp_path / "materializer-staging"
     service = DatalayerSnapshotService(
         planning=FixturePlanning(),
+        roster_identities=FakeRosterIdentities(),
         requests=requests,
         snapshots=snapshots,
         materializer=SQLiteSnapshotMaterializer(staging),

--- a/backend/tests/services/datalayer/test_snapshot_sqlite_schema.py
+++ b/backend/tests/services/datalayer/test_snapshot_sqlite_schema.py
@@ -12,6 +12,7 @@ EXPECTED_TABLES = {
     "season_context",
     "users",
     "rosters",
+    "roster_identities",
     "roster_players",
     "team_profiles",
     "draft_picks",
@@ -27,8 +28,8 @@ EXPECTED_TABLES = {
 }
 
 
-def test_v1_schema_is_snapshot_only_and_complete() -> None:
-    schema = get_snapshot_schema("1")
+def test_v2_schema_is_snapshot_only_and_complete() -> None:
+    schema = get_snapshot_schema("2")
 
     assert set(schema.tables) == EXPECTED_TABLES
     assert set(schema.table_order) == EXPECTED_TABLES
@@ -37,7 +38,7 @@ def test_v1_schema_is_snapshot_only_and_complete() -> None:
 
 
 def test_metadata_omits_volatile_snapshot_instance_fields() -> None:
-    columns = set(get_snapshot_schema("1").tables["snapshot_metadata"].c.keys())
+    columns = set(get_snapshot_schema("2").tables["snapshot_metadata"].c.keys())
 
     assert {
         "build_key",
@@ -47,8 +48,19 @@ def test_metadata_omits_volatile_snapshot_instance_fields() -> None:
     assert not {"snapshot_id", "created_at", "completed_at", "code_version"} & columns
 
 
+def test_roster_identity_table_has_stable_one_to_one_keys() -> None:
+    table = get_snapshot_schema("2").tables["roster_identities"]
+
+    assert [column.name for column in table.primary_key.columns] == [
+        "league_id",
+        "roster_id",
+    ]
+    assert table.c.season_roster_id.unique
+    assert table.c.franchise_id.unique
+
+
 def test_playoff_nodes_have_stable_key_and_legacy_matchup_seam() -> None:
-    table = get_snapshot_schema("1").tables["playoff_matchups"]
+    table = get_snapshot_schema("2").tables["playoff_matchups"]
 
     assert [column.name for column in table.primary_key.columns] == [
         "league_id",
@@ -61,7 +73,7 @@ def test_playoff_nodes_have_stable_key_and_legacy_matchup_seam() -> None:
 
 def test_real_sqlite_ddl_enforces_singleton_metadata(tmp_path: Path) -> None:
     engine = create_engine(f"sqlite:///{tmp_path / 'schema.sqlite'}")
-    schema = get_snapshot_schema("1")
+    schema = get_snapshot_schema("2")
     schema.metadata.create_all(engine)
     try:
         assert set(inspect(engine).get_table_names()) == EXPECTED_TABLES
@@ -79,7 +91,7 @@ def test_real_sqlite_ddl_enforces_singleton_metadata(tmp_path: Path) -> None:
                     "season_year": 2026,
                     "through_week": 8,
                     "as_of_date": "2026-10-27",
-                    "snapshot_projection_version": "1",
+                    "snapshot_projection_version": "2",
                     "selected_requests_json": "[]",
                     "completeness_warnings_json": "[]",
                 },
@@ -100,7 +112,7 @@ def test_real_sqlite_ddl_enforces_singleton_metadata(tmp_path: Path) -> None:
         engine.dispose()
 
 
-@pytest.mark.parametrize("version", ["", "2", " 1"])
+@pytest.mark.parametrize("version", ["", "1", " 2", "3"])
 def test_unknown_projection_version_is_rejected(version: str) -> None:
     with pytest.raises(ValueError, match="unsupported"):
         get_snapshot_schema(version)

--- a/backend/tests/services/datalayer/test_versions.py
+++ b/backend/tests/services/datalayer/test_versions.py
@@ -6,4 +6,4 @@ from backend.services.datalayer import (
 
 def test_compatibility_versions_are_explicit_nonempty_strings() -> None:
     assert INGESTION_NORMALIZER_VERSION == "1"
-    assert SNAPSHOT_PROJECTION_VERSION == "1"
+    assert SNAPSHOT_PROJECTION_VERSION == "2"

--- a/docs/datalayer/snapshots-and-query-runtime.md
+++ b/docs/datalayer/snapshots-and-query-runtime.md
@@ -8,6 +8,7 @@ consists of:
 
 - an explicit cutoff contract;
 - one selected complete API request per required endpoint scope;
+- one exact stable core identity for every selected Sleeper roster;
 - one snapshot projection version covering normalization, derivation, and
   SQLite compatibility;
 - a content-addressed, read-only SQLite artifact;
@@ -64,7 +65,7 @@ Selection is endpoint-aware:
   comes from the selected Week 8 matchup payload, not from a Week 10 rosters
   response.
 
-V1 does not accept an instant-based domain or observation cutoff. The source
+V2 does not accept an instant-based domain or observation cutoff. The source
 data needed to reconstruct matchups, transactions, lineups, and standings is
 week-scoped, and the datalayer does not need timestamp-level simulation
 precision. Exact knowledge-time replay is deliberately outside this contract.
@@ -100,6 +101,8 @@ sequenceDiagram
     else this caller claimed the build
         Service->>Obs: get season-stable planning settings
         Obs-->>Service: SnapshotPlanningContext
+        Service->>Obs: list stable roster identities
+        Obs-->>Service: SeasonRosterIdentity rows
         Service->>Require: plan(spec, season settings)
         Require-->>Service: SnapshotRequirements
         Service->>Obs: list candidate metadata for required season/scopes
@@ -137,12 +140,12 @@ The manager operations that claim/reuse identity and seal readiness are atomic;
 the overall build is intentionally not one database transaction. Candidate
 reads, payload verification, normalization, SQLite work, and local-file writes
 happen between those operations. If the content-addressed file write succeeds
-but sealing fails, the file is a harmless unreferenced orphan. V1 retains it
+but sealing fails, the file is a harmless unreferenced orphan. V2 retains it
 rather than adding a reference-aware cleanup workflow.
 
 ## Required Request Set
 
-V1 assumes structural league settings remain stable within one competition
+V2 assumes structural league settings remain stable within one competition
 season. `LeagueSeasonManager` returns a season-scoped `SnapshotPlanningContext`
 from the current normalized league configuration; a pure planner expands that
 context and the `SnapshotRequest` into explicit `SnapshotRequirements` using
@@ -153,7 +156,7 @@ artifact's league content and provenance.
 
 The selector never infers that a conditional scope was optional merely because
 no request candidate exists. Historical midseason settings changes are
-deliberately unsupported in v1; supporting them later requires versioned
+deliberately unsupported in v2; supporting them later requires versioned
 settings observations and a snapshot-projection-version change.
 
 For the initial single-season artifact:
@@ -326,6 +329,7 @@ so existing curated SQL can be moved with minimal change:
 - `season_context`;
 - `users`;
 - `rosters`;
+- `roster_identities`;
 - `roster_players`;
 - `team_profiles`;
 - `draft_picks`;
@@ -337,10 +341,11 @@ so existing curated SQL can be moved with minimal change:
 - `transactions`;
 - `transaction_moves`;
 - `playoff_matchups`;
-- `snapshot_metadata` (new).
+- `snapshot_metadata`.
 
-Internal UUID columns may be added alongside the existing `league_id`,
-`roster_id`, and `player_id` columns:
+Projection v2 keeps provider-facing `rosters` compatible and adds a separate
+one-to-one `roster_identities` relation. Each row binds `league_id` plus
+`roster_id` to:
 
 - `competition_id`;
 - `competition_season_id`;
@@ -348,8 +353,10 @@ Internal UUID columns may be added alongside the existing `league_id`,
 - `season_roster_id`.
 
 The initial curated queries continue to scope to one Sleeper league/season.
-Internal IDs support unambiguous tool results and future queries without
-silently combining multiple seasons now.
+The snapshot service reads these UUIDs from the scoped core roster resource and
+requires an exact match with the selected Sleeper roster response before the
+artifact can be built. The materializer and frozen runtime both reject missing,
+duplicate, malformed, or cross-scope mappings.
 
 ### Snapshot metadata table
 
@@ -373,7 +380,8 @@ The materializer:
 
 1. creates a new file using the declared snapshot projection version;
 2. inserts endpoint records in stable key order;
-3. derives snapshot-only facts from explicit selected endpoint records;
+3. derives snapshot-only facts and stable roster identity rows from explicit
+   selected inputs;
 4. inserts snapshot metadata;
 5. runs integrity and leakage checks;
 6. closes the connection and computes file hash/size;
@@ -433,7 +441,7 @@ The reporter does not receive a database storage key. Before
 4. makes the verified immutable file available for the duration of the run;
 5. returns `ReadyDataSnapshot` with a `VerifiedLocalArtifact`.
 
-In v1 the content-addressed file is already local, so resolution does not copy or
+In v2 the content-addressed file is already local, so resolution does not copy or
 download it. If API and worker processes are separated, they must share the
 configured data directory. A future hosted deployment can replace this seam
 with shared storage without changing snapshot identity or query runtime.
@@ -456,6 +464,14 @@ effective week and all identity come from sealed metadata.
 The existing `get_roster_current()` name should become
 `get_roster_at_cutoff()` because “current” inside this runtime always means the
 snapshot boundary, not current PostgreSQL state.
+
+`resolve_roster_identity(roster_key)` is the typed, non-model-facing identity
+seam used by later memory tools. It accepts a positive Sleeper roster ID or an
+exact case-insensitive team/manager name and returns one of
+`ResolvedRosterIdentity`, `AmbiguousRosterIdentity`, or
+`RosterIdentityNotFound`. A resolved value contains the frozen competition,
+competition-season, season-roster, franchise, Sleeper roster, team-name, and
+manager-name identity. It never consults PostgreSQL or source APIs.
 
 ## Curated Query Compatibility
 
@@ -494,7 +510,7 @@ statements, oversized results, and attempts to inspect attached databases.
 
 ## Retention
 
-Ready snapshot membership and meaning are immutable. V1 performs no proactive
+Ready snapshot membership and meaning are immutable. V2 performs no proactive
 snapshot or orphan deletion: healthy ready artifacts and benign unreferenced
 content-addressed files are retained. If a ready artifact is missing or corrupt,
 the service marks its snapshot expired while preserving request membership,

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -143,18 +143,13 @@ These are explicit design questions, not implied implementation details:
    generic event payloads, string-key upserts, and candidate expansion do not all
    exist in the new contract. The exact decisions are listed in
    [`transition.md`](transition.md#memory-tool-compatibility).
-3. **Reporter identity resolution is incomplete.** Typed memory writes need
-   durable franchise/season-roster IDs, while the current public
-   `FrozenLeagueData` surface resolves model-facing roster keys only inside
-   curated queries and does not expose the core identity mapping to the memory
-   adapter.
-4. **Cross-resource success atomicity is not yet settled.** The memory contract
+3. **Cross-resource success atomicity is not yet settled.** The memory contract
    currently commits through `RevisionManager`, while reporting finalization
    must also pin the selected reporter outputs and succeed the generation. The
    owner of a single all-or-nothing finalization transaction, or the accepted
    recovery semantics if it remains multi-transactional, must be decided before
    that slice is implemented.
-5. **The closed reporter-adapter PR is prior art, not an upstream dependency.**
+4. **The closed reporter-adapter PR is prior art, not an upstream dependency.**
    It proved the 18 frozen-data handlers can delegate to `FrozenLeagueData`, but
    the new integration must recreate that adapter under the new backend reporter
    package and verify it against current `main`.

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -228,11 +228,37 @@ exact non-tool metadata contract used to seed `research/brief.md` must be made
 public or supplied by `GenerationService`.
 
 Typed memory proposals involving a team require durable `franchise_id` or
-`season_roster_id`. The datalayer design promises stable core identity in frozen
-snapshots, but the current public `FrozenLeagueData` reporter surface does not
-expose a roster-key-to-core-ID resolver. The datalayer owner must define that
-read-only adapter seam before team-scoped memory tools can be implemented. The
-generation design does not invent its return shape.
+`season_roster_id`. Snapshot projection v2 stores one exact core identity for
+every selected Sleeper roster and `FrozenLeagueData` exposes the typed,
+read-only resolution seam:
+
+```python
+class FrozenRosterIdentity(BaseModel, frozen=True):
+    competition_id: UUID
+    competition_season_id: UUID
+    season_roster_id: UUID
+    franchise_id: UUID
+    sleeper_roster_id: str
+    team_name: str | None
+    manager_name: str | None
+
+
+RosterIdentityResolution = (
+    ResolvedRosterIdentity
+    | AmbiguousRosterIdentity
+    | RosterIdentityNotFound
+)
+
+
+def resolve_roster_identity(
+    roster_key: str | int,
+) -> RosterIdentityResolution: ...
+```
+
+Positive Sleeper roster IDs resolve exactly. Other keys use an exact,
+case-insensitive team-name or manager-name match. Ambiguity and absence are
+typed results rather than exceptions. Resolution reads only the already-open
+immutable snapshot; reporter memory tools never query PostgreSQL for identity.
 
 ## Typed Memory Adapter
 

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -241,6 +241,9 @@ are immutable.
 
 The service opens the frozen snapshot with a context manager, creates
 `GenerationMemoryContext` at the pinned revision, and calls the reporter.
+Snapshot projection v2 also exposes typed roster/team-to-core identity
+resolution from that same immutable runtime; memory tools do not consult a
+separate live identity source.
 
 The reporter:
 

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -199,13 +199,28 @@ equivalent; provider order remains the tool ordinal under parallel completion.
 **Exit gate:** all artifact histories can be reconstructed from immutable
 versions and the submitted output revision is represented exactly once.
 
-### `generation-8` — typed memory reporter adapter
+### `generation-8a` — frozen roster identity seam
+
+- Add stable season-roster and franchise identity reads to the scoped roster
+  resource.
+- Require one exact core identity for every selected Sleeper roster during
+  snapshot materialization.
+- Bump the snapshot projection to v2 and store the mapping in a separate
+  immutable `roster_identities` table.
+- Expose typed resolved, ambiguous, and not-found results through
+  `FrozenLeagueData.resolve_roster_identity()`.
+
+**Exit gate:** missing, duplicate, malformed, or cross-scope mappings fail the
+snapshot build/runtime, and ID/team/manager keys resolve without PostgreSQL or
+private connection access.
+
+### `generation-8b` — typed memory reporter adapter
 
 - Implement only the memory tool mappings settled in `generation-0`.
 - Register tools over `GenerationMemoryContext`, never over managers or legacy
   `ContextStore`.
-- Add authoritative roster/team-to-core identity resolution from the agreed
-  datalayer seam.
+- Resolve model-facing roster/team references through the generation-8a frozen
+  identity seam.
 - Keep searches pinned and writes buffered.
 - Update prompts/procedures to the approved typed tool vocabulary.
 - Remove legacy memory registration in the target package.
@@ -289,14 +304,16 @@ flowchart LR
     G6 --> G7["G7 artifact persistence"]
     G3 --> G7
     G4D --> G7
-    G1 --> G8["G8 memory adapter"]
-    Memory["Typed memory integration-ready"] --> G8
+    Data --> G8A["G8a roster identity"]
+    G1 --> G8B["G8b memory adapter"]
+    G8A --> G8B
+    Memory["Typed memory integration-ready"] --> G8B
     Data["Merged frozen datalayer"] --> G1
     Data --> G9["G9 generation inputs"]
     G4A --> G9
     G5B --> G9
     G7 --> G9
-    G8 --> G9
+    G8B --> G9
     G9 --> G10["G10 finalization"]
     G4D --> G10
     G10 --> G11["G11 API/worker"]
@@ -329,15 +346,7 @@ Approve a final model-facing set for typed memory, including decisions for:
 The matrix in [`transition.md`](transition.md#memory-tool-compatibility) is the
 starting point.
 
-### 3. Frozen identity resolution
-
-The datalayer contract must expose the stable identity needed to translate a
-model-facing roster/team reference into typed memory entity IDs. Confirm the
-authoritative method and return shape with the datalayer design owner. Do not
-reach into `FrozenLeagueData._connection` or query a PostgreSQL manager from a
-reporter tool.
-
-### 4. Finalization atomicity
+### 3. Finalization atomicity
 
 Choose one documented invariant:
 

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -190,10 +190,10 @@ state or weakened validation.
 | V2 tool | Typed-memory capability | Decision status |
 | --- | --- | --- |
 | `save_persistent_storyline` | typed storyline create/replace | Prefer removal after migrating prompts to the richer typed tool; preserving alias/upsert semantics would hide revision conflicts |
-| `save_team_context` | franchise-scoped `ContextNoteContent` | Adaptable only after an authoritative roster-key-to-franchise resolver exists |
+| `save_team_context` | franchise-scoped `ContextNoteContent` | Adaptable through the frozen typed roster-identity resolver |
 | `save_league_note` | competition-scoped `ContextNoteContent` | Adaptable, but key/value input must map explicitly to typed identity plus narrative/status/tags |
 | `load_persistent_storylines` | filter-only pinned search for storyline kind | Adaptable with a documented response-shape change |
-| `load_team_context` | filter-only pinned search for context-note kind/entity | Adaptable after durable team identity resolution is available |
+| `load_team_context` | filter-only pinned search for context-note kind/entity | Adaptable through the frozen typed roster-identity resolver |
 | `load_league_notes` | filter-only pinned search for competition context notes | Adaptable with a documented response-shape change |
 
 No implementation should register both legacy and new write handlers against


### PR DESCRIPTION
## Summary

- add competition-scoped stable season-roster and franchise identity reads
- require exact core identity coverage for every selected Sleeper roster
- bump frozen snapshot projection to v2 with immutable roster identity rows
- expose typed resolved, ambiguous, and not-found roster identity results

## Verification

- 65 targeted resource, snapshot, frozen-runtime, integration, and composition tests passed
- compile, 99-column, and git diff checks passed
- full suite intentionally not run

## Stack

- base: codex/generation-7
- commit: d5b5052
- next: generation-8b typed memory reporter adapter
