### PR TITLE
feat(generation): execute pinned reporter runs

### DIFF
--- a/backend/services/generations/__init__.py
+++ b/backend/services/generations/__init__.py
@@ -1,5 +1,16 @@
 """Generation workflow helpers that do not own resource persistence."""
 
+from backend.services.generations.contracts import (
+    GenerationBiasSettings,
+    GenerationExecutionResult,
+    GenerationModelSettings,
+    GenerationReportSettings,
+    GenerationRequest,
+    GenerationRetrySettings,
+    GenerationRunnerSettings,
+    GenerationSettings,
+    GenerationToneSettings,
+)
 from backend.services.generations.manifest import (
     MANIFEST_SCHEMA_VERSION,
     BuiltGenerationManifest,
@@ -20,6 +31,7 @@ from backend.services.generations.manifest import (
     canonical_json_sha256,
 )
 from backend.services.generations.recorder import GenerationExecutionRecorder
+from backend.services.generations.service import GenerationService
 
 __all__ = [
     "MANIFEST_SCHEMA_VERSION",
@@ -30,7 +42,17 @@ __all__ = [
     "EvaluationArtifactMemoryInput",
     "GenerationManifestInput",
     "GenerationExecutionRecorder",
+    "GenerationExecutionResult",
+    "GenerationBiasSettings",
+    "GenerationModelSettings",
+    "GenerationReportSettings",
+    "GenerationRequest",
     "GenerationRequestInput",
+    "GenerationRetrySettings",
+    "GenerationRunnerSettings",
+    "GenerationService",
+    "GenerationSettings",
+    "GenerationToneSettings",
     "ManifestCutoffs",
     "ModelExecutionInput",
     "ProcedureInput",

--- a/backend/services/generations/contracts.py
+++ b/backend/services/generations/contracts.py
@@ -1,0 +1,121 @@
+"""Typed workflow values for generation submission and execution."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+from backend.resources.reporting.generations import Generation, GenerationKind
+from backend.services.memory import MemoryMutationBundle
+from backend.services.reporter import ReporterOutput
+
+
+PositiveWeek = Annotated[int, Field(strict=True, ge=1, le=18)]
+PositiveInt = Annotated[int, Field(strict=True, ge=1)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+ControlLevel = Annotated[int, Field(strict=True, ge=0, le=3)]
+
+
+class GenerationToneSettings(ContractModel):
+    snark_level: ControlLevel = 1
+    hype_level: ControlLevel = 1
+    seriousness: ControlLevel = 1
+
+
+class GenerationBiasSettings(ContractModel):
+    favored_teams: tuple[NonBlankStr, ...] = ()
+    disfavored_teams: tuple[NonBlankStr, ...] = ()
+    intensity: ControlLevel = 1
+
+
+class GenerationReportSettings(ContractModel):
+    focus_hints: tuple[NonBlankStr, ...] = ()
+    avoid_topics: tuple[NonBlankStr, ...] = ()
+    focus_teams: tuple[NonBlankStr, ...] = ()
+    voice: NonBlankStr = "sports columnist"
+    tone: GenerationToneSettings = Field(default_factory=GenerationToneSettings)
+    profanity_policy: Literal["none", "mild", "unrestricted"] = "none"
+    bias: GenerationBiasSettings | None = None
+    length_target: PositiveInt = 1000
+    evidence_policy: Literal["strict", "standard", "relaxed"] = "standard"
+
+
+class GenerationRetrySettings(ContractModel):
+    max_retries: NonNegativeInt = 3
+    base_delay_seconds: float = Field(default=1.0, gt=0)
+    max_delay_seconds: float = Field(default=30.0, gt=0)
+
+    @model_validator(mode="after")
+    def validate_delays(self) -> "GenerationRetrySettings":
+        if self.max_delay_seconds < self.base_delay_seconds:
+            raise ValueError("max delay must be greater than or equal to base delay")
+        return self
+
+
+class GenerationModelSettings(ContractModel):
+    fallback_models: tuple[NonBlankStr, ...] = ()
+    retry: GenerationRetrySettings = Field(default_factory=GenerationRetrySettings)
+
+    @model_validator(mode="after")
+    def validate_fallbacks(self) -> "GenerationModelSettings":
+        if len(self.fallback_models) != len(set(self.fallback_models)):
+            raise ValueError("fallback models must be unique")
+        return self
+
+
+class GenerationRunnerSettings(ContractModel):
+    max_turns: PositiveInt = 60
+    procedure_history_mode: Literal["replace", "append"] = "replace"
+
+
+class GenerationSettings(ContractModel):
+    report: GenerationReportSettings = Field(default_factory=GenerationReportSettings)
+    model: GenerationModelSettings = Field(default_factory=GenerationModelSettings)
+    runner: GenerationRunnerSettings = Field(default_factory=GenerationRunnerSettings)
+
+
+class GenerationRequest(ContractModel):
+    generation_id: UUID
+    competition_id: UUID
+    competition_season_id: UUID
+    kind: GenerationKind
+    request_text: NonBlankStr
+    week_start: PositiveWeek
+    week_end: PositiveWeek
+    requested_primary_model: NonBlankStr
+    settings: GenerationSettings = Field(default_factory=GenerationSettings)
+    rerun_of_generation_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_week_range(self) -> "GenerationRequest":
+        if self.week_start > self.week_end:
+            raise ValueError("week_start cannot be after week_end")
+        chain = (
+            self.requested_primary_model,
+            *self.settings.model.fallback_models,
+        )
+        if len(chain) != len(set(chain)):
+            raise ValueError("resolved model chain must not contain duplicates")
+        return self
+
+
+class GenerationExecutionResult(ContractModel):
+    generation: Generation
+    reporter_output: ReporterOutput
+    memory_bundle: MemoryMutationBundle
+
+
+__all__ = [
+    "GenerationBiasSettings",
+    "GenerationExecutionResult",
+    "GenerationModelSettings",
+    "GenerationReportSettings",
+    "GenerationRequest",
+    "GenerationRetrySettings",
+    "GenerationRunnerSettings",
+    "GenerationSettings",
+    "GenerationToneSettings",
+]

--- a/backend/services/generations/manifest.py
+++ b/backend/services/generations/manifest.py
@@ -63,7 +63,7 @@ MemoryInput: TypeAlias = Annotated[
 
 class ManifestCutoffs(ContractModel):
     domain_cutoff_week: PositiveWeek
-    domain_cutoff_at: AwareDatetime
+    domain_cutoff_at: AwareDatetime | None = None
     knowledge_cutoff_at: AwareDatetime
 
 

--- a/backend/services/generations/service.py
+++ b/backend/services/generations/service.py
@@ -1,0 +1,450 @@
+"""Generation-owned input resolution and reporter execution workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+import hashlib
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+from pydantic import JsonValue
+
+from backend.resources.memory.revisions import CanonicalRevision, RevisionManager
+from backend.resources.reporting.ai_calls import AICallManager
+from backend.resources.reporting.artifact_versions import ArtifactVersionManager
+from backend.resources.reporting.artifacts import ArtifactManager
+from backend.resources.reporting.generations import (
+    CreateGeneration,
+    Generation,
+    GenerationKind,
+    GenerationLifecycleConflict,
+    GenerationManager,
+    GenerationStatus,
+    StartGeneration,
+)
+from backend.resources.reporting.tool_calls import ToolCallManager
+from backend.services.datalayer import (
+    DatalayerSnapshotService,
+    FrozenLeagueData,
+    ReadyDataSnapshot,
+    SnapshotRequest,
+)
+from backend.services.generations.contracts import (
+    GenerationExecutionResult,
+    GenerationRequest,
+    GenerationSettings,
+)
+from backend.services.generations.manifest import (
+    BuiltGenerationManifest,
+    CanonicalMemoryInput,
+    CodeRevisionInput,
+    DataSnapshotInput,
+    GenerationManifestInput,
+    GenerationRequestInput,
+    ManifestCutoffs,
+    ModelExecutionInput,
+    ProcedureInput,
+    RetryPolicyInput,
+    RunnerExecutionInput,
+    ToolInput,
+    build_generation_manifest,
+)
+from backend.services.generations.recorder import GenerationExecutionRecorder
+from backend.services.memory import (
+    GenerationMemoryContext,
+    MemoryRetrievalService,
+)
+from backend.services.reporter import (
+    BiasProfile,
+    PreparedReporterDefinition,
+    ProcedureHistoryMode,
+    ReportConfig,
+    ReporterOutput,
+    RunnerConfig,
+    TimeRange,
+    ToneControls,
+    generate_article,
+    prepare_reporter_definition,
+)
+from backend.services.reporter.runner.completion import (
+    CompletionSettings,
+    RetryPolicy,
+)
+
+
+GENERATION_SETTINGS_SCHEMA_VERSION = 1
+SNAPSHOT_REFRESH_POLICY = "never"
+BACKTEST_MEMORY_POLICY = "latest_same_season_at_or_before_week"
+
+ReporterCallable = Callable[..., Awaitable[ReporterOutput]]
+ReporterDefinitionFactory = Callable[..., PreparedReporterDefinition]
+FrozenDataFactory = Callable[[ReadyDataSnapshot], FrozenLeagueData]
+Clock = Callable[[], datetime]
+
+
+class SnapshotResolver(Protocol):
+    def get_or_create(self, request: SnapshotRequest) -> ReadyDataSnapshot: ...
+
+
+class GenerationService:
+    """Submit durable requests and execute one fully pinned reporter run."""
+
+    def __init__(
+        self,
+        *,
+        generations: GenerationManager,
+        snapshots: DatalayerSnapshotService | SnapshotResolver,
+        revisions: RevisionManager,
+        retrieval: MemoryRetrievalService,
+        ai_calls: AICallManager,
+        tool_calls: ToolCallManager,
+        artifacts: ArtifactManager,
+        artifact_versions: ArtifactVersionManager,
+        reporter_revision: str,
+        generation_revision: str,
+        reporter: ReporterCallable = generate_article,
+        prepare_definition: ReporterDefinitionFactory = prepare_reporter_definition,
+        open_frozen_data: FrozenDataFactory = FrozenLeagueData.open,
+        clock: Clock | None = None,
+    ) -> None:
+        self._generations = generations
+        self._snapshots = snapshots
+        self._revisions = revisions
+        self._retrieval = retrieval
+        self._ai_calls = ai_calls
+        self._tool_calls = tool_calls
+        self._artifacts = artifacts
+        self._artifact_versions = artifact_versions
+        self._reporter_revision = _nonblank(reporter_revision, "reporter_revision")
+        self._generation_revision = _nonblank(
+            generation_revision, "generation_revision"
+        )
+        self._reporter = reporter
+        self._prepare_definition = prepare_definition
+        self._open_frozen_data = open_frozen_data
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def submit(self, request: GenerationRequest) -> Generation:
+        """Persist one resolved pending generation without external work."""
+
+        self._require_scope(request.competition_id)
+        settings = _resolved_settings(request.settings)
+        return self._generations.create_pending(
+            CreateGeneration(
+                generation_id=request.generation_id,
+                competition_season_id=request.competition_season_id,
+                kind=request.kind,
+                request_text=request.request_text,
+                week_start=request.week_start,
+                week_end=request.week_end,
+                requested_primary_model=request.requested_primary_model,
+                settings=settings,
+                rerun_of_generation_id=request.rerun_of_generation_id,
+            )
+        )
+
+    async def execute(self, generation_id: UUID) -> GenerationExecutionResult:
+        """Resolve immutable inputs, start atomically, and call the reporter once."""
+
+        pending = self._generations.get(generation_id)
+        if pending.status is not GenerationStatus.PENDING:
+            raise GenerationLifecycleConflict(
+                pending.id,
+                "generation must be pending for execution",
+                expected_statuses=(GenerationStatus.PENDING.value,),
+                actual_status=pending.status.value,
+            )
+        if pending.week_start is None or pending.week_end is None:
+            raise ValueError("generation execution requires a resolved week range")
+
+        execution_at = _aware_utc(self._clock())
+        settings = _decode_settings(pending.settings)
+        snapshot = self._snapshots.get_or_create(
+            SnapshotRequest(
+                competition_season_id=pending.competition_season_id,
+                through_week=pending.week_end,
+                as_of_date=execution_at.date(),
+            )
+        )
+        if (
+            snapshot.competition_id != pending.competition_id
+            or snapshot.primary_competition_season_id
+            != pending.competition_season_id
+            or snapshot.through_week != pending.week_end
+        ):
+            raise ValueError("resolved snapshot differs from generation scope or cutoff")
+
+        revision = self._select_memory_revision(pending)
+        knowledge_cutoff_at = (
+            execution_at
+            if pending.kind is GenerationKind.LIVE
+            else revision.knowledge_cutoff_at or revision.created_at
+        )
+        definition = self._prepare_definition(memory_enabled=True)
+        manifest = _build_manifest(
+            generation=pending,
+            settings=settings,
+            resolved_settings=pending.settings,
+            snapshot=snapshot,
+            revision=revision,
+            knowledge_cutoff_at=knowledge_cutoff_at,
+            definition=definition,
+            reporter_revision=self._reporter_revision,
+            generation_revision=self._generation_revision,
+        )
+        self._generations.start(
+            StartGeneration(
+                generation_id=pending.id,
+                data_snapshot_id=snapshot.id,
+                input_memory_revision_id=revision.revision_id,
+                knowledge_cutoff_at=knowledge_cutoff_at,
+                input_manifest=manifest.manifest,
+                manifest_schema_version=manifest.schema_version,
+                manifest_hash=manifest.manifest_hash,
+                initial_stage="starting",
+            )
+        )
+
+        memory = GenerationMemoryContext(
+            competition_id=pending.competition_id,
+            generation_id=pending.id,
+            pinned_revision_id=revision.revision_id,
+            retrieval=self._retrieval,
+            competition_season_id=pending.competition_season_id,
+            week=pending.week_end,
+            knowledge_cutoff_at=knowledge_cutoff_at,
+        )
+        try:
+            recorder = GenerationExecutionRecorder(
+                pending.id,
+                self._ai_calls,
+                self._tool_calls,
+                self._generations,
+                self._artifacts,
+                self._artifact_versions,
+            )
+            with self._open_frozen_data(snapshot) as data:
+                output = await self._reporter(
+                    data,
+                    _report_config(pending, settings),
+                    memory_context=memory,
+                    completion=_completion_settings(pending, settings),
+                    runner_config=_runner_config(settings),
+                    recorder=recorder,
+                    allow_memory_writes=pending.kind is GenerationKind.LIVE,
+                    definition=definition,
+                )
+            bundle = memory.take_completed_bundle()
+        except BaseException:
+            memory.discard()
+            raise
+
+        return GenerationExecutionResult(
+            generation=self._generations.get(pending.id),
+            reporter_output=output,
+            memory_bundle=bundle,
+        )
+
+    def _select_memory_revision(self, generation: Generation) -> CanonicalRevision:
+        if generation.kind is GenerationKind.LIVE:
+            return self._revisions.current()
+        if generation.week_end is None:
+            raise ValueError("backtest memory selection requires a cutoff week")
+        history = self._revisions.history()
+        eligible = [
+            revision
+            for revision in history
+            if revision.competition_season_id == generation.competition_season_id
+            and revision.week is not None
+            and revision.week <= generation.week_end
+        ]
+        if eligible:
+            return max(eligible, key=lambda revision: revision.sequence_number)
+        roots = [revision for revision in history if revision.sequence_number == 0]
+        if not roots:
+            raise ValueError("backtest memory selection requires a root revision")
+        return roots[0]
+
+    def _require_scope(self, competition_id: UUID) -> None:
+        if competition_id != self._generations.competition_id:
+            raise ValueError("generation request is outside the service competition")
+
+
+def _resolved_settings(settings: GenerationSettings) -> dict[str, JsonValue]:
+    resolved = cast(dict[str, JsonValue], settings.model_dump(mode="json"))
+    return {
+        "schema_version": GENERATION_SETTINGS_SCHEMA_VERSION,
+        **resolved,
+        "input_policy": {
+            "snapshot_refresh": SNAPSHOT_REFRESH_POLICY,
+            "snapshot_as_of_date": "execution_utc_date",
+            "backtest_memory": BACKTEST_MEMORY_POLICY,
+        },
+    }
+
+
+def _decode_settings(value: dict[str, JsonValue]) -> GenerationSettings:
+    if value.get("schema_version") != GENERATION_SETTINGS_SCHEMA_VERSION:
+        raise ValueError("generation settings schema version is unsupported")
+    expected_policy = {
+        "snapshot_refresh": SNAPSHOT_REFRESH_POLICY,
+        "snapshot_as_of_date": "execution_utc_date",
+        "backtest_memory": BACKTEST_MEMORY_POLICY,
+    }
+    if value.get("input_policy") != expected_policy:
+        raise ValueError("generation input policy differs from the submitted policy")
+    return GenerationSettings.model_validate(
+        {key: value[key] for key in ("report", "model", "runner")}
+    )
+
+
+def _build_manifest(
+    *,
+    generation: Generation,
+    settings: GenerationSettings,
+    resolved_settings: dict[str, JsonValue],
+    snapshot: ReadyDataSnapshot,
+    revision: CanonicalRevision,
+    knowledge_cutoff_at: datetime,
+    definition: PreparedReporterDefinition,
+    reporter_revision: str,
+    generation_revision: str,
+) -> BuiltGenerationManifest:
+    if generation.week_end is None:
+        raise ValueError("manifest construction requires a cutoff week")
+    retry = settings.model.retry
+    return build_generation_manifest(
+        GenerationManifestInput(
+            generation=GenerationRequestInput(
+                kind=generation.kind,
+                request_text=generation.request_text,
+                resolved_settings=resolved_settings,
+            ),
+            data_snapshot=DataSnapshotInput(
+                data_snapshot_id=snapshot.id,
+                snapshot_projection_version=snapshot.snapshot_projection_version,
+                artifact_sha256=snapshot.artifact.sha256,
+            ),
+            memory_input=CanonicalMemoryInput(revision_id=revision.revision_id),
+            cutoffs=ManifestCutoffs(
+                domain_cutoff_week=generation.week_end,
+                domain_cutoff_at=None,
+                knowledge_cutoff_at=knowledge_cutoff_at,
+            ),
+            model=ModelExecutionInput(
+                requested_model=generation.requested_primary_model,
+                fallback_models=settings.model.fallback_models,
+                retry=RetryPolicyInput(
+                    max_retries=retry.max_retries,
+                    base_delay_seconds=retry.base_delay_seconds,
+                    max_delay_seconds=retry.max_delay_seconds,
+                ),
+                request_parameters={},
+            ),
+            runner=RunnerExecutionInput(
+                max_turns=settings.runner.max_turns,
+                procedure_history_mode=settings.runner.procedure_history_mode,
+            ),
+            system_prompt_sha256=_content_sha256(definition.system_prompt),
+            procedures=tuple(
+                ProcedureInput(
+                    name=procedure.name,
+                    content_sha256=_content_sha256(procedure.content),
+                )
+                for procedure in definition.procedures
+            ),
+            tools=tuple(
+                ToolInput(
+                    name=tool.name,
+                    definition=cast(dict[str, JsonValue], tool.definition),
+                    implementation_version=tool.implementation_version,
+                )
+                for tool in definition.tools
+            ),
+            code=CodeRevisionInput(
+                reporter_revision=reporter_revision,
+                generation_revision=generation_revision,
+            ),
+        )
+    )
+
+
+def _report_config(
+    generation: Generation,
+    settings: GenerationSettings,
+) -> ReportConfig:
+    if generation.week_start is None or generation.week_end is None:
+        raise ValueError("report configuration requires a week range")
+    report = settings.report
+    bias = report.bias
+    return ReportConfig(
+        time_range=TimeRange.range(generation.week_start, generation.week_end),
+        focus_hints=list(report.focus_hints),
+        avoid_topics=list(report.avoid_topics),
+        focus_teams=list(report.focus_teams),
+        voice=report.voice,
+        tone=ToneControls(**report.tone.model_dump()),
+        profanity_policy=report.profanity_policy,
+        bias_profile=(
+            BiasProfile(
+                favored_teams=list(bias.favored_teams),
+                disfavored_teams=list(bias.disfavored_teams),
+                intensity=bias.intensity,
+            )
+            if bias is not None
+            else None
+        ),
+        length_target=report.length_target,
+        evidence_policy=report.evidence_policy,
+        custom_instructions=generation.request_text,
+    )
+
+
+def _completion_settings(
+    generation: Generation,
+    settings: GenerationSettings,
+) -> CompletionSettings:
+    retry = settings.model.retry
+    return CompletionSettings(
+        model=generation.requested_primary_model,
+        fallback_models=settings.model.fallback_models,
+        retry=RetryPolicy(
+            max_retries=retry.max_retries,
+            base_delay=retry.base_delay_seconds,
+            max_delay=retry.max_delay_seconds,
+        ),
+    )
+
+
+def _runner_config(settings: GenerationSettings) -> RunnerConfig:
+    return RunnerConfig(
+        max_turns=settings.runner.max_turns,
+        procedure_history_mode=ProcedureHistoryMode(
+            settings.runner.procedure_history_mode
+        ),
+    )
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("generation clock must return an aware datetime")
+    return value.astimezone(UTC)
+
+
+def _content_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _nonblank(value: str, field: str) -> str:
+    if not value or value.strip() != value:
+        raise ValueError(f"{field} must be non-blank and trimmed")
+    return value
+
+
+__all__ = [
+    "BACKTEST_MEMORY_POLICY",
+    "GENERATION_SETTINGS_SCHEMA_VERSION",
+    "GenerationService",
+    "SNAPSHOT_REFRESH_POLICY",
+]

--- a/backend/services/memory/generation_context.py
+++ b/backend/services/memory/generation_context.py
@@ -219,6 +219,14 @@ class GenerationMemoryContext:
         self._closed = True
         return bundle
 
+    def discard(self) -> None:
+        """Close and erase an abandoned proposal buffer without persistence."""
+
+        if self._closed:
+            return
+        self._proposals.clear()
+        self._closed = True
+
     def _create(
         self,
         kind: MemoryKind,

--- a/backend/services/reporter/__init__.py
+++ b/backend/services/reporter/__init__.py
@@ -6,6 +6,12 @@ from backend.services.reporter.config import (
     TimeRange,
     ToneControls,
 )
+from backend.services.reporter.definition import (
+    PreparedProcedure,
+    PreparedReporterDefinition,
+    PreparedTool,
+    prepare_reporter_definition,
+)
 from backend.services.reporter.generator import generate_article
 from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.schemas import ReporterOutput
@@ -16,6 +22,9 @@ __all__ = [
     "ReporterOutput",
     "BiasProfile",
     "ProcedureHistoryMode",
+    "PreparedProcedure",
+    "PreparedReporterDefinition",
+    "PreparedTool",
     "ReportConfig",
     "Runner",
     "RunnerConfig",
@@ -23,4 +32,5 @@ __all__ = [
     "ToneControls",
     "ToolRegistry",
     "generate_article",
+    "prepare_reporter_definition",
 ]

--- a/backend/services/reporter/definition.py
+++ b/backend/services/reporter/definition.py
@@ -1,0 +1,106 @@
+"""Immutable reporter inputs prepared before a generation starts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.artifact_tools import (
+    ARTIFACT_TOOL_IMPLEMENTATION_VERSION,
+    ARTIFACT_TOOL_SPECS,
+)
+from backend.services.reporter.runner.tools.datalayer_tools import (
+    DATALAYER_TOOL_IMPLEMENTATION_VERSION,
+    DATALAYER_TOOL_SPECS,
+)
+from backend.services.reporter.runner.tools.memory_tools import (
+    MEMORY_TOOL_IMPLEMENTATION_VERSION,
+    MEMORY_TOOL_SPECS,
+)
+from backend.services.reporter.runner.tools.procedure_tools import (
+    PROCEDURE_DIR,
+    PROCEDURE_TOOL_IMPLEMENTATION_VERSION,
+    PROCEDURE_TOOL_SPECS,
+    VALID_PROCEDURES,
+)
+
+
+class PreparedProcedure(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    content: str
+
+
+class PreparedTool(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    definition: ToolDef
+    implementation_version: str
+
+
+class PreparedReporterDefinition(BaseModel):
+    """The exact prompt, procedures, and tools sealed for one run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    system_prompt: str
+    procedures: tuple[PreparedProcedure, ...]
+    tools: tuple[PreparedTool, ...]
+
+    @property
+    def procedure_contents(self) -> dict[str, str]:
+        return {procedure.name: procedure.content for procedure in self.procedures}
+
+
+def prepare_reporter_definition(
+    *,
+    memory_enabled: bool,
+) -> PreparedReporterDefinition:
+    """Read reporter assets once and snapshot its model-facing tool bundle."""
+
+    reporter_dir = Path(__file__).resolve().parent
+    system_prompt = (reporter_dir / "prompts" / "system.md").read_text(
+        encoding="utf-8"
+    ).strip()
+    procedures = tuple(
+        PreparedProcedure(
+            name=name,
+            content=(PROCEDURE_DIR / f"{name}.md").read_text(encoding="utf-8"),
+        )
+        for name in sorted(VALID_PROCEDURES)
+    )
+    groups = [
+        (ARTIFACT_TOOL_SPECS, ARTIFACT_TOOL_IMPLEMENTATION_VERSION),
+        (PROCEDURE_TOOL_SPECS, PROCEDURE_TOOL_IMPLEMENTATION_VERSION),
+        (DATALAYER_TOOL_SPECS, DATALAYER_TOOL_IMPLEMENTATION_VERSION),
+    ]
+    if memory_enabled:
+        groups.append((MEMORY_TOOL_SPECS, MEMORY_TOOL_IMPLEMENTATION_VERSION))
+
+    tools = tuple(
+        PreparedTool(
+            name=spec["function"]["name"],
+            definition=deepcopy(spec),
+            implementation_version=version,
+        )
+        for specs, version in groups
+        for spec in specs
+    )
+    return PreparedReporterDefinition(
+        system_prompt=system_prompt,
+        procedures=procedures,
+        tools=tools,
+    )
+
+
+__all__ = [
+    "PreparedProcedure",
+    "PreparedReporterDefinition",
+    "PreparedTool",
+    "prepare_reporter_definition",
+]

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -18,6 +18,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from backend.services.reporter.config import ReportConfig
+from backend.services.reporter.definition import (
+    PreparedReporterDefinition,
+    prepare_reporter_definition,
+)
 from backend.services.reporter.runner.completion import (
     CompletionClient,
     CompletionFn,
@@ -55,6 +59,7 @@ async def generate_article(
     complete: CompletionFn | None = None,
     recorder: ExecutionRecorder | None = None,
     allow_memory_writes: bool = True,
+    definition: PreparedReporterDefinition | None = None,
 ) -> ReporterOutput:
     """Generate an article with the single-loop v2 runner.
 
@@ -71,11 +76,16 @@ async def generate_article(
         allow_memory_writes: When False (eval mode), skip memory mutations
             while retaining pinned memory search.
     """
+    prepared = definition or prepare_reporter_definition(
+        memory_enabled=memory_context is not None
+    )
     registry = _build_registry(
         data,
         memory_context=memory_context,
         allow_memory_writes=allow_memory_writes,
+        procedures=prepared.procedure_contents,
     )
+    _require_matching_definition(registry, prepared)
     resolved_recorder = recorder
     if resolved_recorder is None and client is not None:
         resolved_recorder = cast(ExecutionRecorder | None, client.recorder)
@@ -114,7 +124,7 @@ async def generate_article(
         recorder=resolved_recorder,
     )
 
-    return await runner.run(_build_system_prompt(), _build_user_message(config))
+    return await runner.run(prepared.system_prompt, _build_user_message(config))
 
 
 def _seed_artifact_recorder(
@@ -144,10 +154,11 @@ def _build_registry(
     *,
     memory_context: GenerationMemoryContext | None,
     allow_memory_writes: bool,
+    procedures: dict[str, str] | None = None,
 ) -> ToolRegistry:
     registry = ToolRegistry()
     register_artifact_tools(registry)
-    register_procedure_tools(registry)
+    register_procedure_tools(registry, procedures)
     register_datalayer_tools(registry, data)
     if memory_context is not None:
         register_memory_tools(
@@ -157,6 +168,20 @@ def _build_registry(
             allow_memory_writes=allow_memory_writes,
         )
     return registry
+
+
+def _require_matching_definition(
+    registry: ToolRegistry,
+    definition: PreparedReporterDefinition,
+) -> None:
+    expected_specs = [tool.definition for tool in definition.tools]
+    expected_versions = [
+        (tool.name, tool.implementation_version) for tool in definition.tools
+    ]
+    if registry.tool_specs != expected_specs:
+        raise ValueError("prepared reporter tool definitions differ from execution")
+    if registry.tool_implementation_versions != expected_versions:
+        raise ValueError("prepared reporter tool versions differ from execution")
 
 
 def _resolve_client(

--- a/backend/services/reporter/runner/tools/procedure_tools.py
+++ b/backend/services/reporter/runner/tools/procedure_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 
 from backend.services.reporter.runner.models import ToolDef
@@ -12,7 +13,7 @@ from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
 VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
-PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "1"
+PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "2"
 
 PROCEDURE_TOOL_SPECS: list[ToolDef] = [
     {
@@ -38,17 +39,30 @@ PROCEDURE_TOOL_SPECS: list[ToolDef] = [
 ]
 
 
-def register_procedure_tools(registry: ToolRegistry) -> None:
+def register_procedure_tools(
+    registry: ToolRegistry,
+    procedures: Mapping[str, str] | None = None,
+) -> None:
     """Register procedure-loading tools against a ToolRegistry."""
+    frozen_procedures = dict(procedures) if procedures is not None else None
+
+    def handler(ctx: ToolContext, *, name: str) -> str:
+        return load_procedure(ctx, name=name, procedures=frozen_procedures)
+
     registry.register_context_tool(
         "load_procedure",
-        load_procedure,
+        handler,
         PROCEDURE_TOOL_SPECS[0],
         PROCEDURE_TOOL_IMPLEMENTATION_VERSION,
     )
 
 
-def load_procedure(ctx: ToolContext, *, name: str) -> str:
+def load_procedure(
+    ctx: ToolContext,
+    *,
+    name: str,
+    procedures: Mapping[str, str] | None = None,
+) -> str:
     """Load a procedure by name and return its markdown text."""
     if name not in VALID_PROCEDURES:
         return json.dumps(
@@ -60,12 +74,18 @@ def load_procedure(ctx: ToolContext, *, name: str) -> str:
             }
         )
 
-    path = PROCEDURE_DIR / f"{name}.md"
-    if not path.exists():
-        return json.dumps({"error": f"Procedure file not found: {path}"})
+    if procedures is None:
+        path = PROCEDURE_DIR / f"{name}.md"
+        if not path.exists():
+            return json.dumps({"error": f"Procedure file not found: {path}"})
+        content = path.read_text(encoding="utf-8")
+    else:
+        content = procedures.get(name)
+        if content is None:
+            return json.dumps({"error": f"Procedure content not prepared: {name}"})
 
     previous = ctx.procedures.active
     ctx.procedures.active = name
     ctx.log.add_procedure_switch(previous, name, turn=ctx.turn)
 
-    return path.read_text(encoding="utf-8")
+    return content

--- a/backend/tests/services/generations/test_manifest.py
+++ b/backend/tests/services/generations/test_manifest.py
@@ -220,6 +220,21 @@ def test_memory_input_variants_are_explicit() -> None:
     assert live.manifest_hash != evaluation.manifest_hash
 
 
+def test_week_scoped_manifest_allows_no_instant_domain_cutoff() -> None:
+    inputs = _inputs()
+    inputs = inputs.model_copy(
+        update={
+            "cutoffs": inputs.cutoffs.model_copy(
+                update={"domain_cutoff_at": None}
+            )
+        }
+    )
+
+    built = build_generation_manifest(inputs)
+
+    assert built.manifest["cutoffs"]["domain_cutoff_at"] is None
+
+
 def test_manifest_is_input_only_and_submit_schema_is_path_generic() -> None:
     inputs = _inputs()
     built = build_generation_manifest(inputs)

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from backend.resources.memory.common.errors import GenerationMemoryContextClosedError
+from backend.resources.memory.revisions import CanonicalRevision
+from backend.resources.reporting.generations import (
+    Generation,
+    GenerationKind,
+    GenerationLifecycleConflict,
+    GenerationStatus,
+)
+from backend.services.datalayer import ReadyDataSnapshot, VerifiedLocalArtifact
+from backend.services.generations import (
+    GenerationRequest,
+    GenerationService,
+    GenerationSettings,
+)
+from backend.services.reporter import ReporterOutput
+from backend.services.reporter.runner.recording import ArtifactMutation
+
+
+NOW = datetime(2026, 10, 29, 19, 30, tzinfo=UTC)
+
+
+def _uuid(value: int) -> UUID:
+    return UUID(int=value)
+
+
+class FakeGenerationManager:
+    def __init__(self, competition_id: UUID, events: list[str]) -> None:
+        self.competition_id = competition_id
+        self.events = events
+        self.rows: dict[UUID, Generation] = {}
+        self.starts = []
+        self.start_error: Exception | None = None
+
+    def create_pending(self, command):
+        self.events.append("submit")
+        row = _generation(
+            generation_id=command.generation_id,
+            competition_id=self.competition_id,
+            season_id=command.competition_season_id,
+            kind=command.kind,
+            settings=command.settings,
+            request_text=command.request_text,
+            week_start=command.week_start,
+            week_end=command.week_end,
+            model=command.requested_primary_model,
+        )
+        self.rows[row.id] = row
+        return row
+
+    def get(self, generation_id):
+        return self.rows[generation_id]
+
+    def start(self, command):
+        self.events.append("start")
+        if self.start_error is not None:
+            raise self.start_error
+        self.starts.append(command)
+        row = self.rows[command.generation_id]
+        started = row.model_copy(
+            update={
+                "status": GenerationStatus.RUNNING,
+                "data_snapshot_id": command.data_snapshot_id,
+                "input_memory_revision_id": command.input_memory_revision_id,
+                "knowledge_cutoff_at": command.knowledge_cutoff_at,
+                "input_manifest": command.input_manifest,
+                "manifest_schema_version": command.manifest_schema_version,
+                "manifest_hash": command.manifest_hash,
+                "current_stage": command.initial_stage,
+                "started_at": NOW,
+            }
+        )
+        self.rows[row.id] = started
+        return started
+
+
+class FakeSnapshots:
+    def __init__(self, snapshot: ReadyDataSnapshot, events: list[str]) -> None:
+        self.snapshot = snapshot
+        self.events = events
+        self.requests = []
+        self.error: Exception | None = None
+
+    def get_or_create(self, request):
+        self.events.append("snapshot")
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return self.snapshot
+
+
+class FakeRevisions:
+    def __init__(
+        self,
+        current: CanonicalRevision,
+        history: tuple[CanonicalRevision, ...],
+        events: list[str],
+    ) -> None:
+        self.current_revision = current
+        self.revision_history = history
+        self.events = events
+        self.current_calls = 0
+        self.history_calls = 0
+
+    def current(self):
+        self.events.append("memory")
+        self.current_calls += 1
+        return self.current_revision
+
+    def history(self):
+        self.events.append("memory")
+        self.history_calls += 1
+        return self.revision_history
+
+
+class FakeFrozenData:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.closed = False
+
+    def __enter__(self):
+        self.events.append("open")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.events.append("close")
+        self.closed = True
+
+    def run_sql(self, query, *, limit=200):
+        del query, limit
+        return {"rows": [("league-1", "League One")]}
+
+
+class FakeReporter:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.calls = []
+        self.error: BaseException | None = None
+        self.exercise_recorder = False
+
+    async def __call__(self, data, config, **kwargs):
+        self.events.append("reporter")
+        self.calls.append((data, config, kwargs))
+        if self.exercise_recorder:
+            kwargs["recorder"].record_artifact_mutation(
+                ArtifactMutation(
+                    path="research/brief.md",
+                    media_type="text/markdown",
+                    content="brief",
+                    revision=1,
+                    content_hash=(
+                        "1fc40f69be3cfdf6b1e1d7f4d880a67e"
+                        "dcf44d16f501cf91e9f2877f733ed59f"
+                    ),
+                )
+            )
+        if self.error is not None:
+            raise self.error
+        return ReporterOutput()
+
+
+def _generation(
+    *,
+    generation_id: UUID,
+    competition_id: UUID,
+    season_id: UUID,
+    kind: GenerationKind,
+    settings: dict,
+    request_text: str = "weekly recap",
+    week_start: int | None = 7,
+    week_end: int | None = 8,
+    model: str = "gpt-test",
+) -> Generation:
+    return Generation(
+        id=generation_id,
+        competition_id=competition_id,
+        competition_season_id=season_id,
+        data_snapshot_id=None,
+        input_memory_revision_id=None,
+        input_memory_artifact_version_id=None,
+        input_memory_artifact_generation_id=None,
+        evaluation_workspace_id=None,
+        workspace_sequence_number=None,
+        rerun_of_generation_id=None,
+        submitted_artifact_version_id=None,
+        kind=kind,
+        status=GenerationStatus.PENDING,
+        request_text=request_text,
+        week_start=week_start,
+        week_end=week_end,
+        domain_cutoff_week=None,
+        domain_cutoff_at=None,
+        knowledge_cutoff_at=None,
+        requested_primary_model=model,
+        settings=settings,
+        input_manifest=None,
+        manifest_schema_version=None,
+        manifest_hash=None,
+        current_turn=0,
+        current_stage=None,
+        progress_updated_at=None,
+        failure_category=None,
+        failure_summary=None,
+        created_at=NOW,
+        started_at=None,
+        completed_at=None,
+    )
+
+
+def _revision(
+    sequence: int,
+    *,
+    season_id: UUID | None,
+    week: int | None,
+    knowledge_cutoff_at: datetime | None = None,
+) -> CanonicalRevision:
+    return CanonicalRevision(
+        revision_id=_uuid(100 + sequence),
+        competition_id=_uuid(1),
+        sequence_number=sequence,
+        previous_revision_id=None if sequence == 0 else _uuid(99 + sequence),
+        competition_season_id=season_id,
+        week=week,
+        knowledge_cutoff_at=knowledge_cutoff_at,
+        state_content_hash=f"state-{sequence}",
+        created_at=datetime(2026, 9, 1 + sequence, tzinfo=UTC),
+    )
+
+
+def _snapshot(tmp_path: Path) -> ReadyDataSnapshot:
+    digest = "a" * 64
+    return ReadyDataSnapshot(
+        id=_uuid(20),
+        competition_id=_uuid(1),
+        primary_competition_season_id=_uuid(2),
+        through_week=8,
+        as_of_date=NOW.date(),
+        build_key="build-key",
+        snapshot_projection_version="snapshot-v2",
+        artifact=VerifiedLocalArtifact(
+            path=(tmp_path / "snapshot.sqlite").resolve(),
+            storage_key=f"snapshots/sha256/aa/{digest}.sqlite",
+            sha256=digest,
+            byte_length=1,
+        ),
+    )
+
+
+def _request(kind: GenerationKind = GenerationKind.LIVE) -> GenerationRequest:
+    return GenerationRequest(
+        generation_id=_uuid(3),
+        competition_id=_uuid(1),
+        competition_season_id=_uuid(2),
+        kind=kind,
+        request_text="weekly recap",
+        week_start=7,
+        week_end=8,
+        requested_primary_model="gpt-test",
+        settings=GenerationSettings(),
+    )
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    kind: GenerationKind = GenerationKind.LIVE,
+    history: tuple[CanonicalRevision, ...] | None = None,
+):
+    events: list[str] = []
+    manager = FakeGenerationManager(_uuid(1), events)
+    snapshots = FakeSnapshots(_snapshot(tmp_path), events)
+    root = _revision(0, season_id=None, week=None)
+    revisions = FakeRevisions(
+        root,
+        history or (root,),
+        events,
+    )
+    reporter = FakeReporter(events)
+    runtime = FakeFrozenData(events)
+    service = GenerationService(
+        generations=manager,  # type: ignore[arg-type]
+        snapshots=snapshots,
+        revisions=revisions,  # type: ignore[arg-type]
+        retrieval=SimpleNamespace(),  # type: ignore[arg-type]
+        ai_calls=SimpleNamespace(),  # type: ignore[arg-type]
+        tool_calls=SimpleNamespace(),  # type: ignore[arg-type]
+        artifacts=SimpleNamespace(),  # type: ignore[arg-type]
+        artifact_versions=SimpleNamespace(),  # type: ignore[arg-type]
+        reporter_revision="reporter-9",
+        generation_revision="generation-9",
+        reporter=reporter,
+        open_frozen_data=lambda snapshot: runtime,  # type: ignore[arg-type]
+        clock=lambda: NOW,
+    )
+    service.submit(_request(kind))
+    return service, manager, snapshots, revisions, reporter, runtime, events
+
+
+def test_submit_resolves_and_persists_typed_settings(tmp_path) -> None:
+    service, manager, _, _, _, _, events = _service(tmp_path)
+
+    pending = manager.get(_uuid(3))
+
+    assert pending.status is GenerationStatus.PENDING
+    assert pending.settings["schema_version"] == 1
+    assert pending.settings["input_policy"] == {
+        "snapshot_refresh": "never",
+        "snapshot_as_of_date": "execution_utc_date",
+        "backtest_memory": "latest_same_season_at_or_before_week",
+    }
+    assert events == ["submit"]
+    del service
+
+
+def test_submit_rejects_cross_competition_scope(tmp_path) -> None:
+    service, _, _, _, _, _, _ = _service(tmp_path)
+    request = _request().model_copy(update={"competition_id": _uuid(99)})
+
+    with pytest.raises(ValueError, match="outside the service competition"):
+        service.submit(request)
+
+
+@pytest.mark.asyncio
+async def test_live_execution_pins_inputs_before_reporter_and_closes_runtime(
+    tmp_path,
+) -> None:
+    service, manager, snapshots, revisions, reporter, runtime, events = _service(
+        tmp_path
+    )
+
+    result = await service.execute(_uuid(3))
+
+    assert events == ["submit", "snapshot", "memory", "start", "open", "reporter", "close"]
+    assert snapshots.requests[0].through_week == 8
+    assert snapshots.requests[0].as_of_date == NOW.date()
+    assert revisions.current_calls == 1
+    assert result.generation.status is GenerationStatus.RUNNING
+    assert result.memory_bundle.expected_revision_id == _uuid(100)
+    assert result.memory_bundle.proposals == ()
+    assert reporter.calls[0][2]["allow_memory_writes"] is True
+    assert runtime.closed is True
+    manifest = manager.starts[0].input_manifest
+    assert manifest["cutoffs"]["domain_cutoff_at"] is None
+    assert manifest["memory_input"]["revision_id"] == str(_uuid(100))
+    procedure_versions = {
+        entry["name"]: entry["version"]
+        for entry in manifest["tools"]["implementations"]
+    }
+    assert procedure_versions["load_procedure"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_backtest_selects_latest_same_season_revision_and_is_read_only(
+    tmp_path,
+) -> None:
+    cutoff = datetime(2026, 10, 20, tzinfo=UTC)
+    history = (
+        _revision(4, season_id=_uuid(9), week=7),
+        _revision(3, season_id=_uuid(2), week=9),
+        _revision(2, season_id=_uuid(2), week=8, knowledge_cutoff_at=cutoff),
+        _revision(1, season_id=_uuid(2), week=6),
+        _revision(0, season_id=None, week=None),
+    )
+    service, manager, _, revisions, reporter, _, _ = _service(
+        tmp_path,
+        kind=GenerationKind.BACKTEST,
+        history=history,
+    )
+
+    result = await service.execute(_uuid(3))
+
+    assert revisions.current_calls == 0
+    assert revisions.history_calls == 1
+    assert manager.starts[0].input_memory_revision_id == _uuid(102)
+    assert manager.starts[0].knowledge_cutoff_at == cutoff
+    assert reporter.calls[0][2]["allow_memory_writes"] is False
+    assert result.memory_bundle.expected_revision_id == _uuid(102)
+
+
+@pytest.mark.asyncio
+async def test_backtest_falls_back_to_root_revision(tmp_path) -> None:
+    history = (
+        _revision(1, season_id=_uuid(2), week=9),
+        _revision(0, season_id=None, week=None),
+    )
+    service, manager, _, _, _, _, _ = _service(
+        tmp_path,
+        kind=GenerationKind.BACKTEST,
+        history=history,
+    )
+
+    await service.execute(_uuid(3))
+
+    assert manager.starts[0].input_memory_revision_id == _uuid(100)
+    assert manager.starts[0].knowledge_cutoff_at == history[1].created_at
+
+
+@pytest.mark.asyncio
+async def test_pre_start_failure_never_calls_reporter(tmp_path) -> None:
+    service, _, snapshots, _, reporter, runtime, events = _service(tmp_path)
+    snapshots.error = RuntimeError("snapshot unavailable")
+
+    with pytest.raises(RuntimeError, match="snapshot unavailable"):
+        await service.execute(_uuid(3))
+
+    assert "start" not in events
+    assert reporter.calls == []
+    assert runtime.closed is False
+
+
+@pytest.mark.asyncio
+async def test_atomic_start_failure_never_opens_runtime_or_calls_reporter(
+    tmp_path,
+) -> None:
+    service, manager, _, _, reporter, runtime, events = _service(tmp_path)
+    manager.start_error = RuntimeError("start rejected")
+
+    with pytest.raises(RuntimeError, match="start rejected"):
+        await service.execute(_uuid(3))
+
+    assert events[-1] == "start"
+    assert "open" not in events
+    assert reporter.calls == []
+    assert runtime.closed is False
+
+
+@pytest.mark.asyncio
+async def test_non_pending_generation_is_not_executed(tmp_path) -> None:
+    service, manager, snapshots, _, reporter, _, _ = _service(tmp_path)
+    manager.rows[_uuid(3)] = manager.rows[_uuid(3)].model_copy(
+        update={"status": GenerationStatus.FAILED}
+    )
+
+    with pytest.raises(GenerationLifecycleConflict, match="pending for execution"):
+        await service.execute(_uuid(3))
+
+    assert snapshots.requests == []
+    assert reporter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_backtest_without_eligible_or_root_memory_never_starts(tmp_path) -> None:
+    history = (_revision(1, season_id=_uuid(2), week=9),)
+    service, manager, _, _, reporter, _, _ = _service(
+        tmp_path,
+        kind=GenerationKind.BACKTEST,
+        history=history,
+    )
+
+    with pytest.raises(ValueError, match="root revision"):
+        await service.execute(_uuid(3))
+
+    assert manager.starts == []
+    assert reporter.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [RuntimeError("provider"), asyncio.CancelledError()])
+async def test_reporter_failure_or_cancellation_closes_and_discards_context(
+    tmp_path,
+    error,
+) -> None:
+    service, manager, _, _, reporter, runtime, _ = _service(tmp_path)
+    reporter.error = error
+
+    with pytest.raises(type(error)):
+        await service.execute(_uuid(3))
+
+    assert runtime.closed is True
+    assert manager.get(_uuid(3)).status is GenerationStatus.RUNNING
+    memory = reporter.calls[0][2]["memory_context"]
+    with pytest.raises(GenerationMemoryContextClosedError):
+        memory.take_completed_bundle()
+
+
+@pytest.mark.asyncio
+async def test_recorder_failure_closes_runtime_and_discards_context(tmp_path) -> None:
+    service, _, _, _, reporter, runtime, _ = _service(tmp_path)
+    reporter.exercise_recorder = True
+
+    with pytest.raises(AttributeError, match="create_artifact"):
+        await service.execute(_uuid(3))
+
+    assert runtime.closed is True
+    memory = reporter.calls[0][2]["memory_context"]
+    with pytest.raises(GenerationMemoryContextClosedError):
+        memory.take_completed_bundle()
+
+
+def test_request_rejects_duplicate_primary_and_fallback_model() -> None:
+    settings = GenerationSettings.model_validate(
+        {"model": {"fallback_models": ["gpt-test"]}}
+    )
+
+    with pytest.raises(ValueError, match="model chain"):
+        GenerationRequest(
+            generation_id=_uuid(3),
+            competition_id=_uuid(1),
+            competition_season_id=_uuid(2),
+            kind=GenerationKind.LIVE,
+            request_text="weekly recap",
+            week_start=7,
+            week_end=8,
+            requested_primary_model="gpt-test",
+            settings=settings,
+        )

--- a/backend/tests/services/memory/test_generation_context.py
+++ b/backend/tests/services/memory/test_generation_context.py
@@ -108,3 +108,19 @@ def test_context_keeps_search_pinned_and_finalizes_its_buffer_once() -> None:
                 query=SearchDocumentQuery(text="buffered fact")
             )
         )
+
+
+def test_discard_closes_an_abandoned_proposal_buffer() -> None:
+    context = GenerationMemoryContext(
+        competition_id=uuid4(),
+        generation_id=uuid4(),
+        pinned_revision_id=uuid4(),
+        retrieval=RecordingRetrieval(),
+    )
+    context.propose_event(_event())
+
+    context.discard()
+    context.discard()
+
+    with pytest.raises(GenerationMemoryContextClosedError):
+        context.take_completed_bundle()

--- a/backend/tests/services/reporter/test_datalayer_tools.py
+++ b/backend/tests/services/reporter/test_datalayer_tools.py
@@ -9,11 +9,13 @@ from typing import Any
 
 import pytest
 
-from backend.services.datalayer import FrozenLeagueData, ReadyDataSnapshot
-from backend.services.reporter.generator import (
-    _get_league_metadata,
-    _make_roster_resolver,
+from backend.services.datalayer import (
+    FrozenLeagueData,
+    ReadyDataSnapshot,
+    ResolvedRosterIdentity,
+    RosterIdentityNotFound,
 )
+from backend.services.reporter.generator import _get_league_metadata
 from backend.tests.services.datalayer.test_frozen_query_runtime import (
     _without_volatile_player_state,
     ready_snapshot,
@@ -467,32 +469,24 @@ def test_missing_entities_remain_safe_tool_results(
     assert all(result["found"] is False for result in missing.values())
 
 
-def test_generator_metadata_and_legacy_roster_resolution_use_public_frozen_sql(
+def test_generator_metadata_and_typed_roster_resolution_use_frozen_runtime(
     ready_snapshot: ReadyDataSnapshot,
 ) -> None:
     with FrozenLeagueData.open(ready_snapshot) as data:
-        resolve_roster = _make_roster_resolver(data)
-
         assert _get_league_metadata(data) == ("123", "Test League")
-        assert resolve_roster("Alpha") == {
-            "found": True,
-            "roster_id": 1,
-            "team_name": "Alpha",
-        }
-        assert resolve_roster("Alice") == {
-            "found": True,
-            "roster_id": 1,
-            "team_name": "Alpha",
-        }
-        assert resolve_roster("2") == {
-            "found": True,
-            "roster_id": 2,
-            "team_name": "Beta",
-        }
-        assert resolve_roster("missing") == {
-            "found": False,
-            "roster_key": "missing",
-        }
+        for roster_key, roster_id, team_name in (
+            ("Alpha", "1", "Alpha"),
+            ("Alice", "1", "Alpha"),
+            ("2", "2", "Beta"),
+        ):
+            result = data.resolve_roster_identity(roster_key)
+            assert isinstance(result, ResolvedRosterIdentity)
+            assert result.identity.sleeper_roster_id == roster_id
+            assert result.identity.team_name == team_name
+
+        missing = data.resolve_roster_identity("missing")
+        assert isinstance(missing, RosterIdentityNotFound)
+        assert missing.roster_key == "missing"
 
 
 def test_reporter_adapter_and_datalayer_import_boundaries() -> None:

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from backend.services.reporter import prepare_reporter_definition
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.procedure_tools import (
+    PROCEDURE_TOOL_IMPLEMENTATION_VERSION,
+    register_procedure_tools,
+)
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+def test_prepared_definition_matches_registered_execution_bundle() -> None:
+    definition = prepare_reporter_definition(memory_enabled=True)
+    registry = ToolRegistry()
+
+    from backend.services.reporter.runner.tools.artifact_tools import (
+        register_artifact_tools,
+    )
+    from backend.services.reporter.runner.tools.datalayer_tools import (
+        register_datalayer_tools,
+    )
+    from backend.services.reporter.runner.tools.memory_tools import (
+        register_memory_tools,
+    )
+
+    data = object()
+    memory = object()
+    register_artifact_tools(registry)
+    register_procedure_tools(registry, definition.procedure_contents)
+    register_datalayer_tools(registry, data)  # type: ignore[arg-type]
+    register_memory_tools(
+        registry,
+        memory,  # type: ignore[arg-type]
+        data,  # type: ignore[arg-type]
+    )
+
+    assert registry.tool_specs == [tool.definition for tool in definition.tools]
+    assert registry.tool_implementation_versions == [
+        (tool.name, tool.implementation_version) for tool in definition.tools
+    ]
+    assert PROCEDURE_TOOL_IMPLEMENTATION_VERSION == "2"
+    assert {procedure.name for procedure in definition.procedures} == {
+        "drafting",
+        "research",
+        "storyline",
+        "verification",
+    }
+
+
+def test_definition_without_memory_omits_only_memory_tools() -> None:
+    with_memory = prepare_reporter_definition(memory_enabled=True)
+    without_memory = prepare_reporter_definition(memory_enabled=False)
+
+    memory_names = {
+        "search_memory",
+        "propose_fact",
+        "replace_fact",
+        "propose_event",
+        "replace_event",
+        "propose_storyline",
+        "replace_storyline",
+        "propose_trigger",
+        "replace_trigger",
+        "propose_context_note",
+        "replace_context_note",
+    }
+    assert {tool.name for tool in with_memory.tools} - {
+        tool.name for tool in without_memory.tools
+    } == memory_names
+
+
+def test_registered_procedure_uses_prepared_content() -> None:
+    registry = ToolRegistry()
+    register_procedure_tools(registry, {"research": "frozen research"})
+    registry.set_context(
+        ToolContext(
+            artifacts=ArtifactStore(),
+            procedures=ProcedureState(),
+            log=RunLog(),
+        )
+    )
+
+    handler = registry.get_handler("load_procedure")
+
+    assert handler is not None
+    assert handler(name="research") == "frozen research"

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -40,9 +40,20 @@ The service derives snapshot dates/cutoffs and does not accept a raw snapshot
 build key, data artifact path, memory revision selected by an untrusted caller,
 or unhashed manifest.
 
-The exact live-versus-backtest mapping to `SnapshotRequest.as_of_date` and
-knowledge cutoff is owned by generation policy. It must be specified with
-golden tests rather than inferred inside the datalayer.
+Generation v1 uses a generation-owned, never-refresh policy. Both live and
+backtest requests resolve recorded Sleeper inputs with `through_week` equal to
+the request's `week_end`; `as_of_date` is the injected execution clock's UTC
+date and is only a snapshot build/reuse label. A later `resolve_snapshot`
+workflow may replace this fixed policy without changing the datalayer snapshot
+contract.
+
+Live runs pin the current canonical memory revision and use the execution time
+as their knowledge cutoff. Backtests pin the highest-sequence canonical
+revision associated with the same competition season whose week is at or
+before `week_end`, falling back to the competition root revision. They retain
+pinned retrieval but disable proposal writes. This is a best-effort cutoff
+reconstruction, not an exact simulation of what was observable at the
+historical instant.
 
 ## Reporting Resource Manager Contracts
 
@@ -429,7 +440,7 @@ initial API performs both in one process:
 ```python
 class GenerationService:
     def submit(self, request: GenerationRequest) -> Generation: ...
-    async def execute(self, generation_id: UUID) -> GenerationResult: ...
+    async def execute(self, generation_id: UUID) -> GenerationExecutionResult: ...
     def reconcile_stale(self, policy: StaleGenerationPolicy) -> ReconcileResult: ...
 ```
 
@@ -437,6 +448,11 @@ This keeps a clean queue seam without introducing job/lease infrastructure.
 `execute` is idempotent only in the narrow sense that it refuses a generation
 that is not eligible to start; it does not resume or replay a partially executed
 agent loop. An explicit rerun creates another generation.
+
+In generation-9, a successful execution result contains the still-running
+generation, reporter output, and completed in-memory proposal bundle. Durable
+artifact selection, memory application/discard, and the terminal transition are
+the generation-10 finalization boundary.
 
 ## API Boundary
 

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -219,9 +219,17 @@ The service translates generation intent into a datalayer `SnapshotRequest`.
 If policy requires refresh, it invokes refresh first and interprets the typed
 outcome. It then calls `get_or_create()` and receives a `ReadyDataSnapshot`.
 
-In parallel policy terms—but not necessarily parallel code—it pins the canonical
-memory revision and resolves model, fallback, prompt, procedure, tool, runner,
-and code-version inputs.
+The initial generation policy never refreshes implicitly. It uses already
+recorded or backfilled inputs, `week_end` as the factual cutoff, and the
+execution clock's UTC date as the snapshot build/reuse label. Backtests are
+therefore retrospective cutoff reconstructions with completeness warnings,
+not historical-observation simulations.
+
+In parallel policy terms—but not necessarily parallel code—it pins the current
+canonical memory revision for live runs. Backtests select the newest revision
+for the same season at or before the cutoff week, with root fallback, and expose
+it read-only. The service also resolves model, fallback, prompt, frozen
+procedure content, tool, runner, and code-version inputs.
 
 ### 3. Atomic start
 

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -231,13 +231,17 @@ proposals return safe tool errors, and no legacy store is read or written.
 ### `generation-9` — input lifecycle and reporter execution
 
 - Add `GenerationService.submit()` and `execute()`.
-- Implement generation-owned live/backtest cutoff policy.
-- Invoke refresh only under explicit policy.
+- Implement the generation-owned live/backtest cutoff policy over recorded
+  inputs without implicit refresh.
+- Use the execution UTC date only as the snapshot build/reuse label.
 - Resolve/reuse a ready snapshot through
   `DatalayerSnapshotService.get_or_create()`.
-- Pin memory input, construct/hash the manifest, and atomically start.
+- Pin current live memory or the latest same-season backtest revision at or
+  before the cutoff week, construct/hash the manifest, and atomically start.
 - Open `FrozenLeagueData`, create `GenerationMemoryContext` and recorder, and
   call the reporter once.
+- Freeze prompt/procedure/tool inputs before start and return the completed
+  in-memory proposal bundle without applying it.
 - Close the SQLite runtime deterministically on success or failure.
 
 **Exit gate:** no model call can occur before complete input pinning, and the run


### PR DESCRIPTION
## Summary

- add typed generation submission and execution contracts
- pin recorded Sleeper snapshot and canonical memory inputs before any model call
- execute the copied reporter once with durable recording and deterministic SQLite cleanup
- freeze prompt, procedure, tool schema, and implementation-version inputs in the manifest

## Policy

- never refresh implicitly; resolve snapshots only from recorded or backfilled inputs
- use `week_end` as the factual cutoff and execution UTC date as the reuse label
- pin current memory for live runs
- pin the newest same-season revision at or before the cutoff for read-only backtests, with root fallback

## Deferred

- selected artifact and memory finalization
- terminal failure recovery and stale-run reconciliation
- API, worker, and production composition

## Verification

- 191 targeted generation, reporter, memory-context, and snapshot-service tests passed
- compile, Python 99-column, import-boundary, and `git diff --check` gates passed
- full suite intentionally not run
