### PR TITLE
Layer 1: add competition and season resources

### DIFF
--- a/backend/resources/core/__init__.py
+++ b/backend/resources/core/__init__.py
@@ -1,0 +1,45 @@
+from backend.resources.core.competition_seasons import (
+    CompetitionSeason,
+    CompetitionSeasonManager,
+    CompetitionSeasonPage,
+    CompetitionSeasonQuery,
+    CreateCompetitionSeason,
+)
+from backend.resources.core.competitions import (
+    ArchiveCompetition,
+    Competition,
+    CompetitionManager,
+    CompetitionPage,
+    CompetitionQuery,
+    CreateCompetition,
+    RenameCompetition,
+)
+from backend.resources.core.errors import (
+    CompetitionArchivedConflict,
+    CompetitionConcurrencyConflict,
+    CompetitionSeasonYearExists,
+    CoreResourceError,
+    CoreResourceNotFound,
+    SleeperLeagueIdExists,
+)
+
+__all__ = [
+    "ArchiveCompetition",
+    "Competition",
+    "CompetitionArchivedConflict",
+    "CompetitionConcurrencyConflict",
+    "CompetitionManager",
+    "CompetitionPage",
+    "CompetitionQuery",
+    "CompetitionSeason",
+    "CompetitionSeasonManager",
+    "CompetitionSeasonPage",
+    "CompetitionSeasonQuery",
+    "CompetitionSeasonYearExists",
+    "CoreResourceError",
+    "CoreResourceNotFound",
+    "CreateCompetition",
+    "CreateCompetitionSeason",
+    "RenameCompetition",
+    "SleeperLeagueIdExists",
+]

--- a/backend/resources/core/competition_seasons/__init__.py
+++ b/backend/resources/core/competition_seasons/__init__.py
@@ -1,0 +1,17 @@
+from backend.resources.core.competition_seasons.manager import (
+    CompetitionSeasonManager,
+)
+from backend.resources.core.competition_seasons.objects import (
+    CompetitionSeason,
+    CompetitionSeasonPage,
+    CompetitionSeasonQuery,
+    CreateCompetitionSeason,
+)
+
+__all__ = [
+    "CompetitionSeason",
+    "CompetitionSeasonManager",
+    "CompetitionSeasonPage",
+    "CompetitionSeasonQuery",
+    "CreateCompetitionSeason",
+]

--- a/backend/resources/core/competition_seasons/manager.py
+++ b/backend/resources/core/competition_seasons/manager.py
@@ -1,0 +1,185 @@
+"""Competition-scoped manager for durable season identities."""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import Competition as StoredCompetition
+from backend.database.models.core import CompetitionSeason as StoredCompetitionSeason
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.core.competition_seasons.objects import (
+    CompetitionSeason,
+    CompetitionSeasonPage,
+    CompetitionSeasonQuery,
+    CreateCompetitionSeason,
+)
+from backend.resources.core.errors import (
+    CompetitionArchivedConflict,
+    CompetitionConcurrencyConflict,
+    CompetitionSeasonYearExists,
+    CoreResourceNotFound,
+    SleeperLeagueIdExists,
+)
+
+
+_SEASON_YEAR_CONSTRAINT = "uq_competition_seasons_competition_id_season_year"
+_SEQUENCE_CONSTRAINT = "uq_competition_seasons_competition_id_sequence_number"
+_SLEEPER_LEAGUE_ID_CONSTRAINT = "uq_competition_seasons_sleeper_league_id"
+
+
+class CompetitionSeasonManager:
+    """Own immutable season attachment and competition-scoped reads."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    @property
+    def competition_id(self) -> UUID:
+        return self._competition_id
+
+    def create(self, command: CreateCompetitionSeason) -> CompetitionSeason:
+        try:
+            with transaction_session(self._session_factory) as session:
+                competition = _load_competition(
+                    session,
+                    self._competition_id,
+                    lock=True,
+                )
+                if competition.archived_at is not None:
+                    raise CompetitionArchivedConflict(competition.id)
+                current_sequence = session.scalar(
+                    sa.select(
+                        sa.func.coalesce(
+                            sa.func.max(StoredCompetitionSeason.sequence_number),
+                            0,
+                        )
+                    ).where(
+                        StoredCompetitionSeason.competition_id
+                        == self._competition_id
+                    )
+                )
+                stored = StoredCompetitionSeason(
+                    id=uuid4(),
+                    competition_id=self._competition_id,
+                    season_year=command.season_year,
+                    sequence_number=cast(int, current_sequence) + 1,
+                    sleeper_league_id=command.sleeper_league_id,
+                )
+                session.add(stored)
+                session.flush()
+                return _decode(stored)
+        except IntegrityError as error:
+            constraint_name = _constraint_name(error)
+            if constraint_name == _SEASON_YEAR_CONSTRAINT:
+                raise CompetitionSeasonYearExists(
+                    self._competition_id,
+                    command.season_year,
+                ) from None
+            if constraint_name == _SLEEPER_LEAGUE_ID_CONSTRAINT:
+                raise SleeperLeagueIdExists(command.sleeper_league_id) from None
+            message = (
+                "competition season sequence allocation conflicted"
+                if constraint_name == _SEQUENCE_CONSTRAINT
+                else "competition season identity is already allocated"
+            )
+            raise CompetitionConcurrencyConflict(
+                message,
+                constraint_name=constraint_name,
+            ) from None
+
+    def get(self, competition_season_id: UUID) -> CompetitionSeason:
+        with read_only_session(self._session_factory) as session:
+            stored = session.scalar(
+                sa.select(StoredCompetitionSeason).where(
+                    StoredCompetitionSeason.id == competition_season_id,
+                    StoredCompetitionSeason.competition_id == self._competition_id,
+                )
+            )
+            if stored is None:
+                raise CoreResourceNotFound(
+                    "competition_season",
+                    competition_season_id,
+                )
+            return _decode(stored)
+
+    def list(self, query: CompetitionSeasonQuery) -> CompetitionSeasonPage:
+        with read_only_session(self._session_factory) as session:
+            _load_competition(session, self._competition_id)
+            condition = (
+                StoredCompetitionSeason.competition_id == self._competition_id
+            )
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredCompetitionSeason)
+                    .where(condition)
+                ),
+            )
+            rows = session.scalars(
+                sa.select(StoredCompetitionSeason)
+                .where(condition)
+                .order_by(
+                    StoredCompetitionSeason.sequence_number.desc(),
+                    StoredCompetitionSeason.id.asc(),
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return CompetitionSeasonPage(
+                items=tuple(_decode(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+
+def _load_competition(
+    session: Session,
+    competition_id: UUID,
+    *,
+    lock: bool = False,
+) -> StoredCompetition:
+    statement = sa.select(StoredCompetition).where(
+        StoredCompetition.id == competition_id
+    )
+    if lock:
+        statement = statement.with_for_update()
+    stored = session.scalar(statement)
+    if stored is None:
+        raise CoreResourceNotFound("competition", competition_id)
+    return stored
+
+
+def _constraint_name(error: IntegrityError) -> str | None:
+    diagnostic = getattr(error.orig, "diag", None)
+    return cast(str | None, getattr(diagnostic, "constraint_name", None))
+
+
+def _decode(stored: StoredCompetitionSeason) -> CompetitionSeason:
+    return CompetitionSeason(
+        id=stored.id,
+        competition_id=stored.competition_id,
+        season_year=stored.season_year,
+        sequence_number=stored.sequence_number,
+        sleeper_league_id=stored.sleeper_league_id,
+        created_at=stored.created_at,
+    )
+
+
+__all__ = ["CompetitionSeasonManager"]

--- a/backend/resources/core/competition_seasons/objects.py
+++ b/backend/resources/core/competition_seasons/objects.py
@@ -1,0 +1,50 @@
+"""Immutable commands and views for competition season identities."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+SeasonYear = Annotated[int, Field(strict=True, ge=1900, le=9999)]
+SequenceNumber = Annotated[int, Field(strict=True, ge=1)]
+
+
+class CreateCompetitionSeason(ContractModel):
+    season_year: SeasonYear
+    sleeper_league_id: NonBlankStr
+
+
+class CompetitionSeasonQuery(ContractModel):
+    limit: PageLimit = 50
+    offset: NonNegativeInt = 0
+
+
+class CompetitionSeason(ContractModel):
+    id: UUID
+    competition_id: UUID
+    season_year: SeasonYear
+    sequence_number: SequenceNumber
+    sleeper_league_id: str
+    created_at: AwareDatetime
+
+
+class CompetitionSeasonPage(ContractModel):
+    items: tuple[CompetitionSeason, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+__all__ = [
+    "CompetitionSeason",
+    "CompetitionSeasonPage",
+    "CompetitionSeasonQuery",
+    "CreateCompetitionSeason",
+]

--- a/backend/resources/core/competitions/__init__.py
+++ b/backend/resources/core/competitions/__init__.py
@@ -1,0 +1,19 @@
+from backend.resources.core.competitions.manager import CompetitionManager
+from backend.resources.core.competitions.objects import (
+    ArchiveCompetition,
+    Competition,
+    CompetitionPage,
+    CompetitionQuery,
+    CreateCompetition,
+    RenameCompetition,
+)
+
+__all__ = [
+    "ArchiveCompetition",
+    "Competition",
+    "CompetitionManager",
+    "CompetitionPage",
+    "CompetitionQuery",
+    "CreateCompetition",
+    "RenameCompetition",
+]

--- a/backend/resources/core/competitions/manager.py
+++ b/backend/resources/core/competitions/manager.py
@@ -1,0 +1,156 @@
+"""Global lifecycle manager for durable competition identities."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import Competition as StoredCompetition
+from backend.database.sessions import (
+    SessionFactory,
+    read_only_session,
+    transaction_session,
+)
+from backend.resources.context import GlobalScope, ManagerContext
+from backend.resources.core.competitions.objects import (
+    ArchiveCompetition,
+    Competition,
+    CompetitionPage,
+    CompetitionQuery,
+    CreateCompetition,
+    RenameCompetition,
+)
+from backend.resources.core.errors import (
+    CompetitionArchivedConflict,
+    CompetitionConcurrencyConflict,
+    CoreResourceNotFound,
+)
+
+
+class CompetitionManager:
+    """Own competition creation, active listing, renaming, and archival."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[GlobalScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._context = context
+
+    def create(self, command: CreateCompetition) -> Competition:
+        try:
+            with transaction_session(self._session_factory) as session:
+                stored = StoredCompetition(
+                    id=uuid4(),
+                    display_name=command.display_name,
+                )
+                session.add(stored)
+                session.flush()
+                return _decode(stored)
+        except IntegrityError as error:
+            raise CompetitionConcurrencyConflict(
+                "competition identity is already allocated",
+                constraint_name=_constraint_name(error),
+            ) from None
+
+    def get(self, competition_id: UUID) -> Competition:
+        with read_only_session(self._session_factory) as session:
+            return _decode(_load(session, competition_id))
+
+    def list(self, query: CompetitionQuery) -> CompetitionPage:
+        with read_only_session(self._session_factory) as session:
+            conditions: list[sa.ColumnElement[bool]] = []
+            if not query.include_archived:
+                conditions.append(StoredCompetition.archived_at.is_(None))
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredCompetition)
+                    .where(*conditions)
+                ),
+            )
+            rows = session.scalars(
+                sa.select(StoredCompetition)
+                .where(*conditions)
+                .order_by(
+                    sa.func.lower(StoredCompetition.display_name).asc(),
+                    StoredCompetition.id.asc(),
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return CompetitionPage(
+                items=tuple(_decode(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def rename(self, command: RenameCompetition) -> Competition:
+        with transaction_session(self._session_factory) as session:
+            stored = _load(session, command.competition_id, lock=True)
+            _require_active(stored)
+            if stored.display_name == command.display_name:
+                return _decode(stored)
+            stored.display_name = command.display_name
+            stored.updated_at = datetime.now(UTC)
+            session.flush()
+            return _decode(stored)
+
+    def archive(self, command: ArchiveCompetition) -> Competition:
+        with transaction_session(self._session_factory) as session:
+            stored = _load(session, command.competition_id, lock=True)
+            if stored.archived_at is not None:
+                return _decode(stored)
+            archived_at = datetime.now(UTC)
+            stored.archived_at = archived_at
+            stored.updated_at = archived_at
+            session.flush()
+            return _decode(stored)
+
+
+def _load(
+    session: Session,
+    competition_id: UUID,
+    *,
+    lock: bool = False,
+) -> StoredCompetition:
+    statement = sa.select(StoredCompetition).where(
+        StoredCompetition.id == competition_id
+    )
+    if lock:
+        statement = statement.with_for_update()
+    stored = session.scalar(statement)
+    if stored is None:
+        raise CoreResourceNotFound("competition", competition_id)
+    return stored
+
+
+def _require_active(stored: StoredCompetition) -> None:
+    if stored.archived_at is not None:
+        raise CompetitionArchivedConflict(stored.id)
+
+
+def _constraint_name(error: IntegrityError) -> str | None:
+    diagnostic = getattr(error.orig, "diag", None)
+    return cast(str | None, getattr(diagnostic, "constraint_name", None))
+
+
+def _decode(stored: StoredCompetition) -> Competition:
+    return Competition(
+        id=stored.id,
+        display_name=stored.display_name,
+        created_at=stored.created_at,
+        updated_at=stored.updated_at,
+        archived_at=stored.archived_at,
+    )
+
+
+__all__ = ["CompetitionManager"]

--- a/backend/resources/core/competitions/objects.py
+++ b/backend/resources/core/competitions/objects.py
@@ -1,0 +1,58 @@
+"""Immutable commands and views for durable competition identities."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+
+
+class CreateCompetition(ContractModel):
+    display_name: NonBlankStr
+
+
+class RenameCompetition(ContractModel):
+    competition_id: UUID
+    display_name: NonBlankStr
+
+
+class ArchiveCompetition(ContractModel):
+    competition_id: UUID
+
+
+class CompetitionQuery(ContractModel):
+    include_archived: bool = False
+    limit: PageLimit = 50
+    offset: NonNegativeInt = 0
+
+
+class Competition(ContractModel):
+    id: UUID
+    display_name: str
+    created_at: AwareDatetime
+    updated_at: AwareDatetime
+    archived_at: AwareDatetime | None
+
+
+class CompetitionPage(ContractModel):
+    items: tuple[Competition, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+__all__ = [
+    "ArchiveCompetition",
+    "Competition",
+    "CompetitionPage",
+    "CompetitionQuery",
+    "CreateCompetition",
+    "RenameCompetition",
+]

--- a/backend/resources/core/errors.py
+++ b/backend/resources/core/errors.py
@@ -1,0 +1,64 @@
+"""Stable application failures for core competition resources."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+class CoreResourceError(RuntimeError):
+    """Base class for core resource failures safe at service boundaries."""
+
+
+class CoreResourceNotFound(CoreResourceError):
+    def __init__(self, resource_kind: str, resource_id: UUID) -> None:
+        self.resource_kind = resource_kind
+        self.resource_id = resource_id
+        super().__init__(f"{resource_kind} {resource_id} was not found")
+
+
+class CompetitionArchivedConflict(CoreResourceError):
+    def __init__(self, competition_id: UUID) -> None:
+        self.competition_id = competition_id
+        self.message = "archived competitions cannot be changed"
+        super().__init__(self.message)
+
+
+class CompetitionSeasonYearExists(CoreResourceError):
+    def __init__(self, competition_id: UUID, season_year: int) -> None:
+        self.competition_id = competition_id
+        self.season_year = season_year
+        self.message = (
+            f"competition {competition_id} already has season year {season_year}"
+        )
+        super().__init__(self.message)
+
+
+class SleeperLeagueIdExists(CoreResourceError):
+    def __init__(self, sleeper_league_id: str) -> None:
+        self.sleeper_league_id = sleeper_league_id
+        self.message = (
+            f"Sleeper league ID {sleeper_league_id!r} is already attached to a season"
+        )
+        super().__init__(self.message)
+
+
+class CompetitionConcurrencyConflict(CoreResourceError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        constraint_name: str | None = None,
+    ) -> None:
+        self.message = message
+        self.constraint_name = constraint_name
+        super().__init__(message)
+
+
+__all__ = [
+    "CompetitionArchivedConflict",
+    "CompetitionConcurrencyConflict",
+    "CompetitionSeasonYearExists",
+    "CoreResourceError",
+    "CoreResourceNotFound",
+    "SleeperLeagueIdExists",
+]

--- a/backend/tests/resources/core/__init__.py
+++ b/backend/tests/resources/core/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for caller-facing core resources."""

--- a/backend/tests/resources/core/conftest.py
+++ b/backend/tests/resources/core/conftest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.sessions import SessionFactory, create_session_factory
+from backend.resources.context import (
+    CompetitionScope,
+    GlobalScope,
+    LocalUserActor,
+    ManagerContext,
+)
+from backend.resources.core import CompetitionManager
+from backend.tests.database.conftest import database_engine, migrated_database
+
+
+@pytest.fixture(autouse=True)
+def clean_core_resources(request: pytest.FixtureRequest) -> None:
+    if "database_engine" not in request.fixturenames:
+        return
+    engine = request.getfixturevalue("database_engine")
+    with engine.begin() as connection:
+        connection.execute(sa.text("TRUNCATE TABLE core.competitions CASCADE"))
+
+
+@pytest.fixture
+def session_factory(database_engine: Engine) -> SessionFactory:
+    return create_session_factory(database_engine)
+
+
+def global_context() -> ManagerContext[GlobalScope]:
+    return ManagerContext[GlobalScope](
+        actor=LocalUserActor(),
+        scope=GlobalScope(reason="manage competition catalog"),
+        correlation_id=uuid4(),
+    )
+
+
+def competition_context(
+    competition_id: UUID,
+) -> ManagerContext[CompetitionScope]:
+    return ManagerContext[CompetitionScope](
+        actor=LocalUserActor(),
+        scope=CompetitionScope(competition_id=competition_id),
+        correlation_id=uuid4(),
+    )
+
+
+@pytest.fixture
+def competition_manager(session_factory: SessionFactory) -> CompetitionManager:
+    return CompetitionManager(session_factory, global_context())
+
+
+__all__ = ["database_engine", "migrated_database"]

--- a/backend/tests/resources/core/test_competition_manager.py
+++ b/backend/tests/resources/core/test_competition_manager.py
@@ -1,0 +1,93 @@
+from uuid import uuid4
+
+import pytest
+
+from backend.resources.core import (
+    ArchiveCompetition,
+    CompetitionArchivedConflict,
+    CompetitionManager,
+    CompetitionQuery,
+    CoreResourceNotFound,
+    CreateCompetition,
+    RenameCompetition,
+)
+
+
+def test_create_get_and_paginated_list_are_stable_and_normalized(
+    competition_manager: CompetitionManager,
+) -> None:
+    zulu = competition_manager.create(CreateCompetition(display_name="Zulu"))
+    alpha = competition_manager.create(CreateCompetition(display_name=" alpha "))
+    bravo = competition_manager.create(CreateCompetition(display_name="Bravo"))
+
+    first_page = competition_manager.list(CompetitionQuery(limit=2))
+    second_page = competition_manager.list(CompetitionQuery(limit=2, offset=2))
+
+    assert first_page.total == 3
+    assert [item.id for item in first_page.items] == [alpha.id, bravo.id]
+    assert [item.id for item in second_page.items] == [zulu.id]
+    assert competition_manager.get(alpha.id) == alpha
+    assert alpha.display_name == "alpha"
+    assert alpha.created_at.tzinfo is not None
+    assert alpha.updated_at.tzinfo is not None
+
+
+def test_rename_is_idempotent_and_archive_is_one_way_and_retry_safe(
+    competition_manager: CompetitionManager,
+) -> None:
+    created = competition_manager.create(CreateCompetition(display_name="Original"))
+
+    unchanged = competition_manager.rename(
+        RenameCompetition(
+            competition_id=created.id,
+            display_name="Original",
+        )
+    )
+    renamed = competition_manager.rename(
+        RenameCompetition(
+            competition_id=created.id,
+            display_name=" Renamed ",
+        )
+    )
+    archived = competition_manager.archive(
+        ArchiveCompetition(competition_id=created.id)
+    )
+    archived_again = competition_manager.archive(
+        ArchiveCompetition(competition_id=created.id)
+    )
+
+    assert unchanged.updated_at == created.updated_at
+    assert renamed.display_name == "Renamed"
+    assert archived.archived_at is not None
+    assert archived.updated_at == archived.archived_at
+    assert archived_again == archived
+    assert competition_manager.get(created.id) == archived
+    assert competition_manager.list(CompetitionQuery()).items == ()
+    assert competition_manager.list(
+        CompetitionQuery(include_archived=True)
+    ).items == (archived,)
+    with pytest.raises(CompetitionArchivedConflict):
+        competition_manager.rename(
+            RenameCompetition(
+                competition_id=created.id,
+                display_name="Cannot Change",
+            )
+        )
+
+
+def test_competition_reads_and_mutations_return_typed_not_found(
+    competition_manager: CompetitionManager,
+) -> None:
+    missing_id = uuid4()
+
+    with pytest.raises(CoreResourceNotFound, match="competition"):
+        competition_manager.get(missing_id)
+    with pytest.raises(CoreResourceNotFound, match="competition"):
+        competition_manager.rename(
+            RenameCompetition(
+                competition_id=missing_id,
+                display_name="Missing",
+            )
+        )
+    with pytest.raises(CoreResourceNotFound, match="competition"):
+        competition_manager.archive(ArchiveCompetition(competition_id=missing_id))

--- a/backend/tests/resources/core/test_competition_objects.py
+++ b/backend/tests/resources/core/test_competition_objects.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import ValidationError
+
+from backend.resources.core import (
+    CompetitionQuery,
+    CompetitionSeasonQuery,
+    CreateCompetition,
+    CreateCompetitionSeason,
+)
+
+
+def test_competition_commands_normalize_nonblank_strings() -> None:
+    competition = CreateCompetition(display_name="  The League  ")
+    season = CreateCompetitionSeason(
+        season_year=2026,
+        sleeper_league_id="  sleeper-2026  ",
+    )
+
+    assert competition.display_name == "The League"
+    assert season.sleeper_league_id == "sleeper-2026"
+
+
+@pytest.mark.parametrize(
+    ("factory", "values"),
+    [
+        (CreateCompetition, {"display_name": "  "}),
+        (
+            CreateCompetitionSeason,
+            {"season_year": 2026, "sleeper_league_id": "  "},
+        ),
+        (
+            CreateCompetitionSeason,
+            {"season_year": "2026", "sleeper_league_id": "league"},
+        ),
+        (
+            CreateCompetitionSeason,
+            {"season_year": 1899, "sleeper_league_id": "league"},
+        ),
+        (
+            CreateCompetitionSeason,
+            {"season_year": 10000, "sleeper_league_id": "league"},
+        ),
+        (CompetitionQuery, {"limit": 0}),
+        (CompetitionQuery, {"limit": 201}),
+        (CompetitionQuery, {"offset": -1}),
+        (CompetitionSeasonQuery, {"limit": 0}),
+        (CompetitionSeasonQuery, {"limit": 201}),
+        (CompetitionSeasonQuery, {"offset": -1}),
+    ],
+)
+def test_core_contracts_reject_invalid_boundaries(factory, values) -> None:
+    with pytest.raises(ValidationError):
+        factory(**values)

--- a/backend/tests/resources/core/test_competition_season_manager.py
+++ b/backend/tests/resources/core/test_competition_season_manager.py
@@ -1,0 +1,171 @@
+from concurrent.futures import ThreadPoolExecutor
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.database.sessions import SessionFactory
+from backend.resources.core import (
+    ArchiveCompetition,
+    CompetitionArchivedConflict,
+    CompetitionManager,
+    CompetitionSeasonManager,
+    CompetitionSeasonQuery,
+    CompetitionSeasonYearExists,
+    CoreResourceNotFound,
+    CreateCompetition,
+    CreateCompetitionSeason,
+    SleeperLeagueIdExists,
+)
+from backend.tests.resources.core.conftest import competition_context
+
+
+def _season_manager(
+    session_factory: SessionFactory,
+    competition_id: UUID,
+) -> CompetitionSeasonManager:
+    return CompetitionSeasonManager(
+        session_factory,
+        competition_context(competition_id),
+    )
+
+
+def test_create_get_list_and_scope_seasons(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    competition = competition_manager.create(CreateCompetition(display_name="Main"))
+    other = competition_manager.create(CreateCompetition(display_name="Other"))
+    manager = _season_manager(session_factory, competition.id)
+
+    first = manager.create(
+        CreateCompetitionSeason(
+            season_year=2025,
+            sleeper_league_id=" sleeper-2025 ",
+        )
+    )
+    second = manager.create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id="sleeper-2026",
+        )
+    )
+
+    page = manager.list(CompetitionSeasonQuery(limit=1))
+    next_page = manager.list(CompetitionSeasonQuery(limit=1, offset=1))
+    assert first.sequence_number == 1
+    assert first.sleeper_league_id == "sleeper-2025"
+    assert second.sequence_number == 2
+    assert page.total == 2
+    assert page.items == (second,)
+    assert next_page.items == (first,)
+    assert manager.get(first.id) == first
+    with pytest.raises(CoreResourceNotFound, match="competition_season"):
+        _season_manager(session_factory, other.id).get(first.id)
+
+
+def test_duplicate_year_and_global_sleeper_id_are_distinct_typed_conflicts(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    first_competition = competition_manager.create(
+        CreateCompetition(display_name="First")
+    )
+    second_competition = competition_manager.create(
+        CreateCompetition(display_name="Second")
+    )
+    first_manager = _season_manager(session_factory, first_competition.id)
+    second_manager = _season_manager(session_factory, second_competition.id)
+    first_manager.create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id="shared-sleeper-id",
+        )
+    )
+
+    with pytest.raises(CompetitionSeasonYearExists) as year_error:
+        first_manager.create(
+            CreateCompetitionSeason(
+                season_year=2026,
+                sleeper_league_id="different-sleeper-id",
+            )
+        )
+    assert year_error.value.competition_id == first_competition.id
+    assert year_error.value.season_year == 2026
+
+    with pytest.raises(SleeperLeagueIdExists) as sleeper_error:
+        second_manager.create(
+            CreateCompetitionSeason(
+                season_year=2025,
+                sleeper_league_id="shared-sleeper-id",
+            )
+        )
+    assert sleeper_error.value.sleeper_league_id == "shared-sleeper-id"
+
+
+def test_archived_competitions_keep_historical_reads_but_reject_new_seasons(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    competition = competition_manager.create(
+        CreateCompetition(display_name="Archive Test")
+    )
+    manager = _season_manager(session_factory, competition.id)
+    season = manager.create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id="archive-season",
+        )
+    )
+    competition_manager.archive(ArchiveCompetition(competition_id=competition.id))
+
+    assert manager.get(season.id) == season
+    assert manager.list(CompetitionSeasonQuery()).items == (season,)
+    with pytest.raises(CompetitionArchivedConflict):
+        manager.create(
+            CreateCompetitionSeason(
+                season_year=2027,
+                sleeper_league_id="archived-new-season",
+            )
+        )
+
+
+def test_missing_competition_scope_is_typed_for_list_and_create(
+    session_factory: SessionFactory,
+) -> None:
+    manager = _season_manager(session_factory, uuid4())
+
+    with pytest.raises(CoreResourceNotFound, match="competition"):
+        manager.list(CompetitionSeasonQuery())
+    with pytest.raises(CoreResourceNotFound, match="competition"):
+        manager.create(
+            CreateCompetitionSeason(
+                season_year=2026,
+                sleeper_league_id="missing-scope",
+            )
+        )
+
+
+def test_concurrent_creates_allocate_distinct_sequences(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    competition = competition_manager.create(
+        CreateCompetition(display_name="Concurrent")
+    )
+    manager = _season_manager(session_factory, competition.id)
+    commands = (
+        CreateCompetitionSeason(
+            season_year=2025,
+            sleeper_league_id="concurrent-2025",
+        ),
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id="concurrent-2026",
+        ),
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        created = tuple(pool.map(manager.create, commands))
+
+    assert {season.sequence_number for season in created} == {1, 2}
+    assert manager.list(CompetitionSeasonQuery()).total == 2

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -81,6 +81,12 @@ Season creation must return `409` codes for at least
 after observations exist is out of v1 scope; the API should not expose a broad
 season patch until that lifecycle is designed.
 
+Competition archive is one-way in v1. Active competition lists exclude archived
+rows by default, while direct competition and historical season reads remain
+available. Repeating archive is idempotent; renaming an archived competition or
+attaching another season is rejected. Restore and cascading changes to existing
+generation or memory resources are out of scope.
+
 ## Required Refresh and Data Audit API
 
 | Method and path | Purpose | Status |


### PR DESCRIPTION
## Summary

- add immutable competition and season resource contracts with scoped managers
- implement one-way competition archive and concurrency-safe season sequence allocation
- translate named PostgreSQL uniqueness constraints into typed resource conflicts
- document archive behavior without adding HTTP routes, Sleeper calls, or schema changes

## Testing

- `.\.venv\Scripts\python.exe -m pytest backend/tests/resources/core/ -q` (`12 passed, 8 skipped`)
- `git diff --cached --check`

PostgreSQL manager tests were collected but skipped because `AIDAM_TEST_DATABASE_URL` is not configured in the current environment.