### PR TITLE
feat(api): add competition season product routes

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -9,11 +9,13 @@ from fastapi import FastAPI
 
 from backend.api.errors import (
     REPORTING_APPLICATION_ERRORS,
+    core_resource_error_handler,
     memory_application_error_handler,
     reporting_application_error_handler,
 )
 from backend.api.routes import api_router, health_router
 from backend.composition import ApiRuntimeDependencies, build_api_runtime
+from backend.resources.core import CoreResourceError
 from backend.resources.memory.common import MemoryApplicationError
 
 RuntimeFactory = Callable[[], ApiRuntimeDependencies]
@@ -44,6 +46,10 @@ def create_app(
     application.add_exception_handler(
         MemoryApplicationError,
         memory_application_error_handler,
+    )
+    application.add_exception_handler(
+        CoreResourceError,
+        core_resource_error_handler,
     )
     for error_type in REPORTING_APPLICATION_ERRORS:
         application.add_exception_handler(

--- a/backend/api/dependencies/__init__.py
+++ b/backend/api/dependencies/__init__.py
@@ -1,5 +1,9 @@
 """FastAPI dependency providers."""
 
+from backend.api.dependencies.competitions import (
+    get_competition_catalog_dependencies,
+    get_competition_season_dependencies,
+)
 from backend.api.dependencies.generations import (
     authorize_local_competition,
     get_generation_api_dependencies,
@@ -14,6 +18,8 @@ from backend.api.dispatch import get_generation_dispatcher
 __all__ = [
     "authorize_local_competition",
     "get_api_runtime",
+    "get_competition_catalog_dependencies",
+    "get_competition_season_dependencies",
     "get_correlation_id",
     "get_generation_api_dependencies",
     "get_generation_dispatcher",

--- a/backend/api/dependencies/competitions.py
+++ b/backend/api/dependencies/competitions.py
@@ -1,0 +1,66 @@
+"""Dependency composition for competition and season product routes."""
+
+from typing import Annotated, cast
+from uuid import UUID
+
+from fastapi import Depends
+
+from backend.api.dependencies.memory import get_correlation_id
+from backend.api.dependencies.services import get_api_runtime
+from backend.composition import (
+    ApiRuntimeDependencies,
+    CompetitionApiRuntimeDependencies,
+    CompetitionCatalogDependencies,
+    CompetitionSeasonDependencies,
+    build_competition_catalog_dependencies,
+    build_competition_season_dependencies,
+)
+from backend.resources.context import (
+    CompetitionScope,
+    GlobalScope,
+    LocalUserActor,
+    ManagerContext,
+)
+
+
+def get_competition_catalog_dependencies(
+    correlation_id: Annotated[UUID, Depends(get_correlation_id)],
+    runtime: Annotated[ApiRuntimeDependencies, Depends(get_api_runtime)],
+) -> CompetitionCatalogDependencies:
+    """Build one request's global local-user competition boundary."""
+
+    core_runtime = cast(CompetitionApiRuntimeDependencies, runtime)
+    context = ManagerContext[GlobalScope](
+        actor=LocalUserActor(),
+        scope=GlobalScope(reason="manage competition catalog"),
+        correlation_id=correlation_id,
+    )
+    return build_competition_catalog_dependencies(
+        core_runtime.session_factory,
+        context,
+    )
+
+
+def get_competition_season_dependencies(
+    competition_id: UUID,
+    correlation_id: Annotated[UUID, Depends(get_correlation_id)],
+    runtime: Annotated[ApiRuntimeDependencies, Depends(get_api_runtime)],
+) -> CompetitionSeasonDependencies:
+    """Build one request's competition-scoped season boundary."""
+
+    core_runtime = cast(CompetitionApiRuntimeDependencies, runtime)
+    context = ManagerContext[CompetitionScope](
+        actor=LocalUserActor(),
+        scope=CompetitionScope(competition_id=competition_id),
+        correlation_id=correlation_id,
+    )
+    return build_competition_season_dependencies(
+        core_runtime.session_factory,
+        context,
+    )
+
+
+__all__ = [
+    "get_competition_catalog_dependencies",
+    "get_competition_season_dependencies",
+]

--- a/backend/api/errors/__init__.py
+++ b/backend/api/errors/__init__.py
@@ -1,5 +1,6 @@
 """HTTP error translation helpers."""
 
+from backend.api.errors.core import CoreErrorResponse, core_resource_error_handler
 from backend.api.errors.memory import memory_application_error_handler
 from backend.api.errors.reporting import (
     REPORTING_APPLICATION_ERRORS,
@@ -7,7 +8,9 @@ from backend.api.errors.reporting import (
 )
 
 __all__ = [
+    "CoreErrorResponse",
     "REPORTING_APPLICATION_ERRORS",
     "memory_application_error_handler",
+    "core_resource_error_handler",
     "reporting_application_error_handler",
 ]

--- a/backend/api/errors/core.py
+++ b/backend/api/errors/core.py
@@ -1,0 +1,114 @@
+"""Stable HTTP translation for competition resource failures."""
+
+from typing import Literal
+
+from fastapi import Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from backend.resources.core import (
+    CompetitionArchivedConflict,
+    CompetitionConcurrencyConflict,
+    CompetitionSeasonYearExists,
+    CoreResourceError,
+    CoreResourceNotFound,
+    SleeperLeagueIdExists,
+)
+
+
+CoreErrorCode = Literal[
+    "competition_not_found",
+    "competition_season_not_found",
+    "competition_archived",
+    "competition_season_year_exists",
+    "sleeper_league_id_exists",
+    "competition_concurrency_conflict",
+]
+
+
+class CoreErrorDetail(BaseModel):
+    code: CoreErrorCode
+    summary: str
+    field_errors: dict[str, list[str]] | None = None
+    correlation_id: str | None = None
+
+
+class CoreErrorResponse(BaseModel):
+    error: CoreErrorDetail
+
+
+async def core_resource_error_handler(
+    request: Request,
+    error: Exception,
+) -> JSONResponse:
+    if not isinstance(error, CoreResourceError):
+        raise TypeError("core error handler received a non-core exception")
+    status_code, code, summary, field_errors = _http_error(error)
+    correlation_id = request.headers.get("X-Correlation-ID")
+    payload = CoreErrorResponse(
+        error=CoreErrorDetail(
+            code=code,
+            summary=summary,
+            field_errors=field_errors,
+            correlation_id=correlation_id,
+        )
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(payload, exclude_none=True),
+    )
+
+
+def _http_error(
+    error: CoreResourceError,
+) -> tuple[int, CoreErrorCode, str, dict[str, list[str]] | None]:
+    if isinstance(error, CoreResourceNotFound):
+        if error.resource_kind == "competition":
+            return (
+                status.HTTP_404_NOT_FOUND,
+                "competition_not_found",
+                "competition was not found",
+                None,
+            )
+        return (
+            status.HTTP_404_NOT_FOUND,
+            "competition_season_not_found",
+            "competition season was not found",
+            None,
+        )
+    if isinstance(error, CompetitionArchivedConflict):
+        return (
+            status.HTTP_409_CONFLICT,
+            "competition_archived",
+            "archived competitions cannot be changed",
+            None,
+        )
+    if isinstance(error, CompetitionSeasonYearExists):
+        return (
+            status.HTTP_409_CONFLICT,
+            "competition_season_year_exists",
+            "that season year is already attached to this competition",
+            {"season_year": ["Already attached to this competition."]},
+        )
+    if isinstance(error, SleeperLeagueIdExists):
+        return (
+            status.HTTP_409_CONFLICT,
+            "sleeper_league_id_exists",
+            "that Sleeper league ID is already attached to a season",
+            {"sleeper_league_id": ["Already attached to another season."]},
+        )
+    if isinstance(error, CompetitionConcurrencyConflict):
+        return (
+            status.HTTP_409_CONFLICT,
+            "competition_concurrency_conflict",
+            "competition state changed concurrently; retry the request",
+            None,
+        )
+    raise TypeError(f"unsupported core application error {type(error).__name__}")
+
+
+__all__ = [
+    "CoreErrorResponse",
+    "core_resource_error_handler",
+]

--- a/backend/api/routes/__init__.py
+++ b/backend/api/routes/__init__.py
@@ -2,12 +2,14 @@
 
 from fastapi import APIRouter
 
+from backend.api.routes.competitions import router as competitions_router
 from backend.api.routes.data import router as data_router
 from backend.api.routes.generations import router as generations_router
 from backend.api.routes.health import router as health_router
 from backend.api.routes.memory import router as memory_router
 
 api_router = APIRouter()
+api_router.include_router(competitions_router)
 api_router.include_router(generations_router)
 api_router.include_router(memory_router)
 api_router.include_router(data_router)

--- a/backend/api/routes/competitions.py
+++ b/backend/api/routes/competitions.py
@@ -1,0 +1,216 @@
+"""Competition catalog and season identity HTTP routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, status
+
+from backend.api.dependencies.competitions import (
+    get_competition_catalog_dependencies,
+    get_competition_season_dependencies,
+)
+from backend.api.errors.core import CoreErrorResponse
+from backend.api.schemas.competitions import (
+    CompetitionOverviewResponse,
+    CompetitionPageResponse,
+    CompetitionResponse,
+    CompetitionSeasonDetailResponse,
+    CompetitionSeasonPageResponse,
+    CompetitionSeasonResponse,
+    CreateCompetitionBody,
+    CreateCompetitionSeasonBody,
+    PatchCompetitionBody,
+)
+from backend.composition import (
+    CompetitionCatalogDependencies,
+    CompetitionSeasonDependencies,
+)
+from backend.resources.core import (
+    ArchiveCompetition,
+    CompetitionQuery,
+    CompetitionSeasonQuery,
+    CreateCompetition,
+    CreateCompetitionSeason,
+    RenameCompetition,
+)
+
+
+router = APIRouter(
+    prefix="/competitions",
+    tags=["competitions"],
+    responses={
+        404: {
+            "model": CoreErrorResponse,
+            "description": "The competition or scoped season was not found.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "code": "competition_not_found",
+                            "summary": "competition was not found",
+                        }
+                    }
+                }
+            },
+        },
+        409: {
+            "model": CoreErrorResponse,
+            "description": "The requested identity or lifecycle change conflicts.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": {
+                            "code": "competition_season_year_exists",
+                            "summary": (
+                                "that season year is already attached to this "
+                                "competition"
+                            ),
+                            "field_errors": {
+                                "season_year": [
+                                    "Already attached to this competition."
+                                ]
+                            },
+                        }
+                    }
+                }
+            },
+        },
+    },
+)
+CatalogApi = Annotated[
+    CompetitionCatalogDependencies,
+    Depends(get_competition_catalog_dependencies),
+]
+SeasonApi = Annotated[
+    CompetitionSeasonDependencies,
+    Depends(get_competition_season_dependencies),
+]
+PageLimit = Annotated[int, Query(ge=1, le=200)]
+PageOffset = Annotated[int, Query(ge=0)]
+
+
+@router.get("", response_model=CompetitionPageResponse)
+def competition_list(
+    dependencies: CatalogApi,
+    include_archived: bool = False,
+    limit: PageLimit = 50,
+    offset: PageOffset = 0,
+) -> CompetitionPageResponse:
+    return CompetitionPageResponse(
+        page=dependencies.overviews.list_competitions(
+            CompetitionQuery(
+                include_archived=include_archived,
+                limit=limit,
+                offset=offset,
+            )
+        )
+    )
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CompetitionResponse,
+)
+def create_competition(
+    body: CreateCompetitionBody,
+    dependencies: CatalogApi,
+) -> CompetitionResponse:
+    competition = dependencies.competitions.create(
+        CreateCompetition(display_name=body.display_name)
+    )
+    return CompetitionResponse(competition=competition)
+
+
+@router.get(
+    "/{competition_id}",
+    response_model=CompetitionOverviewResponse,
+)
+def competition_detail(
+    competition_id: UUID,
+    dependencies: CatalogApi,
+) -> CompetitionOverviewResponse:
+    overview = dependencies.overviews.get_competition(competition_id)
+    return CompetitionOverviewResponse(
+        competition=overview.competition,
+        summary=overview.summary,
+    )
+
+
+@router.patch(
+    "/{competition_id}",
+    response_model=CompetitionResponse,
+)
+def update_competition(
+    competition_id: UUID,
+    body: PatchCompetitionBody,
+    dependencies: CatalogApi,
+) -> CompetitionResponse:
+    if body.display_name is not None:
+        competition = dependencies.competitions.rename(
+            RenameCompetition(
+                competition_id=competition_id,
+                display_name=body.display_name,
+            )
+        )
+    else:
+        competition = dependencies.competitions.archive(
+            ArchiveCompetition(competition_id=competition_id)
+        )
+    return CompetitionResponse(competition=competition)
+
+
+@router.get(
+    "/{competition_id}/seasons",
+    response_model=CompetitionSeasonPageResponse,
+)
+def competition_season_list(
+    competition_id: UUID,
+    dependencies: SeasonApi,
+    limit: PageLimit = 50,
+    offset: PageOffset = 0,
+) -> CompetitionSeasonPageResponse:
+    return CompetitionSeasonPageResponse(
+        page=dependencies.overviews.list_seasons(
+            competition_id,
+            CompetitionSeasonQuery(limit=limit, offset=offset),
+        )
+    )
+
+
+@router.post(
+    "/{competition_id}/seasons",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CompetitionSeasonResponse,
+)
+def create_competition_season(
+    body: CreateCompetitionSeasonBody,
+    dependencies: SeasonApi,
+) -> CompetitionSeasonResponse:
+    season = dependencies.seasons.create(
+        CreateCompetitionSeason(
+            season_year=body.season_year,
+            sleeper_league_id=body.sleeper_league_id,
+        )
+    )
+    return CompetitionSeasonResponse(season=season)
+
+
+@router.get(
+    "/{competition_id}/seasons/{season_id}",
+    response_model=CompetitionSeasonDetailResponse,
+)
+def competition_season_detail(
+    competition_id: UUID,
+    season_id: UUID,
+    dependencies: SeasonApi,
+) -> CompetitionSeasonDetailResponse:
+    detail = dependencies.overviews.get_season(competition_id, season_id)
+    return CompetitionSeasonDetailResponse(
+        season=detail.season,
+        summary=detail.summary,
+        normalized_overview=detail.normalized_overview,
+    )
+
+
+__all__ = ["router"]

--- a/backend/api/schemas/competitions.py
+++ b/backend/api/schemas/competitions.py
@@ -1,0 +1,96 @@
+"""Strict transport models for competition and season routes."""
+
+from typing import Annotated, ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from backend.resources._contracts import NonBlankStr
+from backend.resources.core import (
+    Competition,
+    CompetitionActivitySummary,
+    CompetitionOverviewPage,
+    CompetitionSeason,
+    CompetitionSeasonActivitySummary,
+    CompetitionSeasonOverviewPage,
+)
+from backend.resources.sleeper_data import LeagueSeasonOverview
+
+
+class CompetitionApiModel(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+
+class CreateCompetitionBody(CompetitionApiModel):
+    display_name: NonBlankStr
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={"examples": [{"display_name": "The League"}]},
+    )
+
+
+class PatchCompetitionBody(CompetitionApiModel):
+    display_name: NonBlankStr | None = None
+    archived: Literal[True] | None = None
+
+    @model_validator(mode="after")
+    def validate_exactly_one_change(self) -> "PatchCompetitionBody":
+        fields = self.model_fields_set
+        rename = fields == {"display_name"} and self.display_name is not None
+        archive = fields == {"archived"} and self.archived is True
+        if not rename and not archive:
+            raise ValueError(
+                "provide exactly one of display_name or archived=true"
+            )
+        return self
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "examples": [
+                {"display_name": "Renamed League"},
+                {"archived": True},
+            ]
+        },
+    )
+
+
+class CreateCompetitionSeasonBody(CompetitionApiModel):
+    season_year: Annotated[int, Field(strict=True, ge=1900, le=9999)]
+    sleeper_league_id: NonBlankStr
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "examples": [
+                {"season_year": 2026, "sleeper_league_id": "1234567890"}
+            ]
+        },
+    )
+
+
+class CompetitionResponse(CompetitionApiModel):
+    competition: Competition
+
+
+class CompetitionOverviewResponse(CompetitionApiModel):
+    competition: Competition
+    summary: CompetitionActivitySummary
+
+
+class CompetitionPageResponse(CompetitionApiModel):
+    page: CompetitionOverviewPage
+
+
+class CompetitionSeasonResponse(CompetitionApiModel):
+    season: CompetitionSeason
+
+
+class CompetitionSeasonPageResponse(CompetitionApiModel):
+    page: CompetitionSeasonOverviewPage
+
+
+class CompetitionSeasonDetailResponse(CompetitionApiModel):
+    season: CompetitionSeason
+    summary: CompetitionSeasonActivitySummary
+    normalized_overview: LeagueSeasonOverview | None

--- a/backend/composition.py
+++ b/backend/composition.py
@@ -14,7 +14,16 @@ from backend.config import (
 from backend.database.engine import build_runtime_engine
 from backend.database.health import assert_database_ready, read_database_health
 from backend.database.sessions import SessionFactory, create_session_factory
-from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.context import (
+    CompetitionScope,
+    GlobalScope,
+    ManagerContext,
+)
+from backend.resources.core import (
+    CompetitionManager,
+    CompetitionOverviewReader,
+    CompetitionSeasonManager,
+)
 from backend.resources.memory.context_notes import ContextNoteManager
 from backend.resources.memory.events import EventManager
 from backend.resources.memory.facts import FactManager
@@ -62,6 +71,12 @@ class MemoryApiRuntimeDependencies(ApiRuntimeDependencies, Protocol):
 
 class GenerationRuntimeDependencies(ApiRuntimeDependencies, Protocol):
     """Runtime capabilities required by generation API and worker boundaries."""
+
+    session_factory: SessionFactory
+
+
+class CompetitionApiRuntimeDependencies(ApiRuntimeDependencies, Protocol):
+    """Runtime capabilities required by competition product routes."""
 
     session_factory: SessionFactory
 
@@ -131,6 +146,22 @@ class MemoryApiDependencies:
 
 
 @dataclass(frozen=True, slots=True)
+class CompetitionCatalogDependencies:
+    """One request's global competition catalog capabilities."""
+
+    competitions: CompetitionManager
+    overviews: CompetitionOverviewReader
+
+
+@dataclass(frozen=True, slots=True)
+class CompetitionSeasonDependencies:
+    """One request's competition-scoped season capabilities."""
+
+    seasons: CompetitionSeasonManager
+    overviews: CompetitionOverviewReader
+
+
+@dataclass(frozen=True, slots=True)
 class DatalayerRefreshDependencies:
     """One scoped refresh service and its owned source transport."""
 
@@ -158,6 +189,30 @@ class GenerationDependencies:
     tool_calls: ToolCallManager
     artifacts: ArtifactManager
     artifact_versions: ArtifactVersionManager
+
+
+def build_competition_catalog_dependencies(
+    session_factory: SessionFactory,
+    context: ManagerContext[GlobalScope],
+) -> CompetitionCatalogDependencies:
+    """Compose global competition lifecycle and overview reads."""
+
+    return CompetitionCatalogDependencies(
+        competitions=CompetitionManager(session_factory, context),
+        overviews=CompetitionOverviewReader(session_factory),
+    )
+
+
+def build_competition_season_dependencies(
+    session_factory: SessionFactory,
+    context: ManagerContext[CompetitionScope],
+) -> CompetitionSeasonDependencies:
+    """Compose scoped season lifecycle and overview reads."""
+
+    return CompetitionSeasonDependencies(
+        seasons=CompetitionSeasonManager(session_factory, context),
+        overviews=CompetitionOverviewReader(session_factory),
+    )
 
 
 def build_memory_api_dependencies(

--- a/backend/resources/core/__init__.py
+++ b/backend/resources/core/__init__.py
@@ -22,6 +22,17 @@ from backend.resources.core.errors import (
     CoreResourceNotFound,
     SleeperLeagueIdExists,
 )
+from backend.resources.core.overviews import (
+    CompetitionActivitySummary,
+    CompetitionOverview,
+    CompetitionOverviewPage,
+    CompetitionOverviewReader,
+    CompetitionSeasonActivitySummary,
+    CompetitionSeasonDetail,
+    CompetitionSeasonOverview,
+    CompetitionSeasonOverviewPage,
+    LatestRefreshSummary,
+)
 
 __all__ = [
     "ArchiveCompetition",
@@ -29,10 +40,18 @@ __all__ = [
     "CompetitionArchivedConflict",
     "CompetitionConcurrencyConflict",
     "CompetitionManager",
+    "CompetitionActivitySummary",
+    "CompetitionOverview",
+    "CompetitionOverviewPage",
+    "CompetitionOverviewReader",
     "CompetitionPage",
     "CompetitionQuery",
     "CompetitionSeason",
     "CompetitionSeasonManager",
+    "CompetitionSeasonActivitySummary",
+    "CompetitionSeasonDetail",
+    "CompetitionSeasonOverview",
+    "CompetitionSeasonOverviewPage",
     "CompetitionSeasonPage",
     "CompetitionSeasonQuery",
     "CompetitionSeasonYearExists",
@@ -41,5 +60,6 @@ __all__ = [
     "CreateCompetition",
     "CreateCompetitionSeason",
     "RenameCompetition",
+    "LatestRefreshSummary",
     "SleeperLeagueIdExists",
 ]

--- a/backend/resources/core/overviews.py
+++ b/backend/resources/core/overviews.py
@@ -1,0 +1,480 @@
+"""Set-based product projections for competition and season screens."""
+
+from __future__ import annotations
+
+from typing import Annotated, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from pydantic import AwareDatetime, Field
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import Competition as StoredCompetition
+from backend.database.models.core import CompetitionSeason as StoredCompetitionSeason
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.models.sleeper import DataSnapshot as StoredDataSnapshot
+from backend.database.models.sleeper import League as StoredLeague
+from backend.database.models.sleeper import RefreshRun as StoredRefreshRun
+from backend.database.models.sleeper import Roster as StoredRoster
+from backend.database.sessions import SessionFactory, read_only_session
+from backend.resources._contracts import ContractModel
+from backend.resources.core.competition_seasons.objects import (
+    CompetitionSeason,
+    CompetitionSeasonQuery,
+)
+from backend.resources.core.competitions.objects import Competition, CompetitionQuery
+from backend.resources.core.errors import CoreResourceNotFound
+from backend.resources.sleeper_data import LeagueSeasonOverview
+from backend.services.datalayer.contracts import RefreshStatus
+
+
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+PageLimit = Annotated[int, Field(strict=True, ge=1, le=200)]
+
+
+class LatestRefreshSummary(ContractModel):
+    status: RefreshStatus
+    requested_through_week: int | None
+    completed_at: AwareDatetime
+    request_count: NonNegativeInt
+    succeeded_request_count: NonNegativeInt
+    failed_request_count: NonNegativeInt
+
+
+class CompetitionActivitySummary(ContractModel):
+    season_count: NonNegativeInt
+    latest_season: CompetitionSeason | None
+    latest_terminal_refresh: LatestRefreshSummary | None
+    latest_successful_refresh_at: AwareDatetime | None
+    latest_ready_snapshot_at: AwareDatetime | None
+    latest_submitted_article_at: AwareDatetime | None
+
+
+class CompetitionOverview(ContractModel):
+    competition: Competition
+    summary: CompetitionActivitySummary
+
+
+class CompetitionOverviewPage(ContractModel):
+    items: tuple[CompetitionOverview, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+class CompetitionSeasonActivitySummary(ContractModel):
+    league_name: str | None
+    league_status: str | None
+    latest_terminal_refresh: LatestRefreshSummary | None
+    latest_successful_refresh_at: AwareDatetime | None
+    latest_ready_snapshot_at: AwareDatetime | None
+
+
+class CompetitionSeasonOverview(ContractModel):
+    season: CompetitionSeason
+    summary: CompetitionSeasonActivitySummary
+
+
+class CompetitionSeasonOverviewPage(ContractModel):
+    items: tuple[CompetitionSeasonOverview, ...]
+    total: NonNegativeInt
+    limit: PageLimit
+    offset: NonNegativeInt
+
+
+class CompetitionSeasonDetail(CompetitionSeasonOverview):
+    normalized_overview: LeagueSeasonOverview | None
+
+
+class CompetitionOverviewReader:
+    """Read product summaries without issuing one query per projected row."""
+
+    def __init__(self, session_factory: SessionFactory) -> None:
+        self._session_factory = session_factory
+
+    def list_competitions(
+        self,
+        query: CompetitionQuery,
+    ) -> CompetitionOverviewPage:
+        conditions: list[sa.ColumnElement[bool]] = []
+        if not query.include_archived:
+            conditions.append(StoredCompetition.archived_at.is_(None))
+        with read_only_session(self._session_factory) as session:
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredCompetition)
+                    .where(*conditions)
+                ),
+            )
+            rows = session.execute(
+                _competition_statement()
+                .where(*conditions)
+                .order_by(
+                    sa.func.lower(StoredCompetition.display_name).asc(),
+                    StoredCompetition.id.asc(),
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return CompetitionOverviewPage(
+                items=tuple(_decode_competition(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def get_competition(self, competition_id: UUID) -> CompetitionOverview:
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(
+                _competition_statement().where(
+                    StoredCompetition.id == competition_id
+                )
+            ).one_or_none()
+            if row is None:
+                raise CoreResourceNotFound("competition", competition_id)
+            return _decode_competition(row)
+
+    def list_seasons(
+        self,
+        competition_id: UUID,
+        query: CompetitionSeasonQuery,
+    ) -> CompetitionSeasonOverviewPage:
+        with read_only_session(self._session_factory) as session:
+            _require_competition(session, competition_id)
+            condition = StoredCompetitionSeason.competition_id == competition_id
+            total = cast(
+                int,
+                session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(StoredCompetitionSeason)
+                    .where(condition)
+                ),
+            )
+            rows = session.execute(
+                _season_statement()
+                .where(condition)
+                .order_by(
+                    StoredCompetitionSeason.sequence_number.desc(),
+                    StoredCompetitionSeason.id.asc(),
+                )
+                .limit(query.limit)
+                .offset(query.offset)
+            ).all()
+            return CompetitionSeasonOverviewPage(
+                items=tuple(_decode_season(row) for row in rows),
+                total=total,
+                limit=query.limit,
+                offset=query.offset,
+            )
+
+    def get_season(
+        self,
+        competition_id: UUID,
+        season_id: UUID,
+    ) -> CompetitionSeasonDetail:
+        with read_only_session(self._session_factory) as session:
+            row = session.execute(
+                _season_detail_statement().where(
+                    StoredCompetitionSeason.competition_id == competition_id,
+                    StoredCompetitionSeason.id == season_id,
+                )
+            ).one_or_none()
+            if row is None:
+                raise CoreResourceNotFound("competition_season", season_id)
+            projected = _decode_season(row)
+            league = row._mapping[StoredLeague]
+            normalized = None
+            if league is not None:
+                normalized = LeagueSeasonOverview(
+                    competition_id=competition_id,
+                    competition_season_id=projected.season.id,
+                    competition_name=row._mapping["competition_name"],
+                    sleeper_league_id=projected.season.sleeper_league_id,
+                    season_year=projected.season.season_year,
+                    sequence_number=projected.season.sequence_number,
+                    league_name=league.name,
+                    status=league.status,
+                    scoring_settings=league.scoring_settings,
+                    roster_positions=tuple(league.roster_positions),
+                    provider_settings=league.provider_settings,
+                    playoff_start_week=league.playoff_start_week,
+                    playoff_team_count=league.playoff_team_count,
+                    league_average_match=league.league_average_match,
+                    roster_count=row._mapping["roster_count"],
+                    source_api_request_id=league.source_api_request_id,
+                )
+            return CompetitionSeasonDetail(
+                season=projected.season,
+                summary=projected.summary,
+                normalized_overview=normalized,
+            )
+
+
+def _competition_statement() -> sa.Select[tuple[StoredCompetition]]:
+    season_count = (
+        sa.select(sa.func.count())
+        .select_from(StoredCompetitionSeason)
+        .where(StoredCompetitionSeason.competition_id == StoredCompetition.id)
+        .correlate(StoredCompetition)
+        .scalar_subquery()
+    )
+    def latest_season_value(
+        column: sa.ColumnElement[object],
+    ) -> sa.ScalarSelect[object]:
+        return (
+            sa.select(column)
+            .where(StoredCompetitionSeason.competition_id == StoredCompetition.id)
+            .order_by(
+                StoredCompetitionSeason.sequence_number.desc(),
+                StoredCompetitionSeason.id.desc(),
+            )
+            .limit(1)
+            .correlate(StoredCompetition)
+            .scalar_subquery()
+        )
+
+    latest_season_id = latest_season_value(StoredCompetitionSeason.id)
+    terminal = _latest_refresh_subquery(
+        StoredRefreshRun.competition_id == StoredCompetition.id,
+        StoredRefreshRun.status != RefreshStatus.RUNNING.value,
+    ).correlate(StoredCompetition)
+    latest_success = _latest_timestamp(
+        StoredRefreshRun.completed_at,
+        StoredRefreshRun.id,
+        StoredRefreshRun.competition_id == StoredCompetition.id,
+        StoredRefreshRun.status == RefreshStatus.SUCCEEDED.value,
+    ).correlate(StoredCompetition)
+    latest_snapshot = _latest_timestamp(
+        StoredDataSnapshot.completed_at,
+        StoredDataSnapshot.id,
+        StoredDataSnapshot.competition_id == StoredCompetition.id,
+        StoredDataSnapshot.status == "ready",
+    ).correlate(StoredCompetition)
+    latest_article = _latest_timestamp(
+        StoredGeneration.completed_at,
+        StoredGeneration.id,
+        StoredGeneration.competition_id == StoredCompetition.id,
+        StoredGeneration.status == "succeeded",
+        StoredGeneration.submitted_artifact_version_id.is_not(None),
+    ).correlate(StoredCompetition)
+    return sa.select(
+        StoredCompetition,
+        season_count.label("season_count"),
+        latest_season_id.label("latest_season_id"),
+        latest_season_value(StoredCompetitionSeason.season_year).label(
+            "latest_season_year"
+        ),
+        latest_season_value(StoredCompetitionSeason.sequence_number).label(
+            "latest_season_sequence_number"
+        ),
+        latest_season_value(StoredCompetitionSeason.sleeper_league_id).label(
+            "latest_season_sleeper_league_id"
+        ),
+        latest_season_value(StoredCompetitionSeason.created_at).label(
+            "latest_season_created_at"
+        ),
+        *(_refresh_scalar(terminal, column) for column in _REFRESH_COLUMNS),
+        latest_success.scalar_subquery().label("latest_successful_refresh_at"),
+        latest_snapshot.scalar_subquery().label("latest_ready_snapshot_at"),
+        latest_article.scalar_subquery().label("latest_submitted_article_at"),
+    )
+
+
+def _season_statement() -> sa.Select[tuple[StoredCompetitionSeason]]:
+    terminal = _latest_refresh_subquery(
+        StoredRefreshRun.competition_season_id == StoredCompetitionSeason.id,
+        StoredRefreshRun.status != RefreshStatus.RUNNING.value,
+    ).correlate(StoredCompetitionSeason)
+    latest_success = _latest_timestamp(
+        StoredRefreshRun.completed_at,
+        StoredRefreshRun.id,
+        StoredRefreshRun.competition_season_id == StoredCompetitionSeason.id,
+        StoredRefreshRun.status == RefreshStatus.SUCCEEDED.value,
+    ).correlate(StoredCompetitionSeason)
+    latest_snapshot = _latest_timestamp(
+        StoredDataSnapshot.completed_at,
+        StoredDataSnapshot.id,
+        StoredDataSnapshot.primary_competition_season_id
+        == StoredCompetitionSeason.id,
+        StoredDataSnapshot.status == "ready",
+    ).correlate(StoredCompetitionSeason)
+    return (
+        sa.select(
+            StoredCompetitionSeason,
+            StoredLeague.name.label("league_name"),
+            StoredLeague.status.label("league_status"),
+            *(_refresh_scalar(terminal, column) for column in _REFRESH_COLUMNS),
+            latest_success.scalar_subquery().label("latest_successful_refresh_at"),
+            latest_snapshot.scalar_subquery().label("latest_ready_snapshot_at"),
+        )
+        .outerjoin(
+            StoredLeague,
+            StoredLeague.competition_season_id == StoredCompetitionSeason.id,
+        )
+    )
+
+
+def _season_detail_statement() -> sa.Select[tuple[StoredCompetitionSeason]]:
+    roster_count = (
+        sa.select(sa.func.count())
+        .select_from(StoredRoster)
+        .where(StoredRoster.competition_season_id == StoredCompetitionSeason.id)
+        .correlate(StoredCompetitionSeason)
+        .scalar_subquery()
+    )
+    return (
+        _season_statement()
+        .add_columns(
+            StoredLeague,
+            StoredCompetition.display_name.label("competition_name"),
+            roster_count.label("roster_count"),
+        )
+        .join(
+            StoredCompetition,
+            StoredCompetition.id == StoredCompetitionSeason.competition_id,
+        )
+    )
+
+
+_REFRESH_COLUMNS = (
+    "status",
+    "requested_through_week",
+    "completed_at",
+    "request_count",
+    "succeeded_request_count",
+    "failed_request_count",
+)
+
+
+def _latest_refresh_subquery(
+    *conditions: sa.ColumnElement[bool],
+) -> sa.Select[tuple[StoredRefreshRun]]:
+    return (
+        sa.select(StoredRefreshRun)
+        .where(*conditions, StoredRefreshRun.completed_at.is_not(None))
+        .order_by(StoredRefreshRun.completed_at.desc(), StoredRefreshRun.id.desc())
+        .limit(1)
+    )
+
+
+def _refresh_scalar(
+    latest: sa.Select[tuple[StoredRefreshRun]],
+    column: str,
+) -> sa.Label[object]:
+    selected = latest.with_only_columns(getattr(StoredRefreshRun, column))
+    return selected.scalar_subquery().label(f"latest_refresh_{column}")
+
+
+def _latest_timestamp(
+    timestamp: sa.ColumnElement[object],
+    identity: sa.ColumnElement[object],
+    *conditions: sa.ColumnElement[bool],
+) -> sa.Select[tuple[object]]:
+    return (
+        sa.select(timestamp)
+        .where(*conditions, timestamp.is_not(None))
+        .order_by(timestamp.desc(), identity.desc())
+        .limit(1)
+    )
+
+
+def _decode_competition(row: sa.Row[object]) -> CompetitionOverview:
+    stored = cast(StoredCompetition, row[0])
+    mapping = row._mapping
+    latest_id = mapping["latest_season_id"]
+    latest_season = None
+    if latest_id is not None:
+        # The complete identity is fetched without another query by a scalar row
+        # encoded from the same deterministic latest-season ordering.
+        latest_season = CompetitionSeason(
+            id=latest_id,
+            competition_id=stored.id,
+            season_year=mapping["latest_season_year"],
+            sequence_number=mapping["latest_season_sequence_number"],
+            sleeper_league_id=mapping["latest_season_sleeper_league_id"],
+            created_at=mapping["latest_season_created_at"],
+        )
+    return CompetitionOverview(
+        competition=_decode_competition_identity(stored),
+        summary=CompetitionActivitySummary(
+            season_count=mapping["season_count"],
+            latest_season=latest_season,
+            latest_terminal_refresh=_decode_latest_refresh(mapping),
+            latest_successful_refresh_at=mapping["latest_successful_refresh_at"],
+            latest_ready_snapshot_at=mapping["latest_ready_snapshot_at"],
+            latest_submitted_article_at=mapping["latest_submitted_article_at"],
+        ),
+    )
+
+
+def _decode_season(row: sa.Row[object]) -> CompetitionSeasonOverview:
+    stored = cast(StoredCompetitionSeason, row[0])
+    mapping = row._mapping
+    return CompetitionSeasonOverview(
+        season=_decode_season_identity(stored),
+        summary=CompetitionSeasonActivitySummary(
+            league_name=mapping["league_name"],
+            league_status=mapping["league_status"],
+            latest_terminal_refresh=_decode_latest_refresh(mapping),
+            latest_successful_refresh_at=mapping["latest_successful_refresh_at"],
+            latest_ready_snapshot_at=mapping["latest_ready_snapshot_at"],
+        ),
+    )
+
+
+def _decode_latest_refresh(mapping: sa.RowMapping) -> LatestRefreshSummary | None:
+    completed_at = mapping["latest_refresh_completed_at"]
+    if completed_at is None:
+        return None
+    return LatestRefreshSummary(
+        status=RefreshStatus(mapping["latest_refresh_status"]),
+        requested_through_week=mapping["latest_refresh_requested_through_week"],
+        completed_at=completed_at,
+        request_count=mapping["latest_refresh_request_count"],
+        succeeded_request_count=mapping["latest_refresh_succeeded_request_count"],
+        failed_request_count=mapping["latest_refresh_failed_request_count"],
+    )
+
+
+def _decode_competition_identity(stored: StoredCompetition) -> Competition:
+    return Competition(
+        id=stored.id,
+        display_name=stored.display_name,
+        created_at=stored.created_at,
+        updated_at=stored.updated_at,
+        archived_at=stored.archived_at,
+    )
+
+
+def _decode_season_identity(stored: StoredCompetitionSeason) -> CompetitionSeason:
+    return CompetitionSeason(
+        id=stored.id,
+        competition_id=stored.competition_id,
+        season_year=stored.season_year,
+        sequence_number=stored.sequence_number,
+        sleeper_league_id=stored.sleeper_league_id,
+        created_at=stored.created_at,
+    )
+
+
+def _require_competition(session: Session, competition_id: UUID) -> None:
+    found = session.scalar(
+        sa.select(StoredCompetition.id).where(StoredCompetition.id == competition_id)
+    )
+    if found is None:
+        raise CoreResourceNotFound("competition", competition_id)
+
+
+__all__ = [
+    "CompetitionActivitySummary",
+    "CompetitionOverview",
+    "CompetitionOverviewPage",
+    "CompetitionOverviewReader",
+    "CompetitionSeasonActivitySummary",
+    "CompetitionSeasonDetail",
+    "CompetitionSeasonOverview",
+    "CompetitionSeasonOverviewPage",
+    "LatestRefreshSummary",
+]

--- a/backend/tests/api/test_competition_routes.py
+++ b/backend/tests/api/test_competition_routes.py
@@ -1,0 +1,411 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.api.app import create_app
+from backend.api.dependencies.competitions import (
+    get_competition_catalog_dependencies,
+    get_competition_season_dependencies,
+)
+from backend.composition import ApiRuntimeDependencies
+from backend.resources.core import (
+    Competition,
+    CompetitionActivitySummary,
+    CompetitionArchivedConflict,
+    CompetitionConcurrencyConflict,
+    CompetitionOverview,
+    CompetitionOverviewPage,
+    CompetitionQuery,
+    CompetitionSeason,
+    CompetitionSeasonActivitySummary,
+    CompetitionSeasonDetail,
+    CompetitionSeasonOverview,
+    CompetitionSeasonOverviewPage,
+    CompetitionSeasonQuery,
+    CompetitionSeasonYearExists,
+    CoreResourceNotFound,
+    SleeperLeagueIdExists,
+)
+
+
+NOW = datetime(2026, 8, 23, 12, tzinfo=UTC)
+
+
+class StubRuntime:
+    def assert_ready(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def runtime_factory() -> ApiRuntimeDependencies:
+    return StubRuntime()
+
+
+class StubCompetitionManager:
+    def __init__(self, competition: Competition) -> None:
+        self.competition = competition
+        self.created: list[object] = []
+        self.renamed: list[object] = []
+        self.archived: list[object] = []
+        self.error: Exception | None = None
+
+    def create(self, command: object) -> Competition:
+        self.created.append(command)
+        self._raise()
+        return self.competition
+
+    def rename(self, command: object) -> Competition:
+        self.renamed.append(command)
+        self._raise()
+        return self.competition.model_copy(update={"display_name": "Renamed"})
+
+    def archive(self, command: object) -> Competition:
+        self.archived.append(command)
+        self._raise()
+        return self.competition.model_copy(update={"archived_at": NOW})
+
+    def _raise(self) -> None:
+        if self.error is not None:
+            raise self.error
+
+
+class StubSeasonManager:
+    def __init__(self, season: CompetitionSeason) -> None:
+        self.season = season
+        self.created: list[object] = []
+        self.error: Exception | None = None
+
+    def create(self, command: object) -> CompetitionSeason:
+        self.created.append(command)
+        if self.error is not None:
+            raise self.error
+        return self.season
+
+
+class StubOverviewReader:
+    def __init__(
+        self,
+        overview: CompetitionOverview,
+        season_overview: CompetitionSeasonOverview,
+        season_detail: CompetitionSeasonDetail,
+    ) -> None:
+        self.overview = overview
+        self.season_overview = season_overview
+        self.season_detail = season_detail
+        self.competition_queries: list[CompetitionQuery] = []
+        self.season_queries: list[tuple[UUID, CompetitionSeasonQuery]] = []
+        self.competition_ids: list[UUID] = []
+        self.season_ids: list[tuple[UUID, UUID]] = []
+        self.error: Exception | None = None
+
+    def list_competitions(self, query: CompetitionQuery) -> CompetitionOverviewPage:
+        self.competition_queries.append(query)
+        self._raise()
+        return CompetitionOverviewPage(
+            items=(self.overview,), total=1, limit=query.limit, offset=query.offset
+        )
+
+    def get_competition(self, competition_id: UUID) -> CompetitionOverview:
+        self.competition_ids.append(competition_id)
+        self._raise()
+        return self.overview
+
+    def list_seasons(
+        self,
+        competition_id: UUID,
+        query: CompetitionSeasonQuery,
+    ) -> CompetitionSeasonOverviewPage:
+        self.season_queries.append((competition_id, query))
+        self._raise()
+        return CompetitionSeasonOverviewPage(
+            items=(self.season_overview,),
+            total=1,
+            limit=query.limit,
+            offset=query.offset,
+        )
+
+    def get_season(
+        self,
+        competition_id: UUID,
+        season_id: UUID,
+    ) -> CompetitionSeasonDetail:
+        self.season_ids.append((competition_id, season_id))
+        self._raise()
+        return self.season_detail
+
+    def _raise(self) -> None:
+        if self.error is not None:
+            raise self.error
+
+
+def _dependencies() -> SimpleNamespace:
+    competition_id = uuid4()
+    season_id = uuid4()
+    competition = Competition(
+        id=competition_id,
+        display_name="The League",
+        created_at=NOW,
+        updated_at=NOW,
+        archived_at=None,
+    )
+    season = CompetitionSeason(
+        id=season_id,
+        competition_id=competition_id,
+        season_year=2026,
+        sequence_number=1,
+        sleeper_league_id="sleeper-2026",
+        created_at=NOW,
+    )
+    season_summary = CompetitionSeasonActivitySummary(
+        league_name=None,
+        league_status=None,
+        latest_terminal_refresh=None,
+        latest_successful_refresh_at=None,
+        latest_ready_snapshot_at=None,
+    )
+    season_overview = CompetitionSeasonOverview(
+        season=season,
+        summary=season_summary,
+    )
+    overview = CompetitionOverview(
+        competition=competition,
+        summary=CompetitionActivitySummary(
+            season_count=1,
+            latest_season=season,
+            latest_terminal_refresh=None,
+            latest_successful_refresh_at=None,
+            latest_ready_snapshot_at=None,
+            latest_submitted_article_at=None,
+        ),
+    )
+    reader = StubOverviewReader(
+        overview,
+        season_overview,
+        CompetitionSeasonDetail(
+            season=season,
+            summary=season_summary,
+            normalized_overview=None,
+        ),
+    )
+    return SimpleNamespace(
+        competition=competition,
+        season=season,
+        competitions=StubCompetitionManager(competition),
+        seasons=StubSeasonManager(season),
+        overviews=reader,
+    )
+
+
+async def _client(dependencies: SimpleNamespace) -> tuple[Any, AsyncClient]:
+    app = create_app(runtime_factory=runtime_factory)
+    app.dependency_overrides[get_competition_catalog_dependencies] = lambda: (
+        dependencies
+    )
+    app.dependency_overrides[get_competition_season_dependencies] = lambda: (
+        dependencies
+    )
+    return app, AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+
+@pytest.mark.asyncio
+async def test_competition_catalog_routes_preserve_contracts() -> None:
+    dependencies = _dependencies()
+    app, client = await _client(dependencies)
+    base = "/api/v1/competitions"
+
+    async with app.router.lifespan_context(app), client:
+        listed = await client.get(
+            f"{base}?include_archived=true&limit=12&offset=3"
+        )
+        created = await client.post(base, json={"display_name": " The League "})
+        detail = await client.get(f"{base}/{dependencies.competition.id}")
+        renamed = await client.patch(
+            f"{base}/{dependencies.competition.id}",
+            json={"display_name": " Renamed "},
+        )
+        archived = await client.patch(
+            f"{base}/{dependencies.competition.id}",
+            json={"archived": True},
+        )
+        archived_again = await client.patch(
+            f"{base}/{dependencies.competition.id}",
+            json={"archived": True},
+        )
+
+    assert listed.status_code == 200
+    assert listed.json()["page"]["items"][0]["summary"]["season_count"] == 1
+    assert dependencies.overviews.competition_queries == [
+        CompetitionQuery(include_archived=True, limit=12, offset=3)
+    ]
+    assert created.status_code == 201
+    assert dependencies.competitions.created[0].display_name == "The League"
+    assert detail.json()["competition"]["id"] == str(dependencies.competition.id)
+    assert renamed.json()["competition"]["display_name"] == "Renamed"
+    assert dependencies.competitions.renamed[0].display_name == "Renamed"
+    assert archived.json()["competition"]["archived_at"] is not None
+    assert archived_again.status_code == 200
+    assert dependencies.competitions.archived[0].competition_id == (
+        dependencies.competition.id
+    )
+
+
+@pytest.mark.asyncio
+async def test_competition_season_routes_are_scoped_and_ordered() -> None:
+    dependencies = _dependencies()
+    app, client = await _client(dependencies)
+    base = f"/api/v1/competitions/{dependencies.competition.id}/seasons"
+
+    async with app.router.lifespan_context(app), client:
+        listed = await client.get(f"{base}?limit=7&offset=2")
+        created = await client.post(
+            base,
+            json={
+                "season_year": 2026,
+                "sleeper_league_id": " sleeper-2026 ",
+            },
+        )
+        detail = await client.get(f"{base}/{dependencies.season.id}")
+
+    assert listed.status_code == 200
+    assert dependencies.overviews.season_queries == [
+        (
+            dependencies.competition.id,
+            CompetitionSeasonQuery(limit=7, offset=2),
+        )
+    ]
+    assert created.status_code == 201
+    assert dependencies.seasons.created[0].sleeper_league_id == "sleeper-2026"
+    assert detail.status_code == 200
+    assert detail.json()["normalized_overview"] is None
+    assert dependencies.overviews.season_ids == [
+        (dependencies.competition.id, dependencies.season.id)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"display_name": None},
+        {"archived": False},
+        {"display_name": "Renamed", "archived": True},
+        {"unknown": "value"},
+    ],
+)
+async def test_competition_patch_rejects_ambiguous_bodies(
+    payload: dict[str, object],
+) -> None:
+    dependencies = _dependencies()
+    app, client = await _client(dependencies)
+
+    async with app.router.lifespan_context(app), client:
+        response = await client.patch(
+            f"/api/v1/competitions/{dependencies.competition.id}",
+            json=payload,
+        )
+
+    assert response.status_code == 422
+    assert dependencies.competitions.renamed == []
+    assert dependencies.competitions.archived == []
+
+
+@pytest.mark.asyncio
+async def test_typed_core_errors_have_stable_safe_payloads() -> None:
+    dependencies = _dependencies()
+    app, client = await _client(dependencies)
+    base = f"/api/v1/competitions/{dependencies.competition.id}"
+
+    async with app.router.lifespan_context(app), client:
+        dependencies.overviews.error = CoreResourceNotFound(
+            "competition", dependencies.competition.id
+        )
+        missing_competition = await client.get(base)
+        dependencies.overviews.error = CoreResourceNotFound(
+            "competition_season", dependencies.season.id
+        )
+        missing = await client.get(f"{base}/seasons/{dependencies.season.id}")
+        dependencies.overviews.error = None
+        dependencies.seasons.error = CompetitionSeasonYearExists(
+            dependencies.competition.id, 2026
+        )
+        duplicate = await client.post(
+            f"{base}/seasons",
+            json={"season_year": 2026, "sleeper_league_id": "different"},
+            headers={"X-Correlation-ID": str(uuid4())},
+        )
+        dependencies.seasons.error = SleeperLeagueIdExists("different")
+        duplicate_league = await client.post(
+            f"{base}/seasons",
+            json={"season_year": 2027, "sleeper_league_id": "different"},
+        )
+        dependencies.seasons.error = CompetitionArchivedConflict(
+            dependencies.competition.id
+        )
+        archived = await client.post(
+            f"{base}/seasons",
+            json={"season_year": 2027, "sleeper_league_id": "new"},
+        )
+        dependencies.competitions.error = CompetitionConcurrencyConflict(
+            "unsafe database detail", constraint_name="secret_constraint"
+        )
+        concurrent = await client.post(
+            "/api/v1/competitions", json={"display_name": "Concurrent"}
+        )
+
+    assert missing_competition.status_code == 404
+    assert missing_competition.json()["error"]["code"] == "competition_not_found"
+    assert missing.status_code == 404
+    assert missing.json() == {
+        "error": {
+            "code": "competition_season_not_found",
+            "summary": "competition season was not found",
+        }
+    }
+    assert duplicate.status_code == 409
+    assert duplicate.json()["error"]["code"] == "competition_season_year_exists"
+    assert duplicate.json()["error"]["field_errors"] == {
+        "season_year": ["Already attached to this competition."]
+    }
+    assert "constraint" not in duplicate.text
+    assert duplicate_league.status_code == 409
+    assert duplicate_league.json()["error"]["code"] == "sleeper_league_id_exists"
+    assert duplicate_league.json()["error"]["field_errors"] == {
+        "sleeper_league_id": ["Already attached to another season."]
+    }
+    assert archived.status_code == 409
+    assert archived.json()["error"]["code"] == "competition_archived"
+    assert concurrent.status_code == 409
+    assert concurrent.json()["error"]["code"] == (
+        "competition_concurrency_conflict"
+    )
+    assert "secret_constraint" not in concurrent.text
+    assert "unsafe database detail" not in concurrent.text
+
+
+def test_openapi_contains_competition_and_season_boundaries() -> None:
+    schema = create_app(runtime_factory=runtime_factory).openapi()
+    paths = set(schema["paths"])
+    base = "/api/v1/competitions"
+
+    assert {
+        base,
+        f"{base}/{{competition_id}}",
+        f"{base}/{{competition_id}}/seasons",
+        f"{base}/{{competition_id}}/seasons/{{season_id}}",
+    }.issubset(paths)
+    patch_schema = schema["paths"][f"{base}/{{competition_id}}"]["patch"]
+    assert "422" in patch_schema["responses"]
+    assert "409" in patch_schema["responses"]
+    assert patch_schema["responses"]["409"]["content"]["application/json"][
+        "example"
+    ]["error"]["code"] == "competition_season_year_exists"

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -7,6 +7,8 @@ from sqlalchemy.engine import make_url
 
 from backend.composition import (
     build_api_runtime,
+    build_competition_catalog_dependencies,
+    build_competition_season_dependencies,
     build_datalayer_refresh_dependencies,
     build_datalayer_snapshot_dependencies,
     build_generation_dependencies,
@@ -16,10 +18,54 @@ from backend.composition import (
 from backend.config import DatalayerSettings, GenerationRuntimeSettings
 from backend.database.sessions import create_session_factory
 from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.context import GlobalScope
+from backend.resources.core import (
+    CompetitionManager,
+    CompetitionOverviewReader,
+    CompetitionSeasonManager,
+)
 from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.datalayer.snapshot_service import DatalayerSnapshotService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 from backend.services.generations import GenerationService
+
+
+def test_competition_api_composition_builds_global_and_scoped_dependencies() -> None:
+    competition_id = uuid4()
+    engine = create_engine("sqlite://")
+    session_factory = create_session_factory(engine)
+    global_context = ManagerContext[GlobalScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {"kind": "global", "reason": "test catalog"},
+            "correlation_id": uuid4(),
+        }
+    )
+    scoped_context = ManagerContext[CompetitionScope].model_validate(
+        {
+            "actor": {"kind": "local_user"},
+            "scope": {
+                "kind": "competition",
+                "competition_id": competition_id,
+            },
+            "correlation_id": uuid4(),
+        }
+    )
+    try:
+        catalog = build_competition_catalog_dependencies(
+            session_factory, global_context
+        )
+        seasons = build_competition_season_dependencies(
+            session_factory, scoped_context
+        )
+
+        assert isinstance(catalog.competitions, CompetitionManager)
+        assert isinstance(catalog.overviews, CompetitionOverviewReader)
+        assert isinstance(seasons.seasons, CompetitionSeasonManager)
+        assert seasons.seasons.competition_id == competition_id
+        assert isinstance(seasons.overviews, CompetitionOverviewReader)
+    finally:
+        engine.dispose()
 
 
 def test_build_api_runtime_uses_url_identity_and_local_tls_setting(

--- a/backend/tests/resources/core/test_competition_overviews.py
+++ b/backend/tests/resources/core/test_competition_overviews.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.reporting import Artifact, ArtifactVersion
+from backend.database.models.reporting import Generation as StoredGeneration
+from backend.database.models.sleeper import DataSnapshot, RefreshRun
+from backend.database.sessions import SessionFactory
+from backend.resources.core import (
+    ArchiveCompetition,
+    CompetitionManager,
+    CompetitionOverviewReader,
+    CompetitionQuery,
+    CompetitionSeasonManager,
+    CompetitionSeasonQuery,
+    CoreResourceNotFound,
+    CreateCompetition,
+    CreateCompetitionSeason,
+)
+from backend.tests.resources.core.conftest import competition_context
+
+
+def _season_manager(
+    session_factory: SessionFactory,
+    competition_id: UUID,
+) -> CompetitionSeasonManager:
+    return CompetitionSeasonManager(
+        session_factory,
+        competition_context(competition_id),
+    )
+
+
+def test_overview_pages_are_ordered_paginated_and_archive_aware(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    zulu = competition_manager.create(CreateCompetition(display_name="Zulu"))
+    alpha = competition_manager.create(CreateCompetition(display_name="alpha"))
+    archived = competition_manager.create(
+        CreateCompetition(display_name="Archived")
+    )
+    latest = _season_manager(session_factory, alpha.id).create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id=f"league-{uuid4()}",
+        )
+    )
+    competition_manager.archive(ArchiveCompetition(competition_id=archived.id))
+    reader = CompetitionOverviewReader(session_factory)
+
+    active = reader.list_competitions(CompetitionQuery(limit=1))
+    next_page = reader.list_competitions(CompetitionQuery(limit=1, offset=1))
+    all_rows = reader.list_competitions(
+        CompetitionQuery(include_archived=True, limit=10)
+    )
+
+    assert active.total == 2
+    assert active.items[0].competition.id == alpha.id
+    assert active.items[0].summary.season_count == 1
+    assert active.items[0].summary.latest_season == latest
+    assert next_page.items[0].competition.id == zulu.id
+    assert all_rows.total == 3
+    assert archived.id in {item.competition.id for item in all_rows.items}
+
+
+def test_activity_summaries_filter_status_and_use_deterministic_ties(
+    database_engine: Engine,
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    competition = competition_manager.create(
+        CreateCompetition(display_name="Activity")
+    )
+    season = _season_manager(session_factory, competition.id).create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id=f"league-{uuid4()}",
+        )
+    )
+    other = competition_manager.create(CreateCompetition(display_name="Other"))
+    other_season = _season_manager(session_factory, other.id).create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id=f"league-{uuid4()}",
+        )
+    )
+    base = datetime(2026, 8, 20, 12, tzinfo=UTC)
+    successful_id = UUID(int=1)
+    tied_failed_id = UUID(int=2)
+    tied_partial_id = UUID(int=3)
+    snapshot_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(RefreshRun),
+            [
+                {
+                    "id": successful_id,
+                    "competition_id": competition.id,
+                    "competition_season_id": season.id,
+                    "requested_through_week": 7,
+                    "endpoint_scope": {},
+                    "trigger_source": "manual",
+                    "status": "succeeded",
+                    "code_version": "test",
+                    "normalizer_version": "test",
+                    "started_at": base,
+                    "completed_at": base,
+                    "request_count": 4,
+                    "succeeded_request_count": 4,
+                    "failed_request_count": 0,
+                },
+                {
+                    "id": tied_failed_id,
+                    "competition_id": competition.id,
+                    "competition_season_id": season.id,
+                    "requested_through_week": 8,
+                    "endpoint_scope": {},
+                    "trigger_source": "manual",
+                    "status": "failed",
+                    "code_version": "test",
+                    "normalizer_version": "test",
+                    "started_at": base + timedelta(days=1),
+                    "completed_at": base + timedelta(days=1),
+                    "request_count": 4,
+                    "succeeded_request_count": 0,
+                    "failed_request_count": 4,
+                },
+                {
+                    "id": tied_partial_id,
+                    "competition_id": competition.id,
+                    "competition_season_id": season.id,
+                    "requested_through_week": 9,
+                    "endpoint_scope": {},
+                    "trigger_source": "manual",
+                    "status": "partial",
+                    "code_version": "test",
+                    "normalizer_version": "test",
+                    "started_at": base + timedelta(days=1),
+                    "completed_at": base + timedelta(days=1),
+                    "request_count": 5,
+                    "succeeded_request_count": 4,
+                    "failed_request_count": 1,
+                },
+                {
+                    "id": uuid4(),
+                    "competition_id": competition.id,
+                    "competition_season_id": season.id,
+                    "requested_through_week": 10,
+                    "endpoint_scope": {},
+                    "trigger_source": "manual",
+                    "status": "running",
+                    "code_version": "test",
+                    "normalizer_version": "test",
+                    "started_at": base + timedelta(days=2),
+                    "request_count": 0,
+                    "succeeded_request_count": 0,
+                    "failed_request_count": 0,
+                },
+            ],
+        )
+        connection.execute(
+            sa.insert(DataSnapshot),
+            [
+                {
+                    "id": snapshot_id,
+                    "competition_id": competition.id,
+                    "primary_competition_season_id": season.id,
+                    "build_key": "a" * 64,
+                    "domain_cutoff_week": 9,
+                    "as_of_date": date(2026, 8, 21),
+                    "status": "ready",
+                    "snapshot_projection_version": "1",
+                    "code_version": "test",
+                    "completeness_warnings": [],
+                    "sqlite_artifact_sha256": "b" * 64,
+                    "sqlite_artifact_byte_length": 10,
+                    "sqlite_artifact_storage_key": "snapshots/activity.sqlite",
+                    "created_at": base,
+                    "completed_at": base + timedelta(days=2),
+                },
+                {
+                    "id": uuid4(),
+                    "competition_id": competition.id,
+                    "primary_competition_season_id": season.id,
+                    "build_key": "c" * 64,
+                    "domain_cutoff_week": 10,
+                    "as_of_date": date(2026, 8, 22),
+                    "status": "failed",
+                    "snapshot_projection_version": "1",
+                    "code_version": "test",
+                    "completeness_warnings": [],
+                    "failure_summary": {
+                        "code": "failed",
+                        "summary": "not ready",
+                    },
+                    "created_at": base,
+                    "completed_at": base + timedelta(days=3),
+                },
+            ],
+        )
+        _insert_submitted_generation(
+            connection,
+            competition.id,
+            season.id,
+            completed_at=base + timedelta(days=4),
+        )
+        _insert_unsubmitted_generation(
+            connection,
+            competition.id,
+            season.id,
+            completed_at=base + timedelta(days=5),
+        )
+        connection.execute(
+            sa.insert(RefreshRun),
+            {
+                "id": uuid4(),
+                "competition_id": other.id,
+                "competition_season_id": other_season.id,
+                "requested_through_week": 18,
+                "endpoint_scope": {},
+                "trigger_source": "manual",
+                "status": "succeeded",
+                "code_version": "test",
+                "normalizer_version": "test",
+                "started_at": base + timedelta(days=10),
+                "completed_at": base + timedelta(days=10),
+                "request_count": 1,
+                "succeeded_request_count": 1,
+                "failed_request_count": 0,
+            },
+        )
+
+    reader = CompetitionOverviewReader(session_factory)
+    overview = reader.get_competition(competition.id)
+    season_item = reader.list_seasons(
+        competition.id, CompetitionSeasonQuery()
+    ).items[0]
+
+    assert overview.summary.latest_terminal_refresh is not None
+    assert overview.summary.latest_terminal_refresh.status.value == "partial"
+    assert overview.summary.latest_terminal_refresh.requested_through_week == 9
+    assert overview.summary.latest_successful_refresh_at == base
+    assert overview.summary.latest_ready_snapshot_at == base + timedelta(days=2)
+    assert overview.summary.latest_submitted_article_at == base + timedelta(days=4)
+    assert season_item.summary.latest_terminal_refresh is not None
+    assert season_item.summary.latest_terminal_refresh.failed_request_count == 1
+    assert season_item.summary.league_name is None
+
+
+def test_season_detail_masks_cross_competition_and_allows_missing_normalized_data(
+    session_factory: SessionFactory,
+    competition_manager: CompetitionManager,
+) -> None:
+    first = competition_manager.create(CreateCompetition(display_name="First"))
+    second = competition_manager.create(CreateCompetition(display_name="Second"))
+    season = _season_manager(session_factory, first.id).create(
+        CreateCompetitionSeason(
+            season_year=2026,
+            sleeper_league_id=f"league-{uuid4()}",
+        )
+    )
+    reader = CompetitionOverviewReader(session_factory)
+
+    detail = reader.get_season(first.id, season.id)
+    assert detail.normalized_overview is None
+    with pytest.raises(CoreResourceNotFound, match="competition_season"):
+        reader.get_season(second.id, season.id)
+
+
+def _insert_submitted_generation(
+    connection: sa.Connection,
+    competition_id: UUID,
+    season_id: UUID,
+    *,
+    completed_at: datetime,
+) -> None:
+    generation_id = uuid4()
+    artifact_id = uuid4()
+    version_id = uuid4()
+    connection.execute(
+        sa.insert(StoredGeneration),
+        {
+            "id": generation_id,
+            "competition_id": competition_id,
+            "competition_season_id": season_id,
+            "kind": "live",
+            "status": "pending",
+            "request_text": "recap",
+            "requested_primary_model": "test-model",
+            "settings_jsonb": {"schema_version": 1},
+            "current_turn": 0,
+        },
+    )
+    connection.execute(
+        sa.insert(Artifact),
+        {
+            "id": artifact_id,
+            "generation_id": generation_id,
+            "path": "article.md",
+            "media_type": "text/markdown",
+        },
+    )
+    connection.execute(
+        sa.insert(ArtifactVersion),
+        {
+            "id": version_id,
+            "artifact_id": artifact_id,
+            "generation_id": generation_id,
+            "revision_number": 1,
+            "content": "# Article",
+            "content_hash": "d" * 64,
+        },
+    )
+    connection.execute(
+        sa.update(Artifact)
+        .where(Artifact.id == artifact_id)
+        .values(finalized_version_id=version_id, finalized_at=completed_at)
+    )
+    connection.execute(
+        sa.update(StoredGeneration)
+        .where(StoredGeneration.id == generation_id)
+        .values(
+            status="succeeded",
+            submitted_artifact_version_id=version_id,
+            completed_at=completed_at,
+        )
+    )
+
+
+def _insert_unsubmitted_generation(
+    connection: sa.Connection,
+    competition_id: UUID,
+    season_id: UUID,
+    *,
+    completed_at: datetime,
+) -> None:
+    connection.execute(
+        sa.insert(StoredGeneration),
+        {
+            "id": uuid4(),
+            "competition_id": competition_id,
+            "competition_season_id": season_id,
+            "kind": "live",
+            "status": "succeeded",
+            "request_text": "draft only",
+            "requested_primary_model": "test-model",
+            "settings_jsonb": {"schema_version": 1},
+            "current_turn": 1,
+            "completed_at": completed_at,
+        },
+    )

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -49,13 +49,13 @@ Recommended routes:
 
 | Method and path | Purpose | Status |
 | --- | --- | --- |
-| `GET /competitions` | List active competitions with season/freshness/article summary | Missing |
-| `POST /competitions` | Create `{display_name}` | Missing |
-| `GET /competitions/{competition_id}` | Competition detail and summary | Missing |
-| `PATCH /competitions/{competition_id}` | Rename or archive through explicit allowed fields | Missing |
-| `GET /competitions/{competition_id}/seasons` | Ordered season list | Missing |
-| `POST /competitions/{competition_id}/seasons` | Attach `{season_year, sleeper_league_id}` and derive sequence | Missing |
-| `GET /competitions/{competition_id}/seasons/{season_id}` | Season identity plus normalized league overview when present | Missing |
+| `GET /competitions` | List active competitions with season/freshness/article summary | Implemented |
+| `POST /competitions` | Create `{display_name}` | Implemented |
+| `GET /competitions/{competition_id}` | Competition detail and summary | Implemented |
+| `PATCH /competitions/{competition_id}` | Rename or archive through explicit allowed fields | Implemented |
+| `GET /competitions/{competition_id}/seasons` | Ordered season list | Implemented |
+| `POST /competitions/{competition_id}/seasons` | Attach `{season_year, sleeper_league_id}` and derive sequence | Implemented |
+| `GET /competitions/{competition_id}/seasons/{season_id}` | Season identity plus normalized league overview when present | Implemented |
 
 Example creation response:
 
@@ -71,10 +71,49 @@ Example creation response:
 }
 ```
 
+`PATCH /competitions/{competition_id}` accepts exactly one sparse change:
+
+```json
+{"display_name": "Renamed League"}
+```
+
+or:
+
+```json
+{"archived": true}
+```
+
+Empty bodies, null values, `archived: false`, combined changes, and unknown
+fields are rejected with `422`. Restore remains out of scope.
+
 The list/detail projection should include summaries the UI otherwise has to
 assemble with N+1 requests: season count/latest season, latest terminal and
 successful refresh timestamps, latest ready snapshot time, and latest submitted
 article time. These are read projections, not denormalized write contracts.
+
+Competition list items and detail responses carry the canonical competition
+beside that activity summary. Season list items carry the canonical season,
+normalized league name/status when available, latest terminal refresh status,
+boundary and counts, latest successful refresh time, and latest ready snapshot
+time. Season detail adds the complete normalized league overview when one has
+been loaded; before the first refresh that field is `null`.
+
+Typed competition errors use the new product envelope:
+
+```json
+{
+  "error": {
+    "code": "competition_season_year_exists",
+    "summary": "that season year is already attached to this competition",
+    "field_errors": {"season_year": ["Already attached to this competition."]}
+  }
+}
+```
+
+The stable core codes are `competition_not_found`,
+`competition_season_not_found`, `competition_archived`,
+`competition_season_year_exists`, `sleeper_league_id_exists`, and
+`competition_concurrency_conflict`.
 
 Season creation must return `409` codes for at least
 `competition_season_year_exists` and `sleeper_league_id_exists`. Editing an ID


### PR DESCRIPTION
## Summary

- add competition catalog and scoped season HTTP routes
- add set-based activity projections for seasons, refreshes, snapshots, and submitted articles
- add stable core product errors, composition wiring, and OpenAPI examples
- document the finalized competition API contract

## Verification

- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_competition_routes.py backend/tests/api/test_composition.py -k "competition"` — 10 passed
- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_app.py` — 5 passed
- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_generation_routes.py` — 4 passed
- `.venv\Scripts\python.exe -m pytest backend/tests/resources/core/` — 12 passed, 11 skipped
- `git diff --cached --check`

## Gate

Draft until `AIDAM_TEST_DATABASE_URL` is configured and the PostgreSQL-backed manager and overview tests pass.

Stacked on #163 / `codex/ui-1-competition-resources`.
