### PR TITLE
UI 0: plan initial product journeys and frontend architecture

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -1,0 +1,119 @@
+# Product UI Design
+
+**Status:** Proposed product and frontend contract
+
+**Scope:** Competition management, article generation, generated-article
+inspection, execution audit, and usage/cost visibility
+
+**Backend baseline:** The modular monolith under `backend/`
+
+## Purpose
+
+This design turns the backend platform into an operator-facing application for
+running one or more fantasy-football reporters. It starts with three complete
+journeys:
+
+1. create a durable competition, attach its Sleeper league ID for each season,
+   refresh source data, and understand data freshness;
+2. configure and start a live generation or historical backtest, including the
+   primary and fallback model chain; and
+3. browse submitted articles by competition and inspect the exact generation,
+   artifacts, model/tool execution, token usage, and estimated cost behind each
+   article.
+
+The first release is a local single-operator product. Authentication, hosted
+multi-user ownership, collaborative editing, and public article publishing are
+not part of this UI slice.
+
+## Documents
+
+| Document | Owns |
+| --- | --- |
+| [`user-journeys.md`](user-journeys.md) | Information architecture, page inventory, flows, and user-visible states |
+| [`application-contracts.md`](application-contracts.md) | Required HTTP surface, implemented coverage, gaps, and transport semantics |
+| [`frontend-architecture.md`](frontend-architecture.md) | TypeScript application structure, libraries, data flow, quality gates, and delivery |
+
+The dependency-ordered implementation plan is intentionally local and mutable
+under `.context/ui/stack.md`, following the existing datalayer, memory, and
+generation workflow.
+
+## Product Vocabulary
+
+The UI must use the backend's domain words consistently:
+
+| Term | Product meaning |
+| --- | --- |
+| Competition | A continuous fantasy league identity across multiple seasons |
+| Season | One competition year mapped to exactly one Sleeper league ID |
+| Refresh | A manual pull from Sleeper that records source observations and updates the normalized current view |
+| Snapshot | An immutable, cutoff-safe SQLite generation input built or reused by the generation service |
+| Generation / run | One durable reporter execution, whether or not it succeeds or submits an article |
+| Article | The exact submitted artifact version of a successful generation |
+| Artifact | A versioned Markdown work product created during a generation |
+| Live generation | A run using the requested current-season boundary and canonical memory |
+| Backtest | A historical, cutoff-aware run isolated from canonical memory writes |
+| Evaluation workspace | Isolated simulated memory state that may be explicitly discarded or fast-forward promoted |
+
+In particular, the league screen says **Refresh Sleeper data**, not “create a
+snapshot.” A refresh calls Sleeper; a snapshot is a separate reproducibility
+artifact created for a generation. The screen can show both timestamps, but it
+must not collapse them into one freshness concept.
+
+User-facing navigation may say **Leagues** because that is the familiar fantasy
+football term. Routes, API contracts, and code retain `competition` for the
+durable cross-season identity.
+
+## Settled Product Decisions
+
+- The application opens on the league/competition list. After a competition is
+  selected, primary navigation is `Overview`, `Articles`, and `Generate`.
+- A competition may be created before any season exists. It is not ready to
+  refresh or generate until at least one season is attached.
+- A season's Sleeper league ID is treated as durable identity once source data
+  or generations reference it. Correction is a backend lifecycle operation,
+  not an unrestricted text-field edit in the first UI.
+- Manual refresh is explicit. Starting a generation does not silently refresh
+  Sleeper data; the form shows freshness and lets the operator refresh first.
+- Generation submission navigates immediately to the durable run page. The UI
+  polls that page until the run is terminal and survives browser reloads.
+- Advanced reporter controls are available but visually secondary to season,
+  week range, mode, request, and model chain.
+- Generation intent has two dimensions: current versus historical factual time,
+  and canonical versus isolated memory effects. Current canonical work is a
+  live generation; current isolated work is a simulation that may be
+  fast-forward promoted; historical work is a backtest and is evaluation-only
+  under the accepted memory contract.
+- Isolated memory never changes canonical memory merely because a run
+  succeeded. Promotion is a separate, confirmed command available only when
+  the workspace started from the still-current canonical revision.
+- Article content is rendered from the exact submitted artifact version.
+  Intermediate artifacts and later/earlier versions never replace it by path
+  convention.
+- Cost is labeled **estimated cost**. The backend calculates it from persisted
+  actual provider/model usage and a named pricing revision; missing usage or
+  pricing remains visibly unknown rather than being treated as zero.
+- The package manager is `pnpm`. Yarn and npm lockfiles are not introduced.
+
+## Release Boundary
+
+The first useful release includes:
+
+- competition and season CRUD needed by the three journeys;
+- synchronous manual refresh plus refresh history/freshness reads;
+- model catalog and generation form;
+- polling-oriented run state;
+- article history and article/run detail;
+- artifacts, AI calls, tool calls, aggregate token usage, and cost estimate; and
+- isolated one-workspace-at-a-time current simulation and fast-forward
+  promotion if the backend workspace service lands in the same release.
+
+Memory browsing/editing, comparisons, scheduled generation, templates, public
+publishing, dashboards across competitions, and streaming execution logs are
+deliberately deferred.
+
+The requested ability to promote memory from a historical backtest conflicts
+with the accepted backend invariant that an old-base workspace is
+evaluation-only. Supporting that behavior would require an explicit memory
+architecture change (merge/rebase or a different meaning of “backtest”), not
+just a UI control. The safe initial product promotes current-based simulations
+and keeps historical backtests isolated.

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -1,0 +1,270 @@
+# UI Application and API Contracts
+
+## Contract Principles
+
+- The frontend consumes only `/api/v1` HTTP contracts. It never imports Python
+  domain objects or depends on database schemas.
+- Competition scope remains explicit in URLs and must agree with returned
+  resource scope.
+- Writes are domain commands, not generic table patches.
+- List responses use `{items, total, limit, offset}` semantics consistently.
+- Timestamps are timezone-aware ISO 8601 values; the frontend localizes them.
+- IDs remain opaque UUID strings. Sleeper league IDs remain strings.
+- API errors need a stable machine code, safe summary, and optional field
+  details so forms do not parse exception text.
+- The generated OpenAPI document is the source for TypeScript transport types.
+
+## Current Backend Coverage
+
+Generation routes already exist under
+`/api/v1/generations/competitions/{competition_id}`:
+
+| Capability | Route | UI readiness |
+| --- | --- | --- |
+| Submit generation | `POST /generations/competitions/{competition_id}` | Implemented; body already includes kind, season, weeks, primary model, and nested settings |
+| Rerun exact request | `POST /generations/competitions/{competition_id}/{generation_id}/reruns` | Implemented |
+| Run history | `GET /generations/competitions/{competition_id}` | Implemented with season/kind/status/rerun filters |
+| Submitted article history | `GET /generations/competitions/{competition_id}/articles` | Implemented with season/kind filters |
+| Run detail | `GET /generations/competitions/{competition_id}/{generation_id}` | Implemented |
+| Submitted article | `GET /generations/competitions/{competition_id}/{generation_id}/article` | Implemented and returns the exact generation, artifact, and version |
+| AI call list/detail | `GET .../{generation_id}/ai-calls[/{ai_call_id}]` | Implemented |
+| Tool call list/detail | `GET .../{generation_id}/tool-calls[/{tool_call_id}]` | Implemented |
+| Artifact list/detail | `GET .../{generation_id}/artifacts[/{artifact_id}]` | Implemented |
+| Artifact versions | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented |
+
+The current `backend/api/routes/data.py` registers only an empty `/data`
+router. Core competition/season persistence, refresh service, snapshot manager,
+and evaluation-workspace tables exist, but they do not yet have complete
+product resource/service/HTTP surfaces.
+
+The existing generation route hierarchy is functional but inverted. Before a
+public client contract is stable, consider moving it to
+`/api/v1/competitions/{competition_id}/generations/...` alongside the new
+competition resources. If it remains unchanged, the frontend API adapter must
+hide that path irregularity from feature code.
+
+## Required Competition API
+
+Recommended routes:
+
+| Method and path | Purpose | Status |
+| --- | --- | --- |
+| `GET /competitions` | List active competitions with season/freshness/article summary | Missing |
+| `POST /competitions` | Create `{display_name}` | Missing |
+| `GET /competitions/{competition_id}` | Competition detail and summary | Missing |
+| `PATCH /competitions/{competition_id}` | Rename or archive through explicit allowed fields | Missing |
+| `GET /competitions/{competition_id}/seasons` | Ordered season list | Missing |
+| `POST /competitions/{competition_id}/seasons` | Attach `{season_year, sleeper_league_id}` and derive sequence | Missing |
+| `GET /competitions/{competition_id}/seasons/{season_id}` | Season identity plus normalized league overview when present | Missing |
+
+Example creation response:
+
+```json
+{
+  "competition": {
+    "id": "uuid",
+    "display_name": "The League",
+    "created_at": "2026-08-23T12:00:00Z",
+    "updated_at": "2026-08-23T12:00:00Z",
+    "archived_at": null
+  }
+}
+```
+
+The list/detail projection should include summaries the UI otherwise has to
+assemble with N+1 requests: season count/latest season, latest terminal and
+successful refresh timestamps, latest ready snapshot time, and latest submitted
+article time. These are read projections, not denormalized write contracts.
+
+Season creation must return `409` codes for at least
+`competition_season_year_exists` and `sleeper_league_id_exists`. Editing an ID
+after observations exist is out of v1 scope; the API should not expose a broad
+season patch until that lifecycle is designed.
+
+## Required Refresh and Data Audit API
+
+| Method and path | Purpose | Status |
+| --- | --- | --- |
+| `POST /data/competitions/{competition_id}/seasons/{season_id}/refreshes` | Run manual refresh with optional `{through_week}` | Service exists; route missing |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes` | Page refresh history | Manager list/query missing |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes/{refresh_id}` | Read terminal/running refresh and counts | Manager get exists; route missing |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/overview` | Normalized league metadata/current overview | Manager read exists; route missing |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/snapshots` | Page snapshot audit metadata | Snapshot resource exists; list route/query missing |
+
+V1 manual refresh may be synchronous because the implemented refresh service is
+synchronous and the existing datalayer plan explicitly calls for a synchronous
+manual route. It should return `201 Created` with a terminal `RefreshOutcome`.
+The frontend must use a generous request timeout and show in-flight state. If
+refresh duration becomes operationally unreliable, replace this with a durable
+`202 Accepted` job boundary rather than pretending a background task is durable.
+
+Request body:
+
+```json
+{
+  "through_week": 8
+}
+```
+
+Blank/null `through_week` asks the service to derive the effective week. The
+server fixes the trigger to `manual`; callers do not claim trusted provenance.
+The response includes the durable refresh, effective through week, and
+scope-level results/warnings already represented by `RefreshOutcome`.
+
+### Refresh-to-generation freshness gap
+
+Snapshot identity currently uses season, cutoff week, UTC date, and projection
+version; the first healthy ready snapshot for that daily key is reused. A
+manual refresh later on the same day therefore does **not** guarantee that the
+next generation sees the newly recorded observations if a matching ready
+snapshot already exists.
+
+That behavior is consistent with the present datalayer contract but conflicts
+with the natural product expectation “refresh, then generate from the refresh.”
+Before calling the journey complete, the datalayer design must choose one of:
+
+- make selected source-head identity part of snapshot identity;
+- let snapshot resolution require observations at least as new as a specific
+  refresh run and create a new immutable revision when needed; or
+- state clearly that refresh does not invalidate the daily generation snapshot
+  and offer a separate explicit rebuild policy.
+
+The UI cannot solve this with cache invalidation. It needs a backend snapshot
+selection guarantee and corresponding audit metadata.
+
+## Generation API Extensions
+
+The existing generation contract is enough to create basic live and read-only
+backtest runs. These additions complete the planned UI:
+
+| Method and path | Purpose | Priority |
+| --- | --- | --- |
+| `POST .../{generation_id}/cancel` | Cancel a pending/running generation | Should-have; manager supports cancellation |
+| Extend article/run list query | Model, week overlap, completion range, request text | Later unless list size demands it |
+| Extend generation body | Explicit memory mode and optional `evaluation_workspace_id` for isolated simulation sequencing | Required for workspace promotion |
+| `GET .../{generation_id}/usage` | Aggregate tokens, latency, calls, and price quote | Required |
+| Optional `GET .../{generation_id}/audit` | One bounded detail projection for article + artifacts + calls | Optimization only; existing resources remain authoritative |
+
+The UI polls run detail. WebSockets or server-sent events are not required for
+v1. A future event channel must remain an acceleration layer; durable GET state
+is still the recovery authority.
+
+## Model Catalog and Pricing
+
+The form must not hard-code the deployable model set. Add:
+
+```text
+GET /api/v1/models
+```
+
+Each item includes:
+
+```json
+{
+  "provider": "openai",
+  "model": "model-id",
+  "display_name": "Display name",
+  "selectable": true,
+  "is_default": false,
+  "supports_reasoning": true,
+  "pricing_revision": "2026-08-23",
+  "pricing": {
+    "currency": "USD",
+    "input_per_million": "0.000000",
+    "cached_input_per_million": "0.000000",
+    "output_per_million": "0.000000"
+  }
+}
+```
+
+Prices above are shape examples, not values. Decimal strings avoid binary float
+rounding in the transport. The backend configuration/service owns model aliases,
+availability, provider billing semantics, and pricing revisions.
+
+`GET .../{generation_id}/usage` aggregates **all recorded attempts**, including
+failed/fallback attempts when the provider reported billable usage. It prices
+the actual provider/model, not merely the requested primary model. A response
+contains:
+
+- totals by token class;
+- breakdown by actual provider/model;
+- unpriced/missing-usage call IDs;
+- pricing revision(s) and quote time;
+- estimated cost as a decimal string and currency; and
+- `complete: false` whenever any applicable call cannot be priced.
+
+Cached tokens must not be double-counted as full-price input when provider usage
+reports them as a subset. Reasoning-token billing differs by provider/model and
+must be captured in the pricing rule rather than guessed by the frontend. The
+first implementation may keep the pricing catalog in versioned server
+configuration. Persisted historical dollar cost is not required; persisted raw
+usage plus a reproducible price revision is.
+
+## Evaluation Workspace and Promotion API
+
+The database schema anticipates workspaces, but a public manager/service/API is
+missing. Promotable current simulations and longitudinal evaluations require:
+
+| Method and path | Purpose |
+| --- | --- |
+| `POST /competitions/{competition_id}/evaluation-workspaces` | Create an active workspace pinned to a server-selected canonical base revision |
+| `GET /competitions/{competition_id}/evaluation-workspaces/{workspace_id}` | Status, base/current artifact, generations, and promotion eligibility |
+| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/promote` | Fast-forward isolated memory into one new canonical revision |
+| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/discard` | Close without canonical mutation |
+
+Workspace creation accepts the competition season/use case but does not accept
+an arbitrary untrusted canonical base from the browser; the service resolves and
+returns it. Generation submission accepts the resulting workspace ID only for
+an isolated memory mode. The service allocates sequence numbers and pins the
+workspace's current memory artifact.
+
+Promotion is an atomic command with an expected workspace/current-artifact
+version. It succeeds only when the workspace is active, its final memory
+artifact is complete, and the canonical head still equals its base revision.
+Otherwise it returns a typed `409 workspace_base_stale` or lifecycle conflict.
+No automatic merge or partial promotion is allowed. Consequently, a current
+simulation may be promotable and a historical old-base backtest is
+evaluation-only.
+
+Until these contracts exist, the UI must accurately offer basic read-only
+backtests and hide promotion rather than exposing a control that cannot preserve
+simulated memory.
+
+## Article List Projection Gap
+
+The implemented article list returns `GenerationSummary`, which has no article
+title/excerpt, actual-model summary, aggregate tokens, cost, or log counts. A
+first UI can fetch these after opening one article, but a useful paged library
+must not issue child requests for every row. Extend the article summary read
+model with submitted-output presentation metadata and usage summary, or add a
+dedicated article projection. Title should eventually be persisted as output
+metadata; deriving the first Markdown heading is only an MVP fallback.
+
+## Error and Pagination Contract
+
+New routes should converge on:
+
+```json
+{
+  "error": {
+    "code": "stable_machine_code",
+    "summary": "Safe operator-facing summary",
+    "field_errors": {"sleeper_league_id": ["Already attached"]},
+    "correlation_id": "optional-id"
+  }
+}
+```
+
+Use `400` for malformed workflow input not covered by validation, `404` for
+scope-masked absence, `409` for uniqueness/lifecycle/stale-base conflicts,
+`422` for field validation, and `503` for unavailable external/runtime
+dependencies. Refresh and generation failures that already created durable rows
+should normally be read from those resources rather than erased into a generic
+HTTP failure.
+
+Offset pagination matches the implemented reporting managers and is sufficient
+for v1. UI query keys must include competition, filters, limit, and offset.
+
+Current reporting, memory, FastAPI validation, and readiness errors do not yet
+share this shape. Until backend convergence lands, the frontend uses one API
+error normalizer and components never branch on raw `detail` payload variants.

--- a/docs/ui/frontend-architecture.md
+++ b/docs/ui/frontend-architecture.md
@@ -1,0 +1,228 @@
+# Frontend Architecture
+
+## Stack Decision
+
+The frontend is a standalone TypeScript application under `frontend/`:
+
+| Concern | Choice |
+| --- | --- |
+| Package manager | `pnpm` with `packageManager` pinned in `package.json` and `pnpm-lock.yaml` committed |
+| Build/dev server | Vite |
+| UI runtime | React + TypeScript in strict mode |
+| Routing | React Router with route-level lazy loading |
+| Component system | shadcn/ui components stored in the repository, Tailwind CSS, accessible primitives |
+| Server state | TanStack Query |
+| Forms | React Hook Form + Zod form schemas |
+| HTTP contracts | FastAPI OpenAPI -> `openapi-typescript` types + a small typed fetch client |
+| Tables | TanStack Table only where sorting/filtering/table behavior is needed |
+| Markdown | `react-markdown` + GFM; raw HTML disabled |
+| Frontend automated tests | Deferred until the UI stabilizes or regressions justify them |
+| Formatting/linting | Prettier + ESLint with type-aware rules |
+
+Vite is appropriate because this is an authenticated/local product console, not
+an SEO-dependent publishing site. Server rendering would add a deployment and
+data-loading model without helping the initial journeys. The backend remains a
+separately runnable FastAPI process.
+
+TanStack Query owns remote state and polling. React context is limited to app
+shell concerns such as the active competition and theme. Do not add Redux or a
+generic client store for API resources.
+
+## Package Layout
+
+```text
+frontend/
+├── package.json
+├── pnpm-lock.yaml
+├── components.json
+├── index.html
+├── vite.config.ts
+├── tsconfig.json
+├── eslint.config.js
+├── src/
+│   ├── app/
+│   │   ├── router.tsx
+│   │   ├── providers.tsx
+│   │   ├── shell.tsx
+│   │   └── query-client.ts
+│   ├── api/
+│   │   ├── generated/schema.d.ts
+│   │   ├── client.ts
+│   │   ├── errors.ts
+│   │   └── query-keys.ts
+│   ├── components/
+│   │   ├── ui/
+│   │   └── shared/
+│   ├── features/
+│   │   ├── competitions/
+│   │   ├── seasons/
+│   │   ├── refreshes/
+│   │   ├── generations/
+│   │   ├── articles/
+│   │   ├── artifacts/
+│   │   ├── execution/
+│   │   └── usage/
+│   ├── routes/
+│   ├── lib/
+│   │   ├── date-time.ts
+│   │   ├── money.ts
+│   │   └── markdown.tsx
+│   ├── main.tsx
+│   └── index.css
+```
+
+Using `src/` as the application source root is the conventional Vite/React
+layout. It keeps application modules separate from package metadata, build
+configuration, generated output, and future operational files. The
+feature-oriented folders inside `src/` are also a common scaling pattern: code
+is grouped by product capability while low-level shadcn components and shared
+infrastructure remain easy to find.
+
+The tree is a target shape, not a requirement to scaffold every directory on
+day one. Create `app`, `api`, `components/ui`, and the first active feature and
+route; add later feature folders only when their implementation begins.
+
+Feature folders contain feature-specific components, query/mutation hooks,
+form schemas, and presentation helpers. `components/ui` contains only shadcn
+source components; product logic does not accumulate there. Route modules
+compose features and own route parameters, error boundaries, and page layout.
+
+## API Type Workflow
+
+FastAPI's OpenAPI output is the source of transport truth. A deterministic
+script generates `src/api/generated/schema.d.ts`; CI regenerates and fails on a
+diff so backend contract changes cannot silently bypass frontend review.
+
+Generated files contain types only. A hand-written client owns:
+
+- base URL and Vite development proxy behavior;
+- JSON parsing;
+- typed error normalization;
+- correlation headers;
+- request cancellation via `AbortSignal`; and
+- the small set of call helpers used by feature hooks.
+
+Do not duplicate complete API response interfaces by hand. Zod schemas remain
+appropriate for form state because form inputs have UI-specific coercion and
+cross-field validation that differ from wire types.
+
+Development proxies `/api` and health requests to the local FastAPI port. The
+production hosting decision should preserve same-origin `/api` when possible;
+otherwise the backend needs an explicit allowlisted CORS configuration rather
+than `*`.
+
+## Server State and Polling
+
+Query keys are factories rooted by competition:
+
+```text
+competitions.list(filters)
+competitions.detail(competitionId)
+seasons.list(competitionId)
+refreshes.list(competitionId, seasonId, page)
+generations.list(competitionId, filters, page)
+generations.detail(competitionId, generationId)
+generations.article(competitionId, generationId)
+generations.aiCalls(competitionId, generationId, page)
+generations.toolCalls(competitionId, generationId, page)
+generations.artifacts(competitionId, generationId, page)
+generations.usage(competitionId, generationId)
+```
+
+Generation detail polls while status is `pending` or `running`, pauses when the
+document is hidden/offline, and stops at a terminal state. Child telemetry is
+refetched on stage/turn changes or when its tab is open; do not poll every
+large tool result on the article tab. Refresh mutation invalidates season,
+refresh-history, competition-summary, and relevant generation-readiness keys.
+
+Mutations use server-returned resources and targeted invalidation. Optimistic
+updates are reserved for reversible presentation changes; competition creation,
+refresh, generation, promotion, and discard wait for server confirmation.
+
+## Form Model
+
+`GenerationFormValues` is UI-specific and maps once to
+`SubmitGenerationBody`. Important transformations are explicit:
+
+- mode -> `kind`;
+- tags/chips -> ordered string arrays;
+- slider/display values -> integer control levels;
+- empty optional bias -> `null`/omitted according to the API;
+- ordered fallback rows -> `settings.model.fallback_models`; and
+- advanced defaults -> complete settings accepted by the backend.
+
+Validate week order and model-chain uniqueness in the form for immediate
+feedback, while treating server validation as authoritative. Preserve dirty
+form state during a refresh detour and before navigating away.
+
+## Design System Direction
+
+The visual language should feel like an editorial operations desk: high
+information density, readable long-form typography, restrained status color,
+and clear separation between the article and its machinery. Avoid a grid of
+decorative KPI cards when a compact list or metadata rail communicates more.
+
+Initial shadcn components likely include button, input, textarea, select,
+combobox/command, dialog, sheet, tabs, table, badge, alert, skeleton, tooltip,
+popover, dropdown menu, accordion/collapsible, separator, slider, checkbox,
+toast/sonner, and sidebar/breadcrumb. Components are added only as pages need
+them so local source remains reviewable.
+
+Use a prose style for rendered Markdown that is independent from compact
+operator typography. Raw HTML is disabled, external links are visibly marked,
+and code/JSON areas wrap or scroll without changing the page width.
+
+## Frontend Verification Policy
+
+Automated frontend tests are deferred for the initial implementation. The UI is
+still being discovered, so component snapshots, mocked API tests, and a browser
+suite would create maintenance cost while page structure and interactions are
+changing quickly.
+
+Each frontend layer instead has four required checks:
+
+1. strict TypeScript compilation;
+2. lint and formatting checks;
+3. a successful production build; and
+4. a short manual acceptance pass through the affected journey against the real
+   local backend.
+
+The manual pass is recorded in `.context/ui/log.md`, including the route,
+important states checked, and any known limitations. New backend resources and
+workflow invariants still receive targeted backend tests under `backend/tests`;
+the deferral applies only to frontend automated tests.
+
+Frontend tests can be introduced later where evidence makes them valuable—for
+example, a repeatedly broken generation-form mapping, polling lifecycle, cost
+calculation presentation, or canonical-memory promotion flow. No test framework
+is installed preemptively.
+
+## Delivery and Quality Gates
+
+The frontend has scripts for `dev`, `build`, `typecheck`, `lint`,
+`format:check`, and `api:generate`. Root documentation may provide convenience
+commands, but JavaScript dependencies and the lockfile remain under `frontend/`.
+
+CI uses the pnpm version pinned by the `packageManager` field, installs with
+`pnpm install --frozen-lockfile`, checks generated API drift, then runs format,
+lint, typecheck, and the production build.
+
+Initial performance goals are pragmatic: route-level code splitting, no eager
+loading of artifact/call bodies, bounded list pages, and responsive interaction
+on ordinary league histories. Manual acceptance includes accessibility checks
+for dialogs, tabs, navigation, form errors, keyboard focus, and status updates
+until automated accessibility checks are justified.
+
+## Deferred Choices
+
+- frontend hosting and FastAPI static-asset ownership;
+- authentication/session transport;
+- websocket or server-sent progress;
+- rich-text article editing;
+- public article rendering/SEO;
+- multi-competition analytics;
+- a shared JavaScript monorepo/package layer; and
+- frontend unit, component, and browser test infrastructure.
+
+None is required to scaffold the top-level `frontend/` application or complete
+the three initial journeys.

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -1,0 +1,256 @@
+# UI User Journeys and Page Model
+
+## User and Mental Model
+
+The initial user is the league reporter/operator. They understand seasons,
+weeks, Sleeper league IDs, and article prompts, but should not need to understand
+database revisions, artifact foreign keys, or snapshot build keys to complete a
+normal task.
+
+The application answers four questions in order:
+
+1. Which competition am I working in?
+2. Is its selected season's data fresh enough?
+3. What should the reporter generate, against which historical boundary and
+   model chain?
+4. What did it produce, how did it get there, and what did it consume?
+
+## Information Architecture
+
+```text
+Competitions
+├── Competition overview
+│   ├── Seasons and Sleeper IDs
+│   ├── Refresh actions and freshness
+│   └── Recent activity
+├── Articles
+│   ├── Article history
+│   └── Generation detail
+│       ├── Article
+│       ├── Artifacts
+│       ├── Execution
+│       └── Usage
+└── Generate
+    ├── Live generation
+    └── Historical backtest
+        └── Review and promote/discard evaluation memory
+```
+
+A persistent application shell contains the product name, a competition
+switcher, and primary competition navigation. Breadcrumbs carry the selected
+competition and current resource. A narrow viewport collapses navigation into
+a sheet, but tables retain meaningful card/list alternatives instead of
+requiring horizontal scrolling for core actions.
+
+## Route and Page Inventory
+
+| Route | Page | Primary responsibility |
+| --- | --- | --- |
+| `/` | Redirect | Continue to `/competitions` or the last valid competition |
+| `/competitions` | Competition list | Browse, create, archive, and choose a competition |
+| `/competitions/:competitionId` | Competition overview | Seasons, freshness, refresh history, and recent runs |
+| `/competitions/:competitionId/articles` | Article history | Filter and browse submitted articles for one competition |
+| `/competitions/:competitionId/generate` | Generate article | Configure, validate, and submit a generation |
+| `/competitions/:competitionId/generations/:generationId` | Generation detail | Article/run status plus artifacts, execution, and usage tabs |
+
+Creation stays in a dialog or sheet on `/competitions`; it does not need a
+dedicated route in v1. Season creation is a dialog on the competition overview.
+The generation detail route represents pending, running, failed, cancelled, and
+successful runs. Successful article-history entries link to the same route,
+avoiding a second detail model for “article” versus “generation.”
+
+## Journey 1: View and Manage Leagues
+
+### Competition list
+
+The list shows display name, season count, latest season, last successful
+Sleeper refresh, most recent article, and an attention state. Empty state copy
+explains that a competition is the cross-season identity and offers `Create
+competition`.
+
+Creating a competition asks only for a display name. After success, the user is
+taken to its overview and prompted to add a season.
+
+### Add a season
+
+The add-season dialog asks for:
+
+- season year;
+- Sleeper league ID; and
+- sequence/order only if it cannot be derived from existing seasons.
+
+Before saving, the UI explains that Sleeper creates a new league ID for each
+season. Duplicate season years and globally reused Sleeper league IDs are
+reported inline from typed API conflicts. The UI does not guess that linked
+Sleeper predecessor/successor IDs belong to the same AIdam competition.
+
+### Competition overview
+
+The page header shows competition name and the active/latest season selector.
+Each season row/card shows:
+
+- year and Sleeper league ID;
+- normalized Sleeper league name and status when data exists;
+- latest refresh outcome and completion time;
+- requested through-week boundary;
+- request success/failure counts; and
+- latest ready generation snapshot time, if one exists.
+
+`Refresh Sleeper data` opens a confirmation sheet with the selected season and
+an optional through-week field. Blank means the backend derives the effective
+week from NFL state. While the synchronous request is in flight, the button is
+disabled and progress copy makes clear that multiple Sleeper endpoints are
+being fetched. Success, partial success, and failure are distinct outcomes.
+A partial refresh remains inspectable and never claims the season is fully
+fresh.
+
+Refresh history is a compact table with status, trigger, requested through
+week, started/completed times, and request counts. A row can expand to endpoint
+scope results once the audit API supplies them.
+
+### Freshness rules
+
+- “Last refreshed” uses the latest terminal refresh completion time.
+- “Last successful refresh” excludes partial and failed outcomes.
+- A running refresh is shown separately and never overwrites the last successful
+  timestamp.
+- Snapshot time is not used as Sleeper freshness. It tells the user when a
+  frozen generation input was built/reused.
+- Timestamps show relative time with exact local time in a tooltip or detail.
+
+## Journey 2: Generate an Article
+
+### Form layout
+
+The page uses a two-column layout on wide screens: the form on the left and a
+sticky run summary on the right. Sections are:
+
+1. **Scope:** season, start week, end week, and generation mode.
+2. **Assignment:** plain-language request text, focus teams/topics, and topics
+   to avoid.
+3. **Voice:** voice, target length, evidence policy, profanity policy, tone
+   controls, and optional team bias framing.
+4. **Models:** primary model and ordered unique fallback models.
+5. **Advanced execution:** retry and maximum-turn controls, collapsed by
+   default.
+
+The primary button is `Generate article`. Defaults come from a backend model
+catalog and frontend form defaults, not from a previous run unless the user
+explicitly chooses `Use these settings` on that run.
+
+### Generation modes
+
+The form presents three product modes while preserving the backend's existing
+`live`/`backtest` kind where applicable:
+
+| Mode | Factual boundary | Memory effect | Promotion |
+| --- | --- | --- | --- |
+| Live | Selected current boundary | Writes canonical memory on success | Not applicable; already canonical |
+| Current simulation | Selected current boundary | Writes only an evaluation workspace | Eligible for explicit fast-forward promotion while its base remains current |
+| Historical backtest | Historical week cutoff | Historical pinned memory, isolated/read-only | Not eligible under the accepted architecture |
+
+Live mode is described as “generate from the selected current season boundary
+and canonical reporter memory.” The page shows the last successful refresh and
+warns when no usable observations exist. Because generation currently never
+refreshes implicitly, the warning provides a `Refresh now` action and returns
+to the preserved form afterward.
+
+### Simulation and backtest behavior
+
+Backtest mode makes the historical boundary prominent and explains that future
+Sleeper data is physically excluded from the frozen snapshot. It also explains
+the memory limitation accurately: the existing simple backtest path pins an
+earlier canonical revision and disables writes; promotable simulated memory
+requires an evaluation workspace.
+
+When evaluation workspaces are available, submitting a current simulation
+creates or selects the competition's active workspace and records the run in
+that workspace. The form does not offer an “automatically promote on success”
+checkbox. After a successful workspace run, the generation page offers:
+
+- `Promote memory`, enabled only if the workspace is complete and its base is
+  still the canonical head; and
+- `Discard simulation`, which closes the workspace without canonical changes.
+
+Promotion shows the base revision, proposed resulting revision, run count, and
+a confirmation warning. A stale-base conflict instructs the user to discard or
+restart the simulation; it never silently merges competing memory.
+
+A historical workspace started from an old memory revision remains useful for
+longitudinal evaluation, but promotion is disabled with an explanation. If the
+product must promote historical results, that decision first changes the
+durable memory policy; the frontend must not imply that a merge/rebase exists.
+
+### Model selection
+
+The primary model is a combobox sourced from the backend catalog. Fallbacks are
+an ordered list with add, remove, and reorder controls. The primary model cannot
+also appear as a fallback, and fallbacks cannot repeat. Each option shows
+provider, model label/ID, availability, and pricing availability without
+turning the generation form into a pricing calculator.
+
+### Submission and progress
+
+On `201 Created`, navigate to the generation detail page. Pending/running views
+show status, stage, turn, elapsed time, model chain, scope, and request. Polling
+continues while the tab is visible and stops at a terminal status. Reloading the
+page resumes from durable backend state. Failure keeps the request/settings
+visible and offers `Rerun` plus `Edit settings and try again`.
+
+## Journey 3: View Articles and Audit Runs
+
+### Article history
+
+Article history is competition-scoped and newest-first. Filters include season,
+live/backtest kind, week or week range, model, and a free-text request search
+when the API supports it. Each row/card shows:
+
+- completion time;
+- season and week range;
+- live/backtest badge;
+- request excerpt;
+- requested primary model;
+- token total and estimated cost when available; and
+- rerun/workspace relationship.
+
+Only generations with an explicit submitted artifact version appear here.
+Pending and failed work remains on recent activity/run history, not in the
+article library.
+
+### Generation detail tabs
+
+**Article** renders the exact submitted Markdown version with readable editorial
+typography. A metadata rail shows request, dates, mode, model chain, snapshot,
+memory input, and manifest hash. `Copy Markdown` is available; editing and
+publishing are deferred.
+
+**Artifacts** lists logical path, media type, finalization state, revision
+count, and modified time. Selecting an artifact shows its version history and
+content. The submitted version is visibly marked. Arbitrary HTML in artifacts
+is not executed.
+
+**Execution** presents a chronological turn timeline. AI attempts show
+requested/actual model, status, latency, finish reason, and usage. Nested tool
+calls show tool name, status, duration, arguments, structured result/full text,
+and errors in expandable panels. Large JSON/text starts collapsed, is copyable,
+and is never loaded into the article reading surface by default.
+
+**Usage** shows aggregate input, cached input, output, reasoning, and total
+tokens; model/provider breakdown; attempt count; latency; and estimated cost.
+The pricing revision and “estimated” label are always visible. Unknown price or
+usage produces an incomplete-estimate warning and identifies the affected
+calls.
+
+## Common States and Guardrails
+
+Every page defines loading skeleton, empty, permission/not-found, recoverable
+error, and stale-data states. Mutations use inline errors plus a toast for the
+outcome; toasts never contain the only explanation of a failure.
+
+Destructive or canonical-state operations require confirmation. Ordinary
+creation, refresh, generation, and rerun actions do not require a second generic
+confirmation unless they have an unusual consequence.
+
+All controls are keyboard reachable, status is conveyed by text as well as
+color, focus returns predictably after dialogs, data tables have accessible
+headers, and polling status updates use a non-disruptive live region.


### PR DESCRIPTION
## Summary

- define the initial competition management, article generation, and article audit user journeys
- catalog the existing generation APIs and the missing competition, refresh, model, cost, and evaluation-workspace contracts
- establish the page inventory and unified generation/article detail model
- choose a pnpm, Vite, React, TypeScript, and shadcn/ui frontend architecture
- record refresh-versus-snapshot freshness and historical-memory promotion constraints as explicit implementation gates
- defer frontend automated tests while retaining typecheck, lint, build, and manual acceptance gates

## Scope

This is the Layer 0 design PR. It changes documentation only and intentionally does not scaffold the frontend or implement backend routes.

Local implementation sequencing and status remain under ignored `.context/ui/` files.

## Verification

- `git diff --cached --check` before commit
- documentation-only change; no automated tests run
