### PR TITLE
UI 6c: Refresh operations

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -54,7 +54,10 @@ export async function apiRequest<TResponse>(
       headers,
     });
   } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError")
+    if (
+      error instanceof DOMException &&
+      (error.name === "AbortError" || error.name === "TimeoutError")
+    )
       throw error;
     throw normalizeApiError(
       0,

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -14,5 +14,48 @@ export const queryKeys = {
       ["competitions", competitionId, "seasons"] as const,
     seasonDetail: (competitionId: string, seasonId: string) =>
       ["competitions", competitionId, "seasons", seasonId] as const,
+    refreshes: (competitionId: string, seasonId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "seasons",
+        seasonId,
+        "refreshes",
+      ] as const,
+    refreshList: (
+      competitionId: string,
+      seasonId: string,
+      page: Readonly<object>,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "seasons",
+        seasonId,
+        "refreshes",
+        "list",
+        page,
+      ] as const,
+    refreshDetail: (
+      competitionId: string,
+      seasonId: string,
+      refreshId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "seasons",
+        seasonId,
+        "refreshes",
+        refreshId,
+      ] as const,
+    snapshots: (competitionId: string, seasonId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "seasons",
+        seasonId,
+        "snapshots",
+      ] as const,
   },
 } as const;

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -11,14 +11,20 @@ export const SheetClose = SheetPrimitive.Close;
 export function SheetContent({
   className,
   children,
+  side = "left",
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content>): React.JSX.Element {
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "left" | "right";
+}): React.JSX.Element {
   return (
     <SheetPrimitive.Portal>
       <SheetPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45 data-[state=closed]:animate-out data-[state=open]:animate-in" />
       <SheetPrimitive.Content
         className={cn(
-          "fixed inset-y-0 left-0 z-50 flex w-[min(22rem,88vw)] flex-col border-r border-border bg-background p-6 shadow-xl outline-none",
+          "fixed inset-y-0 z-50 flex w-[min(26rem,92vw)] flex-col bg-background p-6 shadow-xl outline-none",
+          side === "left"
+            ? "left-0 border-r border-border"
+            : "right-0 border-l border-border",
           className,
         )}
         {...props}
@@ -26,7 +32,7 @@ export function SheetContent({
         {children}
         <SheetPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring">
           <X className="size-5" aria-hidden="true" />
-          <span className="sr-only">Close navigation</span>
+          <span className="sr-only">Close sheet</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPrimitive.Portal>

--- a/frontend/src/features/refreshes/api.ts
+++ b/frontend/src/features/refreshes/api.ts
@@ -1,0 +1,59 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type ManualRefreshResponse =
+  components["schemas"]["ManualRefreshResponse"];
+export type RefreshRun = components["schemas"]["RefreshRun"];
+export type RefreshRunPageResponse =
+  components["schemas"]["RefreshRunPageResponse"];
+export type RefreshRunResponse = components["schemas"]["RefreshRunResponse"];
+
+export interface RefreshListParameters {
+  limit: number;
+  offset: number;
+}
+
+function refreshBase(competitionId: string, seasonId: string): string {
+  return `/api/v1/data/competitions/${competitionId}/seasons/${seasonId}/refreshes`;
+}
+
+export function listRefreshes(
+  competitionId: string,
+  seasonId: string,
+  parameters: RefreshListParameters,
+  signal?: AbortSignal,
+): Promise<RefreshRunPageResponse> {
+  const query = new URLSearchParams({
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(
+    `${refreshBase(competitionId, seasonId)}?${query.toString()}`,
+    {
+      signal,
+    },
+  );
+}
+
+export function getRefresh(
+  competitionId: string,
+  seasonId: string,
+  refreshId: string,
+  signal?: AbortSignal,
+): Promise<RefreshRunResponse> {
+  return apiRequest(`${refreshBase(competitionId, seasonId)}/${refreshId}`, {
+    signal,
+  });
+}
+
+export function runManualRefresh(
+  competitionId: string,
+  seasonId: string,
+  throughWeek?: number,
+): Promise<ManualRefreshResponse> {
+  return apiRequest(refreshBase(competitionId, seasonId), {
+    method: "POST",
+    json: throughWeek === undefined ? {} : { through_week: throughWeek },
+    signal: AbortSignal.timeout(300_000),
+  });
+}

--- a/frontend/src/features/refreshes/queries.ts
+++ b/frontend/src/features/refreshes/queries.ts
@@ -1,0 +1,78 @@
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  getRefresh,
+  listRefreshes,
+  runManualRefresh,
+  type RefreshListParameters,
+} from "@/features/refreshes/api";
+
+export function useRefreshList(
+  competitionId: string,
+  seasonId: string,
+  parameters: RefreshListParameters,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.refreshList(
+      competitionId,
+      seasonId,
+      parameters,
+    ),
+    queryFn: ({ signal }) =>
+      listRefreshes(competitionId, seasonId, parameters, signal),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useRefreshDetail(
+  competitionId: string,
+  seasonId: string,
+  refreshId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.refreshDetail(
+      competitionId,
+      seasonId,
+      refreshId ?? "missing",
+    ),
+    queryFn: ({ signal }) =>
+      getRefresh(competitionId, seasonId, refreshId ?? "", signal),
+    enabled: refreshId !== undefined,
+  });
+}
+
+export function useManualRefresh(competitionId: string, seasonId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (throughWeek?: number) =>
+      runManualRefresh(competitionId, seasonId, throughWeek),
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.seasons(competitionId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.seasonDetail(
+            competitionId,
+            seasonId,
+          ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.refreshes(competitionId, seasonId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.snapshots(competitionId, seasonId),
+        }),
+      ]);
+    },
+  });
+}

--- a/frontend/src/features/refreshes/refresh-history.tsx
+++ b/frontend/src/features/refreshes/refresh-history.tsx
@@ -1,0 +1,281 @@
+import { ArrowLeft, ArrowRight, CircleAlert } from "lucide-react";
+import { useEffect } from "react";
+
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { RefreshRun } from "@/features/refreshes/api";
+import { useRefreshList } from "@/features/refreshes/queries";
+import { RefreshStatusBadge } from "@/features/refreshes/status-badge";
+
+const PAGE_SIZE = 20;
+
+function RequestCounts({
+  refresh,
+}: {
+  refresh: RefreshRun;
+}): React.JSX.Element {
+  return (
+    <span>
+      {refresh.succeeded_request_count}/{refresh.request_count} succeeded
+      {refresh.failed_request_count > 0
+        ? ` · ${String(refresh.failed_request_count)} failed`
+        : ""}
+    </span>
+  );
+}
+
+function RefreshDetails({
+  refresh,
+}: {
+  refresh: RefreshRun;
+}): React.JSX.Element {
+  return (
+    <details>
+      <summary className="cursor-pointer text-xs font-medium text-muted-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring">
+        Inspect stored details
+      </summary>
+      <div className="mt-3 space-y-3 rounded-md bg-muted/55 p-3 text-xs">
+        <div>
+          <p className="font-medium">Planned endpoint scopes</p>
+          <ul className="mt-2 space-y-1 text-muted-foreground">
+            {refresh.endpoint_scope.map((scope) => (
+              <li key={scope.scope_key.value} className="break-all">
+                {scope.scope_key.value} · {scope.endpoint_kind}
+                {scope.required ? " · required" : " · optional"}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {refresh.error ? (
+          <div>
+            <p className="font-medium text-destructive">Recorded error</p>
+            <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-background p-2 text-destructive">
+              {JSON.stringify(refresh.error, null, 2)}
+            </pre>
+          </div>
+        ) : null}
+        <p className="leading-5 text-muted-foreground">
+          Per-endpoint outcomes are returned immediately after a manual refresh;
+          stored history currently retains the plan, aggregate counts, and safe
+          refresh error only.
+        </p>
+      </div>
+    </details>
+  );
+}
+
+function DesktopHistory({ items }: { items: RefreshRun[] }): React.JSX.Element {
+  return (
+    <div className="hidden overflow-hidden rounded-lg border border-border bg-card md:block">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <tr>
+            <th className="px-5 py-3 font-semibold">Status</th>
+            <th className="px-4 py-3 font-semibold">Trigger</th>
+            <th className="px-4 py-3 font-semibold">Boundary</th>
+            <th className="px-4 py-3 font-semibold">Started / completed</th>
+            <th className="px-4 py-3 font-semibold">Requests</th>
+            <th className="px-4 py-3 font-semibold">Audit</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {items.map((refresh) => (
+            <tr key={refresh.id} className="align-top">
+              <td className="px-5 py-4">
+                <RefreshStatusBadge status={refresh.status} />
+              </td>
+              <td className="px-4 py-4 capitalize">{refresh.trigger}</td>
+              <td className="px-4 py-4">
+                {refresh.requested_through_week
+                  ? `Week ${String(refresh.requested_through_week)}`
+                  : "Derived"}
+              </td>
+              <td className="px-4 py-4">
+                <div>
+                  <DateTime value={refresh.started_at} />
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Completed:{" "}
+                  <DateTime
+                    value={refresh.completed_at}
+                    empty="Still running"
+                  />
+                </div>
+              </td>
+              <td className="px-4 py-4 text-xs text-muted-foreground">
+                <RequestCounts refresh={refresh} />
+              </td>
+              <td className="max-w-64 px-4 py-4">
+                <RefreshDetails refresh={refresh} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MobileHistory({ items }: { items: RefreshRun[] }): React.JSX.Element {
+  return (
+    <div className="space-y-3 md:hidden">
+      {items.map((refresh) => (
+        <article
+          key={refresh.id}
+          className="rounded-lg border border-border bg-card p-4"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <RefreshStatusBadge status={refresh.status} />
+            <span className="text-xs capitalize text-muted-foreground">
+              {refresh.trigger}
+            </span>
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <dt className="text-xs text-muted-foreground">Boundary</dt>
+              <dd className="mt-1">
+                {refresh.requested_through_week
+                  ? `Week ${String(refresh.requested_through_week)}`
+                  : "Derived"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Requests</dt>
+              <dd className="mt-1">
+                <RequestCounts refresh={refresh} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Started</dt>
+              <dd className="mt-1">
+                <DateTime value={refresh.started_at} />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Completed</dt>
+              <dd className="mt-1">
+                <DateTime value={refresh.completed_at} empty="Still running" />
+              </dd>
+            </div>
+          </dl>
+          <div className="mt-4 border-t border-border pt-4">
+            <RefreshDetails refresh={refresh} />
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function RefreshHistory({
+  competitionId,
+  seasonId,
+  page,
+  onPageChange,
+}: {
+  competitionId: string;
+  seasonId: string;
+  page: number;
+  onPageChange: (page: number) => void;
+}): React.JSX.Element {
+  const query = useRefreshList(competitionId, seasonId, {
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  });
+  const totalPages = Math.max(
+    1,
+    Math.ceil((query.data?.page.total ?? 0) / PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    if (query.data && page > totalPages) onPageChange(totalPages);
+  }, [onPageChange, page, query.data, totalPages]);
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-3" aria-label="Loading refresh history">
+        {[0, 1, 2].map((item) => (
+          <Skeleton key={item} className="h-24 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+        <CircleAlert className="size-6 text-destructive" aria-hidden="true" />
+        <p className="mt-3 text-sm text-destructive">
+          {query.error instanceof ApiError
+            ? query.error.message
+            : "Refresh history could not be loaded."}
+        </p>
+        <Button
+          className="mt-4"
+          variant="outline"
+          onClick={() => void query.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const items = query.data.page.items;
+  if (items.length === 0 && page === 1) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/60 p-8 text-center">
+        <p className="font-medium">No refreshes recorded</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Manual, generation, scheduled, and backfill refreshes will appear
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex min-h-5 justify-end">
+        {query.isFetching ? (
+          <span className="text-xs text-muted-foreground" role="status">
+            Updating…
+          </span>
+        ) : null}
+      </div>
+      <DesktopHistory items={items} />
+      <MobileHistory items={items} />
+      {query.data.page.total > PAGE_SIZE ? (
+        <div className="mt-5 flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            Page {page} of {totalPages} · {query.data.page.total} refreshes
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => {
+                onPageChange(page - 1);
+              }}
+            >
+              <ArrowLeft className="size-4" aria-hidden="true" /> Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => {
+                onPageChange(page + 1);
+              }}
+            >
+              Next <ArrowRight className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/refreshes/refresh-outcome.tsx
+++ b/frontend/src/features/refreshes/refresh-outcome.tsx
@@ -1,0 +1,106 @@
+import { AlertTriangle, CheckCircle2, CircleX } from "lucide-react";
+
+import { DateTime } from "@/components/shared/date-time";
+import type { ManualRefreshResponse } from "@/features/refreshes/api";
+import { RefreshStatusBadge } from "@/features/refreshes/status-badge";
+import { cn } from "@/lib/utils";
+
+export function RefreshOutcomePanel({
+  outcome,
+}: {
+  outcome: ManualRefreshResponse;
+}): React.JSX.Element {
+  const status = outcome.refresh.status;
+  const Icon =
+    status === "succeeded"
+      ? CheckCircle2
+      : status === "partial"
+        ? AlertTriangle
+        : CircleX;
+
+  return (
+    <section
+      className={cn(
+        "mt-8 rounded-lg border p-5",
+        status === "succeeded" && "border-primary/30 bg-primary/5",
+        status === "partial" && "border-border bg-accent/60",
+        status === "failed" && "border-destructive/30 bg-destructive/5",
+      )}
+      aria-labelledby="latest-refresh-outcome"
+    >
+      <div className="flex items-start gap-3">
+        <Icon
+          className={cn(
+            "mt-0.5 size-5 shrink-0",
+            status === "failed" ? "text-destructive" : "text-primary",
+          )}
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-3">
+            <h2
+              id="latest-refresh-outcome"
+              className="font-editorial text-xl font-semibold"
+            >
+              Latest manual refresh outcome
+            </h2>
+            <RefreshStatusBadge status={status} />
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Effective through week{" "}
+            {outcome.effective_through_week ?? "not available"} · completed{" "}
+            <DateTime value={outcome.refresh.completed_at} />
+          </p>
+          <p className="mt-3 text-sm">
+            {outcome.refresh.succeeded_request_count} of{" "}
+            {outcome.refresh.request_count} requests succeeded;{" "}
+            {outcome.refresh.failed_request_count} failed.
+          </p>
+        </div>
+      </div>
+
+      {outcome.scope_results.length > 0 ? (
+        <details className="mt-5 border-t border-border pt-4">
+          <summary className="cursor-pointer text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            Inspect endpoint results
+          </summary>
+          <ul className="mt-3 space-y-2">
+            {outcome.scope_results.map((result) => (
+              <li
+                key={result.api_request_id}
+                className="rounded-md bg-background/70 p-3 text-xs"
+              >
+                <p className="break-all font-medium">
+                  {result.scope_key.value}
+                </p>
+                <p className="mt-1 text-muted-foreground">
+                  Fetch: {result.fetch_status} · normalization:{" "}
+                  {result.normalization_status} ·{" "}
+                  {result.changed_current_view
+                    ? "current view changed"
+                    : "current view unchanged"}
+                </p>
+                {result.warning_codes.length > 0 ? (
+                  <p className="mt-1 text-muted-foreground">
+                    Warnings: {result.warning_codes.join(", ")}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      {outcome.refresh.error ? (
+        <details className="mt-4 border-t border-border pt-4">
+          <summary className="cursor-pointer text-sm font-medium text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            Inspect recorded error
+          </summary>
+          <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/80 p-3 text-xs text-destructive">
+            {JSON.stringify(outcome.refresh.error, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/features/refreshes/refresh-sheet.tsx
+++ b/frontend/src/features/refreshes/refresh-sheet.tsx
@@ -1,0 +1,207 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { ApiError } from "@/api/errors";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { ManualRefreshResponse } from "@/features/refreshes/api";
+import { useManualRefresh } from "@/features/refreshes/queries";
+
+const formSchema = z.object({
+  throughWeek: z
+    .string()
+    .trim()
+    .refine(
+      (value) => {
+        if (value === "") return true;
+        const parsed = Number(value);
+        return Number.isInteger(parsed) && parsed >= 1 && parsed <= 18;
+      },
+      { message: "Use a whole week from 1 through 18, or leave it blank." },
+    ),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface RefreshSheetProps {
+  competitionId: string;
+  seasonId: string;
+  seasonYear: number;
+  leagueName?: string | null;
+  disabled?: boolean;
+  onOutcome: (outcome: ManualRefreshResponse) => void;
+}
+
+export function RefreshSheet({
+  competitionId,
+  seasonId,
+  seasonYear,
+  leagueName,
+  disabled = false,
+  onOutcome,
+}: RefreshSheetProps): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const mutation = useManualRefresh(competitionId, seasonId);
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { throughWeek: "" },
+  });
+
+  function handleOpenChange(nextOpen: boolean): void {
+    if (mutation.isPending && !nextOpen) return;
+    setOpen(nextOpen);
+    if (nextOpen) mutation.reset();
+    if (!nextOpen) reset();
+  }
+
+  const submit = handleSubmit(async ({ throughWeek }) => {
+    const parsedWeek = throughWeek === "" ? undefined : Number(throughWeek);
+    try {
+      const outcome = await mutation.mutateAsync(parsedWeek);
+      onOutcome(outcome);
+      if (outcome.refresh.status === "succeeded") {
+        toast.success("Sleeper refresh succeeded", {
+          description: `${String(outcome.refresh.succeeded_request_count)} requests completed successfully.`,
+        });
+      } else if (outcome.refresh.status === "partial") {
+        toast.warning("Sleeper refresh completed partially", {
+          description: `${String(outcome.refresh.failed_request_count)} requests failed. Review the outcome before generating.`,
+        });
+      } else {
+        toast.error("Sleeper refresh failed", {
+          description: "The failed refresh was recorded for inspection.",
+        });
+      }
+      handleOpenChange(false);
+    } catch {
+      // The normalized mutation error remains visible in the sheet.
+    }
+  });
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetTrigger asChild>
+        <Button disabled={disabled}>
+          <RefreshCw className="size-4" aria-hidden="true" />
+          Refresh Sleeper data
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Refresh Sleeper data</SheetTitle>
+          <SheetDescription>
+            Fetch the current Sleeper endpoint set for {leagueName ?? "season"}{" "}
+            {seasonYear}. This may take several minutes.
+          </SheetDescription>
+        </SheetHeader>
+
+        <form
+          className="flex flex-1 flex-col"
+          onSubmit={(event) => void submit(event)}
+          noValidate
+        >
+          <div className="rounded-md border border-border bg-muted/50 p-4 text-sm">
+            <p className="font-medium">Selected season</p>
+            <p className="mt-1 text-muted-foreground">
+              {seasonYear}
+              {leagueName ? ` · ${leagueName}` : ""}
+            </p>
+          </div>
+
+          <div className="mt-6 space-y-2">
+            <Label htmlFor="refresh-through-week">
+              Through week (optional)
+            </Label>
+            <Input
+              id="refresh-through-week"
+              type="number"
+              min={1}
+              max={18}
+              step={1}
+              inputMode="numeric"
+              placeholder="Derive from NFL state"
+              disabled={mutation.isPending}
+              aria-invalid={errors.throughWeek ? true : undefined}
+              aria-describedby="refresh-through-week-help"
+              {...register("throughWeek")}
+            />
+            <p
+              id="refresh-through-week-help"
+              className="text-xs leading-5 text-muted-foreground"
+            >
+              Leave blank to let the backend derive the effective week from the
+              current NFL state.
+            </p>
+            {errors.throughWeek ? (
+              <p className="text-sm text-destructive">
+                {errors.throughWeek.message}
+              </p>
+            ) : null}
+          </div>
+
+          {mutation.isPending ? (
+            <div
+              className="mt-6 rounded-md border border-border bg-accent/50 p-4"
+              role="status"
+              aria-live="polite"
+            >
+              <p className="font-medium">Fetching Sleeper endpoints…</p>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                League, roster, player, matchup, transaction, and bracket data
+                are processed as one recorded refresh.
+              </p>
+            </div>
+          ) : null}
+
+          {mutation.error ? (
+            <p
+              role="alert"
+              className="mt-6 rounded-md bg-destructive/10 p-4 text-sm text-destructive"
+            >
+              {mutation.error instanceof ApiError
+                ? mutation.error.message
+                : mutation.error instanceof DOMException &&
+                    mutation.error.name === "TimeoutError"
+                  ? "The refresh request exceeded five minutes. Check refresh history before retrying."
+                  : "The refresh request could not be completed. Check refresh history before retrying."}
+            </p>
+          ) : null}
+
+          <div className="mt-auto flex flex-col-reverse gap-2 pt-8 sm:flex-row sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={mutation.isPending}
+              onClick={() => {
+                handleOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Refreshing…" : "Start refresh"}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/features/refreshes/status-badge.tsx
+++ b/frontend/src/features/refreshes/status-badge.tsx
@@ -1,0 +1,13 @@
+import { Badge } from "@/components/ui/badge";
+
+export function RefreshStatusBadge({
+  status,
+}: {
+  status: string;
+}): React.JSX.Element {
+  if (status === "succeeded") return <Badge variant="outline">Succeeded</Badge>;
+  if (status === "partial") return <Badge variant="secondary">Partial</Badge>;
+  if (status === "failed") return <Badge variant="destructive">Failed</Badge>;
+  if (status === "running") return <Badge variant="secondary">Running</Badge>;
+  return <Badge variant="outline">Cancelled</Badge>;
+}

--- a/frontend/src/routes/competition-overview.tsx
+++ b/frontend/src/routes/competition-overview.tsx
@@ -1,5 +1,5 @@
 import { CircleAlert, Database, RefreshCw, Trophy } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router";
 
 import { ApiError } from "@/api/errors";
@@ -8,12 +8,21 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCompetitionDetail } from "@/features/competitions/queries";
+import type { ManualRefreshResponse } from "@/features/refreshes/api";
+import { RefreshHistory } from "@/features/refreshes/refresh-history";
+import { RefreshOutcomePanel } from "@/features/refreshes/refresh-outcome";
+import { RefreshSheet } from "@/features/refreshes/refresh-sheet";
 import { AddSeasonDialog } from "@/features/seasons/add-season-dialog";
 import type { CompetitionSeasonOverview } from "@/features/seasons/api";
 import { useSeasonDetail, useSeasonList } from "@/features/seasons/queries";
 import { cn } from "@/lib/utils";
 
 const seasonListParameters = { limit: 200, offset: 0 } as const;
+
+function positivePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
 
 function refreshBadge(status: string): {
   label: string;
@@ -219,10 +228,15 @@ function OverviewSkeleton(): React.JSX.Element {
 export function Component(): React.JSX.Element {
   const { competitionId } = useParams();
   const [searchParameters, setSearchParameters] = useSearchParams();
+  const [latestOutcome, setLatestOutcome] = useState<{
+    seasonId: string;
+    outcome: ManualRefreshResponse;
+  }>();
   const competitionQuery = useCompetitionDetail(competitionId);
   const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
   const seasons = seasonsQuery.data?.page.items ?? [];
   const requestedSeasonId = searchParameters.get("season") ?? undefined;
+  const refreshPage = positivePage(searchParameters.get("refreshPage"));
   const requestedSeason = seasons.find(
     ({ season }) => season.id === requestedSeasonId,
   );
@@ -254,6 +268,16 @@ export function Component(): React.JSX.Element {
     next.delete("refreshPage");
     setSearchParameters(next);
   }
+
+  const setRefreshPage = useCallback(
+    (page: number): void => {
+      const next = new URLSearchParams(searchParameters);
+      if (page === 1) next.delete("refreshPage");
+      else next.set("refreshPage", String(page));
+      setSearchParameters(next);
+    },
+    [searchParameters, setSearchParameters],
+  );
 
   if (competitionQuery.isPending || seasonsQuery.isPending)
     return <OverviewSkeleton />;
@@ -331,11 +355,25 @@ export function Component(): React.JSX.Element {
               </select>
             </label>
           ) : null}
-          <AddSeasonDialog
-            competitionId={competition.id}
-            disabled={archived}
-            onCreated={selectSeason}
-          />
+          <div className="flex flex-wrap gap-2">
+            {selectedSeasonId && selectedSeason ? (
+              <RefreshSheet
+                competitionId={competition.id}
+                seasonId={selectedSeasonId}
+                seasonYear={selectedSeason.season.season_year}
+                leagueName={selectedSeason.summary.league_name}
+                disabled={archived}
+                onOutcome={(outcome) => {
+                  setLatestOutcome({ seasonId: selectedSeasonId, outcome });
+                }}
+              />
+            ) : null}
+            <AddSeasonDialog
+              competitionId={competition.id}
+              disabled={archived}
+              onCreated={selectSeason}
+            />
+          </div>
         </div>
       </header>
 
@@ -549,6 +587,36 @@ export function Component(): React.JSX.Element {
               </div>
             ) : null}
           </section>
+
+          {latestOutcome && latestOutcome.seasonId === selectedSeasonId ? (
+            <RefreshOutcomePanel outcome={latestOutcome.outcome} />
+          ) : null}
+
+          {selectedSeasonId ? (
+            <section
+              className="mt-10"
+              aria-labelledby="refresh-history-heading"
+            >
+              <h2
+                id="refresh-history-heading"
+                className="font-editorial text-2xl font-semibold"
+              >
+                Refresh history
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Newest-first source refreshes for the selected season. Stored
+                history preserves terminal status and aggregate request audit.
+              </p>
+              <div className="mt-5">
+                <RefreshHistory
+                  competitionId={competition.id}
+                  seasonId={selectedSeasonId}
+                  page={refreshPage}
+                  onPageChange={setRefreshPage}
+                />
+              </div>
+            </section>
+          ) : null}
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

- add typed manual-refresh and refresh-history transport with season-scoped
  TanStack Query keys and settlement invalidation
- add a five-minute, duplicate-safe refresh confirmation sheet with optional
  through-week input and status-authoritative succeeded/partial/failed outcomes
- add responsive newest-first refresh history with URL-backed pagination,
  stored audit disclosure, and clear freshness/snapshot distinctions

## Verification

- `.venv\Scripts\python.exe -m pytest backend/tests/api/test_data_routes.py --basetemp=.test-tmp-ui6-data` — 13 passed
- `pnpm install --frozen-lockfile`
- `pnpm api:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Manual acceptance against real FastAPI/PostgreSQL with a temporary
  fixture-backed Sleeper endpoint covered succeeded, partial, and failed
  outcomes; validation; in-flight state; history; timestamps; URL state; and
  responsive presentation.

## Known limitation

Newly attached seasons do not yet receive franchise/season-roster identity
mappings through the product API. A disposable explicit mapping seed was needed
to exercise the fully successful refresh path; resolving that backend lifecycle
belongs before the Layer 7 generation journey.

Stacked on `codex/ui-6b-season-management`.
