### PR TITLE
Generation 10: finalize reporter runs atomically

### DIFF
--- a/backend/resources/memory/revisions/manager.py
+++ b/backend/resources/memory/revisions/manager.py
@@ -110,69 +110,75 @@ class RevisionManager:
         if not bundle.writes:
             return None
 
-        state_readers = _state_readers()
         with transaction_session(self._session_factory) as session:
-            parent = lock_current_revision(
+            return _commit_canonical_bundle_in_session(
                 session,
                 self._competition_id,
-                bundle.expected_revision_id,
+                bundle,
             )
-            parent_state = _read_state(
-                session,
-                self._competition_id,
-                state_readers,
-            )
-            validate_reference_targets(session, self._competition_id, bundle.writes)
-            revision = MemoryRevision(
-                id=uuid4(),
-                competition_id=self._competition_id,
-                sequence_number=parent.next_sequence_number,
-                previous_revision_id=parent.current_revision_id,
-                producing_generation_id=bundle.generation_id,
-                competition_season_id=bundle.competition_season_id,
-                week=bundle.week,
-                knowledge_cutoff_at=bundle.knowledge_cutoff_at,
-                state_content_hash="pending",
-            )
-            resolved, retired = build_version_envelopes(session, revision, bundle)
-            expected_hash = compute_state_content_hash(
-                self._competition_id,
-                _resulting_state(parent_state, resolved),
-            )
-            revision.state_content_hash = expected_hash
-            persist_version_envelopes(
-                session,
-                revision,
-                new_items=(
-                    item
-                    for write, item, _ in resolved
-                    if write.operation == "create"
-                ),
-                new_versions=(version for _, _, version in resolved),
-                retired_versions=retired,
-            )
-            for write, item, version in sorted(
-                resolved,
-                key=lambda entry: entry[0].dependency_order,
-            ):
-                write.persist_typed(session, item, version)
-                session.flush()
 
-            actual_hash = compute_state_content_hash(
-                self._competition_id,
-                _read_state(session, self._competition_id, state_readers),
-            )
-            if actual_hash != expected_hash:
-                raise CanonicalStateHashMismatchError(expected_hash, actual_hash)
-            advance_current_revision(
-                session,
-                self._competition_id,
-                parent,
-                revision.id,
-            )
-            session.flush()
 
-        return _to_revision(revision)
+def _commit_canonical_bundle_in_session(
+    session: Session,
+    competition_id: UUID,
+    bundle: CanonicalWriteBundle,
+) -> CanonicalRevision | None:
+    """Commit one canonical transition inside a caller-owned transaction."""
+
+    if bundle.competition_id != competition_id:
+        raise ValueError("mutation bundle is outside the manager competition")
+    if not bundle.writes:
+        return None
+    state_readers = _state_readers()
+    parent = lock_current_revision(
+        session,
+        competition_id,
+        bundle.expected_revision_id,
+    )
+    parent_state = _read_state(session, competition_id, state_readers)
+    validate_reference_targets(session, competition_id, bundle.writes)
+    revision = MemoryRevision(
+        id=uuid4(),
+        competition_id=competition_id,
+        sequence_number=parent.next_sequence_number,
+        previous_revision_id=parent.current_revision_id,
+        producing_generation_id=bundle.generation_id,
+        competition_season_id=bundle.competition_season_id,
+        week=bundle.week,
+        knowledge_cutoff_at=bundle.knowledge_cutoff_at,
+        state_content_hash="pending",
+    )
+    resolved, retired = build_version_envelopes(session, revision, bundle)
+    expected_hash = compute_state_content_hash(
+        competition_id,
+        _resulting_state(parent_state, resolved),
+    )
+    revision.state_content_hash = expected_hash
+    persist_version_envelopes(
+        session,
+        revision,
+        new_items=(
+            item for write, item, _ in resolved if write.operation == "create"
+        ),
+        new_versions=(version for _, _, version in resolved),
+        retired_versions=retired,
+    )
+    for write, item, version in sorted(
+        resolved,
+        key=lambda entry: entry[0].dependency_order,
+    ):
+        write.persist_typed(session, item, version)
+        session.flush()
+
+    actual_hash = compute_state_content_hash(
+        competition_id,
+        _read_state(session, competition_id, state_readers),
+    )
+    if actual_hash != expected_hash:
+        raise CanonicalStateHashMismatchError(expected_hash, actual_hash)
+    advance_current_revision(session, competition_id, parent, revision.id)
+    session.flush()
+    return _to_revision(revision)
 
 
 def _to_revision(row: MemoryRevision) -> CanonicalRevision:

--- a/backend/resources/reporting/artifacts/manager.py
+++ b/backend/resources/reporting/artifacts/manager.py
@@ -87,42 +87,11 @@ class ArtifactManager:
 
     def finalize_artifact(self, command: FinalizeArtifact) -> Artifact:
         with transaction_session(self._session_factory) as session:
-            stored, generation = self._load_with_generation(
-                session, command.artifact_id, lock=True
+            return _finalize_artifact_in_session(
+                session,
+                self._competition_id,
+                command,
             )
-            if stored.finalized_version_id is not None:
-                if stored.finalized_version_id == command.artifact_version_id:
-                    return _decode(stored)
-                raise ArtifactLifecycleConflict(
-                    stored.id,
-                    "artifact finalization is immutable",
-                    actual_status="finalized",
-                )
-            self._require_running(generation)
-            selected = session.scalar(
-                sa.select(StoredArtifactVersion).where(
-                    StoredArtifactVersion.id == command.artifact_version_id,
-                    StoredArtifactVersion.artifact_id == stored.id,
-                    StoredArtifactVersion.generation_id == stored.generation_id,
-                )
-            )
-            if selected is None:
-                raise ArtifactResourceNotFound(
-                    "artifact_version", command.artifact_version_id
-                )
-            latest_revision = session.scalar(
-                sa.select(sa.func.max(StoredArtifactVersion.revision_number)).where(
-                    StoredArtifactVersion.artifact_id == stored.id
-                )
-            )
-            if selected.revision_number != latest_revision:
-                raise ArtifactConcurrencyConflict(
-                    "only the latest artifact version can be finalized"
-                )
-            stored.finalized_version_id = selected.id
-            stored.finalized_at = datetime.now(UTC)
-            session.flush()
-            return _decode(stored)
 
     def get(self, artifact_id: UUID) -> Artifact:
         with read_only_session(self._session_factory) as session:
@@ -168,25 +137,12 @@ class ArtifactManager:
         *,
         lock: bool = False,
     ) -> tuple[StoredArtifact, StoredGeneration]:
-        statement = (
-            sa.select(StoredArtifact, StoredGeneration)
-            .join(
-                StoredGeneration,
-                StoredGeneration.id == StoredArtifact.generation_id,
-            )
-            .where(
-                StoredArtifact.id == artifact_id,
-                StoredGeneration.competition_id == self._competition_id,
-            )
+        return _load_artifact_with_generation_in_session(
+            session,
+            self._competition_id,
+            artifact_id,
+            lock=lock,
         )
-        if lock:
-            statement = statement.with_for_update(
-                of=(StoredGeneration, StoredArtifact)
-            )
-        row = session.execute(statement).one_or_none()
-        if row is None:
-            raise ArtifactResourceNotFound("artifact", artifact_id)
-        return row._tuple()
 
     def _load_generation(
         self,
@@ -230,6 +186,132 @@ def _decode(stored: StoredArtifact) -> Artifact:
 
 def _decode_summary(stored: StoredArtifact) -> ArtifactSummary:
     return ArtifactSummary.model_validate(_decode(stored).model_dump())
+
+
+def _resolve_exact_artifact_version_in_session(
+    session: Session,
+    competition_id: UUID,
+    *,
+    generation_id: UUID,
+    path: str,
+    media_type: str,
+    revision_number: int,
+    content: str,
+    content_hash: str,
+) -> tuple[StoredArtifact, StoredArtifactVersion]:
+    """Lock and resolve an exact reporter snapshot without path role inference."""
+
+    row = session.execute(
+        sa.select(StoredArtifact, StoredArtifactVersion)
+        .join(
+            StoredArtifactVersion,
+            StoredArtifactVersion.artifact_id == StoredArtifact.id,
+        )
+        .join(
+            StoredGeneration,
+            StoredGeneration.id == StoredArtifact.generation_id,
+        )
+        .where(
+            StoredGeneration.id == generation_id,
+            StoredGeneration.competition_id == competition_id,
+            StoredArtifact.path == path,
+            StoredArtifact.media_type == media_type,
+            StoredArtifactVersion.generation_id == generation_id,
+            StoredArtifactVersion.revision_number == revision_number,
+            StoredArtifactVersion.content_hash == content_hash,
+            StoredArtifactVersion.content == content,
+        )
+        .with_for_update(of=(StoredArtifact, StoredArtifactVersion))
+    ).one_or_none()
+    if row is None:
+        raise ArtifactConcurrencyConflict(
+            "reporter submission does not match a durable artifact version"
+        )
+    artifact, version = row._tuple()
+    latest_revision = session.scalar(
+        sa.select(sa.func.max(StoredArtifactVersion.revision_number)).where(
+            StoredArtifactVersion.artifact_id == artifact.id
+        )
+    )
+    if version.revision_number != latest_revision:
+        raise ArtifactConcurrencyConflict(
+            "reporter submission must select the latest durable artifact version"
+        )
+    return artifact, version
+
+
+def _load_artifact_with_generation_in_session(
+    session: Session,
+    competition_id: UUID,
+    artifact_id: UUID,
+    *,
+    lock: bool = False,
+) -> tuple[StoredArtifact, StoredGeneration]:
+    statement = (
+        sa.select(StoredArtifact, StoredGeneration)
+        .join(
+            StoredGeneration,
+            StoredGeneration.id == StoredArtifact.generation_id,
+        )
+        .where(
+            StoredArtifact.id == artifact_id,
+            StoredGeneration.competition_id == competition_id,
+        )
+    )
+    if lock:
+        statement = statement.with_for_update(of=(StoredGeneration, StoredArtifact))
+    row = session.execute(statement).one_or_none()
+    if row is None:
+        raise ArtifactResourceNotFound("artifact", artifact_id)
+    return row._tuple()
+
+
+def _finalize_artifact_in_session(
+    session: Session,
+    competition_id: UUID,
+    command: FinalizeArtifact,
+    *,
+    finalized_at: datetime | None = None,
+) -> Artifact:
+    """Finalize an artifact inside a caller-owned transaction."""
+
+    stored, generation = _load_artifact_with_generation_in_session(
+        session,
+        competition_id,
+        command.artifact_id,
+        lock=True,
+    )
+    if stored.finalized_version_id is not None:
+        if stored.finalized_version_id == command.artifact_version_id:
+            return _decode(stored)
+        raise ArtifactLifecycleConflict(
+            stored.id,
+            "artifact finalization is immutable",
+            actual_status="finalized",
+        )
+    ArtifactManager._require_running(generation)
+    selected = session.scalar(
+        sa.select(StoredArtifactVersion).where(
+            StoredArtifactVersion.id == command.artifact_version_id,
+            StoredArtifactVersion.artifact_id == stored.id,
+            StoredArtifactVersion.generation_id == stored.generation_id,
+        )
+    )
+    if selected is None:
+        raise ArtifactResourceNotFound("artifact_version", command.artifact_version_id)
+    latest_revision = session.scalar(
+        sa.select(sa.func.max(StoredArtifactVersion.revision_number)).where(
+            StoredArtifactVersion.artifact_id == stored.id
+        )
+    )
+    if selected.revision_number != latest_revision:
+        raise ArtifactConcurrencyConflict(
+            "only the latest artifact version can be finalized"
+        )
+    stored.finalized_version_id = selected.id
+    stored.finalized_at = finalized_at or datetime.now(UTC)
+    session.flush()
+    return _decode(stored)
 
 
 __all__ = ["ArtifactManager"]

--- a/backend/resources/reporting/generations/manager.py
+++ b/backend/resources/reporting/generations/manager.py
@@ -177,38 +177,19 @@ class GenerationManager:
 
     def succeed(self, command: SucceedGeneration) -> Generation:
         with transaction_session(self._session_factory) as session:
-            stored = self._load(session, command.generation_id, lock=True)
-            self._require_status(stored, GenerationStatus.RUNNING)
-            submitted_artifact = session.scalar(
-                sa.select(Artifact.id).where(
-                    Artifact.generation_id == stored.id,
-                    Artifact.finalized_version_id
-                    == command.submitted_artifact_version_id,
-                )
+            return _succeed_generation_in_session(
+                session,
+                self._competition_id,
+                command,
             )
-            if submitted_artifact is None:
-                raise GenerationLifecycleConflict(
-                    stored.id,
-                    "submitted output must be a finalized artifact version owned by "
-                    "the generation",
-                    expected_statuses=(GenerationStatus.RUNNING.value,),
-                    actual_status=stored.status,
-                )
-            now = datetime.now(UTC)
-            stored.submitted_artifact_version_id = (
-                command.submitted_artifact_version_id
-            )
-            stored.status = GenerationStatus.SUCCEEDED.value
-            stored.current_stage = "succeeded"
-            stored.progress_updated_at = now
-            stored.completed_at = now
-            session.flush()
-            return _decode(stored)
 
     def fail(self, command: FailGeneration) -> Generation:
         with transaction_session(self._session_factory) as session:
             stored = self._load(session, command.generation_id, lock=True)
-            self._require_active(stored)
+            if command.expected_status is None:
+                self._require_active(stored)
+            else:
+                self._require_status(stored, command.expected_status)
             now = datetime.now(UTC)
             stored.status = GenerationStatus.FAILED.value
             stored.current_stage = "failed"
@@ -222,7 +203,10 @@ class GenerationManager:
     def cancel(self, command: CancelGeneration) -> Generation:
         with transaction_session(self._session_factory) as session:
             stored = self._load(session, command.generation_id, lock=True)
-            self._require_active(stored)
+            if command.expected_status is None:
+                self._require_active(stored)
+            else:
+                self._require_status(stored, command.expected_status)
             now = datetime.now(UTC)
             stored.status = GenerationStatus.CANCELLED.value
             stored.current_stage = "cancelled"
@@ -232,6 +216,44 @@ class GenerationManager:
             stored.completed_at = now
             session.flush()
             return _decode(stored)
+
+    def fail_stale_running(
+        self,
+        *,
+        stale_before: datetime,
+        limit: int,
+    ) -> tuple[Generation, ...]:
+        """Fail one bounded, competition-scoped batch of stale running rows."""
+
+        if stale_before.tzinfo is None or stale_before.utcoffset() is None:
+            raise ValueError("stale_before must be timezone-aware")
+        if limit < 1 or limit > 200:
+            raise ValueError("stale reconciliation limit must be between 1 and 200")
+        with transaction_session(self._session_factory) as session:
+            rows = session.scalars(
+                sa.select(StoredGeneration)
+                .where(
+                    StoredGeneration.competition_id == self._competition_id,
+                    StoredGeneration.status == GenerationStatus.RUNNING.value,
+                    StoredGeneration.progress_updated_at < stale_before,
+                )
+                .order_by(
+                    StoredGeneration.progress_updated_at.asc(),
+                    StoredGeneration.id.asc(),
+                )
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            ).all()
+            now = datetime.now(UTC)
+            for stored in rows:
+                stored.status = GenerationStatus.FAILED.value
+                stored.current_stage = "failed"
+                stored.failure_category = "stale_execution"
+                stored.failure_summary = "Generation execution became stale"
+                stored.progress_updated_at = now
+                stored.completed_at = now
+            session.flush()
+            return tuple(_decode(stored) for stored in rows)
 
     def get(self, generation_id: UUID) -> GenerationDetail:
         with read_only_session(self._session_factory) as session:
@@ -370,16 +392,12 @@ class GenerationManager:
         *,
         lock: bool = False,
     ) -> StoredGeneration:
-        statement = sa.select(StoredGeneration).where(
-            StoredGeneration.id == generation_id,
-            StoredGeneration.competition_id == self._competition_id,
+        return _load_generation_in_session(
+            session,
+            self._competition_id,
+            generation_id,
+            lock=lock,
         )
-        if lock:
-            statement = statement.with_for_update()
-        stored = session.scalar(statement)
-        if stored is None:
-            raise GenerationResourceNotFound("generation", generation_id)
-        return stored
 
     def _load_workspace(
         self,
@@ -443,6 +461,65 @@ def _lifecycle(
         expected_statuses=expected_statuses,
         actual_status=stored.status,
     )
+
+
+def _load_generation_in_session(
+    session: Session,
+    competition_id: UUID,
+    generation_id: UUID,
+    *,
+    lock: bool = False,
+) -> StoredGeneration:
+    statement = sa.select(StoredGeneration).where(
+        StoredGeneration.id == generation_id,
+        StoredGeneration.competition_id == competition_id,
+    )
+    if lock:
+        statement = statement.with_for_update()
+    stored = session.scalar(statement)
+    if stored is None:
+        raise GenerationResourceNotFound("generation", generation_id)
+    return stored
+
+
+def _succeed_generation_in_session(
+    session: Session,
+    competition_id: UUID,
+    command: SucceedGeneration,
+    *,
+    completed_at: datetime | None = None,
+) -> Generation:
+    """Pin one finalized output and succeed inside a caller-owned transaction."""
+
+    stored = _load_generation_in_session(
+        session,
+        competition_id,
+        command.generation_id,
+        lock=True,
+    )
+    GenerationManager._require_status(stored, GenerationStatus.RUNNING)
+    submitted_artifact = session.scalar(
+        sa.select(Artifact.id).where(
+            Artifact.generation_id == stored.id,
+            Artifact.finalized_version_id == command.submitted_artifact_version_id,
+        )
+    )
+    if submitted_artifact is None:
+        raise GenerationLifecycleConflict(
+            stored.id,
+            "submitted output must be a finalized artifact version owned by "
+            "the generation",
+            expected_statuses=(GenerationStatus.RUNNING.value,),
+            actual_status=stored.status,
+        )
+    now = completed_at or datetime.now(UTC)
+    stored.submitted_artifact_version_id = command.submitted_artifact_version_id
+    stored.status = GenerationStatus.SUCCEEDED.value
+    stored.current_stage = "succeeded"
+    stored.progress_updated_at = now
+    stored.completed_at = now
+    session.flush()
+    return _decode(stored)
 
 
 def _generation_values(stored: StoredGeneration) -> dict[str, object]:

--- a/backend/resources/reporting/generations/objects.py
+++ b/backend/resources/reporting/generations/objects.py
@@ -126,11 +126,13 @@ class FailGeneration(ContractModel):
     generation_id: UUID
     category: FailureCategory
     summary: FailureSummary
+    expected_status: GenerationStatus | None = None
 
 
 class CancelGeneration(ContractModel):
     generation_id: UUID
     summary: FailureSummary | None = None
+    expected_status: GenerationStatus | None = None
 
 
 class GenerationQuery(ContractModel):

--- a/backend/services/generations/__init__.py
+++ b/backend/services/generations/__init__.py
@@ -10,6 +10,14 @@ from backend.services.generations.contracts import (
     GenerationRunnerSettings,
     GenerationSettings,
     GenerationToneSettings,
+    ReconcileResult,
+    RerunGenerationRequest,
+    StaleGenerationPolicy,
+)
+from backend.services.generations.finalization import (
+    GenerationFinalizationError,
+    GenerationFinalizationResult,
+    GenerationFinalizer,
 )
 from backend.services.generations.manifest import (
     MANIFEST_SCHEMA_VERSION,
@@ -43,6 +51,9 @@ __all__ = [
     "GenerationManifestInput",
     "GenerationExecutionRecorder",
     "GenerationExecutionResult",
+    "GenerationFinalizationError",
+    "GenerationFinalizationResult",
+    "GenerationFinalizer",
     "GenerationBiasSettings",
     "GenerationModelSettings",
     "GenerationReportSettings",
@@ -57,8 +68,11 @@ __all__ = [
     "ModelExecutionInput",
     "ProcedureInput",
     "RetryPolicyInput",
+    "ReconcileResult",
+    "RerunGenerationRequest",
     "RunnerExecutionInput",
     "ToolInput",
+    "StaleGenerationPolicy",
     "build_generation_manifest",
     "canonical_json_bytes",
     "canonical_json_sha256",

--- a/backend/services/generations/contracts.py
+++ b/backend/services/generations/contracts.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import Field, model_validator
+from pydantic import AwareDatetime, Field, model_validator
 
 from backend.resources._contracts import ContractModel, NonBlankStr
-from backend.resources.reporting.generations import Generation, GenerationKind
-from backend.services.memory import MemoryMutationBundle
+from backend.resources.reporting.generations import (
+    Generation,
+    GenerationKind,
+    GenerationStatus,
+)
+from backend.services.memory import MemoryMutationResult
 from backend.services.reporter import ReporterOutput
 
 
@@ -104,8 +108,46 @@ class GenerationRequest(ContractModel):
 
 class GenerationExecutionResult(ContractModel):
     generation: Generation
-    reporter_output: ReporterOutput
-    memory_bundle: MemoryMutationBundle
+    reporter_output: ReporterOutput | None = None
+    memory_result: MemoryMutationResult | None = None
+
+    @model_validator(mode="after")
+    def validate_terminal_shape(self) -> "GenerationExecutionResult":
+        if self.generation.status is GenerationStatus.SUCCEEDED:
+            if self.reporter_output is None:
+                raise ValueError("successful execution requires reporter output")
+            if self.generation.submitted_artifact_version_id is None:
+                raise ValueError("successful execution requires a submitted version")
+            return self
+        if self.generation.status not in {
+            GenerationStatus.FAILED,
+            GenerationStatus.CANCELLED,
+        }:
+            raise ValueError("execution result requires a terminal generation")
+        if self.reporter_output is not None or self.memory_result is not None:
+            raise ValueError("unsuccessful execution cannot expose ephemeral output")
+        return self
+
+
+class RerunGenerationRequest(ContractModel):
+    source_generation_id: UUID
+    generation_id: UUID
+
+    @model_validator(mode="after")
+    def validate_distinct_ids(self) -> "RerunGenerationRequest":
+        if self.source_generation_id == self.generation_id:
+            raise ValueError("rerun generation ID must differ from its source")
+        return self
+
+
+class StaleGenerationPolicy(ContractModel):
+    stale_before: AwareDatetime
+    limit: int = Field(default=100, strict=True, ge=1, le=200)
+
+
+class ReconcileResult(ContractModel):
+    stale_before: AwareDatetime
+    generations: tuple[Generation, ...]
 
 
 __all__ = [
@@ -114,8 +156,11 @@ __all__ = [
     "GenerationModelSettings",
     "GenerationReportSettings",
     "GenerationRequest",
+    "ReconcileResult",
+    "RerunGenerationRequest",
     "GenerationRetrySettings",
     "GenerationRunnerSettings",
     "GenerationSettings",
     "GenerationToneSettings",
+    "StaleGenerationPolicy",
 ]

--- a/backend/services/generations/finalization.py
+++ b/backend/services/generations/finalization.py
@@ -1,0 +1,183 @@
+"""Atomic selected-artifact, canonical-memory, and generation finalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.sessions import SessionFactory, transaction_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.memory.revisions.manager import (
+    _commit_canonical_bundle_in_session,
+)
+from backend.resources.reporting.artifacts import FinalizeArtifact
+from backend.resources.reporting.artifacts.manager import (
+    _finalize_artifact_in_session,
+    _resolve_exact_artifact_version_in_session,
+)
+from backend.resources.reporting.generations import (
+    Generation,
+    GenerationKind,
+    GenerationLifecycleConflict,
+    GenerationStatus,
+    SucceedGeneration,
+)
+from backend.resources.reporting.generations.manager import (
+    _load_generation_in_session,
+    _succeed_generation_in_session,
+)
+from backend.services.memory import MemoryMutationBundle, MemoryMutationResult
+from backend.services.memory.mutation_service import prepare_canonical_bundle
+from backend.services.reporter import ReporterOutput
+
+
+class GenerationFinalizationError(RuntimeError):
+    """Stable workflow failure raised before an atomic success commit."""
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationFinalizationResult:
+    generation: Generation
+    memory_result: MemoryMutationResult | None
+
+
+class GenerationFinalizer:
+    """Own the one PostgreSQL transaction that makes a run successful."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def finalize(
+        self,
+        generation_id: UUID,
+        output: ReporterOutput,
+        memory_bundle: MemoryMutationBundle,
+    ) -> GenerationFinalizationResult:
+        selected = output.submitted_artifact
+        if selected is None:
+            raise GenerationFinalizationError(
+                "reporter output must select one submitted artifact"
+            )
+        if not selected.content.strip():
+            raise GenerationFinalizationError(
+                "reporter output cannot submit an empty artifact"
+            )
+
+        with transaction_session(self._session_factory) as session:
+            stored = _load_generation_in_session(
+                session,
+                self._competition_id,
+                generation_id,
+                lock=True,
+            )
+            if stored.status != GenerationStatus.RUNNING.value:
+                raise GenerationLifecycleConflict(
+                    stored.id,
+                    "generation must be running for finalization",
+                    expected_statuses=(GenerationStatus.RUNNING.value,),
+                    actual_status=stored.status,
+                )
+            self._validate_memory_bundle(stored, memory_bundle)
+            artifact, version = _resolve_exact_artifact_version_in_session(
+                session,
+                self._competition_id,
+                generation_id=generation_id,
+                path=selected.path,
+                media_type=selected.media_type,
+                revision_number=selected.revision,
+                content=selected.content,
+                content_hash=selected.content_hash,
+            )
+
+            memory_result: MemoryMutationResult | None = None
+            if stored.kind == GenerationKind.LIVE.value:
+                prepared = prepare_canonical_bundle(memory_bundle)
+                revision = _commit_canonical_bundle_in_session(
+                    session,
+                    self._competition_id,
+                    prepared,
+                )
+                memory_result = MemoryMutationResult(
+                    revision=revision,
+                    changes=tuple(
+                        proposal.proposed_ref()
+                        for proposal in memory_bundle.proposals
+                    ),
+                )
+            elif stored.kind == GenerationKind.BACKTEST.value:
+                if memory_bundle.proposals:
+                    raise GenerationFinalizationError(
+                        "backtest generations cannot commit canonical memory proposals"
+                    )
+            else:
+                raise GenerationFinalizationError(
+                    "generation kind does not have a finalization policy"
+                )
+
+            completed_at = datetime.now(UTC)
+            _finalize_artifact_in_session(
+                session,
+                self._competition_id,
+                FinalizeArtifact(
+                    artifact_id=artifact.id,
+                    artifact_version_id=version.id,
+                ),
+                finalized_at=completed_at,
+            )
+            generation = _succeed_generation_in_session(
+                session,
+                self._competition_id,
+                SucceedGeneration(
+                    generation_id=generation_id,
+                    submitted_artifact_version_id=version.id,
+                ),
+                completed_at=completed_at,
+            )
+        return GenerationFinalizationResult(
+            generation=generation,
+            memory_result=memory_result,
+        )
+
+    def _validate_memory_bundle(
+        self,
+        stored: StoredGeneration,
+        bundle: MemoryMutationBundle,
+    ) -> None:
+        expected = (
+            self._competition_id,
+            stored.id,
+            stored.input_memory_revision_id,
+            stored.competition_season_id,
+            stored.week_end,
+            stored.knowledge_cutoff_at,
+        )
+        actual = (
+            bundle.competition_id,
+            bundle.generation_id,
+            bundle.expected_revision_id,
+            bundle.competition_season_id,
+            bundle.week,
+            bundle.knowledge_cutoff_at,
+        )
+        if actual != expected:
+            raise GenerationFinalizationError(
+                "completed memory bundle differs from the generation's pinned inputs"
+            )
+
+
+__all__ = [
+    "GenerationFinalizationError",
+    "GenerationFinalizationResult",
+    "GenerationFinalizer",
+]

--- a/backend/services/generations/service.py
+++ b/backend/services/generations/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 import hashlib
@@ -15,7 +16,9 @@ from backend.resources.reporting.ai_calls import AICallManager
 from backend.resources.reporting.artifact_versions import ArtifactVersionManager
 from backend.resources.reporting.artifacts import ArtifactManager
 from backend.resources.reporting.generations import (
+    CancelGeneration,
     CreateGeneration,
+    FailGeneration,
     Generation,
     GenerationKind,
     GenerationLifecycleConflict,
@@ -34,7 +37,11 @@ from backend.services.generations.contracts import (
     GenerationExecutionResult,
     GenerationRequest,
     GenerationSettings,
+    ReconcileResult,
+    RerunGenerationRequest,
+    StaleGenerationPolicy,
 )
+from backend.services.generations.finalization import GenerationFinalizationResult
 from backend.services.generations.manifest import (
     BuiltGenerationManifest,
     CanonicalMemoryInput,
@@ -53,6 +60,7 @@ from backend.services.generations.manifest import (
 from backend.services.generations.recorder import GenerationExecutionRecorder
 from backend.services.memory import (
     GenerationMemoryContext,
+    MemoryMutationBundle,
     MemoryRetrievalService,
 )
 from backend.services.reporter import (
@@ -87,6 +95,15 @@ class SnapshotResolver(Protocol):
     def get_or_create(self, request: SnapshotRequest) -> ReadyDataSnapshot: ...
 
 
+class Finalizer(Protocol):
+    def finalize(
+        self,
+        generation_id: UUID,
+        output: ReporterOutput,
+        memory_bundle: MemoryMutationBundle,
+    ) -> GenerationFinalizationResult: ...
+
+
 class GenerationService:
     """Submit durable requests and execute one fully pinned reporter run."""
 
@@ -101,6 +118,7 @@ class GenerationService:
         tool_calls: ToolCallManager,
         artifacts: ArtifactManager,
         artifact_versions: ArtifactVersionManager,
+        finalizer: Finalizer,
         reporter_revision: str,
         generation_revision: str,
         reporter: ReporterCallable = generate_article,
@@ -116,6 +134,7 @@ class GenerationService:
         self._tool_calls = tool_calls
         self._artifacts = artifacts
         self._artifact_versions = artifact_versions
+        self._finalizer = finalizer
         self._reporter_revision = _nonblank(reporter_revision, "reporter_revision")
         self._generation_revision = _nonblank(
             generation_revision, "generation_revision"
@@ -145,7 +164,7 @@ class GenerationService:
         )
 
     async def execute(self, generation_id: UUID) -> GenerationExecutionResult:
-        """Resolve immutable inputs, start atomically, and call the reporter once."""
+        """Resolve, execute, and return one durably terminal generation."""
 
         pending = self._generations.get(generation_id)
         if pending.status is not GenerationStatus.PENDING:
@@ -155,56 +174,79 @@ class GenerationService:
                 expected_statuses=(GenerationStatus.PENDING.value,),
                 actual_status=pending.status.value,
             )
-        if pending.week_start is None or pending.week_end is None:
-            raise ValueError("generation execution requires a resolved week range")
-
-        execution_at = _aware_utc(self._clock())
-        settings = _decode_settings(pending.settings)
-        snapshot = self._snapshots.get_or_create(
-            SnapshotRequest(
-                competition_season_id=pending.competition_season_id,
-                through_week=pending.week_end,
-                as_of_date=execution_at.date(),
+        try:
+            if pending.week_start is None or pending.week_end is None:
+                raise ValueError("generation execution requires a resolved week range")
+            execution_at = _aware_utc(self._clock())
+            settings = _decode_settings(pending.settings)
+            snapshot = self._snapshots.get_or_create(
+                SnapshotRequest(
+                    competition_season_id=pending.competition_season_id,
+                    through_week=pending.week_end,
+                    as_of_date=execution_at.date(),
+                )
             )
-        )
-        if (
-            snapshot.competition_id != pending.competition_id
-            or snapshot.primary_competition_season_id
-            != pending.competition_season_id
-            or snapshot.through_week != pending.week_end
-        ):
-            raise ValueError("resolved snapshot differs from generation scope or cutoff")
-
-        revision = self._select_memory_revision(pending)
-        knowledge_cutoff_at = (
-            execution_at
-            if pending.kind is GenerationKind.LIVE
-            else revision.knowledge_cutoff_at or revision.created_at
-        )
-        definition = self._prepare_definition(memory_enabled=True)
-        manifest = _build_manifest(
-            generation=pending,
-            settings=settings,
-            resolved_settings=pending.settings,
-            snapshot=snapshot,
-            revision=revision,
-            knowledge_cutoff_at=knowledge_cutoff_at,
-            definition=definition,
-            reporter_revision=self._reporter_revision,
-            generation_revision=self._generation_revision,
-        )
-        self._generations.start(
-            StartGeneration(
-                generation_id=pending.id,
-                data_snapshot_id=snapshot.id,
-                input_memory_revision_id=revision.revision_id,
+            if (
+                snapshot.competition_id != pending.competition_id
+                or snapshot.primary_competition_season_id
+                != pending.competition_season_id
+                or snapshot.through_week != pending.week_end
+            ):
+                raise ValueError(
+                    "resolved snapshot differs from generation scope or cutoff"
+                )
+            revision = self._select_memory_revision(pending)
+            knowledge_cutoff_at = (
+                execution_at
+                if pending.kind is GenerationKind.LIVE
+                else revision.knowledge_cutoff_at or revision.created_at
+            )
+            definition = self._prepare_definition(memory_enabled=True)
+            manifest = _build_manifest(
+                generation=pending,
+                settings=settings,
+                resolved_settings=pending.settings,
+                snapshot=snapshot,
+                revision=revision,
                 knowledge_cutoff_at=knowledge_cutoff_at,
-                input_manifest=manifest.manifest,
-                manifest_schema_version=manifest.schema_version,
-                manifest_hash=manifest.manifest_hash,
-                initial_stage="starting",
+                definition=definition,
+                reporter_revision=self._reporter_revision,
+                generation_revision=self._generation_revision,
             )
-        )
+        except asyncio.CancelledError:
+            return self._cancel_result(pending.id, GenerationStatus.PENDING)
+        except Exception as exc:
+            return self._failure_result(
+                pending.id,
+                GenerationStatus.PENDING,
+                "input_resolution",
+                exc,
+            )
+
+        try:
+            self._generations.start(
+                StartGeneration(
+                    generation_id=pending.id,
+                    data_snapshot_id=snapshot.id,
+                    input_memory_revision_id=revision.revision_id,
+                    knowledge_cutoff_at=knowledge_cutoff_at,
+                    input_manifest=manifest.manifest,
+                    manifest_schema_version=manifest.schema_version,
+                    manifest_hash=manifest.manifest_hash,
+                    initial_stage="starting",
+                )
+            )
+        except asyncio.CancelledError:
+            return self._cancel_result(pending.id, GenerationStatus.PENDING)
+        except GenerationLifecycleConflict:
+            raise
+        except Exception as exc:
+            return self._failure_result(
+                pending.id,
+                GenerationStatus.PENDING,
+                "input_resolution",
+                exc,
+            )
 
         memory = GenerationMemoryContext(
             competition_id=pending.competition_id,
@@ -236,15 +278,126 @@ class GenerationService:
                     definition=definition,
                 )
             bundle = memory.take_completed_bundle()
+        except asyncio.CancelledError:
+            memory.discard()
+            return self._cancel_result(pending.id, GenerationStatus.RUNNING)
+        except Exception as exc:
+            memory.discard()
+            return self._failure_result(
+                pending.id,
+                GenerationStatus.RUNNING,
+                "reporter_execution",
+                exc,
+            )
         except BaseException:
             memory.discard()
             raise
 
+        try:
+            finalized = self._finalizer.finalize(pending.id, output, bundle)
+        except Exception as exc:
+            return self._failure_result(
+                pending.id,
+                GenerationStatus.RUNNING,
+                "generation_finalization",
+                exc,
+            )
         return GenerationExecutionResult(
-            generation=self._generations.get(pending.id),
+            generation=finalized.generation,
             reporter_output=output,
-            memory_bundle=bundle,
+            memory_result=finalized.memory_result,
         )
+
+    def rerun(self, request: RerunGenerationRequest) -> Generation:
+        """Copy one terminal generation's intent into a fresh linked request."""
+
+        source = self._generations.get(request.source_generation_id)
+        if source.status not in {
+            GenerationStatus.SUCCEEDED,
+            GenerationStatus.FAILED,
+            GenerationStatus.CANCELLED,
+        }:
+            raise GenerationLifecycleConflict(
+                source.id,
+                "reruns require a terminal source generation",
+                expected_statuses=("succeeded", "failed", "cancelled"),
+                actual_status=source.status.value,
+            )
+        if source.week_start is None or source.week_end is None:
+            raise ValueError("rerun source requires a resolved week range")
+        return self.submit(
+            GenerationRequest(
+                generation_id=request.generation_id,
+                competition_id=source.competition_id,
+                competition_season_id=source.competition_season_id,
+                kind=source.kind,
+                request_text=source.request_text,
+                week_start=source.week_start,
+                week_end=source.week_end,
+                requested_primary_model=source.requested_primary_model,
+                settings=_decode_settings(source.settings),
+                rerun_of_generation_id=source.id,
+            )
+        )
+
+    def reconcile_stale(self, policy: StaleGenerationPolicy) -> ReconcileResult:
+        """Fail a bounded batch of stale running generations without resuming them."""
+
+        stale = self._generations.fail_stale_running(
+            stale_before=policy.stale_before,
+            limit=policy.limit,
+        )
+        return ReconcileResult(
+            stale_before=policy.stale_before,
+            generations=stale,
+        )
+
+    def _failure_result(
+        self,
+        generation_id: UUID,
+        expected_status: GenerationStatus,
+        category: str,
+        exc: Exception,
+    ) -> GenerationExecutionResult:
+        try:
+            generation = self._generations.fail(
+                FailGeneration(
+                    generation_id=generation_id,
+                    category=category,
+                    summary=_failure_summary(category, exc),
+                    expected_status=expected_status,
+                )
+            )
+        except GenerationLifecycleConflict:
+            generation = self._generations.get(generation_id)
+            if generation.status not in {
+                GenerationStatus.FAILED,
+                GenerationStatus.CANCELLED,
+            }:
+                raise
+        return GenerationExecutionResult(generation=generation)
+
+    def _cancel_result(
+        self,
+        generation_id: UUID,
+        expected_status: GenerationStatus,
+    ) -> GenerationExecutionResult:
+        try:
+            generation = self._generations.cancel(
+                CancelGeneration(
+                    generation_id=generation_id,
+                    summary="Generation execution was cancelled",
+                    expected_status=expected_status,
+                )
+            )
+        except GenerationLifecycleConflict:
+            generation = self._generations.get(generation_id)
+            if generation.status not in {
+                GenerationStatus.FAILED,
+                GenerationStatus.CANCELLED,
+            }:
+                raise
+        return GenerationExecutionResult(generation=generation)
 
     def _select_memory_revision(self, generation: Generation) -> CanonicalRevision:
         if generation.kind is GenerationKind.LIVE:
@@ -440,6 +593,11 @@ def _nonblank(value: str, field: str) -> str:
     if not value or value.strip() != value:
         raise ValueError(f"{field} must be non-blank and trimmed")
     return value
+
+
+def _failure_summary(category: str, exc: Exception) -> str:
+    label = category.replace("_", " ").capitalize()
+    return f"{label} failed ({type(exc).__name__})"[:500]
 
 
 __all__ = [

--- a/backend/services/memory/mutation_service.py
+++ b/backend/services/memory/mutation_service.py
@@ -61,18 +61,7 @@ class MemoryMutationService:
     def apply(self, bundle: MemoryMutationBundle) -> MemoryMutationResult:
         """Apply a completed generation bundle exactly as one mutation unit."""
 
-        writes = tuple(_canonical_write(proposal) for proposal in bundle.proposals)
-        revision = self._revision_manager.commit(
-            CanonicalWriteBundle(
-                competition_id=bundle.competition_id,
-                generation_id=bundle.generation_id,
-                expected_revision_id=bundle.expected_revision_id,
-                competition_season_id=bundle.competition_season_id,
-                week=bundle.week,
-                knowledge_cutoff_at=bundle.knowledge_cutoff_at,
-                writes=writes,
-            )
-        )
+        revision = self._revision_manager.commit(prepare_canonical_bundle(bundle))
         return MemoryMutationResult(
             revision=revision,
             changes=tuple(
@@ -252,7 +241,6 @@ class MemoryMutationService:
             metadata=metadata or MemoryMutationMetadata(),
         )
         return self.apply(_single_bundle(self._revision_manager, origin, proposal))
-
     def _single_replace(
         self,
         origin: MemoryMutationOrigin,
@@ -274,6 +262,20 @@ class MemoryMutationService:
             metadata=metadata or MemoryMutationMetadata(),
         )
         return self.apply(_single_bundle(self._revision_manager, origin, proposal))
+
+
+def prepare_canonical_bundle(bundle: MemoryMutationBundle) -> CanonicalWriteBundle:
+    """Translate a completed proposal bundle without opening a transaction."""
+
+    return CanonicalWriteBundle(
+        competition_id=bundle.competition_id,
+        generation_id=bundle.generation_id,
+        expected_revision_id=bundle.expected_revision_id,
+        competition_season_id=bundle.competition_season_id,
+        week=bundle.week,
+        knowledge_cutoff_at=bundle.knowledge_cutoff_at,
+        writes=tuple(_canonical_write(proposal) for proposal in bundle.proposals),
+    )
 
 
 def _single_bundle(

--- a/backend/tests/resources/reporting/generations/test_manager.py
+++ b/backend/tests/resources/reporting/generations/test_manager.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 import pytest
@@ -119,6 +119,64 @@ def test_pending_start_progress_and_terminal_lifecycle_are_atomic(
         generation_manager.get(pending.id).data_snapshot_id
         == running.data_snapshot_id
     )
+
+
+def test_terminal_compare_and_set_does_not_overwrite_another_worker(
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    pending = generation_manager.create_pending(_create_command(generation_domain))
+    generation_manager.start(_start_command(generation_domain, pending.id))
+
+    with pytest.raises(GenerationLifecycleConflict):
+        generation_manager.fail(
+            FailGeneration(
+                generation_id=pending.id,
+                category="input_resolution",
+                summary="late pre-start failure",
+                expected_status="pending",
+            )
+        )
+    with pytest.raises(GenerationLifecycleConflict):
+        generation_manager.cancel(
+            CancelGeneration(
+                generation_id=pending.id,
+                expected_status="pending",
+            )
+        )
+    assert generation_manager.get(pending.id).status.value == "running"
+
+
+def test_stale_reconciliation_is_scoped_bounded_and_running_only(
+    database_engine: Engine,
+    generation_manager: GenerationManager,
+    generation_domain: GenerationDomain,
+) -> None:
+    first = generation_manager.create_pending(_create_command(generation_domain))
+    second = generation_manager.create_pending(_create_command(generation_domain))
+    fresh = generation_manager.create_pending(_create_command(generation_domain))
+    generation_manager.start(_start_command(generation_domain, first.id))
+    generation_manager.start(_start_command(generation_domain, second.id))
+    generation_manager.start(_start_command(generation_domain, fresh.id))
+    cutoff = datetime.now(UTC) - timedelta(minutes=5)
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.update(StoredGeneration)
+            .where(StoredGeneration.id.in_((first.id, second.id)))
+            .values(progress_updated_at=cutoff - timedelta(minutes=5))
+        )
+
+    reconciled = generation_manager.fail_stale_running(
+        stale_before=cutoff,
+        limit=1,
+    )
+
+    assert len(reconciled) == 1
+    assert reconciled[0].status.value == "failed"
+    assert reconciled[0].failure_category == "stale_execution"
+    remaining = {first.id, second.id} - {reconciled[0].id}
+    assert generation_manager.get(remaining.pop()).status.value == "running"
+    assert generation_manager.get(fresh.id).status.value == "running"
 
 
 def test_failed_start_rolls_back_all_input_pinning(

--- a/backend/tests/services/generations/test_finalization.py
+++ b/backend/tests/services/generations/test_finalization.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import hashlib
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from pydantic import TypeAdapter
+from sqlalchemy.engine import Engine
+
+from backend.database.models.memory import CurrentRevision, MemoryRevision
+from backend.database.models.reporting import Artifact, Generation as StoredGeneration
+from backend.database.sessions import create_session_factory
+from backend.resources.memory.common import MemoryKind
+from backend.resources.memory.context_notes import (
+    ContextNoteContent,
+    ContextNoteIdentity,
+)
+from backend.resources.reporting.artifact_versions import (
+    AppendArtifactVersion,
+    ArtifactVersionManager,
+    ArtifactVersionQuery,
+)
+from backend.resources.reporting.artifacts import ArtifactManager, CreateArtifact
+from backend.resources.reporting.generations import (
+    CreateGeneration,
+    GenerationManager,
+    StartGeneration,
+)
+from backend.services.generations import GenerationFinalizer
+from backend.services.memory import (
+    MemoryMutationBundle,
+    MemoryMutationMetadata,
+    MemoryProposal,
+)
+from backend.services.reporter import ReporterOutput
+from backend.services.reporter.runner.schemas import ArtifactSnapshot
+from backend.tests.database.conftest import database_engine, migrated_database
+from backend.tests.resources.reporting.generations.conftest import (
+    generation_context,
+    seed_generation_domain,
+)
+
+
+KNOWLEDGE_CUTOFF = datetime(2026, 10, 27, 20, tzinfo=UTC)
+ARTICLE = "# Final article\n"
+ARTICLE_HASH = hashlib.sha256(ARTICLE.encode()).hexdigest()
+
+
+def _running_generation(engine: Engine, *, kind: str = "live"):
+    domain = seed_generation_domain(engine, label=f"Finalization {kind}")
+    factory = create_session_factory(engine)
+    context = generation_context(domain)
+    generations = GenerationManager(factory, context)
+    pending = generations.create_pending(
+        CreateGeneration(
+            generation_id=uuid4(),
+            competition_season_id=domain.season_id,
+            kind=kind,
+            request_text="write the final article",
+            week_start=8,
+            week_end=8,
+            requested_primary_model="test-model",
+            settings={},
+        )
+    )
+    running = generations.start(
+        StartGeneration(
+            generation_id=pending.id,
+            data_snapshot_id=domain.snapshot_id,
+            input_memory_revision_id=domain.memory_revision_id,
+            knowledge_cutoff_at=KNOWLEDGE_CUTOFF,
+            input_manifest={"version": 1},
+            manifest_schema_version=1,
+            manifest_hash="a" * 64,
+        )
+    )
+    artifacts = ArtifactManager(factory, context)
+    artifact_versions = ArtifactVersionManager(factory, context)
+    artifact = artifacts.create_artifact(
+        CreateArtifact(
+            generation_id=running.id,
+            path="columns/week-8.md",
+            media_type="text/markdown",
+        )
+    )
+    version = artifact_versions.append_artifact_version(
+        AppendArtifactVersion(
+            artifact_id=artifact.id,
+            content=ARTICLE,
+            content_hash=ARTICLE_HASH,
+        )
+    )
+    output = ReporterOutput(
+        submitted_path=artifact.path,
+        artifacts=(
+            ArtifactSnapshot(
+                path=artifact.path,
+                content=ARTICLE,
+                revision=version.revision_number,
+                content_hash=ARTICLE_HASH,
+            ),
+        ),
+    )
+    return domain, factory, context, generations, running, artifact, version, output
+
+
+def _bundle(domain, generation_id, *, proposals=()) -> MemoryMutationBundle:
+    return MemoryMutationBundle(
+        competition_id=domain.competition_id,
+        generation_id=generation_id,
+        expected_revision_id=domain.memory_revision_id,
+        competition_season_id=domain.season_id,
+        week=8,
+        knowledge_cutoff_at=KNOWLEDGE_CUTOFF,
+        proposals=proposals,
+    )
+
+
+def _context_note_proposal() -> MemoryProposal:
+    return MemoryProposal(
+        proposal_id=uuid4(),
+        operation="create",
+        kind=MemoryKind.CONTEXT_NOTE,
+        item_id=uuid4(),
+        version_id=uuid4(),
+        context_note_identity=TypeAdapter(ContextNoteIdentity).validate_python(
+            {"scope": "competition", "note_key": "weekly-form"}
+        ),
+        content=ContextNoteContent.model_validate(
+            {
+                "narrative": "The league's playoff race tightened this week.",
+                "outlook": "Expect aggressive waiver moves.",
+                "status": "active",
+                "tags": ["playoffs"],
+            }
+        ),
+        metadata=MemoryMutationMetadata(change_reason="generation finalization"),
+    )
+
+
+def test_empty_live_bundle_finalizes_existing_version_without_copy(
+    database_engine: Engine,
+) -> None:
+    domain, factory, context, generations, running, artifact, version, output = (
+        _running_generation(database_engine)
+    )
+    finalizer = GenerationFinalizer(factory, context)
+
+    result = finalizer.finalize(running.id, output, _bundle(domain, running.id))
+
+    assert result.generation.status.value == "succeeded"
+    assert result.generation.submitted_artifact_version_id == version.id
+    assert result.memory_result is not None
+    assert result.memory_result.revision is None
+    assert ArtifactManager(factory, context).get(artifact.id).finalized_version_id == version.id
+    assert ArtifactVersionManager(factory, context).list(
+        ArtifactVersionQuery(artifact_id=artifact.id)
+    ).total == 1
+    assert generations.get(running.id).status.value == "succeeded"
+
+
+def test_live_bundle_commits_one_generation_owned_canonical_revision(
+    database_engine: Engine,
+) -> None:
+    domain, factory, context, generations, running, _, version, output = (
+        _running_generation(database_engine)
+    )
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": domain.competition_id,
+                "current_revision_id": domain.memory_revision_id,
+                "lock_version": 0,
+            },
+        )
+    proposal = _context_note_proposal()
+
+    result = GenerationFinalizer(factory, context).finalize(
+        running.id,
+        output,
+        _bundle(domain, running.id, proposals=(proposal,)),
+    )
+
+    assert result.generation.status.value == "succeeded"
+    assert result.generation.submitted_artifact_version_id == version.id
+    assert result.memory_result is not None
+    assert result.memory_result.revision is not None
+    assert result.memory_result.revision.producing_generation_id == running.id
+    assert result.memory_result.changes == (proposal.proposed_ref(),)
+    assert generations.get(running.id).status.value == "succeeded"
+
+
+def test_live_memory_and_reporting_commit_roll_back_together_on_late_failure(
+    database_engine: Engine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    domain, factory, context, generations, running, artifact, _, output = (
+        _running_generation(database_engine)
+    )
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(CurrentRevision),
+            {
+                "competition_id": domain.competition_id,
+                "current_revision_id": domain.memory_revision_id,
+                "lock_version": 0,
+            },
+        )
+    proposal = _context_note_proposal()
+    finalizer = GenerationFinalizer(factory, context)
+
+    def fail_after_memory(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("injected terminal write failure")
+
+    monkeypatch.setattr(
+        "backend.services.generations.finalization._succeed_generation_in_session",
+        fail_after_memory,
+    )
+    with pytest.raises(RuntimeError, match="injected terminal"):
+        finalizer.finalize(
+            running.id,
+            output,
+            _bundle(domain, running.id, proposals=(proposal,)),
+        )
+
+    with database_engine.begin() as connection:
+        finalized_version_id = connection.execute(
+            sa.select(Artifact.finalized_version_id).where(Artifact.id == artifact.id)
+        ).scalar_one()
+        generation_status, submitted_version_id = connection.execute(
+            sa.select(
+                StoredGeneration.status,
+                StoredGeneration.submitted_artifact_version_id,
+            ).where(StoredGeneration.id == running.id)
+        ).one()
+        current = connection.execute(
+            sa.select(CurrentRevision.current_revision_id).where(
+                CurrentRevision.competition_id == domain.competition_id
+            )
+        ).scalar_one()
+        produced = connection.execute(
+            sa.select(sa.func.count()).select_from(MemoryRevision).where(
+                MemoryRevision.producing_generation_id == running.id
+            )
+        ).scalar_one()
+    assert finalized_version_id is None
+    assert generation_status == "running"
+    assert submitted_version_id is None
+    assert current == domain.memory_revision_id
+    assert produced == 0
+
+
+def test_backtest_discards_empty_bundle_and_rejects_memory_proposals(
+    database_engine: Engine,
+) -> None:
+    domain, factory, context, generations, running, artifact, version, output = (
+        _running_generation(database_engine, kind="backtest")
+    )
+    finalizer = GenerationFinalizer(factory, context)
+
+    with pytest.raises(RuntimeError, match="backtest generations"):
+        finalizer.finalize(
+            running.id,
+            output,
+            _bundle(domain, running.id, proposals=(_context_note_proposal(),)),
+        )
+
+    assert generations.get(running.id).status.value == "running"
+    assert ArtifactManager(factory, context).get(artifact.id).finalized_version_id is None
+    result = finalizer.finalize(running.id, output, _bundle(domain, running.id))
+    assert result.generation.status.value == "succeeded"
+    assert result.generation.submitted_artifact_version_id == version.id
+    assert result.memory_result is None
+
+
+def test_missing_or_mismatched_submission_leaves_running_outputs_unchanged(
+    database_engine: Engine,
+) -> None:
+    domain, factory, context, generations, running, artifact, _, _ = (
+        _running_generation(database_engine)
+    )
+    finalizer = GenerationFinalizer(factory, context)
+
+    with pytest.raises(RuntimeError, match="select one submitted artifact"):
+        finalizer.finalize(
+            running.id,
+            ReporterOutput(),
+            _bundle(domain, running.id),
+        )
+    changed = "# Changed after recording\n"
+    mismatch = ReporterOutput(
+        submitted_path=artifact.path,
+        artifacts=(
+            ArtifactSnapshot(
+                path=artifact.path,
+                content=changed,
+                revision=1,
+                content_hash=hashlib.sha256(changed.encode()).hexdigest(),
+            ),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="does not match"):
+        finalizer.finalize(
+            running.id,
+            mismatch,
+            _bundle(domain, running.id),
+        )
+
+    assert generations.get(running.id).status.value == "running"
+    assert ArtifactManager(factory, context).get(artifact.id).finalized_version_id is None

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from uuid import UUID
@@ -21,9 +21,14 @@ from backend.services.generations import (
     GenerationRequest,
     GenerationService,
     GenerationSettings,
+    ReconcileResult,
+    RerunGenerationRequest,
+    StaleGenerationPolicy,
 )
+from backend.services.memory import MemoryMutationResult
 from backend.services.reporter import ReporterOutput
 from backend.services.reporter.runner.recording import ArtifactMutation
+from backend.services.reporter.runner.schemas import ArtifactSnapshot
 
 
 NOW = datetime(2026, 10, 29, 19, 30, tzinfo=UTC)
@@ -53,6 +58,7 @@ class FakeGenerationManager:
             week_start=command.week_start,
             week_end=command.week_end,
             model=command.requested_primary_model,
+            rerun_of_generation_id=command.rerun_of_generation_id,
         )
         self.rows[row.id] = row
         return row
@@ -76,11 +82,67 @@ class FakeGenerationManager:
                 "manifest_schema_version": command.manifest_schema_version,
                 "manifest_hash": command.manifest_hash,
                 "current_stage": command.initial_stage,
+                "progress_updated_at": NOW,
                 "started_at": NOW,
             }
         )
         self.rows[row.id] = started
         return started
+
+    def fail(self, command):
+        self.events.append("fail")
+        row = self.rows[command.generation_id]
+        if command.expected_status is not None and row.status is not command.expected_status:
+            raise GenerationLifecycleConflict(row.id, "status changed")
+        failed = row.model_copy(
+            update={
+                "status": GenerationStatus.FAILED,
+                "current_stage": "failed",
+                "failure_category": command.category,
+                "failure_summary": command.summary,
+                "completed_at": NOW,
+            }
+        )
+        self.rows[row.id] = failed
+        return failed
+
+    def cancel(self, command):
+        self.events.append("cancel")
+        row = self.rows[command.generation_id]
+        if command.expected_status is not None and row.status is not command.expected_status:
+            raise GenerationLifecycleConflict(row.id, "status changed")
+        cancelled = row.model_copy(
+            update={
+                "status": GenerationStatus.CANCELLED,
+                "current_stage": "cancelled",
+                "failure_category": "cancelled",
+                "failure_summary": command.summary,
+                "completed_at": NOW,
+            }
+        )
+        self.rows[row.id] = cancelled
+        return cancelled
+
+    def fail_stale_running(self, *, stale_before, limit):
+        self.events.append("reconcile")
+        stale = [
+            row
+            for row in self.rows.values()
+            if row.status is GenerationStatus.RUNNING
+            and row.progress_updated_at is not None
+            and row.progress_updated_at < stale_before
+        ][:limit]
+        return tuple(
+            self.fail(
+                SimpleNamespace(
+                    generation_id=row.id,
+                    expected_status=GenerationStatus.RUNNING,
+                    category="stale_execution",
+                    summary="Generation execution became stale",
+                )
+            )
+            for row in stale
+        )
 
 
 class FakeSnapshots:
@@ -146,6 +208,7 @@ class FakeReporter:
         self.calls = []
         self.error: BaseException | None = None
         self.exercise_recorder = False
+        self.finalizer = None
 
     async def __call__(self, data, config, **kwargs):
         self.events.append("reporter")
@@ -165,7 +228,54 @@ class FakeReporter:
             )
         if self.error is not None:
             raise self.error
-        return ReporterOutput()
+        content = "# Article"
+        return ReporterOutput(
+            submitted_path="article.md",
+            artifacts=(
+                ArtifactSnapshot(
+                    path="article.md",
+                    content=content,
+                    revision=1,
+                    content_hash=(
+                        "1f4d9127a0b36fbb412b83e36f31f7b0"
+                        "6665f13e8694015f0bb2e5cb04976bbe"
+                    ),
+                ),
+            ),
+        )
+
+
+class FakeFinalizer:
+    def __init__(self, manager, events):
+        self.manager = manager
+        self.events = events
+        self.calls = []
+        self.error: Exception | None = None
+
+    def finalize(self, generation_id, output, memory_bundle):
+        self.events.append("finalize")
+        self.calls.append((generation_id, output, memory_bundle))
+        if self.error is not None:
+            raise self.error
+        row = self.manager.rows[generation_id]
+        succeeded = row.model_copy(
+            update={
+                "status": GenerationStatus.SUCCEEDED,
+                "submitted_artifact_version_id": _uuid(500),
+                "current_stage": "succeeded",
+                "completed_at": NOW,
+            }
+        )
+        self.manager.rows[generation_id] = succeeded
+        memory_result = (
+            MemoryMutationResult(revision=None, changes=())
+            if row.kind is GenerationKind.LIVE
+            else None
+        )
+        return SimpleNamespace(
+            generation=succeeded,
+            memory_result=memory_result,
+        )
 
 
 def _generation(
@@ -179,6 +289,7 @@ def _generation(
     week_start: int | None = 7,
     week_end: int | None = 8,
     model: str = "gpt-test",
+    rerun_of_generation_id: UUID | None = None,
 ) -> Generation:
     return Generation(
         id=generation_id,
@@ -190,7 +301,7 @@ def _generation(
         input_memory_artifact_generation_id=None,
         evaluation_workspace_id=None,
         workspace_sequence_number=None,
-        rerun_of_generation_id=None,
+        rerun_of_generation_id=rerun_of_generation_id,
         submitted_artifact_version_id=None,
         kind=kind,
         status=GenerationStatus.PENDING,
@@ -285,6 +396,8 @@ def _service(
         events,
     )
     reporter = FakeReporter(events)
+    finalizer = FakeFinalizer(manager, events)
+    reporter.finalizer = finalizer
     runtime = FakeFrozenData(events)
     service = GenerationService(
         generations=manager,  # type: ignore[arg-type]
@@ -295,8 +408,9 @@ def _service(
         tool_calls=SimpleNamespace(),  # type: ignore[arg-type]
         artifacts=SimpleNamespace(),  # type: ignore[arg-type]
         artifact_versions=SimpleNamespace(),  # type: ignore[arg-type]
-        reporter_revision="reporter-9",
-        generation_revision="generation-9",
+        finalizer=finalizer,
+        reporter_revision="reporter-10",
+        generation_revision="generation-10",
         reporter=reporter,
         open_frozen_data=lambda snapshot: runtime,  # type: ignore[arg-type]
         clock=lambda: NOW,
@@ -339,13 +453,24 @@ async def test_live_execution_pins_inputs_before_reporter_and_closes_runtime(
 
     result = await service.execute(_uuid(3))
 
-    assert events == ["submit", "snapshot", "memory", "start", "open", "reporter", "close"]
+    assert events == [
+        "submit",
+        "snapshot",
+        "memory",
+        "start",
+        "open",
+        "reporter",
+        "close",
+        "finalize",
+    ]
     assert snapshots.requests[0].through_week == 8
     assert snapshots.requests[0].as_of_date == NOW.date()
     assert revisions.current_calls == 1
-    assert result.generation.status is GenerationStatus.RUNNING
-    assert result.memory_bundle.expected_revision_id == _uuid(100)
-    assert result.memory_bundle.proposals == ()
+    assert result.generation.status is GenerationStatus.SUCCEEDED
+    assert result.memory_result == MemoryMutationResult(revision=None, changes=())
+    bundle = reporter.finalizer.calls[0][2]
+    assert bundle.expected_revision_id == _uuid(100)
+    assert bundle.proposals == ()
     assert reporter.calls[0][2]["allow_memory_writes"] is True
     assert runtime.closed is True
     manifest = manager.starts[0].input_manifest
@@ -383,7 +508,8 @@ async def test_backtest_selects_latest_same_season_revision_and_is_read_only(
     assert manager.starts[0].input_memory_revision_id == _uuid(102)
     assert manager.starts[0].knowledge_cutoff_at == cutoff
     assert reporter.calls[0][2]["allow_memory_writes"] is False
-    assert result.memory_bundle.expected_revision_id == _uuid(102)
+    assert reporter.finalizer.calls[0][2].expected_revision_id == _uuid(102)
+    assert result.memory_result is None
 
 
 @pytest.mark.asyncio
@@ -406,15 +532,19 @@ async def test_backtest_falls_back_to_root_revision(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_pre_start_failure_never_calls_reporter(tmp_path) -> None:
-    service, _, snapshots, _, reporter, runtime, events = _service(tmp_path)
-    snapshots.error = RuntimeError("snapshot unavailable")
+    service, manager, snapshots, _, reporter, runtime, events = _service(tmp_path)
+    snapshots.error = RuntimeError("snapshot unavailable sk-secret-value")
 
-    with pytest.raises(RuntimeError, match="snapshot unavailable"):
-        await service.execute(_uuid(3))
+    result = await service.execute(_uuid(3))
 
     assert "start" not in events
     assert reporter.calls == []
     assert runtime.closed is False
+    assert result.generation.status is GenerationStatus.FAILED
+    assert result.reporter_output is None
+    assert result.generation.failure_category == "input_resolution"
+    assert "secret" not in (result.generation.failure_summary or "")
+    assert manager.get(_uuid(3)).status is GenerationStatus.FAILED
 
 
 @pytest.mark.asyncio
@@ -424,13 +554,13 @@ async def test_atomic_start_failure_never_opens_runtime_or_calls_reporter(
     service, manager, _, _, reporter, runtime, events = _service(tmp_path)
     manager.start_error = RuntimeError("start rejected")
 
-    with pytest.raises(RuntimeError, match="start rejected"):
-        await service.execute(_uuid(3))
+    result = await service.execute(_uuid(3))
 
-    assert events[-1] == "start"
+    assert events[-1] == "fail"
     assert "open" not in events
     assert reporter.calls == []
     assert runtime.closed is False
+    assert result.generation.status is GenerationStatus.FAILED
 
 
 @pytest.mark.asyncio
@@ -456,11 +586,11 @@ async def test_backtest_without_eligible_or_root_memory_never_starts(tmp_path) -
         history=history,
     )
 
-    with pytest.raises(ValueError, match="root revision"):
-        await service.execute(_uuid(3))
+    result = await service.execute(_uuid(3))
 
     assert manager.starts == []
     assert reporter.calls == []
+    assert result.generation.status is GenerationStatus.FAILED
 
 
 @pytest.mark.asyncio
@@ -472,11 +602,17 @@ async def test_reporter_failure_or_cancellation_closes_and_discards_context(
     service, manager, _, _, reporter, runtime, _ = _service(tmp_path)
     reporter.error = error
 
-    with pytest.raises(type(error)):
-        await service.execute(_uuid(3))
+    result = await service.execute(_uuid(3))
 
     assert runtime.closed is True
-    assert manager.get(_uuid(3)).status is GenerationStatus.RUNNING
+    expected = (
+        GenerationStatus.CANCELLED
+        if isinstance(error, asyncio.CancelledError)
+        else GenerationStatus.FAILED
+    )
+    assert result.generation.status is expected
+    assert result.reporter_output is None
+    assert manager.get(_uuid(3)).status is expected
     memory = reporter.calls[0][2]["memory_context"]
     with pytest.raises(GenerationMemoryContextClosedError):
         memory.take_completed_bundle()
@@ -484,16 +620,74 @@ async def test_reporter_failure_or_cancellation_closes_and_discards_context(
 
 @pytest.mark.asyncio
 async def test_recorder_failure_closes_runtime_and_discards_context(tmp_path) -> None:
-    service, _, _, _, reporter, runtime, _ = _service(tmp_path)
+    service, manager, _, _, reporter, runtime, _ = _service(tmp_path)
     reporter.exercise_recorder = True
 
-    with pytest.raises(AttributeError, match="create_artifact"):
-        await service.execute(_uuid(3))
+    result = await service.execute(_uuid(3))
 
     assert runtime.closed is True
+    assert result.generation.status is GenerationStatus.FAILED
+    assert manager.get(_uuid(3)).failure_category == "reporter_execution"
     memory = reporter.calls[0][2]["memory_context"]
     with pytest.raises(GenerationMemoryContextClosedError):
         memory.take_completed_bundle()
+
+
+@pytest.mark.asyncio
+async def test_finalization_failure_returns_failed_without_partial_output(tmp_path) -> None:
+    service, manager, _, _, reporter, runtime, _ = _service(tmp_path)
+    reporter.finalizer.error = RuntimeError("commit failed sk-secret-value")
+
+    result = await service.execute(_uuid(3))
+
+    assert runtime.closed is True
+    assert result.generation.status is GenerationStatus.FAILED
+    assert result.generation.failure_category == "generation_finalization"
+    assert result.reporter_output is None
+    assert "secret" not in (result.generation.failure_summary or "")
+    assert manager.get(_uuid(3)).submitted_artifact_version_id is None
+
+
+def test_rerun_copies_terminal_intent_and_links_fresh_pending_row(tmp_path) -> None:
+    service, manager, _, _, _, _, _ = _service(tmp_path)
+    manager.rows[_uuid(3)] = manager.rows[_uuid(3)].model_copy(
+        update={"status": GenerationStatus.FAILED, "completed_at": NOW}
+    )
+
+    rerun = service.rerun(
+        RerunGenerationRequest(
+            source_generation_id=_uuid(3),
+            generation_id=_uuid(4),
+        )
+    )
+
+    assert rerun.status is GenerationStatus.PENDING
+    assert rerun.rerun_of_generation_id == _uuid(3)
+    assert rerun.request_text == manager.get(_uuid(3)).request_text
+    assert rerun.settings == manager.get(_uuid(3)).settings
+    assert rerun.data_snapshot_id is None
+    assert manager.get(_uuid(3)).status is GenerationStatus.FAILED
+
+
+def test_reconcile_stale_returns_only_bounded_running_rows(tmp_path) -> None:
+    service, manager, _, _, _, _, _ = _service(tmp_path)
+    manager.rows[_uuid(3)] = manager.rows[_uuid(3)].model_copy(
+        update={
+            "status": GenerationStatus.RUNNING,
+            "progress_updated_at": NOW - timedelta(minutes=10),
+        }
+    )
+
+    result = service.reconcile_stale(
+        StaleGenerationPolicy(
+            stale_before=NOW - timedelta(minutes=5),
+            limit=1,
+        )
+    )
+
+    assert isinstance(result, ReconcileResult)
+    assert [row.id for row in result.generations] == [_uuid(3)]
+    assert result.generations[0].failure_category == "stale_execution"
 
 
 def test_request_rejects_duplicate_primary_and_fallback_model() -> None:

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -143,12 +143,10 @@ These are explicit design questions, not implied implementation details:
    generic event payloads, string-key upserts, and candidate expansion do not all
    exist in the new contract. The exact decisions are listed in
    [`transition.md`](transition.md#memory-tool-compatibility).
-3. **Cross-resource success atomicity is not yet settled.** The memory contract
-   currently commits through `RevisionManager`, while reporting finalization
-   must also pin the selected reporter outputs and succeed the generation. The
-   owner of a single all-or-nothing finalization transaction, or the accepted
-   recovery semantics if it remains multi-transactional, must be decided before
-   that slice is implemented.
+3. **Generation success uses one database transaction.** The generation
+   finalizer reuses session-bound resource operations to commit canonical memory,
+   finalize the selected existing artifact version, and succeed the generation
+   atomically. Failure leaves all three success outputs uncommitted.
 4. **The closed reporter-adapter PR is prior art, not an upstream dependency.**
    It proved the 18 frozen-data handlers can delegate to `FrozenLeagueData`, but
    the new integration must recreate that adapter under the new backend reporter

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -98,9 +98,8 @@ class ArtifactVersionManager:
     ) -> ArtifactVersion: ...
 ```
 
-Successful finalization requires one additional service operation whose exact
-shape depends on the unresolved cross-resource memory transaction decision. It
-must at minimum ensure that:
+Successful finalization uses one transaction-coordination operation over
+session-bound resource writes. It ensures that:
 
 - the generation is still running;
 - the reporter-selected version exists, belongs to the generation, and is the
@@ -449,10 +448,22 @@ This keeps a clean queue seam without introducing job/lease infrastructure.
 that is not eligible to start; it does not resume or replay a partially executed
 agent loop. An explicit rerun creates another generation.
 
-In generation-9, a successful execution result contains the still-running
-generation, reporter output, and completed in-memory proposal bundle. Durable
-artifact selection, memory application/discard, and the terminal transition are
-the generation-10 finalization boundary.
+`execute()` returns only terminal generations. A successful result includes the
+reporter output and canonical memory mutation result when applicable. Failed or
+cancelled results contain no ephemeral reporter or memory payload; durable call,
+tool, and working-artifact records remain available for diagnostics.
+
+Finalization verifies the reporter snapshot against the exact existing durable
+path, media type, revision, content, and hash. It then commits live canonical
+memory proposals, finalizes that version, and succeeds the generation in one
+PostgreSQL transaction. Backtests require an empty proposal bundle and do not
+write canonical memory.
+
+Stale reconciliation accepts an aware cutoff plus a bounded batch size, locks
+only matching running generations in competition scope, and marks them failed
+without resuming the agent loop. Explicit reruns copy a terminal source's
+request and settings into a linked pending generation; they never copy pinned
+inputs, telemetry, or artifacts.
 
 ## API Boundary
 

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -284,8 +284,12 @@ submitted output is eligible for success. `GenerationService` then:
 - transitions the generation to succeeded only when its required final outputs
   and memory outcome satisfy the selected finalization contract.
 
-The all-or-nothing boundary between the reporting finalization and canonical
-memory commit remains an explicit open decision.
+One PostgreSQL transaction owns the all-or-nothing boundary between canonical
+memory commit, selected-artifact finalization, and generation success. Resource
+modules retain their SQL and validation through session-bound operations; the
+generation finalizer coordinates only their shared transaction. An exception at
+any boundary rolls back all three success outputs while preserving telemetry and
+working artifact versions committed before finalization began.
 
 ### 6. Failure and cancellation
 
@@ -295,8 +299,10 @@ calls, and artifact versions, discards the uncommitted memory buffer,
 and marks the generation failed. A terminal generation never reopens; a retry
 creates a linked generation.
 
-The baseline does not resume a crashed reporter loop. A stale-running
-reconciliation operation marks it failed.
+The baseline does not resume a crashed reporter loop. A bounded,
+competition-scoped stale-running reconciliation operation marks it failed using
+a caller-supplied cutoff. An explicit rerun creates a linked pending generation
+that copies request intent and settings but resolves fresh immutable inputs.
 
 ## Model and Token Observability
 

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -249,14 +249,15 @@ cannot switch data snapshot or memory revision mid-flight.
 
 ### `generation-10` — finalization and failure recovery
 
-- Implement the settled selected-artifact/memory/generation finalization
-  boundary.
+- Commit selected-artifact, live-memory, and generation success through one
+  shared PostgreSQL transaction over resource-owned session operations.
 - Finalize the reporter-selected artifact and pin that exact version on the
   generation without appending a final copy.
 - Apply one completed memory bundle after successful reporter submission or
   discard it on failure/cancellation.
 - Preserve partial AI/tool/artifact telemetry on failure.
-- Add stale-running reconciliation and explicit rerun behavior.
+- Return terminal success/failure/cancellation results, add bounded stale-running
+  reconciliation, and create explicit reruns with fresh input resolution.
 - Prove terminal immutability and sanitized failure metadata.
 
 **Exit gate:** failure at every boundary has a deterministic generation state,
@@ -348,16 +349,11 @@ to `unverified` or `inferred` confidence.
 
 ### 3. Finalization atomicity
 
-Choose one documented invariant:
-
-- a composed short transaction atomically seals final reporting output,
-  commits the memory revision, and succeeds the generation; or
-- a deliberately ordered multi-transaction workflow with durable intermediate
-  state and an explicit reconciliation operation.
-
-The current memory service's transaction ownership means the first choice may
-require a narrow shared transaction helper or revised ownership contract. That
-change must be agreed with the memory design rather than bypassed.
+Use one composed short PostgreSQL transaction to commit the canonical memory
+revision when present, finalize the selected existing artifact version, and
+succeed the generation. Resource modules expose narrow session-bound operations
+that retain their validation and SQL ownership; the generation finalizer owns
+only the shared transaction. Any exception rolls back all success outputs.
 
 ## Required Acceptance Coverage
 


### PR DESCRIPTION
## Summary

- atomically commit the selected existing artifact version, permitted live
  memory proposals, and generation success
- return terminal results for success, failure, and cancellation without
  exposing ephemeral failed output
- fail stale running generations in bounded scoped batches and create linked
  reruns with fresh inputs

## Finalization invariant

- verify exact path, media type, revision, content, and hash against the durable
  artifact version
- commit canonical memory, artifact finalization, and generation success in one
  PostgreSQL transaction
- roll back every success output on a failure at any finalization boundary
- preserve telemetry and working artifact versions committed before finalization

## Verification

- 84 targeted generation/reporting/memory and reporter-boundary tests passed
- compile, Python 99-column, import-boundary, and `git diff --check` gates passed
- full suite intentionally not run
