### PR TITLE
UI 6b: Season management and freshness

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -12,5 +12,7 @@ export const queryKeys = {
       ["competitions", competitionId, "detail"] as const,
     seasons: (competitionId: string) =>
       ["competitions", competitionId, "seasons"] as const,
+    seasonDetail: (competitionId: string, seasonId: string) =>
+      ["competitions", competitionId, "seasons", seasonId] as const,
   },
 } as const;

--- a/frontend/src/features/seasons/add-season-dialog.tsx
+++ b/frontend/src/features/seasons/add-season-dialog.tsx
@@ -1,0 +1,177 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { ApiError } from "@/api/errors";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useCreateSeason } from "@/features/seasons/queries";
+
+const formSchema = z.object({
+  seasonYear: z
+    .number({ error: "Enter a season year." })
+    .int("Use a four-digit year.")
+    .min(1900, "Season year must be 1900 or later.")
+    .max(9999, "Season year must use four digits."),
+  sleeperLeagueId: z.string().trim().min(1, "Enter the Sleeper league ID."),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface AddSeasonDialogProps {
+  competitionId: string;
+  disabled?: boolean;
+  prominent?: boolean;
+  onCreated: (seasonId: string) => void;
+}
+
+export function AddSeasonDialog({
+  competitionId,
+  disabled = false,
+  prominent = false,
+  onCreated,
+}: AddSeasonDialogProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const mutation = useCreateSeason(competitionId);
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    reset,
+    setError,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      seasonYear: new Date().getFullYear(),
+      sleeperLeagueId: "",
+    },
+  });
+
+  function handleOpenChange(nextOpen: boolean): void {
+    setOpen(nextOpen);
+    if (nextOpen) mutation.reset();
+    if (!nextOpen) reset();
+  }
+
+  const submit = handleSubmit(async (values) => {
+    try {
+      const response = await mutation.mutateAsync(values);
+      handleOpenChange(false);
+      toast.success("Season attached", {
+        description: `${String(response.season.season_year)} is ready for its first refresh.`,
+      });
+      onCreated(response.season.id);
+    } catch (error) {
+      if (!(error instanceof ApiError)) return;
+      const yearMessage = error.fieldErrors.season_year?.[0];
+      const leagueMessage = error.fieldErrors.sleeper_league_id?.[0];
+      if (yearMessage) setError("seasonYear", { message: yearMessage });
+      if (leagueMessage)
+        setError("sleeperLeagueId", { message: leagueMessage });
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant={prominent ? "default" : "outline"} disabled={disabled}>
+          <Plus className="size-4" aria-hidden="true" />
+          Add season
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a Sleeper season</DialogTitle>
+          <DialogDescription>
+            Sleeper creates a new league ID each season. Attach only the ID that
+            belongs to this competition; linked predecessor IDs are not
+            inferred.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="mt-6 space-y-5"
+          onSubmit={(event) => void submit(event)}
+          noValidate
+        >
+          <div className="space-y-2">
+            <Label htmlFor="season-year">Season year</Label>
+            <Input
+              id="season-year"
+              type="number"
+              min={1900}
+              max={9999}
+              step={1}
+              aria-invalid={errors.seasonYear ? true : undefined}
+              aria-describedby={
+                errors.seasonYear ? "season-year-error" : undefined
+              }
+              {...register("seasonYear", { valueAsNumber: true })}
+            />
+            {errors.seasonYear ? (
+              <p id="season-year-error" className="text-sm text-destructive">
+                {errors.seasonYear.message}
+              </p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sleeper-league-id">Sleeper league ID</Label>
+            <Input
+              id="sleeper-league-id"
+              autoComplete="off"
+              aria-invalid={errors.sleeperLeagueId ? true : undefined}
+              aria-describedby={
+                errors.sleeperLeagueId ? "sleeper-league-id-error" : undefined
+              }
+              {...register("sleeperLeagueId")}
+            />
+            {errors.sleeperLeagueId ? (
+              <p
+                id="sleeper-league-id-error"
+                className="text-sm text-destructive"
+              >
+                {errors.sleeperLeagueId.message}
+              </p>
+            ) : null}
+          </div>
+          {mutation.error ? (
+            <p
+              role="alert"
+              className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              {mutation.error instanceof ApiError
+                ? mutation.error.message
+                : "The season could not be attached."}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                handleOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Adding…" : "Add season"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/seasons/api.ts
+++ b/frontend/src/features/seasons/api.ts
@@ -1,0 +1,56 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type CompetitionSeason = components["schemas"]["CompetitionSeason"];
+export type CompetitionSeasonOverview =
+  components["schemas"]["CompetitionSeasonOverview"];
+export type CompetitionSeasonDetailResponse =
+  components["schemas"]["CompetitionSeasonDetailResponse"];
+export type CompetitionSeasonPageResponse =
+  components["schemas"]["CompetitionSeasonPageResponse"];
+export type CompetitionSeasonResponse =
+  components["schemas"]["CompetitionSeasonResponse"];
+
+export interface SeasonListParameters {
+  limit: number;
+  offset: number;
+}
+
+export function listSeasons(
+  competitionId: string,
+  parameters: SeasonListParameters,
+  signal?: AbortSignal,
+): Promise<CompetitionSeasonPageResponse> {
+  const query = new URLSearchParams({
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(
+    `/api/v1/competitions/${competitionId}/seasons?${query.toString()}`,
+    { signal },
+  );
+}
+
+export function getSeason(
+  competitionId: string,
+  seasonId: string,
+  signal?: AbortSignal,
+): Promise<CompetitionSeasonDetailResponse> {
+  return apiRequest(
+    `/api/v1/competitions/${competitionId}/seasons/${seasonId}`,
+    { signal },
+  );
+}
+
+export function createSeason(
+  competitionId: string,
+  values: { seasonYear: number; sleeperLeagueId: string },
+): Promise<CompetitionSeasonResponse> {
+  return apiRequest(`/api/v1/competitions/${competitionId}/seasons`, {
+    method: "POST",
+    json: {
+      season_year: values.seasonYear,
+      sleeper_league_id: values.sleeperLeagueId,
+    },
+  });
+}

--- a/frontend/src/features/seasons/queries.ts
+++ b/frontend/src/features/seasons/queries.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  createSeason,
+  getSeason,
+  listSeasons,
+  type SeasonListParameters,
+} from "@/features/seasons/api";
+
+export function useSeasonList(
+  competitionId: string | undefined,
+  parameters: SeasonListParameters,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.seasons(competitionId ?? "missing"),
+    queryFn: ({ signal }) =>
+      listSeasons(competitionId ?? "", parameters, signal),
+    enabled: competitionId !== undefined,
+  });
+}
+
+export function useSeasonDetail(
+  competitionId: string | undefined,
+  seasonId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.seasonDetail(
+      competitionId ?? "missing",
+      seasonId ?? "missing",
+    ),
+    queryFn: ({ signal }) =>
+      getSeason(competitionId ?? "", seasonId ?? "", signal),
+    enabled: competitionId !== undefined && seasonId !== undefined,
+  });
+}
+
+export function useCreateSeason(competitionId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (values: { seasonYear: number; sleeperLeagueId: string }) =>
+      createSeason(competitionId, values),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.seasons(competitionId),
+        }),
+      ]);
+    },
+  });
+}

--- a/frontend/src/routes/competition-overview.tsx
+++ b/frontend/src/routes/competition-overview.tsx
@@ -1,17 +1,556 @@
-import { LayoutDashboard } from "lucide-react";
-import { useParams } from "react-router";
+import { CircleAlert, Database, RefreshCw, Trophy } from "lucide-react";
+import { useEffect } from "react";
+import { useParams, useSearchParams } from "react-router";
 
-import { PlaceholderPage } from "@/components/shared/placeholder-page";
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCompetitionDetail } from "@/features/competitions/queries";
+import { AddSeasonDialog } from "@/features/seasons/add-season-dialog";
+import type { CompetitionSeasonOverview } from "@/features/seasons/api";
+import { useSeasonDetail, useSeasonList } from "@/features/seasons/queries";
+import { cn } from "@/lib/utils";
+
+const seasonListParameters = { limit: 200, offset: 0 } as const;
+
+function refreshBadge(status: string): {
+  label: string;
+  variant: "outline" | "secondary" | "destructive";
+} {
+  if (status === "succeeded") return { label: "Succeeded", variant: "outline" };
+  if (status === "partial") return { label: "Partial", variant: "secondary" };
+  if (status === "failed") return { label: "Failed", variant: "destructive" };
+  if (status === "running") return { label: "Running", variant: "secondary" };
+  return { label: "Cancelled", variant: "outline" };
+}
+
+function RefreshSummary({
+  summary,
+}: {
+  summary: CompetitionSeasonOverview["summary"];
+}): React.JSX.Element {
+  const refresh = summary.latest_terminal_refresh;
+  if (!refresh) {
+    return (
+      <span className="text-sm text-muted-foreground">Never refreshed</span>
+    );
+  }
+  const badge = refreshBadge(refresh.status);
+  return (
+    <div className="space-y-1">
+      <Badge variant={badge.variant}>{badge.label}</Badge>
+      <p className="text-xs text-muted-foreground">
+        <DateTime value={refresh.completed_at} />
+        {refresh.requested_through_week
+          ? ` · through week ${String(refresh.requested_through_week)}`
+          : " · derived boundary"}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {refresh.succeeded_request_count}/{refresh.request_count} requests
+        succeeded
+      </p>
+    </div>
+  );
+}
+
+function SeasonTable({
+  items,
+  selectedSeasonId,
+  onSelect,
+}: {
+  items: CompetitionSeasonOverview[];
+  selectedSeasonId?: string;
+  onSelect: (seasonId: string) => void;
+}): React.JSX.Element {
+  return (
+    <div className="hidden overflow-hidden rounded-lg border border-border bg-card lg:block">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <tr>
+            <th className="px-5 py-3 font-semibold">Season</th>
+            <th className="px-4 py-3 font-semibold">Sleeper identity</th>
+            <th className="px-4 py-3 font-semibold">Latest refresh</th>
+            <th className="px-4 py-3 font-semibold">Last successful</th>
+            <th className="px-4 py-3 font-semibold">Generation snapshot</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {items.map(({ season, summary }) => (
+            <tr
+              key={season.id}
+              className={cn(
+                "hover:bg-muted/35",
+                selectedSeasonId === season.id && "bg-accent/55",
+              )}
+            >
+              <td className="px-5 py-4">
+                <button
+                  type="button"
+                  className="text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-current={
+                    selectedSeasonId === season.id ? "true" : undefined
+                  }
+                  onClick={() => {
+                    onSelect(season.id);
+                  }}
+                >
+                  <span className="font-editorial text-lg font-semibold">
+                    {season.season_year}
+                  </span>
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    #{season.sequence_number}
+                  </span>
+                </button>
+              </td>
+              <td className="px-4 py-4">
+                <p className="font-medium">
+                  {summary.league_name ?? "Not loaded"}
+                </p>
+                <p
+                  className="mt-1 max-w-52 truncate text-xs text-muted-foreground"
+                  title={season.sleeper_league_id}
+                >
+                  {season.sleeper_league_id}
+                </p>
+                {summary.league_status ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Status: {summary.league_status}
+                  </p>
+                ) : null}
+              </td>
+              <td className="px-4 py-4">
+                <RefreshSummary summary={summary} />
+              </td>
+              <td className="px-4 py-4">
+                <DateTime value={summary.latest_successful_refresh_at} />
+              </td>
+              <td className="px-4 py-4">
+                <DateTime
+                  value={summary.latest_ready_snapshot_at}
+                  empty="None built"
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SeasonCards({
+  items,
+  selectedSeasonId,
+  onSelect,
+}: {
+  items: CompetitionSeasonOverview[];
+  selectedSeasonId?: string;
+  onSelect: (seasonId: string) => void;
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3 lg:hidden">
+      {items.map(({ season, summary }) => (
+        <article
+          key={season.id}
+          className={cn(
+            "rounded-lg border border-border bg-card p-4",
+            selectedSeasonId === season.id && "border-primary/50 bg-accent/45",
+          )}
+        >
+          <button
+            type="button"
+            className="w-full text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-current={selectedSeasonId === season.id ? "true" : undefined}
+            onClick={() => {
+              onSelect(season.id);
+            }}
+          >
+            <span className="font-editorial text-xl font-semibold">
+              {season.season_year}
+            </span>
+            <span className="ml-2 text-xs text-muted-foreground">
+              Season #{season.sequence_number}
+            </span>
+            <span className="mt-1 block text-sm font-medium">
+              {summary.league_name ?? "Sleeper data not loaded"}
+            </span>
+            <span className="mt-1 block break-all text-xs text-muted-foreground">
+              {season.sleeper_league_id}
+            </span>
+          </button>
+          <div className="mt-4 border-t border-border pt-4">
+            <RefreshSummary summary={summary} />
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-4 text-xs">
+            <div>
+              <dt className="text-muted-foreground">Last successful</dt>
+              <dd className="mt-1 text-sm">
+                <DateTime value={summary.latest_successful_refresh_at} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Generation snapshot</dt>
+              <dd className="mt-1 text-sm">
+                <DateTime
+                  value={summary.latest_ready_snapshot_at}
+                  empty="None built"
+                />
+              </dd>
+            </div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function OverviewSkeleton(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-6xl space-y-8 px-5 py-10 sm:px-8 sm:py-14">
+      <Skeleton className="h-12 w-72" />
+      <Skeleton className="h-64 w-full" />
+      <Skeleton className="h-56 w-full" />
+    </div>
+  );
+}
 
 export function Component(): React.JSX.Element {
   const { competitionId } = useParams();
+  const [searchParameters, setSearchParameters] = useSearchParams();
+  const competitionQuery = useCompetitionDetail(competitionId);
+  const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
+  const seasons = seasonsQuery.data?.page.items ?? [];
+  const requestedSeasonId = searchParameters.get("season") ?? undefined;
+  const requestedSeason = seasons.find(
+    ({ season }) => season.id === requestedSeasonId,
+  );
+  const selectedSeasonId = requestedSeason?.season.id ?? seasons[0]?.season.id;
+  const selectedSeason = seasons.find(
+    ({ season }) => season.id === selectedSeasonId,
+  );
+  const seasonDetailQuery = useSeasonDetail(competitionId, selectedSeasonId);
+
+  useEffect(() => {
+    if (!seasonsQuery.isSuccess) return;
+    if (requestedSeasonId === selectedSeasonId) return;
+    const next = new URLSearchParams(searchParameters);
+    if (selectedSeasonId) next.set("season", selectedSeasonId);
+    else next.delete("season");
+    next.delete("refreshPage");
+    setSearchParameters(next, { replace: true });
+  }, [
+    requestedSeasonId,
+    searchParameters,
+    seasonsQuery.isSuccess,
+    selectedSeasonId,
+    setSearchParameters,
+  ]);
+
+  function selectSeason(seasonId: string): void {
+    const next = new URLSearchParams(searchParameters);
+    next.set("season", seasonId);
+    next.delete("refreshPage");
+    setSearchParameters(next);
+  }
+
+  if (competitionQuery.isPending || seasonsQuery.isPending)
+    return <OverviewSkeleton />;
+
+  if (competitionQuery.isError || seasonsQuery.isError) {
+    const error = competitionQuery.error ?? seasonsQuery.error;
+    const missing = error instanceof ApiError && error.status === 404;
+    return (
+      <div className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <CircleAlert className="size-8 text-destructive" aria-hidden="true" />
+        <h1 className="mt-4 font-editorial text-3xl font-semibold">
+          {missing ? "League not found" : "League overview unavailable"}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          {error instanceof ApiError
+            ? error.message
+            : "The competition and its seasons could not be loaded."}
+        </p>
+        <Button
+          className="mt-6"
+          variant="outline"
+          onClick={() => {
+            void Promise.all([
+              competitionQuery.refetch(),
+              seasonsQuery.refetch(),
+            ]);
+          }}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const competition = competitionQuery.data.competition;
+  const archived = competition.archived_at !== null;
+  const detail = seasonDetailQuery.data;
+
   return (
-    <PlaceholderPage
-      eyebrow="Competition overview"
-      title="League operations"
-      description="Season identity, Sleeper freshness, refresh history, and recent reporter activity will meet here."
-      detail={`Competition scope: ${competitionId ?? "unknown"}`}
-      icon={LayoutDashboard}
-    />
+    <div className="mx-auto w-full max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
+      <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Competition overview
+            </p>
+            {archived ? <Badge variant="outline">Archived</Badge> : null}
+          </div>
+          <h1 className="mt-3 font-editorial text-4xl font-semibold tracking-tight sm:text-5xl">
+            {competition.display_name}
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            {seasons.length === 0
+              ? "Attach a Sleeper season to begin managing source data."
+              : `${String(seasons.length)} season${seasons.length === 1 ? "" : "s"} attached`}
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:items-end">
+          {seasons.length > 0 ? (
+            <label className="space-y-1 text-xs font-medium text-muted-foreground">
+              Active season
+              <select
+                className="block h-9 min-w-48 rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                value={selectedSeasonId}
+                onChange={(event) => {
+                  selectSeason(event.target.value);
+                }}
+              >
+                {seasons.map(({ season, summary }) => (
+                  <option key={season.id} value={season.id}>
+                    {season.season_year}
+                    {summary.league_name ? ` · ${summary.league_name}` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          <AddSeasonDialog
+            competitionId={competition.id}
+            disabled={archived}
+            onCreated={selectSeason}
+          />
+        </div>
+      </header>
+
+      {archived ? (
+        <p className="mt-6 rounded-md border border-border bg-muted/60 p-4 text-sm text-muted-foreground">
+          This archived competition is available for historical inspection. New
+          seasons and refresh operations are disabled.
+        </p>
+      ) : null}
+
+      {seasons.length === 0 ? (
+        <section className="mt-10 rounded-lg border border-dashed border-border bg-card/60 p-8 text-center sm:p-12">
+          <div className="mx-auto flex size-12 items-center justify-center rounded-full border border-border bg-background">
+            <Trophy
+              className="size-5 text-muted-foreground"
+              aria-hidden="true"
+            />
+          </div>
+          <h2 className="mt-5 font-editorial text-2xl font-semibold">
+            Add the first season
+          </h2>
+          <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
+            Enter the season year and the Sleeper league ID assigned for that
+            year. Sequence is derived automatically.
+          </p>
+          {!archived ? (
+            <div className="mt-6 flex justify-center">
+              <AddSeasonDialog
+                competitionId={competition.id}
+                prominent
+                onCreated={selectSeason}
+              />
+            </div>
+          ) : null}
+        </section>
+      ) : (
+        <>
+          <section className="mt-10" aria-labelledby="seasons-heading">
+            <div className="mb-4 flex items-center justify-between">
+              <h2
+                id="seasons-heading"
+                className="font-editorial text-2xl font-semibold"
+              >
+                Seasons
+              </h2>
+              {seasonsQuery.isFetching ? (
+                <span className="text-xs text-muted-foreground" role="status">
+                  Updating…
+                </span>
+              ) : null}
+            </div>
+            <SeasonTable
+              items={seasons}
+              selectedSeasonId={selectedSeasonId}
+              onSelect={selectSeason}
+            />
+            <SeasonCards
+              items={seasons}
+              selectedSeasonId={selectedSeasonId}
+              onSelect={selectSeason}
+            />
+          </section>
+
+          <section className="mt-10" aria-labelledby="selected-season-heading">
+            <div className="mb-4 flex items-center gap-3">
+              <Database
+                className="size-5 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <h2
+                id="selected-season-heading"
+                className="font-editorial text-2xl font-semibold"
+              >
+                {selectedSeason?.season.season_year} data status
+              </h2>
+            </div>
+            {seasonDetailQuery.isPending ? (
+              <Skeleton className="h-56 w-full rounded-lg" />
+            ) : seasonDetailQuery.isError ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+                <p className="text-sm text-destructive">
+                  {seasonDetailQuery.error instanceof ApiError
+                    ? seasonDetailQuery.error.message
+                    : "The selected season could not be loaded."}
+                </p>
+                <Button
+                  className="mt-4"
+                  variant="outline"
+                  onClick={() => void seasonDetailQuery.refetch()}
+                >
+                  Try again
+                </Button>
+              </div>
+            ) : detail ? (
+              <div className="grid gap-5 lg:grid-cols-[1.2fr_1fr]">
+                <article className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                        Sleeper league
+                      </p>
+                      <h3 className="mt-2 font-editorial text-2xl font-semibold">
+                        {detail.normalized_overview?.league_name ??
+                          "Awaiting first refresh"}
+                      </h3>
+                      <p className="mt-2 break-all text-sm text-muted-foreground">
+                        ID {detail.season.sleeper_league_id}
+                      </p>
+                    </div>
+                    {detail.normalized_overview?.status ? (
+                      <Badge variant="outline">
+                        {detail.normalized_overview.status}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {detail.normalized_overview ? (
+                    <dl className="mt-6 grid grid-cols-2 gap-5 border-t border-border pt-5 text-sm sm:grid-cols-4">
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Rosters
+                        </dt>
+                        <dd className="mt-1 font-medium">
+                          {detail.normalized_overview.roster_count}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Playoff start
+                        </dt>
+                        <dd className="mt-1 font-medium">
+                          {detail.normalized_overview.playoff_start_week ?? "—"}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          Playoff teams
+                        </dt>
+                        <dd className="mt-1 font-medium">
+                          {detail.normalized_overview.playoff_team_count ?? "—"}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs text-muted-foreground">
+                          League average match
+                        </dt>
+                        <dd className="mt-1 font-medium">
+                          {detail.normalized_overview.league_average_match ??
+                            "—"}
+                        </dd>
+                      </div>
+                    </dl>
+                  ) : (
+                    <p className="mt-6 border-t border-border pt-5 text-sm leading-6 text-muted-foreground">
+                      No normalized Sleeper observations exist yet. A manual
+                      refresh will load league settings, rosters, and the
+                      selected week boundary.
+                    </p>
+                  )}
+                </article>
+
+                <article className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex items-center gap-2">
+                    <RefreshCw
+                      className="size-4 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                    <h3 className="font-semibold">Freshness</h3>
+                  </div>
+                  <dl className="mt-5 space-y-4 text-sm">
+                    <div className="flex items-start justify-between gap-4">
+                      <dt className="text-muted-foreground">Last refreshed</dt>
+                      <dd className="text-right">
+                        <DateTime
+                          value={
+                            detail.summary.latest_terminal_refresh
+                              ?.completed_at ?? null
+                          }
+                          showExact
+                        />
+                      </dd>
+                    </div>
+                    <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+                      <dt className="text-muted-foreground">
+                        Last successful refresh
+                      </dt>
+                      <dd className="text-right">
+                        <DateTime
+                          value={detail.summary.latest_successful_refresh_at}
+                          showExact
+                        />
+                      </dd>
+                    </div>
+                    <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+                      <dt className="text-muted-foreground">
+                        Latest generation snapshot
+                      </dt>
+                      <dd className="text-right">
+                        <DateTime
+                          value={detail.summary.latest_ready_snapshot_at}
+                          empty="None built"
+                          showExact
+                        />
+                      </dd>
+                    </div>
+                  </dl>
+                  <p className="mt-5 border-t border-border pt-4 text-xs leading-5 text-muted-foreground">
+                    Snapshot time records when frozen generation input was built
+                    or reused. It is not Sleeper freshness.
+                  </p>
+                </article>
+              </div>
+            ) : null}
+          </section>
+        </>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- add typed season list, detail, and create transport plus scoped query hooks
- replace the competition overview placeholder with season selection, responsive
  season identity/freshness views, and normalized league detail
- add URL-canonicalized season state and inline duplicate year/Sleeper ID errors

## Verification

- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_competition_routes.py --basetemp=.test-tmp-ui6-competitions` — 9 passed
- `pnpm install --frozen-lockfile`
- `pnpm api:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

Stacked on `codex/ui-6a-competition-catalog`.
