### PR TITLE
UI 6a: Competition catalog and shell

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,9 @@
     "api:check": "node scripts/generate-api.mjs --check"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.9.1",
     "@radix-ui/react-dialog": "^1.1.0",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-separator": "^1.1.0",
     "@tanstack/react-query": "^5.0.0",
     "class-variance-authority": "^0.7.1",
@@ -27,8 +29,11 @@
     "lucide-react": "^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.86.0",
     "react-router": "^8.0.0",
-    "tailwind-merge": "^3.0.0"
+    "sonner": "^2.0.8",
+    "tailwind-merge": "^3.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,9 +7,15 @@ settings:
 importers:
   .:
     dependencies:
+      "@hookform/resolvers":
+        specifier: ^5.9.1
+        version: 5.9.1(react-hook-form@7.86.0(react@19.2.8))(zod@4.4.3)
       "@radix-ui/react-dialog":
         specifier: ^1.1.0
         version: 1.1.23(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-dropdown-menu":
+        specifier: ^2.1.24
+        version: 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@radix-ui/react-separator":
         specifier: ^1.1.0
         version: 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -31,12 +37,21 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.8(react@19.2.8)
+      react-hook-form:
+        specifier: ^7.86.0
+        version: 7.86.0(react@19.2.8)
       react-router:
         specifier: ^8.0.0
         version: 8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      sonner:
+        specifier: ^2.0.8
+        version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: ^3.0.0
         version: 3.6.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.0
@@ -266,6 +281,114 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
+  "@floating-ui/core@1.8.0":
+    resolution:
+      {
+        integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==,
+      }
+
+  "@floating-ui/dom@1.8.0":
+    resolution:
+      {
+        integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==,
+      }
+
+  "@floating-ui/react-dom@2.1.9":
+    resolution:
+      {
+        integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==,
+      }
+    peerDependencies:
+      react: ">=16.8.0"
+      react-dom: ">=16.8.0"
+
+  "@floating-ui/utils@0.2.12":
+    resolution:
+      {
+        integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==,
+      }
+
+  "@hookform/resolvers@5.9.1":
+    resolution:
+      {
+        integrity: sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==,
+      }
+    peerDependencies:
+      "@sinclair/typebox": ">=0.25.24"
+      "@standard-schema/spec": ^1.0.0
+      "@typeschema/main": ">=0.13.7"
+      "@vinejs/vine": ^2.0.0 || ^3.0.0 || ^4.0.0
+      ajv: ^8.12.0
+      ajv-errors: ^3.0.0
+      ajv-formats: ^2.1.1
+      arktype: ^2.0.0
+      ata-validator: ^1.2.0
+      class-transformer: ">=0.4.0"
+      class-validator: ">=0.12.0"
+      computed-types: ^1.0.0
+      effect: ^3.10.3
+      fluentvalidation-ts: ^3.0.0
+      fp-ts: ^2.7.0
+      io-ts: ^2.0.0
+      joi: ^17.0.0 || ^18.0.0
+      nope-validator: ">=0.12.0"
+      react-hook-form: ^7.55.0
+      superstruct: ">=0.12.0"
+      typanion: ^3.3.2
+      valibot: ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc"
+      vest: ">=6.0.0"
+      yup: ^1.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      "@sinclair/typebox":
+        optional: true
+      "@standard-schema/spec":
+        optional: true
+      "@typeschema/main":
+        optional: true
+      "@vinejs/vine":
+        optional: true
+      ajv:
+        optional: true
+      ajv-errors:
+        optional: true
+      ajv-formats:
+        optional: true
+      arktype:
+        optional: true
+      ata-validator:
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+      computed-types:
+        optional: true
+      effect:
+        optional: true
+      fluentvalidation-ts:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      nope-validator:
+        optional: true
+      superstruct:
+        optional: true
+      typanion:
+        optional: true
+      valibot:
+        optional: true
+      vest:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+
   "@humanfs/core@0.19.2":
     resolution:
       {
@@ -344,6 +467,38 @@ packages:
         integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==,
       }
 
+  "@radix-ui/react-arrow@1.1.15":
+    resolution:
+      {
+        integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-collection@1.1.15":
+    resolution:
+      {
+        integrity: sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-compose-refs@1.1.5":
     resolution:
       {
@@ -384,10 +539,38 @@ packages:
       "@types/react-dom":
         optional: true
 
+  "@radix-ui/react-direction@1.1.4":
+    resolution:
+      {
+        integrity: sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-dismissable-layer@1.1.19":
     resolution:
       {
         integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-dropdown-menu@2.1.24":
+    resolution:
+      {
+        integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -440,6 +623,38 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-menu@2.1.24":
+    resolution:
+      {
+        integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-popper@1.3.7":
+    resolution:
+      {
+        integrity: sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@radix-ui/react-portal@1.1.17":
     resolution:
       {
@@ -476,6 +691,22 @@ packages:
     resolution:
       {
         integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      "@types/react-dom": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
+  "@radix-ui/react-roving-focus@1.1.19":
+    resolution:
+      {
+        integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==,
       }
     peerDependencies:
       "@types/react": "*"
@@ -552,6 +783,18 @@ packages:
       "@types/react":
         optional: true
 
+  "@radix-ui/react-use-is-hydrated@0.1.3":
+    resolution:
+      {
+        integrity: sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
   "@radix-ui/react-use-layout-effect@1.1.4":
     resolution:
       {
@@ -563,6 +806,36 @@ packages:
     peerDependenciesMeta:
       "@types/react":
         optional: true
+
+  "@radix-ui/react-use-rect@1.1.4":
+    resolution:
+      {
+        integrity: sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/react-use-size@1.1.4":
+    resolution:
+      {
+        integrity: sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==,
+      }
+    peerDependencies:
+      "@types/react": "*"
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+
+  "@radix-ui/rect@1.1.3":
+    resolution:
+      {
+        integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==,
+      }
 
   "@redocly/ajv@8.11.2":
     resolution:
@@ -728,6 +1001,12 @@ packages:
     resolution:
       {
         integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
+      }
+
+  "@standard-schema/utils@0.3.0":
+    resolution:
+      {
+        integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
       }
 
   "@tailwindcss/node@4.3.3":
@@ -1964,6 +2243,15 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
+  react-hook-form@7.86.0:
+    resolution:
+      {
+        integrity: sha512-4kbWJrh5jPZt1+YqVcXcGKffGcXV/XVbozknLh0Yjh0KhpoAkus21TAQhzRYqNwFkkObmnSvRlZZ3GT+ehoIrA==,
+      }
+    engines: { node: ">=18.0.0" }
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-remove-scroll-bar@2.3.8:
     resolution:
       {
@@ -2072,6 +2360,19 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: ">=8" }
+
+  sonner@2.0.8:
+    resolution:
+      {
+        integrity: sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==,
+      }
+    peerDependencies:
+      "@types/react": ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
 
   source-map-js@1.2.1:
     resolution:
@@ -2450,6 +2751,30 @@ snapshots:
       "@eslint/core": 1.2.1
       levn: 0.4.1
 
+  "@floating-ui/core@1.8.0":
+    dependencies:
+      "@floating-ui/utils": 0.2.12
+
+  "@floating-ui/dom@1.8.0":
+    dependencies:
+      "@floating-ui/core": 1.8.0
+      "@floating-ui/utils": 0.2.12
+
+  "@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@floating-ui/dom": 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  "@floating-ui/utils@0.2.12": {}
+
+  "@hookform/resolvers@5.9.1(react-hook-form@7.86.0(react@19.2.8))(zod@4.4.3)":
+    dependencies:
+      "@standard-schema/utils": 0.3.0
+      react-hook-form: 7.86.0(react@19.2.8)
+    optionalDependencies:
+      zod: 4.4.3
+
   "@humanfs/core@0.19.2":
     dependencies:
       "@humanfs/types": 0.15.0
@@ -2489,6 +2814,27 @@ snapshots:
 
   "@radix-ui/primitive@1.1.7": {}
 
+  "@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
+  "@radix-ui/react-collection@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@radix-ui/react-compose-refs": 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-context": 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-slot": 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
   "@radix-ui/react-compose-refs@1.1.5(@types/react@19.2.18)(react@19.2.8)":
     dependencies:
       react: 19.2.8
@@ -2524,6 +2870,12 @@ snapshots:
       "@types/react": 19.2.18
       "@types/react-dom": 19.2.4(@types/react@19.2.18)
 
+  "@radix-ui/react-direction@1.1.4(@types/react@19.2.18)(react@19.2.8)":
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      "@types/react": 19.2.18
+
   "@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@radix-ui/primitive": 1.1.7
@@ -2531,6 +2883,21 @@ snapshots:
       "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@radix-ui/react-use-callback-ref": 1.1.4(@types/react@19.2.18)(react@19.2.8)
       "@radix-ui/react-use-effect-event": 0.0.5(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
+  "@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.7
+      "@radix-ui/react-compose-refs": 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-context": 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-id": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-menu": 2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-use-controllable-state": 1.2.6(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -2561,6 +2928,50 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.18
 
+  "@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.7
+      "@radix-ui/react-collection": 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-compose-refs": 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-context": 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-direction": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-dismissable-layer": 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-focus-guards": 1.1.6(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-focus-scope": 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-id": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-popper": 1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-portal": 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-presence": 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-roving-focus": 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-slot": 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-callback-ref": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      aria-hidden: 1.2.6
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.18)(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
+  "@radix-ui/react-popper@1.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@floating-ui/react-dom": 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-arrow": 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-compose-refs": 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-context": 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-use-callback-ref": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-layout-effect": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-rect": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-size": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/rect": 1.1.3
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
   "@radix-ui/react-portal@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2583,6 +2994,25 @@ snapshots:
   "@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@radix-ui/react-slot": 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
+      "@types/react-dom": 19.2.4(@types/react@19.2.18)
+
+  "@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
+    dependencies:
+      "@radix-ui/primitive": 1.1.7
+      "@radix-ui/react-collection": 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-compose-refs": 1.1.5(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-context": 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-direction": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-id": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-primitive": 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@radix-ui/react-use-callback-ref": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-controllable-state": 1.2.6(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-is-hydrated": 0.1.3(@types/react@19.2.18)(react@19.2.8)
+      "@radix-ui/react-use-layout-effect": 1.1.4(@types/react@19.2.18)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -2627,11 +3057,33 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.18
 
+  "@radix-ui/react-use-is-hydrated@0.1.3(@types/react@19.2.18)(react@19.2.8)":
+    dependencies:
+      react: 19.2.8
+    optionalDependencies:
+      "@types/react": 19.2.18
+
   "@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.18)(react@19.2.8)":
     dependencies:
       react: 19.2.8
     optionalDependencies:
       "@types/react": 19.2.18
+
+  "@radix-ui/react-use-rect@1.1.4(@types/react@19.2.18)(react@19.2.8)":
+    dependencies:
+      "@radix-ui/rect": 1.1.3
+      react: 19.2.8
+    optionalDependencies:
+      "@types/react": 19.2.18
+
+  "@radix-ui/react-use-size@1.1.4(@types/react@19.2.18)(react@19.2.8)":
+    dependencies:
+      "@radix-ui/react-use-layout-effect": 1.1.4(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+    optionalDependencies:
+      "@types/react": 19.2.18
+
+  "@radix-ui/rect@1.1.3": {}
 
   "@redocly/ajv@8.11.2":
     dependencies:
@@ -2702,6 +3154,8 @@ snapshots:
     optional: true
 
   "@rolldown/pluginutils@1.0.1": {}
+
+  "@standard-schema/utils@0.3.0": {}
 
   "@tailwindcss/node@4.3.3":
     dependencies:
@@ -3358,6 +3812,10 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
+  react-hook-form@7.86.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -3428,6 +3886,13 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  sonner@2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      "@types/react": 19.2.18
 
   source-map-js@1.2.1: {}
 

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -5,7 +5,8 @@ export const queryKeys = {
   },
   competitions: {
     all: ["competitions"] as const,
-    list: (filters: Readonly<Record<string, unknown>> = {}) =>
+    lists: () => ["competitions", "list"] as const,
+    list: (filters: Readonly<object> = {}) =>
       ["competitions", "list", filters] as const,
     detail: (competitionId: string) =>
       ["competitions", competitionId, "detail"] as const,

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren } from "react";
+import { Toaster } from "sonner";
 
 import { queryClient } from "@/app/query-client";
 
@@ -7,6 +8,9 @@ export function AppProviders({
   children,
 }: PropsWithChildren): React.JSX.Element {
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <Toaster richColors position="bottom-right" closeButton />
+    </QueryClientProvider>
   );
 }

--- a/frontend/src/app/shell.tsx
+++ b/frontend/src/app/shell.tsx
@@ -2,9 +2,11 @@ import { Menu, Trophy } from "lucide-react";
 import { Link, Outlet, useMatch } from "react-router";
 
 import { ApiStatus } from "@/components/shared/api-status";
+import { Breadcrumbs } from "@/components/shared/breadcrumbs";
 import { Navigation } from "@/components/shared/navigation";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { CompetitionSwitcher } from "@/features/competitions/competition-switcher";
 import {
   Sheet,
   SheetContent,
@@ -39,6 +41,9 @@ export function AppShell(): React.JSX.Element {
               <SheetTitle>AIdam Shefter</SheetTitle>
               <SheetDescription>Editorial operations desk</SheetDescription>
             </SheetHeader>
+            <div className="mb-5">
+              <CompetitionSwitcher competitionId={competitionId} />
+            </div>
             <Navigation competitionId={competitionId} closeOnNavigate />
           </SheetContent>
         </Sheet>
@@ -71,6 +76,10 @@ export function AppShell(): React.JSX.Element {
           </div>
         </div>
         <Separator />
+        <div className="px-4 py-4">
+          <CompetitionSwitcher competitionId={competitionId} />
+        </div>
+        <Separator />
         <div className="flex-1 overflow-y-auto px-3 py-5">
           <Navigation competitionId={competitionId} />
         </div>
@@ -81,6 +90,7 @@ export function AppShell(): React.JSX.Element {
       </aside>
 
       <main id="main-content" className="md:pl-64">
+        <Breadcrumbs competitionId={competitionId} />
         <Outlet />
       </main>
     </div>

--- a/frontend/src/components/shared/breadcrumbs.tsx
+++ b/frontend/src/components/shared/breadcrumbs.tsx
@@ -1,0 +1,64 @@
+import { ChevronRight } from "lucide-react";
+import { Link, useLocation } from "react-router";
+
+import { useCompetitionDetail } from "@/features/competitions/queries";
+
+interface BreadcrumbsProps {
+  competitionId?: string;
+}
+
+function resourceLabel(pathname: string): string | undefined {
+  if (pathname.endsWith("/articles")) return "Articles";
+  if (pathname.endsWith("/generate")) return "Generate";
+  if (pathname.includes("/generations/")) return "Generation";
+  if (/\/competitions\/[^/]+\/?$/.test(pathname)) return "Overview";
+  return undefined;
+}
+
+export function Breadcrumbs({
+  competitionId,
+}: BreadcrumbsProps): React.JSX.Element {
+  const { pathname } = useLocation();
+  const competitionQuery = useCompetitionDetail(competitionId);
+  const label = resourceLabel(pathname);
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="border-b border-border bg-card/50 px-5 py-3 sm:px-8"
+    >
+      <ol className="mx-auto flex max-w-6xl items-center gap-2 text-xs text-muted-foreground">
+        <li>
+          <Link className="hover:text-foreground" to="/competitions">
+            Leagues
+          </Link>
+        </li>
+        {competitionId ? (
+          <>
+            <li aria-hidden="true">
+              <ChevronRight className="size-3" />
+            </li>
+            <li>
+              <Link
+                className="hover:text-foreground"
+                to={`/competitions/${competitionId}`}
+              >
+                {competitionQuery.data?.competition.display_name ?? "League"}
+              </Link>
+            </li>
+          </>
+        ) : null}
+        {label ? (
+          <>
+            <li aria-hidden="true">
+              <ChevronRight className="size-3" />
+            </li>
+            <li className="font-medium text-foreground" aria-current="page">
+              {label}
+            </li>
+          </>
+        ) : null}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/src/components/shared/date-time.tsx
+++ b/frontend/src/components/shared/date-time.tsx
@@ -1,0 +1,25 @@
+import { formatExactDateTime, formatRelativeDateTime } from "@/lib/date-time";
+
+interface DateTimeProps {
+  value: string | null;
+  empty?: string;
+  showExact?: boolean;
+}
+
+export function DateTime({
+  value,
+  empty = "Not yet",
+  showExact = false,
+}: DateTimeProps): React.JSX.Element {
+  if (!value) return <span className="text-muted-foreground">{empty}</span>;
+
+  const exact = formatExactDateTime(value);
+  return (
+    <span className="inline-flex flex-col" title={exact}>
+      <time dateTime={value}>{formatRelativeDateTime(value)}</time>
+      {showExact ? (
+        <span className="text-xs text-muted-foreground">{exact}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -12,6 +12,8 @@ const buttonVariants = cva(
         outline:
           "border border-border bg-background hover:bg-accent hover:text-accent-foreground",
         ghost: "hover:bg-accent hover:text-accent-foreground",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 dark:text-foreground",
       },
       size: {
         default: "h-9 px-4 py-2",

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,82 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+
+export function DialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>): React.JSX.Element {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45" />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-[min(32rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-background p-6 shadow-xl outline-none",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
+          <X className="size-5" aria-hidden="true" />
+          <span className="sr-only">Close dialog</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+
+export function DialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.JSX.Element {
+  return <div className={cn("space-y-2 pr-7", className)} {...props} />;
+}
+
+export function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>): React.JSX.Element {
+  return (
+    <DialogPrimitive.Title
+      className={cn("font-editorial text-2xl font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<
+  typeof DialogPrimitive.Description
+>): React.JSX.Element {
+  return (
+    <DialogPrimitive.Description
+      className={cn("text-sm leading-6 text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        "mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,74 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+export function DropdownMenuContent({
+  className,
+  sideOffset = 6,
+  ...props
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Content
+>): React.JSX.Element {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-52 rounded-md border border-border bg-background p-1 text-foreground shadow-lg outline-none",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+export function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>): React.JSX.Element {
+  return (
+    <DropdownMenuPrimitive.Item
+      className={cn(
+        "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Label
+>): React.JSX.Element {
+  return (
+    <DropdownMenuPrimitive.Label
+      className={cn(
+        "px-2 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<
+  typeof DropdownMenuPrimitive.Separator
+>): React.JSX.Element {
+  return (
+    <DropdownMenuPrimitive.Separator
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Input({
+  className,
+  type = "text",
+  ...props
+}: React.ComponentProps<"input">): React.JSX.Element {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-border bg-background px-3 py-1 text-sm shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Label({
+  className,
+  ...props
+}: React.ComponentProps<"label">): React.JSX.Element {
+  return (
+    <label
+      className={cn("text-sm font-medium leading-none", className)}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/features/competitions/api.ts
+++ b/frontend/src/features/competitions/api.ts
@@ -1,0 +1,53 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type Competition = components["schemas"]["Competition"];
+export type CompetitionOverview = components["schemas"]["CompetitionOverview"];
+export type CompetitionOverviewResponse =
+  components["schemas"]["CompetitionOverviewResponse"];
+export type CompetitionPageResponse =
+  components["schemas"]["CompetitionPageResponse"];
+export type CompetitionResponse = components["schemas"]["CompetitionResponse"];
+
+export interface CompetitionListParameters {
+  includeArchived?: boolean;
+  limit: number;
+  offset: number;
+}
+
+export function listCompetitions(
+  parameters: CompetitionListParameters,
+  signal?: AbortSignal,
+): Promise<CompetitionPageResponse> {
+  const query = new URLSearchParams({
+    include_archived: String(parameters.includeArchived ?? false),
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(`/api/v1/competitions?${query.toString()}`, { signal });
+}
+
+export function getCompetition(
+  competitionId: string,
+  signal?: AbortSignal,
+): Promise<CompetitionOverviewResponse> {
+  return apiRequest(`/api/v1/competitions/${competitionId}`, { signal });
+}
+
+export function createCompetition(
+  displayName: string,
+): Promise<CompetitionResponse> {
+  return apiRequest("/api/v1/competitions", {
+    method: "POST",
+    json: { display_name: displayName },
+  });
+}
+
+export function archiveCompetition(
+  competitionId: string,
+): Promise<CompetitionResponse> {
+  return apiRequest(`/api/v1/competitions/${competitionId}`, {
+    method: "PATCH",
+    json: { archived: true },
+  });
+}

--- a/frontend/src/features/competitions/archive-competition-dialog.tsx
+++ b/frontend/src/features/competitions/archive-competition-dialog.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/errors";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { Competition } from "@/features/competitions/api";
+import { useArchiveCompetition } from "@/features/competitions/queries";
+
+interface ArchiveCompetitionDialogProps {
+  competition: Competition | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ArchiveCompetitionDialog({
+  competition,
+  onOpenChange,
+}: ArchiveCompetitionDialogProps): React.JSX.Element {
+  const mutation = useArchiveCompetition();
+  const resetMutation = mutation.reset;
+
+  useEffect(() => {
+    if (competition) resetMutation();
+  }, [competition, resetMutation]);
+
+  async function archive(): Promise<void> {
+    if (!competition) return;
+    try {
+      await mutation.mutateAsync(competition.id);
+      toast.success("League archived", {
+        description: `${competition.display_name} was removed from active league lists.`,
+      });
+      onOpenChange(false);
+    } catch {
+      // The normalized mutation error remains visible in the dialog.
+    }
+  }
+
+  return (
+    <Dialog open={competition !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive {competition?.display_name}?</DialogTitle>
+          <DialogDescription>
+            This is one-way in the current product. The league disappears from
+            active lists, but its seasons, articles, and historical direct reads
+            remain available.
+          </DialogDescription>
+        </DialogHeader>
+        {mutation.error ? (
+          <p
+            role="alert"
+            className="mt-5 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            {mutation.error instanceof ApiError
+              ? mutation.error.message
+              : "The competition could not be archived."}
+          </p>
+        ) : null}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            Keep competition
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={mutation.isPending}
+            onClick={() => void archive()}
+          >
+            {mutation.isPending ? "Archiving…" : "Archive competition"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/competitions/competition-switcher.tsx
+++ b/frontend/src/features/competitions/competition-switcher.tsx
@@ -1,0 +1,95 @@
+import { Check, ChevronsUpDown, Trophy } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useCompetitionList } from "@/features/competitions/queries";
+import { cn } from "@/lib/utils";
+
+interface CompetitionSwitcherProps {
+  competitionId?: string;
+}
+
+const switcherParameters = {
+  includeArchived: false,
+  limit: 200,
+  offset: 0,
+} as const;
+
+export function CompetitionSwitcher({
+  competitionId,
+}: CompetitionSwitcherProps): React.JSX.Element {
+  const navigate = useNavigate();
+  const query = useCompetitionList(switcherParameters);
+  const competitions = query.data?.page.items ?? [];
+  const active = competitions.find(
+    ({ competition }) => competition.id === competitionId,
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="w-full justify-between overflow-hidden bg-background"
+          aria-label="Choose active league"
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Trophy className="size-4 shrink-0" aria-hidden="true" />
+            <span className="truncate">
+              {active?.competition.display_name ?? "Choose a league"}
+            </span>
+          </span>
+          <ChevronsUpDown
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-60">
+        <DropdownMenuLabel>Active leagues</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {query.isPending ? (
+          <DropdownMenuItem disabled>Loading leagues…</DropdownMenuItem>
+        ) : query.isError ? (
+          <DropdownMenuItem disabled>Leagues unavailable</DropdownMenuItem>
+        ) : competitions.length === 0 ? (
+          <DropdownMenuItem disabled>No leagues yet</DropdownMenuItem>
+        ) : (
+          competitions.map(({ competition }) => (
+            <DropdownMenuItem
+              key={competition.id}
+              onSelect={() => {
+                void navigate(`/competitions/${competition.id}`);
+              }}
+            >
+              <Check
+                className={cn(
+                  "size-4",
+                  competition.id !== competitionId && "invisible",
+                )}
+                aria-hidden="true"
+              />
+              <span className="truncate">{competition.display_name}</span>
+            </DropdownMenuItem>
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => {
+            void navigate("/competitions");
+          }}
+        >
+          Manage leagues
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/features/competitions/create-competition-dialog.tsx
+++ b/frontend/src/features/competitions/create-competition-dialog.tsx
@@ -1,0 +1,143 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { ApiError } from "@/api/errors";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCreateCompetition } from "@/features/competitions/queries";
+
+const formSchema = z.object({
+  displayName: z.string().trim().min(1, "Enter a league name."),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface CreateCompetitionDialogProps {
+  prominent?: boolean;
+}
+
+export function CreateCompetitionDialog({
+  prominent = false,
+}: CreateCompetitionDialogProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const mutation = useCreateCompetition();
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    reset,
+    setError,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { displayName: "" },
+  });
+
+  function handleOpenChange(nextOpen: boolean): void {
+    setOpen(nextOpen);
+    if (nextOpen) mutation.reset();
+    if (!nextOpen) reset();
+  }
+
+  const submit = handleSubmit(async ({ displayName }) => {
+    try {
+      const response = await mutation.mutateAsync(displayName);
+      handleOpenChange(false);
+      toast.success("League created", {
+        description: `${response.competition.display_name} is ready for its first season.`,
+      });
+      await navigate(`/competitions/${response.competition.id}`);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        const message = error.fieldErrors.display_name?.[0];
+        if (message) setError("displayName", { message });
+      }
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant={prominent ? "default" : "outline"}>
+          <Plus className="size-4" aria-hidden="true" />
+          Create competition
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a competition</DialogTitle>
+          <DialogDescription>
+            A competition is the continuous identity for a fantasy league across
+            seasons. You will attach its first Sleeper season next.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="mt-6 space-y-5"
+          onSubmit={(event) => void submit(event)}
+          noValidate
+        >
+          <div className="space-y-2">
+            <Label htmlFor="competition-name">Display name</Label>
+            <Input
+              id="competition-name"
+              autoFocus
+              autoComplete="off"
+              aria-invalid={errors.displayName ? true : undefined}
+              aria-describedby={
+                errors.displayName ? "competition-name-error" : undefined
+              }
+              {...register("displayName")}
+            />
+            {errors.displayName ? (
+              <p
+                id="competition-name-error"
+                className="text-sm text-destructive"
+              >
+                {errors.displayName.message}
+              </p>
+            ) : null}
+          </div>
+          {mutation.error ? (
+            <p
+              role="alert"
+              className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              {mutation.error instanceof ApiError
+                ? mutation.error.message
+                : "The competition could not be created."}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                handleOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Creating…" : "Create competition"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/competitions/queries.ts
+++ b/frontend/src/features/competitions/queries.ts
@@ -1,0 +1,55 @@
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  archiveCompetition,
+  createCompetition,
+  getCompetition,
+  listCompetitions,
+  type CompetitionListParameters,
+} from "@/features/competitions/api";
+
+export function useCompetitionList(parameters: CompetitionListParameters) {
+  return useQuery({
+    queryKey: queryKeys.competitions.list(parameters),
+    queryFn: ({ signal }) => listCompetitions(parameters, signal),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCompetitionDetail(competitionId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.competitions.detail(competitionId ?? "missing"),
+    queryFn: ({ signal }) => getCompetition(competitionId ?? "", signal),
+    enabled: competitionId !== undefined,
+  });
+}
+
+export function useCreateCompetition() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createCompetition,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.competitions.all,
+      });
+    },
+  });
+}
+
+export function useArchiveCompetition() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: archiveCompetition,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.competitions.all,
+      });
+    },
+  });
+}

--- a/frontend/src/lib/date-time.ts
+++ b/frontend/src/lib/date-time.ts
@@ -1,0 +1,45 @@
+const relativeFormatter = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+});
+
+const exactFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const relativeUnits: readonly (readonly [
+  Intl.RelativeTimeFormatUnit,
+  number,
+])[] = [
+  ["year", 31_536_000],
+  ["month", 2_592_000],
+  ["week", 604_800],
+  ["day", 86_400],
+  ["hour", 3_600],
+  ["minute", 60],
+  ["second", 1],
+];
+
+export function formatExactDateTime(value: string): string {
+  return exactFormatter.format(new Date(value));
+}
+
+export function formatRelativeDateTime(
+  value: string,
+  now = new Date(),
+): string {
+  const date = new Date(value);
+  const differenceSeconds = (date.getTime() - now.getTime()) / 1_000;
+  const fallback: readonly [Intl.RelativeTimeFormatUnit, number] = [
+    "second",
+    1,
+  ];
+  const [unit, seconds] =
+    relativeUnits.find(
+      ([, threshold]) => Math.abs(differenceSeconds) >= threshold,
+    ) ?? fallback;
+  return relativeFormatter.format(
+    Math.round(differenceSeconds / seconds),
+    unit,
+  );
+}

--- a/frontend/src/routes/competitions.tsx
+++ b/frontend/src/routes/competitions.tsx
@@ -1,15 +1,376 @@
-import { Trophy } from "lucide-react";
+import {
+  Archive,
+  ArrowLeft,
+  ArrowRight,
+  CircleAlert,
+  MoreHorizontal,
+  Trophy,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router";
 
-import { PlaceholderPage } from "@/components/shared/placeholder-page";
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArchiveCompetitionDialog } from "@/features/competitions/archive-competition-dialog";
+import type {
+  Competition,
+  CompetitionOverview,
+} from "@/features/competitions/api";
+import { CreateCompetitionDialog } from "@/features/competitions/create-competition-dialog";
+import { useCompetitionList } from "@/features/competitions/queries";
+
+const PAGE_SIZE = 50;
+
+function positivePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function attention(summary: CompetitionOverview["summary"]): {
+  label: string;
+  variant: "secondary" | "outline" | "destructive";
+} {
+  if (summary.season_count === 0)
+    return { label: "Needs a season", variant: "secondary" };
+  if (!summary.latest_terminal_refresh)
+    return { label: "Never refreshed", variant: "outline" };
+  if (summary.latest_terminal_refresh.status === "partial")
+    return { label: "Latest refresh partial", variant: "secondary" };
+  if (summary.latest_terminal_refresh.status === "failed")
+    return { label: "Latest refresh failed", variant: "destructive" };
+  if (summary.latest_terminal_refresh.status === "cancelled")
+    return { label: "Refresh cancelled", variant: "outline" };
+  return { label: "Refreshed", variant: "outline" };
+}
+
+function RowActions({
+  competition,
+  onArchive,
+}: {
+  competition: Competition;
+  onArchive: (competition: Competition) => void;
+}): React.JSX.Element {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={`Actions for ${competition.display_name}`}
+        >
+          <MoreHorizontal className="size-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          className="text-destructive data-[highlighted]:text-destructive"
+          onSelect={() => {
+            onArchive(competition);
+          }}
+        >
+          <Archive className="size-4" aria-hidden="true" />
+          Archive competition
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DesktopTable({
+  items,
+  onArchive,
+}: {
+  items: CompetitionOverview[];
+  onArchive: (competition: Competition) => void;
+}): React.JSX.Element {
+  return (
+    <div className="hidden overflow-hidden rounded-lg border border-border bg-card md:block">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <tr>
+            <th className="px-5 py-3 font-semibold">League</th>
+            <th className="px-4 py-3 font-semibold">Seasons</th>
+            <th className="px-4 py-3 font-semibold">Last successful refresh</th>
+            <th className="px-4 py-3 font-semibold">Latest article</th>
+            <th className="px-4 py-3 font-semibold">Attention</th>
+            <th className="w-12 px-3 py-3">
+              <span className="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {items.map(({ competition, summary }) => {
+            const state = attention(summary);
+            return (
+              <tr key={competition.id} className="hover:bg-muted/35">
+                <td className="px-5 py-4">
+                  <Link
+                    className="font-editorial text-lg font-semibold hover:underline"
+                    to={`/competitions/${competition.id}`}
+                  >
+                    {competition.display_name}
+                  </Link>
+                </td>
+                <td className="px-4 py-4">
+                  <span className="font-medium">{summary.season_count}</span>
+                  <span className="ml-2 text-muted-foreground">
+                    {summary.latest_season
+                      ? `Latest ${String(summary.latest_season.season_year)}`
+                      : "No seasons"}
+                  </span>
+                </td>
+                <td className="px-4 py-4">
+                  <DateTime value={summary.latest_successful_refresh_at} />
+                </td>
+                <td className="px-4 py-4">
+                  <DateTime value={summary.latest_submitted_article_at} />
+                </td>
+                <td className="px-4 py-4">
+                  <Badge variant={state.variant}>{state.label}</Badge>
+                </td>
+                <td className="px-3 py-4">
+                  <RowActions competition={competition} onArchive={onArchive} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MobileCards({
+  items,
+  onArchive,
+}: {
+  items: CompetitionOverview[];
+  onArchive: (competition: Competition) => void;
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3 md:hidden">
+      {items.map(({ competition, summary }) => {
+        const state = attention(summary);
+        return (
+          <article
+            key={competition.id}
+            className="rounded-lg border border-border bg-card p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <Link
+                  className="font-editorial text-xl font-semibold hover:underline"
+                  to={`/competitions/${competition.id}`}
+                >
+                  {competition.display_name}
+                </Link>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {summary.season_count === 0
+                    ? "No seasons"
+                    : `${String(summary.season_count)} season${summary.season_count === 1 ? "" : "s"} · latest ${String(summary.latest_season?.season_year ?? "")}`}
+                </p>
+              </div>
+              <RowActions competition={competition} onArchive={onArchive} />
+            </div>
+            <Badge className="mt-4" variant={state.variant}>
+              {state.label}
+            </Badge>
+            <dl className="mt-4 grid grid-cols-2 gap-4 border-t border-border pt-4 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground">
+                  Last successful refresh
+                </dt>
+                <dd className="mt-1">
+                  <DateTime value={summary.latest_successful_refresh_at} />
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">
+                  Latest article
+                </dt>
+                <dd className="mt-1">
+                  <DateTime value={summary.latest_submitted_article_at} />
+                </dd>
+              </div>
+            </dl>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function CatalogSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-3" aria-label="Loading leagues">
+      {[0, 1, 2].map((item) => (
+        <Skeleton key={item} className="h-24 w-full rounded-lg" />
+      ))}
+    </div>
+  );
+}
 
 export function Component(): React.JSX.Element {
+  const [searchParameters, setSearchParameters] = useSearchParams();
+  const page = positivePage(searchParameters.get("page"));
+  const [archiveCandidate, setArchiveCandidate] = useState<Competition | null>(
+    null,
+  );
+  const query = useCompetitionList({
+    includeArchived: false,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+  const totalPages = Math.max(
+    1,
+    Math.ceil((query.data?.page.total ?? 0) / PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    if (query.data && page > totalPages) {
+      setSearchParameters(
+        totalPages === 1 ? {} : { page: String(totalPages) },
+        { replace: true },
+      );
+    }
+  }, [page, query.data, setSearchParameters, totalPages]);
+
+  function setPage(nextPage: number): void {
+    setSearchParameters(nextPage === 1 ? {} : { page: String(nextPage) });
+  }
+
+  const items = query.data?.page.items ?? [];
+
   return (
-    <PlaceholderPage
-      eyebrow="League desk"
-      title="Leagues"
-      description="Choose the competition and season the reporter should work in. League management arrives in the next product layer."
-      detail="Competition browsing, creation, and archive controls will live here."
-      icon={Trophy}
-    />
+    <div className="mx-auto w-full max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
+      <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            League desk
+          </p>
+          <h1 className="mt-3 font-editorial text-4xl font-semibold tracking-tight sm:text-5xl">
+            Leagues
+          </h1>
+          <p className="mt-4 text-base leading-7 text-muted-foreground">
+            Manage each competition as one continuous league identity across its
+            Sleeper seasons.
+          </p>
+        </div>
+        <CreateCompetitionDialog />
+      </header>
+
+      <section className="mt-10" aria-labelledby="competition-list-heading">
+        <div className="mb-4 flex min-h-6 items-center justify-between gap-3">
+          <h2
+            id="competition-list-heading"
+            className="font-editorial text-xl font-semibold"
+          >
+            Active competitions
+          </h2>
+          {query.isFetching && !query.isPending ? (
+            <span className="text-xs text-muted-foreground" role="status">
+              Updating…
+            </span>
+          ) : null}
+        </div>
+
+        {query.isPending ? <CatalogSkeleton /> : null}
+
+        {query.isError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+            <CircleAlert
+              className="size-6 text-destructive"
+              aria-hidden="true"
+            />
+            <h3 className="mt-3 font-semibold">League catalog unavailable</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {query.error instanceof ApiError
+                ? query.error.message
+                : "The league catalog could not be loaded."}
+            </p>
+            <Button
+              className="mt-4"
+              variant="outline"
+              onClick={() => void query.refetch()}
+            >
+              Try again
+            </Button>
+          </div>
+        ) : null}
+
+        {query.isSuccess && items.length === 0 && page === 1 ? (
+          <div className="rounded-lg border border-dashed border-border bg-card/60 p-8 text-center sm:p-12">
+            <div className="mx-auto flex size-12 items-center justify-center rounded-full border border-border bg-background">
+              <Trophy
+                className="size-5 text-muted-foreground"
+                aria-hidden="true"
+              />
+            </div>
+            <h3 className="mt-5 font-editorial text-2xl font-semibold">
+              Create your first competition
+            </h3>
+            <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
+              A competition connects the same fantasy league across years.
+              Create it now, then attach its first Sleeper season.
+            </p>
+            <div className="mt-6 flex justify-center">
+              <CreateCompetitionDialog prominent />
+            </div>
+          </div>
+        ) : null}
+
+        {query.isSuccess && items.length > 0 ? (
+          <>
+            <DesktopTable items={items} onArchive={setArchiveCandidate} />
+            <MobileCards items={items} onArchive={setArchiveCandidate} />
+            {query.data.page.total > PAGE_SIZE ? (
+              <div className="mt-5 flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">
+                  Page {page} of {totalPages} · {query.data.page.total} leagues
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => {
+                      setPage(page - 1);
+                    }}
+                  >
+                    <ArrowLeft className="size-4" aria-hidden="true" /> Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= totalPages}
+                    onClick={() => {
+                      setPage(page + 1);
+                    }}
+                  >
+                    Next <ArrowRight className="size-4" aria-hidden="true" />
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </section>
+
+      <ArchiveCompetitionDialog
+        competition={archiveCandidate}
+        onOpenChange={(open) => {
+          if (!open) setArchiveCandidate(null);
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- add the typed competition catalog client and TanStack Query boundary
- replace the league placeholder with responsive create, browse, paginate, and
  one-way archive workflows
- add an active-league switcher, competition breadcrumbs, normalized mutation
  errors, and accessible loading/stale/error states to the application shell

## Verification

- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_competition_routes.py --basetemp=.test-tmp-ui6-competitions` — 9 passed
- `pnpm install --frozen-lockfile`
- `pnpm api:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

Stacked on `codex/ui-5-frontend-foundation`.
