### PR TITLE
Layer 6d: Roster identity API

### DIFF
--- a/backend/api/errors/core.py
+++ b/backend/api/errors/core.py
@@ -13,6 +13,7 @@ from backend.resources.core import (
     CompetitionSeasonYearExists,
     CoreResourceError,
     CoreResourceNotFound,
+    RosterMappingConflict,
     SleeperLeagueIdExists,
 )
 
@@ -24,6 +25,8 @@ CoreErrorCode = Literal[
     "competition_season_year_exists",
     "sleeper_league_id_exists",
     "competition_concurrency_conflict",
+    "roster_mapping_conflict",
+    "roster_mapping_source_stale",
 ]
 
 
@@ -103,6 +106,17 @@ def _http_error(
             status.HTTP_409_CONFLICT,
             "competition_concurrency_conflict",
             "competition state changed concurrently; retry the request",
+            None,
+        )
+    if isinstance(error, RosterMappingConflict):
+        return (
+            status.HTTP_409_CONFLICT,
+            (
+                "roster_mapping_source_stale"
+                if error.stale_source
+                else "roster_mapping_conflict"
+            ),
+            error.message,
             None,
         )
     raise TypeError(f"unsupported core application error {type(error).__name__}")

--- a/backend/api/routes/competitions.py
+++ b/backend/api/routes/competitions.py
@@ -20,6 +20,9 @@ from backend.api.schemas.competitions import (
     CreateCompetitionBody,
     CreateCompetitionSeasonBody,
     PatchCompetitionBody,
+    PutRosterMappingsBody,
+    RosterMappingMutationResponse,
+    RosterMappingResponse,
 )
 from backend.composition import (
     CompetitionCatalogDependencies,
@@ -33,6 +36,7 @@ from backend.resources.core import (
     CreateCompetitionSeason,
     RenameCompetition,
 )
+from backend.services.league import ReconcileRosterMappings
 
 
 router = APIRouter(
@@ -210,6 +214,39 @@ def competition_season_detail(
         season=detail.season,
         summary=detail.summary,
         normalized_overview=detail.normalized_overview,
+    )
+
+
+@router.get(
+    "/{competition_id}/seasons/{season_id}/roster-mappings",
+    response_model=RosterMappingResponse,
+)
+def get_roster_mappings(
+    season_id: UUID,
+    dependencies: SeasonApi,
+) -> RosterMappingResponse:
+    return RosterMappingResponse(
+        mapping=dependencies.roster_mappings.get_mapping(season_id)
+    )
+
+
+@router.put(
+    "/{competition_id}/seasons/{season_id}/roster-mappings",
+    response_model=RosterMappingMutationResponse,
+)
+def put_roster_mappings(
+    season_id: UUID,
+    body: PutRosterMappingsBody,
+    dependencies: SeasonApi,
+) -> RosterMappingMutationResponse:
+    return RosterMappingMutationResponse(
+        result=dependencies.roster_mappings.reconcile(
+            season_id,
+            ReconcileRosterMappings(
+                source_api_request_id=body.source_api_request_id,
+                assignments=tuple(item.to_resource() for item in body.assignments),
+            ),
+        )
     )
 
 

--- a/backend/api/schemas/competitions.py
+++ b/backend/api/schemas/competitions.py
@@ -1,6 +1,7 @@
 """Strict transport models for competition and season routes."""
 
 from typing import Annotated, ClassVar, Literal
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -12,8 +13,12 @@ from backend.resources.core import (
     CompetitionSeason,
     CompetitionSeasonActivitySummary,
     CompetitionSeasonOverviewPage,
+    CreateFranchiseTarget,
+    ExistingFranchiseTarget,
+    RosterMappingAssignment,
 )
 from backend.resources.sleeper_data import LeagueSeasonOverview
+from backend.services.league import RosterMappingResult, RosterMappingView
 
 
 class CompetitionApiModel(BaseModel):
@@ -94,3 +99,75 @@ class CompetitionSeasonDetailResponse(CompetitionApiModel):
     season: CompetitionSeason
     summary: CompetitionSeasonActivitySummary
     normalized_overview: LeagueSeasonOverview | None
+
+
+class CreateFranchiseTargetBody(CompetitionApiModel):
+    kind: Literal["new"] = "new"
+    display_name: NonBlankStr
+
+
+class ExistingFranchiseTargetBody(CompetitionApiModel):
+    kind: Literal["existing"] = "existing"
+    franchise_id: UUID
+
+
+class RosterMappingAssignmentBody(CompetitionApiModel):
+    sleeper_roster_id: NonBlankStr
+    target: Annotated[
+        CreateFranchiseTargetBody | ExistingFranchiseTargetBody,
+        Field(discriminator="kind"),
+    ]
+
+    def to_resource(self) -> RosterMappingAssignment:
+        target = self.target
+        resolved = (
+            CreateFranchiseTarget(display_name=target.display_name)
+            if isinstance(target, CreateFranchiseTargetBody)
+            else ExistingFranchiseTarget(franchise_id=target.franchise_id)
+        )
+        return RosterMappingAssignment(
+            sleeper_roster_id=self.sleeper_roster_id,
+            target=resolved,
+        )
+
+
+class PutRosterMappingsBody(CompetitionApiModel):
+    source_api_request_id: UUID
+    assignments: tuple[RosterMappingAssignmentBody, ...]
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "examples": [
+                {
+                    "source_api_request_id": "4fd2ceef-0d7d-47ee-a42f-e70f78684aeb",
+                    "assignments": [
+                        {
+                            "sleeper_roster_id": "1",
+                            "target": {
+                                "kind": "existing",
+                                "franchise_id": (
+                                    "e9c48ec7-95fe-44ed-85d6-d658f7022bd2"
+                                ),
+                            },
+                        },
+                        {
+                            "sleeper_roster_id": "2",
+                            "target": {
+                                "kind": "new",
+                                "display_name": "Expansion Team",
+                            },
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+
+
+class RosterMappingResponse(CompetitionApiModel):
+    mapping: RosterMappingView
+
+
+class RosterMappingMutationResponse(CompetitionApiModel):
+    result: RosterMappingResult

--- a/backend/composition.py
+++ b/backend/composition.py
@@ -24,6 +24,7 @@ from backend.resources.core import (
     CompetitionManager,
     CompetitionOverviewReader,
     CompetitionSeasonManager,
+    RosterMappingManager,
 )
 from backend.resources.memory.context_notes import ContextNoteManager
 from backend.resources.memory.events import EventManager
@@ -53,6 +54,7 @@ from backend.services.datalayer import (
 )
 from backend.services.datalayer.refresh_service import DatalayerRefreshService
 from backend.services.generations import GenerationFinalizer, GenerationService
+from backend.services.league import RosterMappingService
 from backend.services.memory import MemoryMutationService, MemoryRetrievalService
 from backend.services.model_usage import (
     GenerationUsageService,
@@ -180,6 +182,7 @@ class CompetitionSeasonDependencies:
 
     seasons: CompetitionSeasonManager
     overviews: CompetitionOverviewReader
+    roster_mappings: RosterMappingService
 
 
 @dataclass(frozen=True, slots=True)
@@ -242,12 +245,24 @@ def build_competition_catalog_dependencies(
 def build_competition_season_dependencies(
     session_factory: SessionFactory,
     context: ManagerContext[CompetitionScope],
+    *,
+    settings: DatalayerSettings | None = None,
 ) -> CompetitionSeasonDependencies:
     """Compose scoped season lifecycle and overview reads."""
 
+    resolved = settings or DatalayerSettings.from_environment()
+    mapping_manager = RosterMappingManager(session_factory, context)
+    requests = ApiRequestManager(session_factory, context)
+    scopes = NormalizedScopeManager(session_factory, context)
     return CompetitionSeasonDependencies(
         seasons=CompetitionSeasonManager(session_factory, context),
         overviews=CompetitionOverviewReader(session_factory),
+        roster_mappings=RosterMappingService(
+            mappings=mapping_manager,
+            requests=requests,
+            scopes=scopes,
+            files=LocalDatalayerFileStore(resolved.data_root),
+        ),
     )
 
 
@@ -301,6 +316,12 @@ def build_datalayer_refresh_dependencies(
     scopes = NormalizedScopeManager(session_factory, context)
     identities = LeagueSeasonManager(session_factory, context)
     files = LocalDatalayerFileStore(resolved.data_root)
+    roster_mappings = RosterMappingService(
+        mappings=RosterMappingManager(session_factory, context),
+        requests=attempts,
+        scopes=scopes,
+        files=files,
+    )
     return DatalayerRefreshDependencies(
         refresh=DatalayerRefreshService(
             source=source,
@@ -313,6 +334,7 @@ def build_datalayer_refresh_dependencies(
             max_attempts=resolved.sleeper_max_attempts,
             retry_backoff_seconds=resolved.sleeper_retry_backoff_seconds,
             inline_payload_max_bytes=resolved.inline_payload_max_bytes,
+            roster_mappings=roster_mappings,
         ),
         source=source,
     )
@@ -335,17 +357,25 @@ def build_data_api_dependencies(
     attempts = ApiRequestManager(session_factory, context)
     scopes = NormalizedScopeManager(session_factory, context)
     league_seasons = LeagueSeasonManager(session_factory, context)
+    files = LocalDatalayerFileStore(resolved.data_root)
+    roster_mappings = RosterMappingService(
+        mappings=RosterMappingManager(session_factory, context),
+        requests=attempts,
+        scopes=scopes,
+        files=files,
+    )
     refresh = DatalayerRefreshService(
         source=source,
         identities=league_seasons,
         refreshes=refreshes,
         attempts=attempts,
         scopes=scopes,
-        files=LocalDatalayerFileStore(resolved.data_root),
+        files=files,
         code_version=resolved.code_version,
         max_attempts=resolved.sleeper_max_attempts,
         retry_backoff_seconds=resolved.sleeper_retry_backoff_seconds,
         inline_payload_max_bytes=resolved.inline_payload_max_bytes,
+        roster_mappings=roster_mappings,
     )
     return DataApiDependencies(
         refresh=refresh,

--- a/backend/resources/core/__init__.py
+++ b/backend/resources/core/__init__.py
@@ -20,7 +20,19 @@ from backend.resources.core.errors import (
     CompetitionSeasonYearExists,
     CoreResourceError,
     CoreResourceNotFound,
+    RosterMappingConflict,
     SleeperLeagueIdExists,
+)
+from backend.resources.core.roster_mappings import (
+    ApplyRosterMappings,
+    CreateFranchiseTarget,
+    ExistingFranchiseTarget,
+    FranchiseIdentity,
+    MappingTarget,
+    RosterIdentityCatalog,
+    RosterMappingAssignment,
+    RosterMappingManager,
+    SeasonRosterIdentity,
 )
 from backend.resources.core.overviews import (
     CompetitionActivitySummary,
@@ -60,6 +72,16 @@ __all__ = [
     "CreateCompetition",
     "CreateCompetitionSeason",
     "RenameCompetition",
+    "ApplyRosterMappings",
+    "CreateFranchiseTarget",
+    "ExistingFranchiseTarget",
+    "FranchiseIdentity",
+    "MappingTarget",
+    "RosterIdentityCatalog",
+    "RosterMappingAssignment",
+    "RosterMappingConflict",
+    "RosterMappingManager",
+    "SeasonRosterIdentity",
     "LatestRefreshSummary",
     "SleeperLeagueIdExists",
 ]

--- a/backend/resources/core/errors.py
+++ b/backend/resources/core/errors.py
@@ -54,11 +54,19 @@ class CompetitionConcurrencyConflict(CoreResourceError):
         super().__init__(message)
 
 
+class RosterMappingConflict(CoreResourceError):
+    def __init__(self, message: str, *, stale_source: bool = False) -> None:
+        self.message = message
+        self.stale_source = stale_source
+        super().__init__(message)
+
+
 __all__ = [
     "CompetitionArchivedConflict",
     "CompetitionConcurrencyConflict",
     "CompetitionSeasonYearExists",
     "CoreResourceError",
     "CoreResourceNotFound",
+    "RosterMappingConflict",
     "SleeperLeagueIdExists",
 ]

--- a/backend/resources/core/roster_mappings/__init__.py
+++ b/backend/resources/core/roster_mappings/__init__.py
@@ -1,0 +1,23 @@
+from backend.resources.core.roster_mappings.manager import RosterMappingManager
+from backend.resources.core.roster_mappings.objects import (
+    ApplyRosterMappings,
+    CreateFranchiseTarget,
+    ExistingFranchiseTarget,
+    FranchiseIdentity,
+    MappingTarget,
+    RosterIdentityCatalog,
+    RosterMappingAssignment,
+    SeasonRosterIdentity,
+)
+
+__all__ = [
+    "ApplyRosterMappings",
+    "CreateFranchiseTarget",
+    "ExistingFranchiseTarget",
+    "FranchiseIdentity",
+    "MappingTarget",
+    "RosterIdentityCatalog",
+    "RosterMappingAssignment",
+    "RosterMappingManager",
+    "SeasonRosterIdentity",
+]

--- a/backend/resources/core/roster_mappings/manager.py
+++ b/backend/resources/core/roster_mappings/manager.py
@@ -1,0 +1,234 @@
+"""Competition-scoped persistence for franchise and roster mappings."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from backend.database.models.core import (
+    Competition,
+    CompetitionSeason,
+    Franchise,
+    SeasonRoster,
+)
+from backend.database.sessions import SessionFactory, read_only_session, transaction_session
+from backend.resources.context import CompetitionScope, ManagerContext
+from backend.resources.core.errors import (
+    CompetitionArchivedConflict,
+    CoreResourceNotFound,
+    RosterMappingConflict,
+)
+from backend.resources.core.roster_mappings.objects import (
+    ApplyRosterMappings,
+    CreateFranchiseTarget,
+    FranchiseIdentity,
+    RosterIdentityCatalog,
+    SeasonRosterIdentity,
+)
+
+
+class RosterMappingManager:
+    """Own immutable season-roster mappings and durable franchise creation."""
+
+    def __init__(
+        self,
+        session_factory: SessionFactory,
+        context: ManagerContext[CompetitionScope],
+    ) -> None:
+        self._session_factory = session_factory
+        self._competition_id = context.scope.competition_id
+
+    def get_catalog(self, competition_season_id: UUID) -> RosterIdentityCatalog:
+        with read_only_session(self._session_factory) as session:
+            competition, season = self._load_scope(session, competition_season_id)
+            return self._catalog(session, competition, season)
+
+    def apply(self, command: ApplyRosterMappings) -> RosterIdentityCatalog:
+        with transaction_session(self._session_factory) as session:
+            competition, season = self._load_scope(
+                session,
+                command.competition_season_id,
+                lock=True,
+            )
+            if competition.archived_at is not None:
+                raise CompetitionArchivedConflict(competition.id)
+            if not command.assignments:
+                raise RosterMappingConflict(
+                    "roster mapping assignments must not be empty"
+                )
+            sleeper_ids = [item.sleeper_roster_id for item in command.assignments]
+            if len(set(sleeper_ids)) != len(sleeper_ids):
+                raise RosterMappingConflict(
+                    "each Sleeper roster must appear exactly once"
+                )
+
+            existing_rows = {
+                row.sleeper_roster_id: row
+                for row in session.scalars(
+                    sa.select(SeasonRoster).where(
+                        SeasonRoster.competition_season_id == season.id,
+                        SeasonRoster.competition_id == self._competition_id,
+                    )
+                )
+            }
+            requested_existing_ids = [
+                item.target.franchise_id
+                for item in command.assignments
+                if item.target.kind == "existing"
+            ]
+            if len(set(requested_existing_ids)) != len(requested_existing_ids):
+                raise RosterMappingConflict(
+                    "a franchise can be mapped only once in a season"
+                )
+            franchises = {
+                row.id: row
+                for row in session.scalars(
+                    sa.select(Franchise).where(
+                        Franchise.competition_id == self._competition_id,
+                        Franchise.id.in_(requested_existing_ids),
+                    )
+                )
+            }
+            for franchise_id in requested_existing_ids:
+                franchise = franchises.get(franchise_id)
+                if franchise is None:
+                    raise RosterMappingConflict(
+                        "a selected franchise does not belong to this competition"
+                    )
+                if franchise.archived_at is not None:
+                    raise RosterMappingConflict(
+                        "archived franchises cannot receive new season mappings"
+                    )
+
+            for assignment in command.assignments:
+                current = existing_rows.get(assignment.sleeper_roster_id)
+                if current is not None:
+                    target = assignment.target
+                    same_existing = (
+                        target.kind == "existing"
+                        and current.franchise_id == target.franchise_id
+                    )
+                    current_franchise = session.get(Franchise, current.franchise_id)
+                    same_new = (
+                        isinstance(target, CreateFranchiseTarget)
+                        and current_franchise is not None
+                        and current_franchise.display_name == target.display_name
+                    )
+                    if not same_existing and not same_new:
+                        raise RosterMappingConflict(
+                            "existing season-roster mappings cannot be changed"
+                        )
+                    continue
+                target = assignment.target
+                if isinstance(target, CreateFranchiseTarget):
+                    franchise = Franchise(
+                        id=uuid4(),
+                        competition_id=self._competition_id,
+                        display_name=target.display_name,
+                    )
+                    session.add(franchise)
+                    session.flush()
+                    franchise_id = franchise.id
+                else:
+                    franchise_id = target.franchise_id
+                session.add(
+                    SeasonRoster(
+                        id=uuid4(),
+                        competition_id=self._competition_id,
+                        competition_season_id=season.id,
+                        franchise_id=franchise_id,
+                        sleeper_roster_id=assignment.sleeper_roster_id,
+                    )
+                )
+            session.flush()
+            return self._catalog(session, competition, season)
+
+    def bootstrap_first_season(
+        self,
+        competition_season_id: UUID,
+        assignments: Sequence[RosterMappingAssignment],
+    ) -> RosterIdentityCatalog:
+        catalog = self.get_catalog(competition_season_id)
+        if catalog.sequence_number != 1 or catalog.mappings:
+            return catalog
+        return self.apply(
+            ApplyRosterMappings(
+                competition_season_id=competition_season_id,
+                assignments=tuple(assignments),
+            )
+        )
+
+    def _load_scope(
+        self,
+        session: Session,
+        competition_season_id: UUID,
+        *,
+        lock: bool = False,
+    ) -> tuple[Competition, CompetitionSeason]:
+        statement = (
+            sa.select(Competition, CompetitionSeason)
+            .join(
+                CompetitionSeason,
+                CompetitionSeason.competition_id == Competition.id,
+            )
+            .where(
+                Competition.id == self._competition_id,
+                CompetitionSeason.id == competition_season_id,
+            )
+        )
+        if lock:
+            statement = statement.with_for_update(of=(Competition, CompetitionSeason))
+        row = session.execute(statement).one_or_none()
+        if row is None:
+            raise CoreResourceNotFound("competition_season", competition_season_id)
+        return row[0], row[1]
+
+    def _catalog(
+        self,
+        session: Session,
+        competition: Competition,
+        season: CompetitionSeason,
+    ) -> RosterIdentityCatalog:
+        franchises = session.scalars(
+            sa.select(Franchise)
+            .where(Franchise.competition_id == self._competition_id)
+            .order_by(Franchise.display_name, Franchise.id)
+        ).all()
+        mappings = session.scalars(
+            sa.select(SeasonRoster)
+            .where(
+                SeasonRoster.competition_id == self._competition_id,
+                SeasonRoster.competition_season_id == season.id,
+            )
+            .order_by(SeasonRoster.sleeper_roster_id, SeasonRoster.id)
+        ).all()
+        return RosterIdentityCatalog(
+            competition_id=self._competition_id,
+            competition_season_id=season.id,
+            sequence_number=season.sequence_number,
+            competition_archived=competition.archived_at is not None,
+            franchises=tuple(
+                FranchiseIdentity(
+                    id=row.id,
+                    competition_id=row.competition_id,
+                    display_name=row.display_name,
+                    archived_at=row.archived_at,
+                )
+                for row in franchises
+            ),
+            mappings=tuple(
+                SeasonRosterIdentity(
+                    id=row.id,
+                    competition_season_id=row.competition_season_id,
+                    franchise_id=row.franchise_id,
+                    sleeper_roster_id=row.sleeper_roster_id,
+                )
+                for row in mappings
+            ),
+        )
+
+
+__all__ = ["RosterMappingManager"]

--- a/backend/resources/core/roster_mappings/objects.py
+++ b/backend/resources/core/roster_mappings/objects.py
@@ -1,0 +1,71 @@
+"""Caller-facing contracts for durable franchise and season-roster identity."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from backend.resources._contracts import ContractModel, NonBlankStr
+
+
+class FranchiseIdentity(ContractModel):
+    id: UUID
+    competition_id: UUID
+    display_name: str
+    archived_at: AwareDatetime | None
+
+
+class SeasonRosterIdentity(ContractModel):
+    id: UUID
+    competition_season_id: UUID
+    franchise_id: UUID
+    sleeper_roster_id: str
+
+
+class RosterIdentityCatalog(ContractModel):
+    competition_id: UUID
+    competition_season_id: UUID
+    sequence_number: Annotated[int, Field(strict=True, ge=1)]
+    competition_archived: bool
+    franchises: tuple[FranchiseIdentity, ...]
+    mappings: tuple[SeasonRosterIdentity, ...]
+
+
+class CreateFranchiseTarget(ContractModel):
+    kind: Literal["new"] = "new"
+    display_name: NonBlankStr
+
+
+class ExistingFranchiseTarget(ContractModel):
+    kind: Literal["existing"] = "existing"
+    franchise_id: UUID
+
+
+MappingTarget = Annotated[
+    CreateFranchiseTarget | ExistingFranchiseTarget,
+    Field(discriminator="kind"),
+]
+
+
+class RosterMappingAssignment(ContractModel):
+    sleeper_roster_id: NonBlankStr
+    target: MappingTarget
+
+
+class ApplyRosterMappings(ContractModel):
+    competition_season_id: UUID
+    assignments: tuple[RosterMappingAssignment, ...]
+
+
+__all__ = [
+    "ApplyRosterMappings",
+    "CreateFranchiseTarget",
+    "ExistingFranchiseTarget",
+    "FranchiseIdentity",
+    "MappingTarget",
+    "RosterIdentityCatalog",
+    "RosterMappingAssignment",
+    "SeasonRosterIdentity",
+]

--- a/backend/resources/sleeper_data/projections/rosters.py
+++ b/backend/resources/sleeper_data/projections/rosters.py
@@ -21,7 +21,10 @@ from backend.resources.sleeper_data.projections.common import (
     require_users,
     season_roster_identities,
 )
-from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.errors import (
+    DatalayerScopeConflict,
+    RosterIdentityMappingRequired,
+)
 from backend.services.datalayer.sleeper.endpoints.contracts import (
     LeagueRostersEndpointRecords,
 )
@@ -38,7 +41,7 @@ def write_rosters(
     season, identities = season_roster_identities(session, competition_id, request)
     roster_ids = {row.sleeper_roster_id for row in records.rosters}
     if any(roster_id not in identities for roster_id in roster_ids):
-        raise DatalayerScopeConflict(
+        raise RosterIdentityMappingRequired(
             "roster response contains an unmapped Sleeper roster"
         )
     if any(row.sleeper_roster_id not in roster_ids for row in records.managers):

--- a/backend/resources/sleeper_data/requests/manager.py
+++ b/backend/resources/sleeper_data/requests/manager.py
@@ -231,6 +231,54 @@ class ApiRequestManager:
                 for row in rows
             )
 
+    def get_latest_complete_season_request(
+        self,
+        competition_season_id: UUID,
+        endpoint_kind: EndpointKind,
+    ) -> ApiRequestCandidate | None:
+        if endpoint_kind in _GLOBAL_ENDPOINTS:
+            raise InvalidDatalayerRequest(
+                "latest season request requires a season-scoped endpoint"
+            )
+        with read_only_session(self._session_factory) as session:
+            self._require_season(session, competition_season_id)
+            row = session.scalar(
+                sa.select(StoredApiRequest)
+                .join(
+                    StoredRefreshRun,
+                    StoredRefreshRun.id == StoredApiRequest.refresh_run_id,
+                )
+                .where(
+                    StoredRefreshRun.competition_id == self._competition_id,
+                    StoredApiRequest.competition_season_id
+                    == competition_season_id,
+                    StoredApiRequest.endpoint_kind == endpoint_kind.value,
+                    StoredApiRequest.status == RequestStatus.SUCCEEDED.value,
+                    StoredApiRequest.is_complete.is_(True),
+                    StoredApiRequest.payload_id.is_not(None),
+                    StoredApiRequest.response_sha256.is_not(None),
+                )
+                .order_by(
+                    StoredApiRequest.requested_at.desc(),
+                    StoredApiRequest.id.desc(),
+                )
+                .limit(1)
+            )
+            if row is None:
+                return None
+            return ApiRequestCandidate(
+                request_id=row.id,
+                competition_season_id=row.competition_season_id,
+                endpoint_kind=EndpointKind(row.endpoint_kind),
+                scope_key=ScopeKey.parse(row.scope_key),
+                week=row.week,
+                bracket_kind=cast(Any, row.bracket_kind),
+                requested_at=row.requested_at,
+                completed_at=row.completed_at,
+                payload_id=cast(UUID, row.payload_id),
+                response_sha256=cast(str, row.response_sha256),
+            )
+
     def resolve_verified_payloads(
         self,
         request_ids: Collection[UUID],

--- a/backend/services/datalayer/__init__.py
+++ b/backend/services/datalayer/__init__.py
@@ -25,6 +25,7 @@ from backend.services.datalayer.errors import (
     EndpointPayloadRejected,
     InternalDatalayerFailure,
     InvalidDatalayerRequest,
+    RosterIdentityMappingRequired,
     SnapshotUnavailable,
 )
 from backend.services.datalayer.local_files import (
@@ -163,6 +164,7 @@ __all__ = [
     "RosterRecord",
     "SanitizedSourceError",
     "RequestStatus",
+    "RosterIdentityMappingRequired",
     "SNAPSHOT_PROJECTION_VERSION",
     "ScopeKey",
     "ScopeRefreshResult",

--- a/backend/services/datalayer/errors.py
+++ b/backend/services/datalayer/errors.py
@@ -30,6 +30,10 @@ class DatalayerScopeConflict(DatalayerError):
         super().__init__(message)
 
 
+class RosterIdentityMappingRequired(DatalayerScopeConflict):
+    """A complete roster observation cannot yet resolve durable identities."""
+
+
 class EndpointPayloadRejected(DatalayerError):
     """A source payload cannot be normalized without inventing facts."""
 

--- a/backend/services/datalayer/refresh_service.py
+++ b/backend/services/datalayer/refresh_service.py
@@ -32,6 +32,7 @@ from backend.services.datalayer.contracts import (
 from backend.services.datalayer.errors import (
     DatalayerScopeConflict,
     EndpointPayloadRejected,
+    RosterIdentityMappingRequired,
 )
 from backend.services.datalayer.local_files import (
     LocalArtifactKind,
@@ -42,6 +43,8 @@ from backend.services.datalayer.sleeper.endpoints import (
     CompletenessFinding,
     EndpointRecords,
     LeagueEndpointRecords,
+    LeagueRostersEndpointRecords,
+    LeagueUsersEndpointRecords,
     NflStateEndpointRecords,
     build_league_request,
     build_league_rosters_request,
@@ -122,6 +125,15 @@ class ScopeWriter(Protocol):
     ) -> ApplyResult: ...
 
 
+class FirstSeasonRosterMapper(Protocol):
+    def bootstrap_first_season(
+        self,
+        competition_season_id: UUID,
+        rosters: LeagueRostersEndpointRecords,
+        users: LeagueUsersEndpointRecords | None,
+    ) -> None: ...
+
+
 @dataclass(frozen=True, slots=True)
 class PlannedRefresh:
     requests: tuple[EndpointRequest, ...]
@@ -155,6 +167,7 @@ class DatalayerRefreshService:
         retry_backoff_seconds: float = 1.0,
         inline_payload_max_bytes: int = 1024 * 1024,
         delay: Callable[[float], None] = sleep,
+        roster_mappings: FirstSeasonRosterMapper | None = None,
     ) -> None:
         if not code_version.strip():
             raise ValueError("code_version must not be empty")
@@ -188,6 +201,7 @@ class DatalayerRefreshService:
         self._retry_backoff_seconds = retry_backoff_seconds
         self._inline_payload_max_bytes = inline_payload_max_bytes
         self._delay = delay
+        self._roster_mappings = roster_mappings
 
     def refresh(self, request: RefreshRequest) -> RefreshOutcome:
         identity = self._identities.get_refresh_identity(
@@ -320,6 +334,7 @@ class DatalayerRefreshService:
         states: dict[ScopeKey, list[_AttemptState]],
     ) -> None:
         available: set[ScopeKey] = set()
+        normalized_by_kind: dict[EndpointKind, EndpointRecords] = {}
         for endpoint in plan.requests:
             state = states[endpoint.scope_key][-1]
             stored = cast(ApiRequest, state.stored)
@@ -342,6 +357,17 @@ class DatalayerRefreshService:
                 continue
             try:
                 records = _normalize(state.source, endpoint)
+                normalized_by_kind[endpoint.endpoint_kind] = records
+                if (
+                    isinstance(records, LeagueRostersEndpointRecords)
+                    and self._roster_mappings is not None
+                ):
+                    users = normalized_by_kind.get(EndpointKind.LEAGUE_USERS)
+                    self._roster_mappings.bootstrap_first_season(
+                        cast(UUID, stored.competition_season_id),
+                        records,
+                        users if isinstance(users, LeagueUsersEndpointRecords) else None,
+                    )
                 applied = self._scopes.apply_scope(stored.id, records)
             except EndpointPayloadRejected as error:
                 state.stored = self._attempts.reject_normalization(
@@ -349,6 +375,18 @@ class DatalayerRefreshService:
                     NormalizationRejection(code=error.code, summary=error.summary),
                 )
                 state.warning_codes += (error.code,)
+                continue
+            except RosterIdentityMappingRequired:
+                state.stored = self._attempts.reject_normalization(
+                    stored.id,
+                    NormalizationRejection(
+                        code="roster_identity_mapping_required",
+                        summary=(
+                            "Sleeper rosters require durable franchise mappings"
+                        ),
+                    ),
+                )
+                state.warning_codes += ("roster_identity_mapping_required",)
                 continue
             except DatalayerScopeConflict:
                 state.stored = self._attempts.reject_normalization(

--- a/backend/services/league/__init__.py
+++ b/backend/services/league/__init__.py
@@ -1,0 +1,17 @@
+from backend.services.league.contracts import (
+    ObservedRosterMapping,
+    ReconcileRosterMappings,
+    RosterManagerEvidence,
+    RosterMappingResult,
+    RosterMappingView,
+)
+from backend.services.league.roster_mapping_service import RosterMappingService
+
+__all__ = [
+    "ObservedRosterMapping",
+    "ReconcileRosterMappings",
+    "RosterManagerEvidence",
+    "RosterMappingResult",
+    "RosterMappingService",
+    "RosterMappingView",
+]

--- a/backend/services/league/contracts.py
+++ b/backend/services/league/contracts.py
@@ -1,0 +1,55 @@
+"""HTTP-independent contracts for season roster identity onboarding."""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import AwareDatetime, Field
+
+from backend.resources._contracts import ContractModel
+from backend.resources.core import FranchiseIdentity, RosterMappingAssignment
+
+
+class RosterManagerEvidence(ContractModel):
+    sleeper_user_id: str
+    display_name: str
+    team_name: str | None = None
+    role: Literal["owner", "co_owner"]
+
+
+class ObservedRosterMapping(ContractModel):
+    sleeper_roster_id: str
+    suggested_display_name: str
+    managers: tuple[RosterManagerEvidence, ...]
+    franchise_id: UUID | None = None
+    franchise_name: str | None = None
+
+
+class RosterMappingView(ContractModel):
+    status: Literal["awaiting_source", "needs_mapping", "ready"]
+    source_api_request_id: UUID | None = None
+    source_observed_at: AwareDatetime | None = None
+    roster_count: int = Field(strict=True, ge=0)
+    mapped_count: int = Field(strict=True, ge=0)
+    rosters: tuple[ObservedRosterMapping, ...]
+    franchise_options: tuple[FranchiseIdentity, ...]
+
+
+class ReconcileRosterMappings(ContractModel):
+    source_api_request_id: UUID
+    assignments: tuple[RosterMappingAssignment, ...]
+
+
+class RosterMappingResult(ContractModel):
+    mapping: RosterMappingView
+    replay_status: Literal["applied", "deferred"]
+
+
+__all__ = [
+    "ObservedRosterMapping",
+    "ReconcileRosterMappings",
+    "RosterManagerEvidence",
+    "RosterMappingResult",
+    "RosterMappingView",
+]

--- a/backend/services/league/roster_mapping_service.py
+++ b/backend/services/league/roster_mapping_service.py
@@ -1,0 +1,321 @@
+"""Resolve observed Sleeper rosters into durable competition identities."""
+
+from __future__ import annotations
+
+from typing import Protocol, assert_never
+from uuid import UUID
+
+from backend.resources.core import (
+    ApplyRosterMappings,
+    CreateFranchiseTarget,
+    RosterIdentityCatalog,
+    RosterMappingAssignment,
+    RosterMappingConflict,
+)
+from backend.resources.sleeper_data import (
+    ApiRequestCandidate,
+    ApplyResult,
+    InlineVerifiedPayload,
+    ObjectVerifiedPayload,
+    VerifiedPayload,
+)
+from backend.services.datalayer.canonical_json import JsonValue, parse_json_bytes
+from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.local_files import LocalDatalayerFileStore
+from backend.services.datalayer.sleeper.endpoints import (
+    LeagueRostersEndpointRecords,
+    LeagueUsersEndpointRecords,
+    normalize_league_rosters,
+    normalize_league_users,
+)
+from backend.services.datalayer.sleeper.responses import EndpointRequest
+from backend.services.datalayer.sleeper.scope import EndpointKind
+from backend.services.league.contracts import (
+    ObservedRosterMapping,
+    ReconcileRosterMappings,
+    RosterManagerEvidence,
+    RosterMappingResult,
+    RosterMappingView,
+)
+
+
+class MappingStore(Protocol):
+    def get_catalog(self, competition_season_id: UUID) -> RosterIdentityCatalog: ...
+
+    def apply(self, command: ApplyRosterMappings) -> RosterIdentityCatalog: ...
+
+    def bootstrap_first_season(
+        self,
+        competition_season_id: UUID,
+        assignments: tuple[RosterMappingAssignment, ...],
+    ) -> RosterIdentityCatalog: ...
+
+
+class RequestPayloadReader(Protocol):
+    def get_latest_complete_season_request(
+        self,
+        competition_season_id: UUID,
+        endpoint_kind: EndpointKind,
+    ) -> ApiRequestCandidate | None: ...
+
+    def resolve_verified_payloads(
+        self, request_ids: tuple[UUID, ...]
+    ) -> tuple[VerifiedPayload, ...]: ...
+
+
+class ScopeWriter(Protocol):
+    def apply_scope(
+        self,
+        request_id: UUID,
+        records: LeagueRostersEndpointRecords,
+    ) -> ApplyResult: ...
+
+
+class RosterMappingService:
+    """Build mapping views, commit explicit choices, and replay roster scope."""
+
+    def __init__(
+        self,
+        *,
+        mappings: MappingStore,
+        requests: RequestPayloadReader,
+        scopes: ScopeWriter,
+        files: LocalDatalayerFileStore,
+    ) -> None:
+        self._mappings = mappings
+        self._requests = requests
+        self._scopes = scopes
+        self._files = files
+
+    def get_mapping(self, competition_season_id: UUID) -> RosterMappingView:
+        catalog = self._mappings.get_catalog(competition_season_id)
+        source = self._requests.get_latest_complete_season_request(
+            competition_season_id,
+            EndpointKind.LEAGUE_ROSTERS,
+        )
+        if source is None:
+            return RosterMappingView(
+                status="awaiting_source",
+                roster_count=0,
+                mapped_count=len(catalog.mappings),
+                rosters=(),
+                franchise_options=_active_franchises(catalog),
+            )
+        rosters, users = self._load_source_records(competition_season_id, source)
+        return _build_view(catalog, source, rosters, users)
+
+    def reconcile(
+        self,
+        competition_season_id: UUID,
+        command: ReconcileRosterMappings,
+    ) -> RosterMappingResult:
+        source = self._requests.get_latest_complete_season_request(
+            competition_season_id,
+            EndpointKind.LEAGUE_ROSTERS,
+        )
+        if source is None or source.request_id != command.source_api_request_id:
+            raise RosterMappingConflict(
+                "the observed roster source changed; reload team setup",
+                stale_source=True,
+            )
+        rosters, _ = self._load_source_records(competition_season_id, source)
+        observed_ids = {row.sleeper_roster_id for row in rosters.rosters}
+        requested_ids = {row.sleeper_roster_id for row in command.assignments}
+        if (
+            len(requested_ids) != len(command.assignments)
+            or requested_ids != observed_ids
+        ):
+            raise RosterMappingConflict(
+                "assignments must cover every observed Sleeper roster exactly once"
+            )
+        self._mappings.apply(
+            ApplyRosterMappings(
+                competition_season_id=competition_season_id,
+                assignments=command.assignments,
+            )
+        )
+        try:
+            self._scopes.apply_scope(source.request_id, rosters)
+        except DatalayerScopeConflict:
+            replay_status = "deferred"
+        else:
+            replay_status = "applied"
+        return RosterMappingResult(
+            mapping=self.get_mapping(competition_season_id),
+            replay_status=replay_status,
+        )
+
+    def bootstrap_first_season(
+        self,
+        competition_season_id: UUID,
+        rosters: LeagueRostersEndpointRecords,
+        users: LeagueUsersEndpointRecords | None,
+    ) -> None:
+        catalog = self._mappings.get_catalog(competition_season_id)
+        if catalog.sequence_number != 1 or catalog.mappings:
+            return
+        evidence = _manager_evidence(rosters, users)
+        assignments = tuple(
+            RosterMappingAssignment(
+                sleeper_roster_id=roster.sleeper_roster_id,
+                target=CreateFranchiseTarget(
+                    display_name=_suggested_name(
+                        roster.sleeper_roster_id,
+                        evidence[roster.sleeper_roster_id],
+                    )
+                ),
+            )
+            for roster in rosters.rosters
+        )
+        if assignments:
+            self._mappings.bootstrap_first_season(
+                competition_season_id,
+                assignments,
+            )
+
+    def _load_source_records(
+        self,
+        competition_season_id: UUID,
+        roster_source: ApiRequestCandidate,
+    ) -> tuple[LeagueRostersEndpointRecords, LeagueUsersEndpointRecords | None]:
+        users_source = self._requests.get_latest_complete_season_request(
+            competition_season_id,
+            EndpointKind.LEAGUE_USERS,
+        )
+        candidates = (roster_source,) if users_source is None else (
+            roster_source,
+            users_source,
+        )
+        payloads = self._requests.resolve_verified_payloads(
+            tuple(item.request_id for item in candidates)
+        )
+        values = {
+            candidate.endpoint_kind: self._payload_value(payload)
+            for candidate, payload in zip(candidates, payloads, strict=True)
+        }
+        roster_records = normalize_league_rosters(
+            values[EndpointKind.LEAGUE_ROSTERS],
+            _endpoint_request(roster_source),
+        )
+        if users_source is None:
+            return roster_records, None
+        return roster_records, normalize_league_users(
+            values[EndpointKind.LEAGUE_USERS],
+            _endpoint_request(users_source),
+        )
+
+    def _payload_value(self, payload: VerifiedPayload) -> JsonValue:
+        if isinstance(payload, InlineVerifiedPayload):
+            return payload.payload
+        if isinstance(payload, ObjectVerifiedPayload):
+            artifact = self._files.open_verified(
+                payload.storage_key,
+                expected_sha256=payload.sha256,
+                expected_byte_length=payload.byte_length,
+            )
+            return parse_json_bytes(artifact.path.read_bytes())
+        assert_never(payload)
+
+
+def _endpoint_request(candidate: ApiRequestCandidate) -> EndpointRequest:
+    suffix = (
+        "/rosters"
+        if candidate.endpoint_kind is EndpointKind.LEAGUE_ROSTERS
+        else "/users"
+    )
+    return EndpointRequest(
+        endpoint_kind=candidate.endpoint_kind,
+        scope_key=candidate.scope_key,
+        path=f"/league/source{suffix}",
+    )
+
+
+def _build_view(
+    catalog: RosterIdentityCatalog,
+    source: ApiRequestCandidate,
+    rosters: LeagueRostersEndpointRecords,
+    users: LeagueUsersEndpointRecords | None,
+) -> RosterMappingView:
+    mappings = {row.sleeper_roster_id: row for row in catalog.mappings}
+    franchises = {row.id: row for row in catalog.franchises}
+    evidence = _manager_evidence(rosters, users)
+    rows: list[ObservedRosterMapping] = []
+    for roster in rosters.rosters:
+        mapping = mappings.get(roster.sleeper_roster_id)
+        franchise = None if mapping is None else franchises.get(mapping.franchise_id)
+        rows.append(
+            ObservedRosterMapping(
+                sleeper_roster_id=roster.sleeper_roster_id,
+                suggested_display_name=_suggested_name(
+                    roster.sleeper_roster_id,
+                    evidence[roster.sleeper_roster_id],
+                ),
+                managers=evidence[roster.sleeper_roster_id],
+                franchise_id=None if franchise is None else franchise.id,
+                franchise_name=None if franchise is None else franchise.display_name,
+            )
+        )
+    observed_ids = {row.sleeper_roster_id for row in rosters.rosters}
+    mapped_ids = set(mappings).intersection(observed_ids)
+    ready = observed_ids == set(mappings)
+    return RosterMappingView(
+        status="ready" if ready else "needs_mapping",
+        source_api_request_id=source.request_id,
+        source_observed_at=source.completed_at,
+        roster_count=len(observed_ids),
+        mapped_count=len(mapped_ids),
+        rosters=tuple(rows),
+        franchise_options=_active_franchises(catalog),
+    )
+
+
+def _active_franchises(
+    catalog: RosterIdentityCatalog,
+) -> tuple:
+    return tuple(row for row in catalog.franchises if row.archived_at is None)
+
+
+def _manager_evidence(
+    rosters: LeagueRostersEndpointRecords,
+    users: LeagueUsersEndpointRecords | None,
+) -> dict[str, tuple[RosterManagerEvidence, ...]]:
+    profiles = {} if users is None else {
+        row.sleeper_user_id: row for row in users.users
+    }
+    memberships = {} if users is None else {
+        row.sleeper_user_id: row for row in users.league_users
+    }
+    result: dict[str, list[RosterManagerEvidence]] = {
+        row.sleeper_roster_id: [] for row in rosters.rosters
+    }
+    for manager in rosters.managers:
+        profile = profiles.get(manager.sleeper_user_id)
+        membership = memberships.get(manager.sleeper_user_id)
+        result[manager.sleeper_roster_id].append(
+            RosterManagerEvidence(
+                sleeper_user_id=manager.sleeper_user_id,
+                display_name=(
+                    manager.sleeper_user_id
+                    if profile is None
+                    else profile.display_name
+                ),
+                team_name=None if membership is None else membership.team_name,
+                role=manager.role,
+            )
+        )
+    return {key: tuple(value) for key, value in result.items()}
+
+
+def _suggested_name(
+    sleeper_roster_id: str,
+    managers: tuple[RosterManagerEvidence, ...],
+) -> str:
+    owner = next((row for row in managers if row.role == "owner"), None)
+    if owner is not None and owner.team_name and owner.team_name.strip():
+        return owner.team_name.strip()
+    if owner is not None and owner.display_name.strip():
+        return owner.display_name.strip()
+    return f"Roster {sleeper_roster_id}"
+
+
+__all__ = ["RosterMappingService"]

--- a/backend/tests/api/test_competition_routes.py
+++ b/backend/tests/api/test_competition_routes.py
@@ -29,6 +29,12 @@ from backend.resources.core import (
     CompetitionSeasonYearExists,
     CoreResourceNotFound,
     SleeperLeagueIdExists,
+    RosterMappingConflict,
+)
+from backend.services.league import (
+    ReconcileRosterMappings,
+    RosterMappingResult,
+    RosterMappingView,
 )
 
 
@@ -86,6 +92,35 @@ class StubSeasonManager:
         if self.error is not None:
             raise self.error
         return self.season
+
+
+class StubRosterMappings:
+    def __init__(self) -> None:
+        self.view = RosterMappingView(
+            status="awaiting_source",
+            roster_count=0,
+            mapped_count=0,
+            rosters=(),
+            franchise_options=(),
+        )
+        self.season_ids: list[UUID] = []
+        self.commands: list[ReconcileRosterMappings] = []
+        self.error: Exception | None = None
+
+    def get_mapping(self, season_id: UUID) -> RosterMappingView:
+        self.season_ids.append(season_id)
+        if self.error is not None:
+            raise self.error
+        return self.view
+
+    def reconcile(
+        self, season_id: UUID, command: ReconcileRosterMappings
+    ) -> RosterMappingResult:
+        self.season_ids.append(season_id)
+        self.commands.append(command)
+        if self.error is not None:
+            raise self.error
+        return RosterMappingResult(mapping=self.view, replay_status="deferred")
 
 
 class StubOverviewReader:
@@ -199,6 +234,7 @@ def _dependencies() -> SimpleNamespace:
         competitions=StubCompetitionManager(competition),
         seasons=StubSeasonManager(season),
         overviews=reader,
+        roster_mappings=StubRosterMappings(),
     )
 
 
@@ -289,6 +325,67 @@ async def test_competition_season_routes_are_scoped_and_ordered() -> None:
     assert dependencies.overviews.season_ids == [
         (dependencies.competition.id, dependencies.season.id)
     ]
+
+
+@pytest.mark.asyncio
+async def test_roster_mapping_routes_preserve_source_token_and_targets() -> None:
+    dependencies = _dependencies()
+    app, client = await _client(dependencies)
+    source_id = uuid4()
+    franchise_id = uuid4()
+    base = (
+        f"/api/v1/competitions/{dependencies.competition.id}/seasons/"
+        f"{dependencies.season.id}/roster-mappings"
+    )
+
+    async with app.router.lifespan_context(app), client:
+        viewed = await client.get(base)
+        updated = await client.put(
+            base,
+            json={
+                "source_api_request_id": str(source_id),
+                "assignments": [
+                    {
+                        "sleeper_roster_id": "1",
+                        "target": {
+                            "kind": "existing",
+                            "franchise_id": str(franchise_id),
+                        },
+                    },
+                    {
+                        "sleeper_roster_id": "2",
+                        "target": {"kind": "new", "display_name": " New Team "},
+                    },
+                ],
+            },
+        )
+
+    assert viewed.status_code == 200
+    assert viewed.json()["mapping"]["status"] == "awaiting_source"
+    assert updated.status_code == 200
+    command = dependencies.roster_mappings.commands[0]
+    assert command.source_api_request_id == source_id
+    assert command.assignments[0].target.franchise_id == franchise_id
+    assert command.assignments[1].target.display_name == "New Team"
+
+
+@pytest.mark.asyncio
+async def test_roster_mapping_stale_source_has_stable_conflict() -> None:
+    dependencies = _dependencies()
+    dependencies.roster_mappings.error = RosterMappingConflict(
+        "reload team setup", stale_source=True
+    )
+    app, client = await _client(dependencies)
+    base = (
+        f"/api/v1/competitions/{dependencies.competition.id}/seasons/"
+        f"{dependencies.season.id}/roster-mappings"
+    )
+
+    async with app.router.lifespan_context(app), client:
+        response = await client.get(base)
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "roster_mapping_source_stale"
 
 
 @pytest.mark.asyncio
@@ -402,6 +499,7 @@ def test_openapi_contains_competition_and_season_boundaries() -> None:
         f"{base}/{{competition_id}}",
         f"{base}/{{competition_id}}/seasons",
         f"{base}/{{competition_id}}/seasons/{{season_id}}",
+        f"{base}/{{competition_id}}/seasons/{{season_id}}/roster-mappings",
     }.issubset(paths)
     patch_schema = schema["paths"][f"{base}/{{competition_id}}"]["patch"]
     assert "422" in patch_schema["responses"]

--- a/backend/tests/resources/core/test_roster_mapping_manager.py
+++ b/backend/tests/resources/core/test_roster_mapping_manager.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import Engine
+
+from backend.database.models.core import Franchise
+from backend.resources.core import (
+    ApplyRosterMappings,
+    CompetitionManager,
+    CreateCompetition,
+    CreateCompetitionSeason,
+    CreateFranchiseTarget,
+    ExistingFranchiseTarget,
+    RosterMappingAssignment,
+    RosterMappingConflict,
+    RosterMappingManager,
+)
+from backend.resources.core.competition_seasons import CompetitionSeasonManager
+from backend.tests.resources.core.conftest import competition_context, global_context
+
+
+def test_mapping_manager_creates_and_idempotently_reads_mappings(
+    database_engine: Engine,
+    session_factory,
+) -> None:
+    competition = CompetitionManager(session_factory, global_context()).create(
+        CreateCompetition(display_name="Identity League")
+    )
+    seasons = CompetitionSeasonManager(
+        session_factory, competition_context(competition.id)
+    )
+    season = seasons.create(
+        CreateCompetitionSeason(season_year=2026, sleeper_league_id="identity-1")
+    )
+    manager = RosterMappingManager(
+        session_factory, competition_context(competition.id)
+    )
+    command = ApplyRosterMappings(
+        competition_season_id=season.id,
+        assignments=(
+            RosterMappingAssignment(
+                sleeper_roster_id="1",
+                target=CreateFranchiseTarget(display_name="Alpha"),
+            ),
+        ),
+    )
+
+    created = manager.apply(command)
+    repeated = manager.apply(command)
+
+    assert len(created.franchises) == 1
+    assert repeated.mappings == created.mappings
+    with pytest.raises(RosterMappingConflict, match="cannot be changed"):
+        manager.apply(
+            ApplyRosterMappings(
+                competition_season_id=season.id,
+                assignments=(
+                    RosterMappingAssignment(
+                        sleeper_roster_id="1",
+                        target=CreateFranchiseTarget(display_name="Different"),
+                    ),
+                ),
+            )
+        )
+
+
+def test_mapping_manager_rejects_remap_and_cross_competition_franchise(
+    database_engine: Engine,
+    session_factory,
+) -> None:
+    competition = CompetitionManager(session_factory, global_context()).create(
+        CreateCompetition(display_name="Primary")
+    )
+    other = CompetitionManager(session_factory, global_context()).create(
+        CreateCompetition(display_name="Other")
+    )
+    season = CompetitionSeasonManager(
+        session_factory, competition_context(competition.id)
+    ).create(CreateCompetitionSeason(season_year=2026, sleeper_league_id="primary"))
+    other_franchise_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Franchise),
+            {
+                "id": other_franchise_id,
+                "competition_id": other.id,
+                "display_name": "Other Team",
+            },
+        )
+    manager = RosterMappingManager(
+        session_factory, competition_context(competition.id)
+    )
+
+    with pytest.raises(RosterMappingConflict, match="does not belong"):
+        manager.apply(
+            ApplyRosterMappings(
+                competition_season_id=season.id,
+                assignments=(
+                    RosterMappingAssignment(
+                        sleeper_roster_id="1",
+                        target=ExistingFranchiseTarget(
+                            franchise_id=other_franchise_id
+                        ),
+                    ),
+                ),
+            )
+        )
+
+
+def test_first_season_bootstrap_does_not_run_for_later_season(
+    database_engine: Engine,
+    session_factory,
+) -> None:
+    competition = CompetitionManager(session_factory, global_context()).create(
+        CreateCompetition(display_name="Dynasty")
+    )
+    seasons = CompetitionSeasonManager(
+        session_factory, competition_context(competition.id)
+    )
+    seasons.create(CreateCompetitionSeason(season_year=2025, sleeper_league_id="d1"))
+    later = seasons.create(
+        CreateCompetitionSeason(season_year=2026, sleeper_league_id="d2")
+    )
+    manager = RosterMappingManager(
+        session_factory, competition_context(competition.id)
+    )
+
+    catalog = manager.bootstrap_first_season(
+        later.id,
+        (
+            RosterMappingAssignment(
+                sleeper_roster_id="1",
+                target=CreateFranchiseTarget(display_name="Should not exist"),
+            ),
+        ),
+    )
+
+    assert catalog.sequence_number == 2
+    assert catalog.mappings == ()

--- a/backend/tests/services/datalayer/test_refresh_service.py
+++ b/backend/tests/services/datalayer/test_refresh_service.py
@@ -31,6 +31,7 @@ from backend.services.datalayer import (
 )
 from backend.services.datalayer.canonical_json import canonical_json_bytes
 from backend.services.datalayer.errors import DatalayerScopeConflict
+from backend.services.datalayer.errors import RosterIdentityMappingRequired
 from backend.services.datalayer.refresh_service import (
     DatalayerRefreshService,
     build_standard_refresh_plan,
@@ -386,6 +387,56 @@ def test_large_payloads_are_recorded_with_object_receipts(tmp_path: Path) -> Non
 
     assert outcome.status is RefreshStatus.SUCCEEDED
     assert all(command.object_receipt is not None for command in backend.commands)
+
+
+def test_refresh_bootstraps_first_season_before_roster_projection(
+    tmp_path: Path,
+) -> None:
+    backend = FakeBackend()
+    mapper = FakeRosterMapper()
+    payloads = _payloads(nfl_week=1, playoff_week=3)
+    payloads[EndpointKind.LEAGUE_ROSTERS] = [
+        {"roster_id": 1, "settings": {}, "metadata": {}}
+    ]
+    source = FakeSource(payloads=payloads)
+
+    outcome = _service(
+        tmp_path,
+        source,
+        backend,
+        roster_mappings=mapper,
+    ).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    assert outcome.status is RefreshStatus.SUCCEEDED
+    assert mapper.calls == [(SEASON_ID, 1, 0)]
+
+
+def test_missing_later_season_mapping_has_actionable_warning(tmp_path: Path) -> None:
+    backend = FakeBackend(
+        mapping_required_endpoint_kind=EndpointKind.LEAGUE_ROSTERS
+    )
+    source = FakeSource(payloads=_payloads(nfl_week=1, playoff_week=3))
+
+    outcome = _service(tmp_path, source, backend).refresh(
+        RefreshRequest(
+            competition_season_id=SEASON_ID,
+            through_week=1,
+            trigger=RefreshTrigger.MANUAL,
+        )
+    )
+
+    roster_result = next(
+        row
+        for row in outcome.scope_results
+        if row.scope_key.value.startswith("league_rosters:")
+    )
+    assert roster_result.warning_codes == ("roster_identity_mapping_required",)
     assert all(
         command.object_receipt.storage_key.startswith("payloads/sha256/")
         for command in backend.commands
@@ -456,12 +507,16 @@ class FakeSource:
 
 class FakeBackend:
     def __init__(
-        self, *, conflict_endpoint_kind: EndpointKind | None = None
+        self,
+        *,
+        conflict_endpoint_kind: EndpointKind | None = None,
+        mapping_required_endpoint_kind: EndpointKind | None = None,
     ) -> None:
         self.command: StartRefresh | None = None
         self.requests: list[ApiRequest] = []
         self.commands: list[RecordApiAttempt] = []
         self.conflict_endpoint_kind = conflict_endpoint_kind
+        self.mapping_required_endpoint_kind = mapping_required_endpoint_kind
 
     def start_refresh(self, command: StartRefresh) -> RefreshRun:
         self.command = command
@@ -541,6 +596,8 @@ class FakeBackend:
     def apply_scope(self, request_id: UUID, records: Any) -> ApplyResult:
         del records
         current = self._request(request_id)
+        if current.endpoint_kind is self.mapping_required_endpoint_kind:
+            raise RosterIdentityMappingRequired("mapping required")
         if current.endpoint_kind is self.conflict_endpoint_kind:
             raise DatalayerScopeConflict("test mapping conflict")
         request = current.model_copy(
@@ -604,6 +661,7 @@ def _service(
     delay: Any = lambda _: None,
     files: Any | None = None,
     inline_payload_max_bytes: int = 1024 * 1024,
+    roster_mappings: Any | None = None,
 ) -> DatalayerRefreshService:
     return DatalayerRefreshService(
         source=source,
@@ -617,7 +675,22 @@ def _service(
         retry_backoff_seconds=0.5,
         inline_payload_max_bytes=inline_payload_max_bytes,
         delay=delay,
+        roster_mappings=roster_mappings,
     )
+
+
+class FakeRosterMapper:
+    def __init__(self) -> None:
+        self.calls: list[tuple[UUID, int, int]] = []
+
+    def bootstrap_first_season(self, competition_season_id, rosters, users) -> None:
+        self.calls.append(
+            (
+                competition_season_id,
+                len(rosters.rosters),
+                0 if users is None else len(users.users),
+            )
+        )
 
 
 def _payloads(*, nfl_week: int, playoff_week: int) -> dict[EndpointKind, Any]:

--- a/backend/tests/services/league/test_roster_mapping_service.py
+++ b/backend/tests/services/league/test_roster_mapping_service.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from backend.resources.core import (
+    ApplyRosterMappings,
+    CreateFranchiseTarget,
+    FranchiseIdentity,
+    RosterIdentityCatalog,
+    RosterMappingAssignment,
+    RosterMappingConflict,
+    SeasonRosterIdentity,
+)
+from backend.resources.sleeper_data import (
+    ApiRequestCandidate,
+    ApplyResult,
+    InlineVerifiedPayload,
+)
+from backend.services.datalayer import ApplyDisposition, EndpointKind, ScopeKey
+from backend.services.datalayer.local_files import LocalDatalayerFileStore
+from backend.services.datalayer.sleeper.endpoints import (
+    LeagueRostersEndpointRecords,
+    LeagueUsersEndpointRecords,
+)
+from backend.services.league import ReconcileRosterMappings, RosterMappingService
+
+
+COMPETITION_ID = UUID("10000000-0000-0000-0000-000000000001")
+SEASON_ID = UUID("20000000-0000-0000-0000-000000000002")
+REQUEST_ID = UUID("30000000-0000-0000-0000-000000000003")
+NOW = datetime(2026, 8, 23, tzinfo=UTC)
+
+
+class FakeMappings:
+    def __init__(self, *, sequence_number: int = 2) -> None:
+        self.catalog = RosterIdentityCatalog(
+            competition_id=COMPETITION_ID,
+            competition_season_id=SEASON_ID,
+            sequence_number=sequence_number,
+            competition_archived=False,
+            franchises=(
+                FranchiseIdentity(
+                    id=UUID("40000000-0000-0000-0000-000000000004"),
+                    competition_id=COMPETITION_ID,
+                    display_name="Returning Team",
+                    archived_at=None,
+                ),
+            ),
+            mappings=(),
+        )
+        self.applied: ApplyRosterMappings | None = None
+        self.bootstrapped: tuple[RosterMappingAssignment, ...] = ()
+
+    def get_catalog(self, competition_season_id: UUID) -> RosterIdentityCatalog:
+        assert competition_season_id == SEASON_ID
+        return self.catalog
+
+    def apply(self, command: ApplyRosterMappings) -> RosterIdentityCatalog:
+        self.applied = command
+        franchises = list(self.catalog.franchises)
+        mappings: list[SeasonRosterIdentity] = []
+        for assignment in command.assignments:
+            if isinstance(assignment.target, CreateFranchiseTarget):
+                franchise = FranchiseIdentity(
+                    id=uuid4(),
+                    competition_id=COMPETITION_ID,
+                    display_name=assignment.target.display_name,
+                    archived_at=None,
+                )
+                franchises.append(franchise)
+            else:
+                franchise = next(
+                    item
+                    for item in franchises
+                    if item.id == assignment.target.franchise_id
+                )
+            mappings.append(
+                SeasonRosterIdentity(
+                    id=uuid4(),
+                    competition_season_id=SEASON_ID,
+                    franchise_id=franchise.id,
+                    sleeper_roster_id=assignment.sleeper_roster_id,
+                )
+            )
+        self.catalog = self.catalog.model_copy(
+            update={"franchises": tuple(franchises), "mappings": tuple(mappings)}
+        )
+        return self.catalog
+
+    def bootstrap_first_season(
+        self,
+        competition_season_id: UUID,
+        assignments: tuple[RosterMappingAssignment, ...],
+    ) -> RosterIdentityCatalog:
+        self.bootstrapped = assignments
+        return self.apply(
+            ApplyRosterMappings(
+                competition_season_id=competition_season_id,
+                assignments=assignments,
+            )
+        )
+
+
+class FakeRequests:
+    def __init__(self, *, with_source: bool = True) -> None:
+        self.roster_candidate = _candidate(EndpointKind.LEAGUE_ROSTERS, REQUEST_ID)
+        self.users_candidate = _candidate(EndpointKind.LEAGUE_USERS, uuid4())
+        self.with_source = with_source
+        self.payloads = {
+            self.roster_candidate.request_id: _payload(
+                self.roster_candidate,
+                [
+                    {
+                        "roster_id": 1,
+                        "owner_id": "u1",
+                        "settings": {},
+                        "metadata": {},
+                    },
+                    {
+                        "roster_id": 2,
+                        "settings": {},
+                        "metadata": {},
+                    },
+                ],
+            ),
+            self.users_candidate.request_id: _payload(
+                self.users_candidate,
+                [
+                    {
+                        "user_id": "u1",
+                        "display_name": "Manager One",
+                        "metadata": {"team_name": "Alpha Team"},
+                    }
+                ],
+            ),
+        }
+
+    def get_latest_complete_season_request(
+        self,
+        competition_season_id: UUID,
+        endpoint_kind: EndpointKind,
+    ) -> ApiRequestCandidate | None:
+        assert competition_season_id == SEASON_ID
+        if not self.with_source:
+            return None
+        return (
+            self.roster_candidate
+            if endpoint_kind is EndpointKind.LEAGUE_ROSTERS
+            else self.users_candidate
+        )
+
+    def resolve_verified_payloads(
+        self, request_ids: tuple[UUID, ...]
+    ) -> tuple[InlineVerifiedPayload, ...]:
+        return tuple(self.payloads[item] for item in request_ids)
+
+
+class FakeScopes:
+    def __init__(self, *, conflict: bool = False) -> None:
+        self.conflict = conflict
+        self.applied: LeagueRostersEndpointRecords | None = None
+
+    def apply_scope(
+        self,
+        request_id: UUID,
+        records: LeagueRostersEndpointRecords,
+    ) -> ApplyResult:
+        from backend.services.datalayer.errors import DatalayerScopeConflict
+
+        if self.conflict:
+            raise DatalayerScopeConflict("dependency unavailable")
+        self.applied = records
+        return ApplyResult(
+            request_id=request_id,
+            scope_key=ScopeKey.from_parts(EndpointKind.LEAGUE_ROSTERS, SEASON_ID),
+            disposition=ApplyDisposition.APPLIED,
+            head_request_id=request_id,
+            normalized_row_count=2,
+            changed_current_view=True,
+        )
+
+
+def test_mapping_view_waits_for_a_complete_roster_source(tmp_path) -> None:
+    service = _service(tmp_path, FakeMappings(), FakeRequests(with_source=False))
+
+    view = service.get_mapping(SEASON_ID)
+
+    assert view.status == "awaiting_source"
+    assert view.rosters == ()
+    assert view.franchise_options[0].display_name == "Returning Team"
+
+
+def test_mapping_view_uses_team_owner_and_roster_name_fallbacks(tmp_path) -> None:
+    service = _service(tmp_path, FakeMappings(), FakeRequests())
+
+    view = service.get_mapping(SEASON_ID)
+
+    assert view.status == "needs_mapping"
+    assert [row.suggested_display_name for row in view.rosters] == [
+        "Alpha Team",
+        "Roster 2",
+    ]
+    assert view.rosters[0].managers[0].display_name == "Manager One"
+
+
+def test_reconcile_requires_latest_source_and_exact_coverage(tmp_path) -> None:
+    service = _service(tmp_path, FakeMappings(), FakeRequests())
+    command = ReconcileRosterMappings(source_api_request_id=uuid4(), assignments=())
+
+    try:
+        service.reconcile(SEASON_ID, command)
+    except RosterMappingConflict as error:
+        assert error.stale_source
+    else:
+        raise AssertionError("stale source should conflict")
+
+
+def test_reconcile_commits_mapping_and_reports_deferred_replay(tmp_path) -> None:
+    mappings = FakeMappings()
+    scopes = FakeScopes(conflict=True)
+    service = _service(tmp_path, mappings, FakeRequests(), scopes=scopes)
+    existing = mappings.catalog.franchises[0]
+
+    result = service.reconcile(
+        SEASON_ID,
+        ReconcileRosterMappings(
+            source_api_request_id=REQUEST_ID,
+            assignments=(
+                RosterMappingAssignment(
+                    sleeper_roster_id="1",
+                    target={"kind": "existing", "franchise_id": existing.id},
+                ),
+                RosterMappingAssignment(
+                    sleeper_roster_id="2",
+                    target={"kind": "new", "display_name": "Expansion"},
+                ),
+            ),
+        ),
+    )
+
+    assert result.replay_status == "deferred"
+    assert result.mapping.status == "ready"
+    assert result.mapping.mapped_count == 2
+
+
+def test_first_season_bootstrap_creates_only_new_franchises(tmp_path) -> None:
+    mappings = FakeMappings(sequence_number=1)
+    requests = FakeRequests()
+    service = _service(tmp_path, mappings, requests)
+    rosters, users = service._load_source_records(  # noqa: SLF001
+        SEASON_ID, requests.roster_candidate
+    )
+
+    service.bootstrap_first_season(SEASON_ID, rosters, users)
+
+    assert [item.sleeper_roster_id for item in mappings.bootstrapped] == ["1", "2"]
+    assert all(item.target.kind == "new" for item in mappings.bootstrapped)
+
+
+def _service(
+    tmp_path,
+    mappings: FakeMappings,
+    requests: FakeRequests,
+    *,
+    scopes: FakeScopes | None = None,
+) -> RosterMappingService:
+    return RosterMappingService(
+        mappings=mappings,
+        requests=requests,
+        scopes=scopes or FakeScopes(),
+        files=LocalDatalayerFileStore(tmp_path),
+    )
+
+
+def _candidate(kind: EndpointKind, request_id: UUID) -> ApiRequestCandidate:
+    return ApiRequestCandidate(
+        request_id=request_id,
+        competition_season_id=SEASON_ID,
+        endpoint_kind=kind,
+        scope_key=ScopeKey.from_parts(kind, SEASON_ID),
+        week=None,
+        bracket_kind=None,
+        requested_at=NOW,
+        completed_at=NOW,
+        payload_id=uuid4(),
+        response_sha256="a" * 64,
+    )
+
+
+def _payload(
+    candidate: ApiRequestCandidate,
+    payload,
+) -> InlineVerifiedPayload:
+    return InlineVerifiedPayload(
+        request_id=candidate.request_id,
+        scope_key=candidate.scope_key,
+        sha256="a" * 64,
+        byte_length=1,
+        media_type="application/json",
+        payload=payload,
+    )

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -56,6 +56,8 @@ Recommended routes:
 | `GET /competitions/{competition_id}/seasons` | Ordered season list | Implemented |
 | `POST /competitions/{competition_id}/seasons` | Attach `{season_year, sleeper_league_id}` and derive sequence | Implemented |
 | `GET /competitions/{competition_id}/seasons/{season_id}` | Season identity plus normalized league overview when present | Implemented |
+| `GET /competitions/{competition_id}/seasons/{season_id}/roster-mappings` | Read roster-identity readiness and observed mapping evidence | Implemented |
+| `PUT /competitions/{competition_id}/seasons/{season_id}/roster-mappings` | Atomically map every observed roster to an existing or new franchise | Implemented |
 
 Example creation response:
 
@@ -113,7 +115,8 @@ Typed competition errors use the new product envelope:
 The stable core codes are `competition_not_found`,
 `competition_season_not_found`, `competition_archived`,
 `competition_season_year_exists`, `sleeper_league_id_exists`, and
-`competition_concurrency_conflict`.
+`competition_concurrency_conflict`, `roster_mapping_conflict`, and
+`roster_mapping_source_stale`.
 
 Season creation must return `409` codes for at least
 `competition_season_year_exists` and `sleeper_league_id_exists`. Editing an ID
@@ -125,6 +128,14 @@ rows by default, while direct competition and historical season reads remain
 available. Repeating archive is idempotent; renaming an archived competition or
 attaching another season is rejected. Restore and cascading changes to existing
 generation or memory resources are out of scope.
+
+The first complete roster observation for a competition's first season creates
+one durable franchise per Sleeper roster because no cross-season identity choice
+exists. Later seasons never infer continuity from team names, manager names, or
+roster position. Their mapping resource reports `awaiting_source`,
+`needs_mapping`, or `ready`; mutation requires the latest complete roster
+request ID as an optimistic source token and exactly one target per observed
+roster. Existing season-roster mappings are immutable.
 
 ## Required Refresh and Data Audit API
 

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -84,6 +84,14 @@ season. Duplicate season years and globally reused Sleeper league IDs are
 reported inline from typed API conflicts. The UI does not guess that linked
 Sleeper predecessor/successor IDs belong to the same AIdam competition.
 
+The first refresh of the competition's first season creates one durable team
+identity per observed roster. For a later season, a complete roster observation
+may pause normalization until the operator maps every Sleeper roster to one
+unused existing team or creates a new team. The setup view shows team and owner
+labels only as evidence; it never preselects cross-season continuity. After the
+mapping is saved, the application starts a fresh full refresh using the prior
+requested through-week value.
+
 ### Competition overview
 
 The page header shows competition name and the active/latest season selector.

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -70,6 +70,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/competitions/{competition_id}/seasons/{season_id}/roster-mappings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Roster Mappings */
+        get: operations["get_roster_mappings_api_v1_competitions__competition_id__seasons__season_id__roster_mappings_get"];
+        /** Put Roster Mappings */
+        put: operations["put_roster_mappings_api_v1_competitions__competition_id__seasons__season_id__roster_mappings_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/data/competitions/{competition_id}/seasons/{season_id}/overview": {
         parameters: {
             query?: never;
@@ -1400,7 +1418,7 @@ export interface components {
              * Code
              * @enum {string}
              */
-            code: "competition_not_found" | "competition_season_not_found" | "competition_archived" | "competition_season_year_exists" | "sleeper_league_id_exists" | "competition_concurrency_conflict";
+            code: "competition_not_found" | "competition_season_not_found" | "competition_archived" | "competition_season_year_exists" | "sleeper_league_id_exists" | "competition_concurrency_conflict" | "roster_mapping_conflict" | "roster_mapping_source_stale";
             /** Correlation Id */
             correlation_id?: string | null;
             /** Field Errors */
@@ -1436,6 +1454,16 @@ export interface components {
             season_year: number;
             /** Sleeper League Id */
             sleeper_league_id: string;
+        };
+        /** CreateFranchiseTargetBody */
+        CreateFranchiseTargetBody: {
+            /** Display Name */
+            display_name: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "new";
         };
         /** DataErrorDetail */
         DataErrorDetail: {
@@ -1638,6 +1666,19 @@ export interface components {
          * @enum {string}
          */
         EvidenceRole: "origin" | "support" | "update" | "payoff";
+        /** ExistingFranchiseTargetBody */
+        ExistingFranchiseTargetBody: {
+            /**
+             * Franchise Id
+             * Format: uuid
+             */
+            franchise_id: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            kind: "existing";
+        };
         /** FactContent */
         "FactContent-Input": {
             /** Category */
@@ -1780,6 +1821,23 @@ export interface components {
              * @enum {string}
              */
             scope: "franchise";
+        };
+        /** FranchiseIdentity */
+        FranchiseIdentity: {
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Competition Id
+             * Format: uuid
+             */
+            competition_id: string;
+            /** Display Name */
+            display_name: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
         };
         /** FranchiseRef[FactSubjectRole] */
         FranchiseRef_FactSubjectRole_: {
@@ -2598,6 +2656,19 @@ export interface components {
          * @enum {string}
          */
         NormalizationStatus: "pending" | "succeeded" | "rejected" | "not_applicable";
+        /** ObservedRosterMapping */
+        ObservedRosterMapping: {
+            /** Franchise Id */
+            franchise_id?: string | null;
+            /** Franchise Name */
+            franchise_name?: string | null;
+            /** Managers */
+            managers: components["schemas"]["RosterManagerEvidence"][];
+            /** Sleeper Roster Id */
+            sleeper_roster_id: string;
+            /** Suggested Display Name */
+            suggested_display_name: string;
+        };
         /**
          * PatchCompetitionBody
          * @example {
@@ -2686,6 +2757,37 @@ export interface components {
              * Format: uuid
              */
             version_id: string;
+        };
+        /**
+         * PutRosterMappingsBody
+         * @example {
+         *       "assignments": [
+         *         {
+         *           "sleeper_roster_id": "1",
+         *           "target": {
+         *             "franchise_id": "e9c48ec7-95fe-44ed-85d6-d658f7022bd2",
+         *             "kind": "existing"
+         *           }
+         *         },
+         *         {
+         *           "sleeper_roster_id": "2",
+         *           "target": {
+         *             "display_name": "Expansion Team",
+         *             "kind": "new"
+         *           }
+         *         }
+         *       ],
+         *       "source_api_request_id": "4fd2ceef-0d7d-47ee-a42f-e70f78684aeb"
+         *     }
+         */
+        PutRosterMappingsBody: {
+            /** Assignments */
+            assignments: components["schemas"]["RosterMappingAssignmentBody"][];
+            /**
+             * Source Api Request Id
+             * Format: uuid
+             */
+            source_api_request_id: string;
         };
         pydantic__types__JsonValue: unknown;
         /**
@@ -2817,6 +2919,64 @@ export interface components {
         /** RevisionResponse */
         RevisionResponse: {
             revision: components["schemas"]["CanonicalRevision"];
+        };
+        /** RosterManagerEvidence */
+        RosterManagerEvidence: {
+            /** Display Name */
+            display_name: string;
+            /**
+             * Role
+             * @enum {string}
+             */
+            role: "owner" | "co_owner";
+            /** Sleeper User Id */
+            sleeper_user_id: string;
+            /** Team Name */
+            team_name?: string | null;
+        };
+        /** RosterMappingAssignmentBody */
+        RosterMappingAssignmentBody: {
+            /** Sleeper Roster Id */
+            sleeper_roster_id: string;
+            /** Target */
+            target: components["schemas"]["CreateFranchiseTargetBody"] | components["schemas"]["ExistingFranchiseTargetBody"];
+        };
+        /** RosterMappingMutationResponse */
+        RosterMappingMutationResponse: {
+            result: components["schemas"]["RosterMappingResult"];
+        };
+        /** RosterMappingResponse */
+        RosterMappingResponse: {
+            mapping: components["schemas"]["RosterMappingView"];
+        };
+        /** RosterMappingResult */
+        RosterMappingResult: {
+            mapping: components["schemas"]["RosterMappingView"];
+            /**
+             * Replay Status
+             * @enum {string}
+             */
+            replay_status: "applied" | "deferred";
+        };
+        /** RosterMappingView */
+        RosterMappingView: {
+            /** Franchise Options */
+            franchise_options: components["schemas"]["FranchiseIdentity"][];
+            /** Mapped Count */
+            mapped_count: number;
+            /** Roster Count */
+            roster_count: number;
+            /** Rosters */
+            rosters: components["schemas"]["ObservedRosterMapping"][];
+            /** Source Api Request Id */
+            source_api_request_id?: string | null;
+            /** Source Observed At */
+            source_observed_at?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "awaiting_source" | "needs_mapping" | "ready";
         };
         /**
          * ScopeKey
@@ -3928,6 +4088,156 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CompetitionSeasonDetailResponse"];
+                };
+            };
+            /** @description The competition or scoped season was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": {
+                     *         "code": "competition_not_found",
+                     *         "summary": "competition was not found"
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["CoreErrorResponse"];
+                };
+            };
+            /** @description The requested identity or lifecycle change conflicts. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": {
+                     *         "code": "competition_season_year_exists",
+                     *         "field_errors": {
+                     *           "season_year": [
+                     *             "Already attached to this competition."
+                     *           ]
+                     *         },
+                     *         "summary": "that season year is already attached to this competition"
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["CoreErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_roster_mappings_api_v1_competitions__competition_id__seasons__season_id__roster_mappings_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Correlation-ID"?: string | null;
+            };
+            path: {
+                competition_id: string;
+                season_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RosterMappingResponse"];
+                };
+            };
+            /** @description The competition or scoped season was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": {
+                     *         "code": "competition_not_found",
+                     *         "summary": "competition was not found"
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["CoreErrorResponse"];
+                };
+            };
+            /** @description The requested identity or lifecycle change conflicts. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "error": {
+                     *         "code": "competition_season_year_exists",
+                     *         "field_errors": {
+                     *           "season_year": [
+                     *             "Already attached to this competition."
+                     *           ]
+                     *         },
+                     *         "summary": "that season year is already attached to this competition"
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["CoreErrorResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_roster_mappings_api_v1_competitions__competition_id__seasons__season_id__roster_mappings_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Correlation-ID"?: string | null;
+            };
+            path: {
+                competition_id: string;
+                season_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PutRosterMappingsBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RosterMappingMutationResponse"];
                 };
             };
             /** @description The competition or scoped season was not found. */


### PR DESCRIPTION
## Summary

- add durable franchise and season-roster mapping resources plus explicit
  source-tokened reconciliation routes
- auto-bootstrap one franchise per observed roster for a competition's first
  season without inferring later-season continuity
- preserve actionable mapping-required refresh outcomes and replay captured
  roster observations after reconciliation

## Verification

- targeted roster-mapping, refresh-service, competition API, composition,
  OpenAPI, and data-route tests — 51 passed, 3 PostgreSQL-gated skips
- `pnpm api:check`

Stacked on `codex/ui-6c-refresh-operations`.
