### PR TITLE
feat(api): add model catalog and usage quotes

### DIFF
--- a/backend/api/dependencies/__init__.py
+++ b/backend/api/dependencies/__init__.py
@@ -13,6 +13,7 @@ from backend.api.dependencies.memory import (
     get_correlation_id,
     get_memory_api_dependencies,
 )
+from backend.api.dependencies.models import get_model_catalog
 from backend.api.dependencies.services import get_api_runtime
 from backend.api.dispatch import get_generation_dispatcher
 
@@ -26,4 +27,5 @@ __all__ = [
     "get_generation_api_dependencies",
     "get_generation_dispatcher",
     "get_memory_api_dependencies",
+    "get_model_catalog",
 ]

--- a/backend/api/dependencies/generations.py
+++ b/backend/api/dependencies/generations.py
@@ -38,5 +38,6 @@ def get_generation_api_dependencies(
     return build_generation_dependencies(
         generation_runtime.session_factory,
         context,
+        model_registry=generation_runtime.model_registry,
     )
 

--- a/backend/api/dependencies/models.py
+++ b/backend/api/dependencies/models.py
@@ -1,0 +1,15 @@
+"""Process-scoped configured model catalog dependency."""
+
+from typing import Annotated, cast
+
+from fastapi import Depends
+
+from backend.api.dependencies.services import get_api_runtime
+from backend.composition import ApiRuntimeDependencies, ModelApiRuntimeDependencies
+from backend.services.model_usage import ModelCatalogService
+
+
+def get_model_catalog(
+    runtime: Annotated[ApiRuntimeDependencies, Depends(get_api_runtime)],
+) -> ModelCatalogService:
+    return cast(ModelApiRuntimeDependencies, runtime).model_catalog

--- a/backend/api/routes/__init__.py
+++ b/backend/api/routes/__init__.py
@@ -7,11 +7,13 @@ from backend.api.routes.data import router as data_router
 from backend.api.routes.generations import router as generations_router
 from backend.api.routes.health import router as health_router
 from backend.api.routes.memory import router as memory_router
+from backend.api.routes.models import router as models_router
 
 api_router = APIRouter()
 api_router.include_router(competitions_router)
 api_router.include_router(generations_router)
 api_router.include_router(memory_router)
 api_router.include_router(data_router)
+api_router.include_router(models_router)
 
 __all__ = ["api_router", "health_router"]

--- a/backend/api/routes/generations.py
+++ b/backend/api/routes/generations.py
@@ -20,6 +20,7 @@ from backend.api.schemas.generations import (
     GenerationDetailResponse,
     GenerationPageResponse,
     GenerationResponse,
+    GenerationUsageResponse,
     SubmitGenerationBody,
     SubmittedArticleResponse,
     ToolCallPageResponse,
@@ -168,6 +169,14 @@ def generation_detail(
     return GenerationDetailResponse(
         generation=dependencies.generations.get(generation_id)
     )
+
+
+@router.get("/{generation_id}/usage", response_model=GenerationUsageResponse)
+def generation_usage(
+    generation_id: UUID,
+    dependencies: GenerationApi,
+) -> GenerationUsageResponse:
+    return GenerationUsageResponse(usage=dependencies.usage.get(generation_id))
 
 
 @router.get(

--- a/backend/api/routes/models.py
+++ b/backend/api/routes/models.py
@@ -1,0 +1,18 @@
+"""Configured model-selection routes."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.api.dependencies import get_model_catalog
+from backend.api.schemas.models import ModelCatalogResponse
+from backend.services.model_usage import ModelCatalogService
+
+
+router = APIRouter(tags=["models"])
+ModelCatalogDependency = Annotated[ModelCatalogService, Depends(get_model_catalog)]
+
+
+@router.get("/models", response_model=ModelCatalogResponse)
+def model_catalog(catalog: ModelCatalogDependency) -> ModelCatalogResponse:
+    return ModelCatalogResponse(models=catalog.list().models)

--- a/backend/api/schemas/generations.py
+++ b/backend/api/schemas/generations.py
@@ -20,6 +20,7 @@ from backend.resources.reporting.generations import (
 )
 from backend.resources.reporting.tool_calls import ToolCall, ToolCallPage
 from backend.services.generations import GenerationSettings
+from backend.services.model_usage import GenerationUsage
 
 
 PositiveWeek = Annotated[int, Field(strict=True, ge=1, le=18)]
@@ -55,6 +56,10 @@ class GenerationDetailResponse(GenerationApiModel):
 
 class GenerationPageResponse(GenerationApiModel):
     page: GenerationPage
+
+
+class GenerationUsageResponse(GenerationApiModel):
+    usage: GenerationUsage
 
 
 class AICallResponse(GenerationApiModel):

--- a/backend/api/schemas/models.py
+++ b/backend/api/schemas/models.py
@@ -1,0 +1,13 @@
+"""Transport models for configured model selection."""
+
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict
+
+from backend.services.model_usage import ModelCatalogItem
+
+
+class ModelCatalogResponse(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    models: tuple[ModelCatalogItem, ...]

--- a/backend/composition.py
+++ b/backend/composition.py
@@ -10,6 +10,7 @@ from backend.config import (
     DatabaseSettings,
     DatalayerSettings,
     GenerationRuntimeSettings,
+    ModelCatalogSettings,
 )
 from backend.database.engine import build_runtime_engine
 from backend.database.health import assert_database_ready, read_database_health
@@ -53,6 +54,11 @@ from backend.services.datalayer import (
 from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.generations import GenerationFinalizer, GenerationService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
+from backend.services.model_usage import (
+    GenerationUsageService,
+    LiteLLMModelRegistry,
+    ModelCatalogService,
+)
 
 
 class ApiRuntimeDependencies(Protocol):
@@ -73,6 +79,13 @@ class GenerationRuntimeDependencies(ApiRuntimeDependencies, Protocol):
     """Runtime capabilities required by generation API and worker boundaries."""
 
     session_factory: SessionFactory
+    model_registry: LiteLLMModelRegistry
+
+
+class ModelApiRuntimeDependencies(ApiRuntimeDependencies, Protocol):
+    """Runtime capabilities required by the configured model catalog."""
+
+    model_catalog: ModelCatalogService
 
 
 class CompetitionApiRuntimeDependencies(ApiRuntimeDependencies, Protocol):
@@ -96,6 +109,8 @@ class ApiRuntime:
     expected_database: str
     expected_role: str
     require_tls: bool
+    model_registry: LiteLLMModelRegistry
+    model_catalog: ModelCatalogService
 
     def assert_ready(self) -> None:
         """Verify the API's bounded runtime database invariants."""
@@ -209,6 +224,7 @@ class GenerationDependencies:
     tool_calls: ToolCallManager
     artifacts: ArtifactManager
     artifact_versions: ArtifactVersionManager
+    usage: GenerationUsageService
 
 
 def build_competition_catalog_dependencies(
@@ -372,6 +388,7 @@ def build_generation_dependencies(
     *,
     datalayer_settings: DatalayerSettings | None = None,
     runtime_settings: GenerationRuntimeSettings | None = None,
+    model_registry: LiteLLMModelRegistry | None = None,
 ) -> GenerationDependencies:
     """Compose one generation service and its competition-scoped read boundary."""
 
@@ -381,6 +398,7 @@ def build_generation_dependencies(
     tool_calls = ToolCallManager(session_factory, context)
     artifacts = ArtifactManager(session_factory, context)
     artifact_versions = ArtifactVersionManager(session_factory, context)
+    registry = model_registry or LiteLLMModelRegistry()
     memory = build_memory_api_dependencies(session_factory, context)
     snapshots = build_datalayer_snapshot_dependencies(
         session_factory,
@@ -407,6 +425,7 @@ def build_generation_dependencies(
         tool_calls=tool_calls,
         artifacts=artifacts,
         artifact_versions=artifact_versions,
+        usage=GenerationUsageService(ai_calls, registry),
     )
 
 
@@ -418,12 +437,18 @@ def build_api_runtime() -> ApiRuntime:
     if url.database is None or url.username is None:
         raise ValueError("database URL must include a database and runtime user")
     engine = build_runtime_engine(settings.engine_settings("api"))
+    model_registry = LiteLLMModelRegistry()
     return ApiRuntime(
         engine=engine,
         session_factory=create_session_factory(engine),
         expected_database=url.database,
         expected_role=url.username,
         require_tls=settings.require_tls,
+        model_registry=model_registry,
+        model_catalog=ModelCatalogService(
+            ModelCatalogSettings.from_environment(),
+            model_registry,
+        ),
     )
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -126,6 +126,32 @@ class GenerationRuntimeSettings:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelCatalogSettings:
+    """Configured model choices exposed by the product API."""
+
+    primary_model: str
+    fallback_models: tuple[str, ...]
+
+    @classmethod
+    def from_environment(cls) -> "ModelCatalogSettings":
+        primary = os.getenv("REPORTER_MODEL", "gpt-5-mini").strip()
+        if not primary:
+            raise ValueError("REPORTER_MODEL must not be empty")
+        raw_fallbacks = os.getenv("REPORTER_FALLBACK_MODELS", "")
+        ordered: list[str] = []
+        seen = {primary}
+        for raw_model in raw_fallbacks.split(","):
+            model = raw_model.strip()
+            if model and model not in seen:
+                seen.add(model)
+                ordered.append(model)
+        return cls(primary_model=primary, fallback_models=tuple(ordered))
+
+    def model_chain(self) -> tuple[str, ...]:
+        return (self.primary_model, *self.fallback_models)
+
+
+@dataclass(frozen=True, slots=True)
 class DatalayerSettings:
     """Local storage and Sleeper source settings for datalayer composition."""
 

--- a/backend/services/model_usage/__init__.py
+++ b/backend/services/model_usage/__init__.py
@@ -1,0 +1,23 @@
+"""Configured model metadata and generation usage estimates."""
+
+from backend.services.model_usage.catalog import ModelCatalogService
+from backend.services.model_usage.objects import (
+    GenerationUsage,
+    ModelCatalog,
+    ModelCatalogItem,
+    ModelUsageBreakdown,
+    TokenTotals,
+)
+from backend.services.model_usage.pricing import LiteLLMModelRegistry
+from backend.services.model_usage.usage import GenerationUsageService
+
+__all__ = [
+    "GenerationUsage",
+    "GenerationUsageService",
+    "LiteLLMModelRegistry",
+    "ModelCatalog",
+    "ModelCatalogItem",
+    "ModelCatalogService",
+    "ModelUsageBreakdown",
+    "TokenTotals",
+]

--- a/backend/services/model_usage/catalog.py
+++ b/backend/services/model_usage/catalog.py
@@ -1,0 +1,32 @@
+"""Configured model-selection catalog."""
+
+from backend.config import ModelCatalogSettings
+from backend.services.model_usage.objects import ModelCatalog, ModelCatalogItem
+from backend.services.model_usage.pricing import LiteLLMModelRegistry
+
+
+class ModelCatalogService:
+    def __init__(
+        self,
+        settings: ModelCatalogSettings,
+        registry: LiteLLMModelRegistry,
+    ) -> None:
+        self._settings = settings
+        self._registry = registry
+
+    def list(self) -> ModelCatalog:
+        items: list[ModelCatalogItem] = []
+        for model in self._settings.model_chain():
+            info = self._registry.model_info(model)
+            items.append(
+                ModelCatalogItem(
+                    provider=self._registry.provider_for(model),
+                    model=model,
+                    display_name=model.rsplit("/", 1)[-1],
+                    is_default=model == self._settings.primary_model,
+                    supports_reasoning=bool(
+                        info is not None and info.get("supports_reasoning") is True
+                    ),
+                )
+            )
+        return ModelCatalog(models=tuple(items))

--- a/backend/services/model_usage/objects.py
+++ b/backend/services/model_usage/objects.py
@@ -1,0 +1,58 @@
+"""Transport-safe model catalog and generation usage projections."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from backend.resources._contracts import ContractModel
+
+
+NonNegativeInt = Annotated[int, Field(strict=True, ge=0)]
+
+
+class ModelCatalogItem(ContractModel):
+    provider: str | None
+    model: str
+    display_name: str
+    is_default: bool
+    supports_reasoning: bool
+
+
+class ModelCatalog(ContractModel):
+    models: tuple[ModelCatalogItem, ...]
+
+
+class TokenTotals(ContractModel):
+    input_tokens: NonNegativeInt = 0
+    cached_input_tokens: NonNegativeInt = 0
+    output_tokens: NonNegativeInt = 0
+    reasoning_tokens: NonNegativeInt = 0
+    total_tokens: NonNegativeInt = 0
+
+
+class ModelUsageBreakdown(ContractModel):
+    provider: str | None
+    model: str | None
+    attempt_count: NonNegativeInt
+    latency_ms: NonNegativeInt
+    tokens: TokenTotals
+    estimated_cost: str | None
+    currency: str
+    complete: bool
+
+
+class GenerationUsage(ContractModel):
+    generation_id: UUID
+    attempt_count: NonNegativeInt
+    latency_ms: NonNegativeInt
+    tokens: TokenTotals
+    breakdowns: tuple[ModelUsageBreakdown, ...]
+    estimated_cost: str | None
+    currency: str
+    complete: bool
+    missing_usage_call_ids: tuple[UUID, ...]
+    unpriced_call_ids: tuple[UUID, ...]
+    quoted_at: AwareDatetime

--- a/backend/services/model_usage/pricing.py
+++ b/backend/services/model_usage/pricing.py
@@ -1,0 +1,171 @@
+"""Lazy access to LiteLLM's published model metadata and token prices."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from decimal import Decimal
+from importlib.metadata import distribution
+import json
+from pathlib import Path
+from threading import Lock
+from typing import Any, cast
+
+import requests
+
+from backend.resources.reporting.ai_calls import TokenUsage
+
+
+ModelInfo = Mapping[str, Any]
+ModelMap = Mapping[str, ModelInfo]
+ModelMapLoader = Callable[[], ModelMap]
+
+LITELLM_MODEL_MAP_URL = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
+    "model_prices_and_context_window.json"
+)
+
+
+class LiteLLMModelRegistry:
+    """Cache LiteLLM metadata and quote standard text-token usage."""
+
+    def __init__(
+        self,
+        *,
+        remote_loader: ModelMapLoader | None = None,
+        fallback_loader: ModelMapLoader | None = None,
+    ) -> None:
+        self._remote_loader = remote_loader or _load_remote_model_map
+        self._fallback_loader = fallback_loader or _load_bundled_model_map
+        self._model_map: ModelMap | None = None
+        self._lock = Lock()
+
+    def model_info(
+        self,
+        model: str,
+        provider: str | None = None,
+    ) -> ModelInfo | None:
+        resolved = self._resolve(model, provider)
+        return resolved[1] if resolved is not None else None
+
+    def provider_for(self, model: str) -> str | None:
+        info = self.model_info(model)
+        if info is not None:
+            provider = info.get("litellm_provider")
+            if isinstance(provider, str) and provider.strip():
+                return provider.strip()
+        prefix, separator, _ = model.partition("/")
+        return prefix if separator and prefix else None
+
+    def quote(
+        self,
+        provider: str | None,
+        model: str,
+        usage: TokenUsage,
+    ) -> Decimal | None:
+        """Return a current USD estimate for normalized text-token usage."""
+
+        resolved = self._resolve(model, provider)
+        if resolved is None:
+            return None
+        _, info = resolved
+        input_rate = _rate(info, "input_cost_per_token")
+        output_rate = _rate(info, "output_cost_per_token")
+        cached_rate = _first_rate(
+            info,
+            "cache_read_input_token_cost",
+            "input_cost_per_token_cache_hit",
+        )
+        reasoning_rate = _rate(info, "output_cost_per_reasoning_token")
+
+        if usage.input_tokens is None and usage.output_tokens is None:
+            return None
+        cost = Decimal(0)
+        if usage.input_tokens is not None:
+            if input_rate is None:
+                return None
+            cached = usage.cached_input_tokens or 0
+            if cached > usage.input_tokens:
+                return None
+            regular_input = usage.input_tokens - cached
+            cost += Decimal(regular_input) * input_rate
+            cost += Decimal(cached) * (cached_rate or input_rate)
+        if usage.output_tokens is not None:
+            if output_rate is None:
+                return None
+            reasoning = usage.reasoning_tokens or 0
+            if reasoning > usage.output_tokens:
+                return None
+            regular_output = usage.output_tokens - reasoning
+            cost += Decimal(regular_output) * output_rate
+            cost += Decimal(reasoning) * (reasoning_rate or output_rate)
+        return cost
+
+    def _resolve(
+        self,
+        model: str,
+        provider: str | None,
+    ) -> tuple[str, ModelInfo] | None:
+        model_map = self._models()
+        candidates: list[str] = []
+        if provider and not model.startswith(f"{provider}/"):
+            candidates.append(f"{provider}/{model}")
+        candidates.append(model)
+        if "/" in model:
+            candidates.append(model.split("/", 1)[1])
+        for candidate in candidates:
+            info = model_map.get(candidate)
+            if isinstance(info, Mapping):
+                return candidate, cast(ModelInfo, info)
+        return None
+
+    def _models(self) -> ModelMap:
+        if self._model_map is not None:
+            return self._model_map
+        with self._lock:
+            if self._model_map is None:
+                try:
+                    loaded = self._remote_loader()
+                except Exception:
+                    loaded = self._fallback_loader()
+                self._model_map = loaded
+        return self._model_map
+
+
+def _load_remote_model_map() -> ModelMap:
+    response = requests.get(LITELLM_MODEL_MAP_URL, timeout=(3.0, 10.0))
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("LiteLLM model map must be a JSON object")
+    return cast(ModelMap, payload)
+
+
+def _load_bundled_model_map() -> ModelMap:
+    package_file = distribution("litellm").locate_file(
+        "litellm/model_prices_and_context_window_backup.json"
+    )
+    path = Path(package_file)
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("bundled LiteLLM model map must be a JSON object")
+    return cast(ModelMap, payload)
+
+
+def _rate(info: ModelInfo, name: str) -> Decimal | None:
+    raw = info.get(name)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
+        return None
+    try:
+        rate = Decimal(str(raw))
+    except Exception:
+        return None
+    return rate if rate >= 0 and rate.is_finite() else None
+
+
+def _first_rate(info: ModelInfo, *names: str) -> Decimal | None:
+    for name in names:
+        rate = _rate(info, name)
+        if rate is not None:
+            return rate
+    return None

--- a/backend/services/model_usage/usage.py
+++ b/backend/services/model_usage/usage.py
@@ -1,0 +1,178 @@
+"""Aggregate durable model attempts into one generation usage estimate."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from backend.resources.reporting.ai_calls import (
+    AICallManager,
+    AICallQuery,
+    AICallSummary,
+    TokenUsage,
+)
+from backend.services.model_usage.objects import (
+    GenerationUsage,
+    ModelUsageBreakdown,
+    TokenTotals,
+)
+from backend.services.model_usage.pricing import LiteLLMModelRegistry
+
+
+Clock = Callable[[], datetime]
+
+
+@dataclass(slots=True)
+class _Accumulator:
+    provider: str | None
+    model: str | None
+    attempts: int = 0
+    latency_ms: int = 0
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+    total_tokens: int = 0
+    cost: Decimal = field(default_factory=Decimal)
+    priced_attempts: int = 0
+    complete: bool = True
+
+    def add_usage(self, usage: TokenUsage) -> None:
+        self.input_tokens += usage.input_tokens or 0
+        self.cached_input_tokens += usage.cached_input_tokens or 0
+        self.output_tokens += usage.output_tokens or 0
+        self.reasoning_tokens += usage.reasoning_tokens or 0
+        if usage.total_tokens is not None:
+            self.total_tokens += usage.total_tokens
+        elif usage.input_tokens is not None and usage.output_tokens is not None:
+            self.total_tokens += usage.input_tokens + usage.output_tokens
+
+    def tokens(self) -> TokenTotals:
+        return TokenTotals(
+            input_tokens=self.input_tokens,
+            cached_input_tokens=self.cached_input_tokens,
+            output_tokens=self.output_tokens,
+            reasoning_tokens=self.reasoning_tokens,
+            total_tokens=self.total_tokens,
+        )
+
+
+class GenerationUsageService:
+    def __init__(
+        self,
+        ai_calls: AICallManager,
+        registry: LiteLLMModelRegistry,
+        *,
+        clock: Clock | None = None,
+    ) -> None:
+        self._ai_calls = ai_calls
+        self._registry = registry
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def get(self, generation_id: UUID) -> GenerationUsage:
+        calls = self._all_calls(generation_id)
+        total = _Accumulator(provider=None, model=None)
+        groups: dict[tuple[str | None, str | None], _Accumulator] = {}
+        missing_usage: list[UUID] = []
+        unpriced: list[UUID] = []
+
+        for call in calls:
+            key = (call.actual_provider, call.actual_model)
+            group = groups.setdefault(
+                key,
+                _Accumulator(provider=key[0], model=key[1]),
+            )
+            for accumulator in (total, group):
+                accumulator.attempts += 1
+                accumulator.latency_ms += call.latency_ms or 0
+                accumulator.add_usage(call.usage)
+
+            usage_complete = (
+                call.usage.input_tokens is not None
+                and call.usage.output_tokens is not None
+            )
+            if not usage_complete:
+                missing_usage.append(call.id)
+                total.complete = False
+                group.complete = False
+
+            has_priceable_usage = (
+                call.usage.input_tokens is not None
+                or call.usage.output_tokens is not None
+            )
+            quote = None
+            if has_priceable_usage and call.actual_model is not None:
+                quote = self._registry.quote(
+                    call.actual_provider,
+                    call.actual_model,
+                    call.usage,
+                )
+            if has_priceable_usage and quote is None:
+                unpriced.append(call.id)
+                total.complete = False
+                group.complete = False
+            elif quote is not None:
+                total.cost += quote
+                total.priced_attempts += 1
+                group.cost += quote
+                group.priced_attempts += 1
+
+        breakdowns = tuple(
+            ModelUsageBreakdown(
+                provider=group.provider,
+                model=group.model,
+                attempt_count=group.attempts,
+                latency_ms=group.latency_ms,
+                tokens=group.tokens(),
+                estimated_cost=(
+                    _decimal_string(group.cost)
+                    if group.priced_attempts > 0
+                    else None
+                ),
+                currency="USD",
+                complete=group.complete,
+            )
+            for group in groups.values()
+        )
+        return GenerationUsage(
+            generation_id=generation_id,
+            attempt_count=total.attempts,
+            latency_ms=total.latency_ms,
+            tokens=total.tokens(),
+            breakdowns=breakdowns,
+            estimated_cost=(
+                _decimal_string(total.cost) if total.priced_attempts > 0 else None
+            ),
+            currency="USD",
+            complete=bool(calls) and total.complete,
+            missing_usage_call_ids=tuple(missing_usage),
+            unpriced_call_ids=tuple(unpriced),
+            quoted_at=self._clock(),
+        )
+
+    def _all_calls(self, generation_id: UUID) -> tuple[AICallSummary, ...]:
+        collected: list[AICallSummary] = []
+        offset = 0
+        while True:
+            page = self._ai_calls.list(
+                AICallQuery(
+                    generation_id=generation_id,
+                    limit=200,
+                    offset=offset,
+                )
+            )
+            collected.extend(page.items)
+            offset += len(page.items)
+            if offset >= page.total or not page.items:
+                break
+        return tuple(collected)
+
+
+def _decimal_string(value: Decimal) -> str:
+    normalized = value.normalize()
+    if normalized == normalized.to_integral():
+        return format(normalized, "f")
+    return format(normalized, "f")

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -34,6 +34,11 @@ from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.datalayer.snapshot_service import DatalayerSnapshotService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 from backend.services.generations import GenerationService
+from backend.services.model_usage import (
+    GenerationUsageService,
+    LiteLLMModelRegistry,
+    ModelCatalogService,
+)
 
 
 def test_competition_api_composition_builds_global_and_scoped_dependencies() -> None:
@@ -91,6 +96,8 @@ def test_build_api_runtime_uses_url_identity_and_local_tls_setting(
         assert runtime.expected_role == "aidam_api"
         assert runtime.require_tls is False
         assert runtime.session_factory.kw["bind"] is runtime.engine
+        assert isinstance(runtime.model_registry, LiteLLMModelRegistry)
+        assert isinstance(runtime.model_catalog, ModelCatalogService)
     finally:
         runtime.close()
 
@@ -274,5 +281,6 @@ def test_generation_composition_builds_one_scoped_service_without_a_session(
         assert dependencies.tool_calls.competition_id == competition_id
         assert dependencies.artifacts.competition_id == competition_id
         assert dependencies.artifact_versions.competition_id == competition_id
+        assert isinstance(dependencies.usage, GenerationUsageService)
     finally:
         engine.dispose()

--- a/backend/tests/api/test_generation_routes.py
+++ b/backend/tests/api/test_generation_routes.py
@@ -43,6 +43,7 @@ from backend.resources.reporting.tool_calls import (
     ToolCallStatus,
     ToolCallSummary,
 )
+from backend.services.model_usage import GenerationUsage, TokenTotals
 
 
 NOW = datetime(2026, 8, 23, 9, 30, tzinfo=UTC)
@@ -113,6 +114,27 @@ class StubManager:
         if self.error is not None:
             raise self.error
         return self.page
+
+
+class StubUsage:
+    def __init__(self) -> None:
+        self.generation_ids: list[UUID] = []
+
+    def get(self, generation_id: UUID) -> GenerationUsage:
+        self.generation_ids.append(generation_id)
+        return GenerationUsage(
+            generation_id=generation_id,
+            attempt_count=1,
+            latency_ms=10,
+            tokens=TokenTotals(input_tokens=100, output_tokens=40, total_tokens=140),
+            breakdowns=(),
+            estimated_cost="0.0012",
+            currency="USD",
+            complete=True,
+            missing_usage_call_ids=(),
+            unpriced_call_ids=(),
+            quoted_at=NOW,
+        )
 
 
 def _generation(
@@ -288,6 +310,7 @@ def _dependencies(competition_id: UUID, season_id: UUID) -> SimpleNamespace:
                 items=(version_summary,), total=1, limit=50, offset=0
             ),
         ),
+        usage=StubUsage(),
     )
 
 
@@ -353,6 +376,7 @@ async def test_polling_and_resource_routes_preserve_durable_payloads() -> None:
         history = await client.get(f"{base}?status=succeeded")
         articles = await client.get(f"{base}/articles")
         detail = await client.get(f"{base}/{generation.id}")
+        usage_response = await client.get(f"{base}/{generation.id}/usage")
         article = await client.get(f"{base}/{generation.id}/article")
         ai_calls = await client.get(f"{base}/{generation.id}/ai-calls")
         ai_call = await client.get(
@@ -373,6 +397,8 @@ async def test_polling_and_resource_routes_preserve_durable_payloads() -> None:
     assert history.status_code == 200
     assert articles.json()["page"]["items"][0]["status"] == "succeeded"
     assert detail.json()["generation"]["input_manifest"] == {"schema_version": 1}
+    assert usage_response.json()["usage"]["estimated_cost"] == "0.0012"
+    assert dependencies.usage.generation_ids == [generation.id]
     assert article.json()["version"]["content"] == "# Final article"
     assert ai_calls.json()["page"]["items"][0]["usage"]["total_tokens"] == 140
     assert ai_call.json()["ai_call"]["usage"]["raw_provider_usage"] == {
@@ -429,6 +455,7 @@ def test_openapi_contains_generation_polling_and_audit_boundaries() -> None:
         generation,
         f"{generation}/reruns",
         f"{generation}/article",
+        f"{generation}/usage",
         f"{generation}/ai-calls",
         f"{generation}/ai-calls/{{ai_call_id}}",
         f"{generation}/tool-calls",

--- a/backend/tests/api/test_model_routes.py
+++ b/backend/tests/api/test_model_routes.py
@@ -1,0 +1,71 @@
+from collections.abc import Callable
+from typing import final
+
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from backend.api.app import create_app
+from backend.api.dependencies import get_model_catalog
+from backend.composition import ApiRuntimeDependencies
+from backend.services.model_usage import ModelCatalog, ModelCatalogItem
+
+
+@final
+class StubRuntime:
+    def assert_ready(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def runtime_factory() -> Callable[[], ApiRuntimeDependencies]:
+    return StubRuntime
+
+
+class StubCatalog:
+    def list(self) -> ModelCatalog:
+        return ModelCatalog(
+            models=(
+                ModelCatalogItem(
+                    provider="deepseek",
+                    model="deepseek/deepseek-v4-pro",
+                    display_name="deepseek-v4-pro",
+                    is_default=True,
+                    supports_reasoning=True,
+                ),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_model_catalog_returns_selection_metadata_only() -> None:
+    app = create_app(runtime_factory=runtime_factory())
+    app.dependency_overrides[get_model_catalog] = StubCatalog
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    )
+
+    async with app.router.lifespan_context(app), client:
+        response = await client.get("/api/v1/models")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "models": [
+            {
+                "provider": "deepseek",
+                "model": "deepseek/deepseek-v4-pro",
+                "display_name": "deepseek-v4-pro",
+                "is_default": True,
+                "supports_reasoning": True,
+            }
+        ]
+    }
+    assert "pricing" not in response.text
+
+
+def test_openapi_contains_model_catalog() -> None:
+    paths = create_app(runtime_factory=runtime_factory()).openapi()["paths"]
+
+    assert "/api/v1/models" in paths

--- a/backend/tests/services/model_usage/__init__.py
+++ b/backend/tests/services/model_usage/__init__.py
@@ -1,0 +1,1 @@
+"""Model catalog and usage service tests."""

--- a/backend/tests/services/model_usage/test_catalog.py
+++ b/backend/tests/services/model_usage/test_catalog.py
@@ -1,0 +1,92 @@
+from decimal import Decimal
+
+from backend.config import ModelCatalogSettings
+from backend.resources.reporting.ai_calls import TokenUsage
+from backend.services.model_usage import LiteLLMModelRegistry, ModelCatalogService
+
+
+MODEL_MAP = {
+    "deepseek/deepseek-v4-pro": {
+        "litellm_provider": "deepseek",
+        "supports_reasoning": True,
+        "input_cost_per_token": 0.000001,
+        "cache_read_input_token_cost": 0.0000005,
+        "output_cost_per_token": 0.000002,
+        "output_cost_per_reasoning_token": 0.000003,
+    }
+}
+
+
+def test_settings_build_ordered_deduplicated_model_chain(monkeypatch) -> None:
+    monkeypatch.setenv("REPORTER_MODEL", "deepseek/deepseek-v4-pro")
+    monkeypatch.setenv(
+        "REPORTER_FALLBACK_MODELS",
+        "gpt-5.6-luna, deepseek/deepseek-v4-pro, gpt-5.6-luna, backup",
+    )
+
+    settings = ModelCatalogSettings.from_environment()
+
+    assert settings.model_chain() == (
+        "deepseek/deepseek-v4-pro",
+        "gpt-5.6-luna",
+        "backup",
+    )
+
+
+def test_catalog_returns_selection_metadata_without_prices() -> None:
+    registry = LiteLLMModelRegistry(
+        remote_loader=lambda: MODEL_MAP,
+        fallback_loader=lambda: {},
+    )
+    catalog = ModelCatalogService(
+        ModelCatalogSettings(
+            primary_model="deepseek/deepseek-v4-pro",
+            fallback_models=("unknown-model",),
+        ),
+        registry,
+    ).list()
+
+    assert catalog.models[0].model_dump() == {
+        "provider": "deepseek",
+        "model": "deepseek/deepseek-v4-pro",
+        "display_name": "deepseek-v4-pro",
+        "is_default": True,
+        "supports_reasoning": True,
+    }
+    assert catalog.models[1].model_dump() == {
+        "provider": None,
+        "model": "unknown-model",
+        "display_name": "unknown-model",
+        "is_default": False,
+        "supports_reasoning": False,
+    }
+
+
+def test_registry_falls_back_once_and_quotes_decimal_token_cost() -> None:
+    calls = {"remote": 0, "fallback": 0}
+
+    def remote() -> dict[str, object]:
+        calls["remote"] += 1
+        raise OSError("offline")
+
+    def fallback() -> dict[str, object]:
+        calls["fallback"] += 1
+        return MODEL_MAP
+
+    registry = LiteLLMModelRegistry(
+        remote_loader=remote,
+        fallback_loader=fallback,
+    )
+    usage = TokenUsage(
+        input_tokens=100,
+        cached_input_tokens=20,
+        output_tokens=50,
+        reasoning_tokens=10,
+    )
+
+    assert registry.quote("deepseek", "deepseek-v4-pro", usage) == Decimal(
+        "0.0002000"
+    )
+    assert registry.model_info("deepseek/deepseek-v4-pro") is not None
+    assert calls == {"remote": 1, "fallback": 1}
+    assert registry.quote(None, "unknown", usage) is None

--- a/backend/tests/services/model_usage/test_usage.py
+++ b/backend/tests/services/model_usage/test_usage.py
@@ -1,0 +1,150 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from backend.resources.reporting.ai_calls import (
+    AICallPage,
+    AICallStatus,
+    AICallSummary,
+    TokenUsage,
+)
+from backend.services.model_usage import GenerationUsageService, LiteLLMModelRegistry
+
+
+NOW = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+MODEL_MAP = {
+    "test/model": {
+        "litellm_provider": "test",
+        "input_cost_per_token": 0.000001,
+        "cache_read_input_token_cost": 0.0000005,
+        "output_cost_per_token": 0.000002,
+        "output_cost_per_reasoning_token": 0.000003,
+    }
+}
+
+
+class StubAICalls:
+    def __init__(self, calls: tuple[AICallSummary, ...]) -> None:
+        self.calls = calls
+        self.offsets: list[int] = []
+
+    def list(self, query) -> AICallPage:
+        self.offsets.append(query.offset)
+        items = self.calls[query.offset : query.offset + query.limit]
+        return AICallPage(
+            items=items,
+            total=len(self.calls),
+            limit=query.limit,
+            offset=query.offset,
+        )
+
+
+def _call(
+    *,
+    model: str | None = "model",
+    status: AICallStatus = AICallStatus.SUCCEEDED,
+    usage: TokenUsage,
+    latency_ms: int = 10,
+) -> AICallSummary:
+    return AICallSummary(
+        id=uuid4(),
+        generation_id=GENERATION_ID,
+        turn_number=1,
+        attempt_number=0,
+        requested_provider="test",
+        requested_model=model or "requested",
+        actual_provider="test" if model is not None else None,
+        actual_model=model,
+        status=status,
+        finish_reason=None,
+        usage=usage,
+        started_at=NOW,
+        completed_at=NOW,
+        latency_ms=latency_ms,
+    )
+
+
+GENERATION_ID = UUID("00000000-0000-0000-0000-000000000100")
+
+
+def _service(calls: tuple[AICallSummary, ...]) -> tuple[GenerationUsageService, StubAICalls]:
+    manager = StubAICalls(calls)
+    registry = LiteLLMModelRegistry(
+        remote_loader=lambda: MODEL_MAP,
+        fallback_loader=lambda: {},
+    )
+    return (
+        GenerationUsageService(manager, registry, clock=lambda: NOW),  # type: ignore[arg-type]
+        manager,
+    )
+
+
+def test_usage_aggregates_attempts_models_tokens_latency_and_cost() -> None:
+    failed = _call(
+        status=AICallStatus.RETRYABLE_ERROR,
+        usage=TokenUsage(input_tokens=100, output_tokens=0, total_tokens=100),
+        latency_ms=10,
+    )
+    succeeded = _call(
+        usage=TokenUsage(
+            input_tokens=100,
+            cached_input_tokens=20,
+            output_tokens=40,
+            reasoning_tokens=10,
+            total_tokens=140,
+        ),
+        latency_ms=20,
+    )
+    service, _ = _service((failed, succeeded))
+
+    result = service.get(GENERATION_ID)
+
+    assert result.attempt_count == 2
+    assert result.latency_ms == 30
+    assert result.tokens.model_dump() == {
+        "input_tokens": 200,
+        "cached_input_tokens": 20,
+        "output_tokens": 40,
+        "reasoning_tokens": 10,
+        "total_tokens": 240,
+    }
+    assert result.estimated_cost == "0.00028"
+    assert result.complete is True
+    assert result.breakdowns[0].attempt_count == 2
+    assert result.breakdowns[0].estimated_cost == "0.00028"
+
+
+def test_usage_returns_partial_estimate_and_identifies_affected_calls() -> None:
+    priced = _call(usage=TokenUsage(input_tokens=10, output_tokens=0))
+    missing = _call(model=None, usage=TokenUsage())
+    unknown = _call(model="unknown", usage=TokenUsage(input_tokens=3, output_tokens=1))
+    service, _ = _service((priced, missing, unknown))
+
+    result = service.get(GENERATION_ID)
+
+    assert result.estimated_cost == "0.00001"
+    assert result.complete is False
+    assert result.missing_usage_call_ids == (missing.id,)
+    assert result.unpriced_call_ids == (unknown.id,)
+
+
+def test_usage_pages_through_every_attempt() -> None:
+    calls = tuple(
+        _call(usage=TokenUsage(input_tokens=1, output_tokens=0))
+        for _ in range(201)
+    )
+    service, manager = _service(calls)
+
+    result = service.get(GENERATION_ID)
+
+    assert result.attempt_count == 201
+    assert manager.offsets == [0, 200]
+
+
+def test_usage_without_attempts_is_not_a_zero_cost_complete_quote() -> None:
+    service, _ = _service(())
+
+    result = service.get(GENERATION_ID)
+
+    assert result.attempt_count == 0
+    assert result.estimated_cost is None
+    assert result.complete is False

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -90,8 +90,9 @@ durable cross-season identity.
   Intermediate artifacts and later/earlier versions never replace it by path
   convention.
 - Cost is labeled **estimated cost**. The backend calculates it from persisted
-  actual provider/model usage and a named pricing revision; missing usage or
-  pricing remains visibly unknown rather than being treated as zero.
+  actual provider/model usage and the current LiteLLM price map; missing usage
+  or pricing remains visibly unknown rather than being treated as zero. The
+  frontend never calculates cost.
 - The package manager is `pnpm`. Yarn and npm lockfiles are not introduced.
 
 ## Release Boundary

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -204,7 +204,7 @@ The UI polls run detail. WebSockets or server-sent events are not required for
 v1. A future event channel must remain an acceleration layer; durable GET state
 is still the recovery authority.
 
-## Model Catalog and Pricing
+## Model Catalog and Backend Pricing
 
 The form must not hard-code the deployable model set. Add:
 
@@ -219,22 +219,14 @@ Each item includes:
   "provider": "openai",
   "model": "model-id",
   "display_name": "Display name",
-  "selectable": true,
   "is_default": false,
-  "supports_reasoning": true,
-  "pricing_revision": "2026-08-23",
-  "pricing": {
-    "currency": "USD",
-    "input_per_million": "0.000000",
-    "cached_input_per_million": "0.000000",
-    "output_per_million": "0.000000"
-  }
+  "supports_reasoning": true
 }
 ```
 
-Prices above are shape examples, not values. Decimal strings avoid binary float
-rounding in the transport. The backend configuration/service owns model aliases,
-availability, provider billing semantics, and pricing revisions.
+The list is the ordered, deduplicated `REPORTER_MODEL` and
+`REPORTER_FALLBACK_MODELS` chain. It is selection metadata only: the frontend
+does not receive token rates and generation submission remains permissive.
 
 `GET .../{generation_id}/usage` aggregates **all recorded attempts**, including
 failed/fallback attempts when the provider reported billable usage. It prices
@@ -244,16 +236,16 @@ contains:
 - totals by token class;
 - breakdown by actual provider/model;
 - unpriced/missing-usage call IDs;
-- pricing revision(s) and quote time;
+- quote time;
 - estimated cost as a decimal string and currency; and
 - `complete: false` whenever any applicable call cannot be priced.
 
 Cached tokens must not be double-counted as full-price input when provider usage
 reports them as a subset. Reasoning-token billing differs by provider/model and
 must be captured in the pricing rule rather than guessed by the frontend. The
-first implementation may keep the pricing catalog in versioned server
-configuration. Persisted historical dollar cost is not required; persisted raw
-usage plus a reproducible price revision is.
+backend uses the current LiteLLM price map and may fall back to the map bundled
+with the installed LiteLLM package when the remote map is unavailable.
+Historical price reproduction and persisted dollar cost are not required.
 
 ## Evaluation Workspace and Promotion API
 

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -186,8 +186,9 @@ durable memory policy; the frontend must not imply that a merge/rebase exists.
 The primary model is a combobox sourced from the backend catalog. Fallbacks are
 an ordered list with add, remove, and reorder controls. The primary model cannot
 also appear as a fallback, and fallbacks cannot repeat. Each option shows
-provider, model label/ID, availability, and pricing availability without
-turning the generation form into a pricing calculator.
+provider, model label/ID, default status, and reasoning support. The catalog is
+selection metadata only; the frontend never receives token rates or calculates
+cost.
 
 ### Submission and progress
 
@@ -237,9 +238,8 @@ and is never loaded into the article reading surface by default.
 
 **Usage** shows aggregate input, cached input, output, reasoning, and total
 tokens; model/provider breakdown; attempt count; latency; and estimated cost.
-The pricing revision and “estimated” label are always visible. Unknown price or
-usage produces an incomplete-estimate warning and identifies the affected
-calls.
+The quote time and “estimated” label are always visible. Unknown price or usage
+produces an incomplete-estimate warning and identifies the affected calls.
 
 ## Common States and Guardrails
 


### PR DESCRIPTION
## Summary

- expose the configured primary/fallback model chain as selection-only API metadata
- aggregate all durable AI attempts into generation-level token, latency, and provider/model usage
- calculate backend-only estimated costs from the current LiteLLM price map with bundled fallback
- report partial quotes with explicit missing-usage and unpriced call identities
- update the durable UI contracts so the frontend never receives token rates or calculates cost

## Verification

- `.venv\Scripts\python.exe -m pytest backend/tests/services/model_usage/ backend/tests/api/test_model_routes.py backend/tests/api/test_generation_routes.py backend/tests/api/test_composition.py --basetemp=.test-tmp-layer4-final` — 21 passed
- `git diff --cached --check`

## API

- `GET /api/v1/models`
- `GET /api/v1/generations/competitions/{competition_id}/{generation_id}/usage`

Stacked on `codex/ui-3-data-api`.
