### PR TITLE
feat(skills): add feature workflow tracker

### DIFF
--- a/.agents/skills/track-feature-workflow/SKILL.md
+++ b/.agents/skills/track-feature-workflow/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: track-feature-workflow
+description: Manage large, multi-stage AIdamShefter-v2 features by keeping durable design contracts in a feature-specific docs subdirectory and gitignored execution state in the matching .context subdirectory. Use when asked to design, plan, implement, resume, track, hand off, or report progress on a major feature, especially when work spans multiple milestones, branches, or pull requests and needs an implementation plan, current status, and append-only work log.
+---
+
+# Track Feature Workflow
+
+Run a feature from design through verified implementation without mixing durable
+architecture with temporary execution state.
+
+## Preserve the artifact boundary
+
+| Location | Purpose | Content |
+| --- | --- | --- |
+| `docs/<feature>/` | Tracked design authority | Architecture, application contracts, invariants, accepted decisions, non-goals, transition policy |
+| `.context/<feature>/` | Gitignored working state | Implementation plan, current status, append-only log, branch/PR notes |
+| Source and tests | Product behavior | The implementation and its targeted verification |
+
+Keep dates, branch names, changing milestone states, command output, and PR notes
+out of design docs. Promote a discovery from `.context/` into `docs/` only when
+future implementers need it as part of the feature contract.
+
+Before writing local state, confirm `.context/` is ignored. Never stage or
+commit `.context/` files. Do not place secrets, tokens, private payloads, or
+unredacted production data in either location.
+
+## Initialize or resume
+
+1. Read the repository `AGENTS.md`, relevant design docs, nearby code and tests,
+   and current Git state.
+2. Choose one stable lowercase hyphenated feature key. Reuse an established key
+   rather than creating a synonym.
+3. If the workspace is missing, run:
+
+   ```bash
+   python .agents/skills/track-feature-workflow/scripts/init_feature_workflow.py \
+     <feature-key> --title "<Feature Title>" --root .
+   ```
+
+   The script creates only missing files and never overwrites existing work.
+4. Replace every generated prompt with feature-specific content before calling
+   the design or plan complete.
+5. When resuming, read `docs/<feature>/README.md`, the other linked design docs,
+   `.context/<feature>/implementation-plan.md`,
+   `.context/<feature>/status.md`, and the useful tail of
+   `.context/<feature>/log.md`. Reconcile them with the actual branch, diff,
+   commits, and test state. Treat observable repository state as authoritative
+   and record any correction in the log.
+
+If `.context/` is absent in a fresh worktree, reconstruct a truthful current
+plan and status from tracked docs and Git history. Do not invent missing work
+history.
+
+## Establish the durable design
+
+Use the smallest document set that makes the feature unambiguous. The default
+set is:
+
+- `README.md`: purpose, scope, document map, settled direction, non-goals, and
+  open contract questions;
+- `architecture.md`: ownership, boundaries, dependencies, data/control flow,
+  lifecycle, failure semantics, and observability;
+- `application-contracts.md`: public types and operations, invariants, error
+  behavior, compatibility, and acceptance coverage.
+
+Add focused documents such as `transition.md`, schema notes, or user journeys
+only when they own a distinct durable concern. Link every design document from
+the feature README. Inspect existing implementation before settling contracts;
+do not write aspirational interfaces that ignore current seams.
+
+Resolve or explicitly defer material questions. Do not begin a milestone whose
+boundary or exit gate depends on an unanswered decision, unless the user asks
+for a disposable spike.
+
+For older features that already keep an implementation plan in `docs/`, leave
+that tracked history in place unless the user asks to migrate it. Put all new
+mutable progress tracking in `.context/<feature>/`.
+
+## Maintain the local control files
+
+### `implementation-plan.md`
+
+Keep a dependency-ordered plan with:
+
+- objective and links to the durable design baseline;
+- implementation rules and accepted assumptions;
+- stable milestone IDs;
+- status for each milestone: `planned`, `in-progress`, `blocked`, `complete`, or
+  `deferred`;
+- ownership/scope, dependencies, concrete tasks, exit gate, and targeted
+  verification for every milestone.
+
+Allow at most one `in-progress` milestone. Mark a milestone `complete` only
+after its exit gate and verification are satisfied. Split work when one
+milestone crosses several deep boundaries or cannot leave the repository
+runnable.
+
+### `status.md`
+
+Keep this as a compact present-tense snapshot, not a second plan or log. Record:
+
+- last update time, overall state, current branch, and intended base;
+- active milestone and immediate focus;
+- completed work, blockers, and next actions;
+- verification actually run, including failures or skipped dependencies;
+- important dirty-worktree or review state.
+
+Refresh it before implementation, after meaningful progress, before a handoff,
+and at the end of the turn.
+
+### `log.md`
+
+Append timestamped entries in chronological order. Each entry should capture
+the goal, material files or decisions, exact verification commands and concise
+outcomes, milestone/status transitions, commit or PR identifiers when relevant,
+and remaining risks. Never rewrite old entries to make the history cleaner;
+append a correction when an earlier entry is wrong.
+
+## Execute the implementation loop
+
+1. Reconcile the plan and status with Git and test evidence.
+2. Select the first dependency-ready milestone and mark it `in-progress`.
+3. Write the immediate focus and intended verification to `status.md`; append a
+   start entry to `log.md` when beginning a substantial milestone.
+4. Implement the smallest coherent slice that advances its exit gate. Respect
+   repository instructions and preserve unrelated user changes.
+5. If implementation reveals a contract change, update the durable design first,
+   then revise the local plan and record the reason in the log.
+6. Run only the targeted tests and checks required by the affected behavior,
+   unless the user explicitly requests broader verification.
+7. Append results to the log, update the status snapshot, and change milestone
+   state only when supported by evidence.
+8. Inspect the final diff and Git status. Do not commit, push, open a PR, merge,
+   or publish unless the user authorizes that action.
+
+Continue through ready work when the user asked to build or implement the
+feature. Planning artifacts are controls for doing the work, not a substitute
+for it.
+
+## Finish or hand off
+
+Before declaring the feature complete:
+
+- make the durable docs describe the implemented reality;
+- satisfy every non-deferred exit gate;
+- record the final targeted verification and any known unverified surface;
+- set the local status to complete and append a final log entry;
+- confirm `.context/` remains untracked.
+
+For a handoff, provide the active milestone, exact next action, relevant design
+links, current branch/base, verification state, blockers, and the local control
+file paths. Never claim verification that did not run.

--- a/.agents/skills/track-feature-workflow/agents/openai.yaml
+++ b/.agents/skills/track-feature-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Feature Workflow Tracker"
+  short_description: "Design docs and local implementation tracking"
+  default_prompt: "Use $track-feature-workflow to design and implement this feature with durable docs and local progress tracking."

--- a/.agents/skills/track-feature-workflow/scripts/init_feature_workflow.py
+++ b/.agents/skills/track-feature-workflow/scripts/init_feature_workflow.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Initialize durable feature docs and gitignored local workflow state."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+FEATURE_KEY_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create missing docs/<feature> and .context/<feature> workflow files "
+            "without overwriting existing work."
+        )
+    )
+    parser.add_argument("feature", help="Lowercase hyphenated feature key")
+    parser.add_argument("--title", help="Human-readable feature title")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: current directory)",
+    )
+    return parser.parse_args()
+
+
+def write_new(path: Path, content: str, created: list[Path], skipped: list[Path]) -> None:
+    if path.exists():
+        skipped.append(path)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+    created.append(path)
+
+
+def relative_paths(paths: list[Path], root: Path) -> list[str]:
+    return [path.relative_to(root).as_posix() for path in paths]
+
+
+def main() -> int:
+    args = parse_args()
+    if not FEATURE_KEY_PATTERN.fullmatch(args.feature):
+        raise SystemExit(
+            "feature must use lowercase letters, digits, and single hyphens "
+            "(example: generation-audit)"
+        )
+
+    root = args.root.resolve()
+    title = args.title or args.feature.replace("-", " ").title()
+    feature = args.feature
+    docs_dir = root / "docs" / feature
+    context_dir = root / ".context" / feature
+    now = datetime.now().astimezone().isoformat(timespec="minutes")
+    created: list[Path] = []
+    skipped: list[Path] = []
+    document_rows = (
+        "| [`architecture.md`](architecture.md) | Component boundaries, dependencies, "
+        "lifecycle, and failure behavior |\n"
+        "| [`application-contracts.md`](application-contracts.md) | Public contracts, "
+        "invariants, errors, and acceptance coverage |"
+    )
+    milestone_row = (
+        f"| `{feature}-1` | planned | Design accepted | "
+        "<!-- First coherent boundary --> | "
+        "<!-- Observable completion condition --> |"
+    )
+
+    files = {
+        docs_dir / "README.md": f"""
+# {title} Design
+
+**Status:** Proposed
+
+## Purpose
+
+<!-- State the product or engineering outcome this feature owns. -->
+
+## Scope
+
+<!-- Name the components and workflows inside this design boundary. -->
+
+## Documents
+
+| Document | Owns |
+| --- | --- |
+{document_rows}
+
+## Settled Direction
+
+<!-- Record durable decisions future implementers must preserve. -->
+
+## Non-Goals
+
+<!-- List adjacent work this feature deliberately does not own. -->
+
+## Open Questions
+
+<!-- Resolve, defer with an owner, or remove every question before
+implementation depends on it. -->
+""",
+        docs_dir / "architecture.md": f"""
+# {title} Architecture
+
+## Context and Goals
+
+<!-- Describe the current system seam and the target behavior. -->
+
+## System Boundary
+
+<!-- Define owners, dependencies, callers, and forbidden coupling. -->
+
+## Component Model
+
+<!-- Describe responsibilities and collaboration between components. -->
+
+## Data and Control Flow
+
+<!-- Describe important reads, writes, state transitions, and transaction boundaries. -->
+
+## Failure and Recovery Semantics
+
+<!-- Define typed failures, retry/idempotency rules, and partial-failure behavior. -->
+
+## Observability
+
+<!-- Define logs, metrics, traces, audit data, and operator-visible state. -->
+
+## Security and Privacy
+
+<!-- Define trust boundaries, authorization, validation, and sensitive-data handling. -->
+
+## Architecture Decisions
+
+<!-- Record decisions and their rationale. -->
+
+## Open Questions
+
+<!-- Keep only unresolved architecture questions. -->
+""",
+        docs_dir / "application-contracts.md": f"""
+# {title} Application Contracts
+
+## Vocabulary and Ownership
+
+<!-- Define stable terms and the component that owns each concept. -->
+
+## Public Contracts
+
+<!-- Specify caller-facing types, commands, queries, events, or routes. -->
+
+## Lifecycle and State Transitions
+
+<!-- Define valid states, transitions, concurrency, and idempotency. -->
+
+## Invariants
+
+<!-- State rules that must remain true across implementations. -->
+
+## Error Semantics
+
+<!-- Define typed failures, masking, retryability, and boundary translation. -->
+
+## Compatibility and Transition
+
+<!-- Define migration, coexistence, deprecation, or cutover behavior. -->
+
+## Acceptance Coverage
+
+<!-- Map contract behavior to focused tests and operational checks. -->
+""",
+        context_dir / "README.md": f"""
+# {title} Local Workflow
+
+This directory is mutable, gitignored execution state. Durable feature authority
+lives in [`docs/{feature}/`](../../docs/{feature}/).
+
+## Files
+
+- `implementation-plan.md`: dependency-ordered milestones and exit gates;
+- `status.md`: current snapshot for resuming or handing off work;
+- `log.md`: append-only chronology of work and verification.
+
+Do not stage or commit this directory. Promote durable decisions into the design
+docs instead of treating this workspace as architectural authority.
+""",
+        context_dir / "implementation-plan.md": f"""
+# {title} Implementation Plan
+
+Last updated: {now}
+
+## Objective
+
+<!-- Restate the concrete implementation outcome. -->
+
+## Design Baseline
+
+- `docs/{feature}/README.md`
+- `docs/{feature}/architecture.md`
+- `docs/{feature}/application-contracts.md`
+
+## Implementation Rules
+
+<!-- Record feature-specific sequencing, compatibility, and verification rules. -->
+
+## Milestones
+
+| ID | Status | Depends on | Deliverable | Exit gate |
+| --- | --- | --- | --- | --- |
+{milestone_row}
+
+## `{feature}-1` — <!-- Milestone title -->
+
+**Owns**
+
+- <!-- One deep implementation boundary. -->
+
+**Tasks**
+
+- <!-- Concrete change. -->
+
+**Targeted verification**
+
+- <!-- Exact test or check command. -->
+
+**Exit gate:** <!-- Evidence required before status becomes complete. -->
+""",
+        context_dir / "status.md": f"""
+# {title} Status
+
+Last updated: {now}
+
+- **Overall state:** designing
+- **Branch:** <!-- current branch -->
+- **Intended base:** <!-- base branch or commit -->
+- **Active milestone:** none
+- **Immediate focus:** complete the durable design and implementation plan
+
+## Completed
+
+- Workflow workspace initialized.
+
+## In Progress
+
+- Durable design and milestone definition.
+
+## Blockers
+
+- None recorded.
+
+## Next Actions
+
+1. Replace design prompts with repository-grounded decisions.
+2. Define dependency-ordered milestones and targeted verification.
+3. Start the first dependency-ready milestone.
+
+## Verification
+
+- Not run; implementation has not started.
+
+## Working Tree and Review State
+
+<!-- Record relevant dirty files, commits, PRs, or review state. -->
+""",
+        context_dir / "log.md": f"""
+# {title} Implementation Log
+
+Append entries in chronological order. Keep exact commands and concise outcomes;
+never include secrets or rewrite earlier history.
+
+## {now} — Workflow initialized
+
+- Created the durable design workspace at `docs/{feature}/`.
+- Created local implementation controls at `.context/{feature}/`.
+- No implementation verification has run yet.
+""",
+    }
+
+    for path, content in files.items():
+        write_new(path, content, created, skipped)
+
+    print("Created:")
+    for path in relative_paths(created, root):
+        print(f"  {path}")
+    if not created:
+        print("  (none)")
+
+    print("Skipped existing:")
+    for path in relative_paths(skipped, root):
+        print(f"  {path}")
+    if not skipped:
+        print("  (none)")
+
+    print("Next: replace every HTML comment with feature-specific content.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a project-local skill for managing large feature workflows
- keep durable architecture and application contracts under `docs/<feature>/`
- keep mutable implementation plans, status snapshots, and append-only logs under gitignored `.context/<feature>/`
- include an additive-only initializer that never overwrites existing workflow files

## Verification

- skill metadata validation: passed
- initializer smoke test: created all 7 expected files
- rerun safety: existing files skipped with hashes unchanged
- invalid feature-key rejection: passed
- Python line-length and trailing-whitespace audits: passed
