### PR TITLE
Layer 6e: Roster identity setup UI

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -14,6 +14,14 @@ export const queryKeys = {
       ["competitions", competitionId, "seasons"] as const,
     seasonDetail: (competitionId: string, seasonId: string) =>
       ["competitions", competitionId, "seasons", seasonId] as const,
+    rosterMappings: (competitionId: string, seasonId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "seasons",
+        seasonId,
+        "roster-mappings",
+      ] as const,
     refreshes: (competitionId: string, seasonId: string) =>
       [
         "competitions",

--- a/frontend/src/features/refreshes/queries.ts
+++ b/frontend/src/features/refreshes/queries.ts
@@ -72,6 +72,12 @@ export function useManualRefresh(competitionId: string, seasonId: string) {
         queryClient.invalidateQueries({
           queryKey: queryKeys.competitions.snapshots(competitionId, seasonId),
         }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.rosterMappings(
+            competitionId,
+            seasonId,
+          ),
+        }),
       ]);
     },
   });

--- a/frontend/src/features/roster-mappings/api.ts
+++ b/frontend/src/features/roster-mappings/api.ts
@@ -1,0 +1,36 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type FranchiseIdentity = components["schemas"]["FranchiseIdentity"];
+export type ObservedRosterMapping =
+  components["schemas"]["ObservedRosterMapping"];
+export type PutRosterMappingsBody =
+  components["schemas"]["PutRosterMappingsBody"];
+export type RosterMappingMutationResponse =
+  components["schemas"]["RosterMappingMutationResponse"];
+export type RosterMappingResponse =
+  components["schemas"]["RosterMappingResponse"];
+export type RosterMappingView = components["schemas"]["RosterMappingView"];
+
+function mappingPath(competitionId: string, seasonId: string): string {
+  return `/api/v1/competitions/${competitionId}/seasons/${seasonId}/roster-mappings`;
+}
+
+export function getRosterMappings(
+  competitionId: string,
+  seasonId: string,
+  signal?: AbortSignal,
+): Promise<RosterMappingResponse> {
+  return apiRequest(mappingPath(competitionId, seasonId), { signal });
+}
+
+export function putRosterMappings(
+  competitionId: string,
+  seasonId: string,
+  body: PutRosterMappingsBody,
+): Promise<RosterMappingMutationResponse> {
+  return apiRequest(mappingPath(competitionId, seasonId), {
+    method: "PUT",
+    json: body,
+  });
+}

--- a/frontend/src/features/roster-mappings/queries.ts
+++ b/frontend/src/features/roster-mappings/queries.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  getRosterMappings,
+  putRosterMappings,
+  type PutRosterMappingsBody,
+} from "@/features/roster-mappings/api";
+
+export function useRosterMappings(
+  competitionId: string | undefined,
+  seasonId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.rosterMappings(
+      competitionId ?? "missing",
+      seasonId ?? "missing",
+    ),
+    queryFn: ({ signal }) =>
+      getRosterMappings(competitionId ?? "", seasonId ?? "", signal),
+    enabled: competitionId !== undefined && seasonId !== undefined,
+  });
+}
+
+export function usePutRosterMappings(competitionId: string, seasonId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: PutRosterMappingsBody) =>
+      putRosterMappings(competitionId, seasonId, body),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.rosterMappings(
+            competitionId,
+            seasonId,
+          ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.seasonDetail(
+            competitionId,
+            seasonId,
+          ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.competitions.seasons(competitionId),
+        }),
+      ]);
+    },
+  });
+}

--- a/frontend/src/features/roster-mappings/roster-mapping-panel.tsx
+++ b/frontend/src/features/roster-mappings/roster-mapping-panel.tsx
@@ -1,0 +1,505 @@
+import { CheckCircle2, Link2, UsersRound } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/errors";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { ManualRefreshResponse } from "@/features/refreshes/api";
+import { useManualRefresh } from "@/features/refreshes/queries";
+import type {
+  PutRosterMappingsBody,
+  RosterMappingView,
+} from "@/features/roster-mappings/api";
+import {
+  usePutRosterMappings,
+  useRosterMappings,
+} from "@/features/roster-mappings/queries";
+
+interface DraftChoice {
+  choice: string;
+  newName: string;
+}
+
+function mergeMappingDrafts(
+  mapping: RosterMappingView,
+  current: Record<string, DraftChoice> = {},
+): Record<string, DraftChoice> {
+  return Object.fromEntries(
+    mapping.rosters.map((roster) => {
+      const previous = current[roster.sleeper_roster_id];
+      if (roster.franchise_id) {
+        return [
+          roster.sleeper_roster_id,
+          {
+            choice: `existing:${roster.franchise_id}`,
+            newName: roster.suggested_display_name,
+          },
+        ];
+      }
+      return [
+        roster.sleeper_roster_id,
+        previous ?? {
+          choice: "",
+          newName: roster.suggested_display_name,
+        },
+      ];
+    }),
+  );
+}
+
+interface RosterMappingPanelProps {
+  competitionId: string;
+  seasonId: string;
+  seasonYear: number;
+  requestedThroughWeek?: number | null;
+  disabled?: boolean;
+  onOutcome: (outcome: ManualRefreshResponse) => void;
+}
+
+export function RosterMappingPanel({
+  competitionId,
+  seasonId,
+  seasonYear,
+  requestedThroughWeek,
+  disabled = false,
+  onOutcome,
+}: RosterMappingPanelProps): React.JSX.Element {
+  const query = useRosterMappings(competitionId, seasonId);
+  const [setupMapping, setSetupMapping] = useState<RosterMappingView>();
+
+  if (query.isPending) {
+    return (
+      <div className="mt-5 h-24 animate-pulse rounded-lg border border-border bg-muted/50" />
+    );
+  }
+  if (query.isError) {
+    return (
+      <div className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+        <p className="text-sm text-destructive">
+          {query.error instanceof ApiError
+            ? query.error.message
+            : "Team identity readiness could not be loaded."}
+        </p>
+        <Button
+          className="mt-3"
+          size="sm"
+          variant="outline"
+          onClick={() => void query.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const mapping = setupMapping ?? query.data.mapping;
+  if (mapping.status === "ready") {
+    return (
+      <div className="mt-5 flex flex-col gap-3 rounded-lg border border-emerald-600/25 bg-emerald-500/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <CheckCircle2
+            className="mt-0.5 size-5 text-emerald-700"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="font-medium">Team identities ready</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {mapping.mapped_count} of {mapping.roster_count} teams are
+              connected for this season.
+            </p>
+          </div>
+        </div>
+        <Badge variant="outline">Teams connected</Badge>
+      </div>
+    );
+  }
+
+  if (mapping.status === "awaiting_source") {
+    return (
+      <div className="mt-5 flex items-start gap-3 rounded-lg border border-border bg-muted/45 p-4">
+        <UsersRound
+          className="mt-0.5 size-5 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="font-medium">Team identities pending</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Run a Sleeper refresh to discover this season&apos;s rosters. The
+            first season is connected automatically; later seasons ask you to
+            confirm team continuity.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-5 flex flex-col gap-4 rounded-lg border border-amber-600/30 bg-amber-500/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-start gap-3">
+        <Link2 className="mt-0.5 size-5 text-amber-700" aria-hidden="true" />
+        <div>
+          <p className="font-medium">Team setup required</p>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            Confirm how {mapping.roster_count} Sleeper rosters continue the
+            competition&apos;s teams before generating.
+          </p>
+        </div>
+      </div>
+      <RosterMappingSheet
+        competitionId={competitionId}
+        seasonId={seasonId}
+        seasonYear={seasonYear}
+        mapping={mapping}
+        requestedThroughWeek={requestedThroughWeek}
+        disabled={disabled}
+        onReload={async () => {
+          const result = await query.refetch();
+          if (result.data) {
+            setSetupMapping(result.data.mapping);
+            return result.data.mapping;
+          }
+          return undefined;
+        }}
+        onOpenStateChange={(nextOpen) => {
+          setSetupMapping(nextOpen ? mapping : undefined);
+        }}
+        onOutcome={onOutcome}
+      />
+    </div>
+  );
+}
+
+function RosterMappingSheet({
+  competitionId,
+  seasonId,
+  seasonYear,
+  mapping,
+  requestedThroughWeek,
+  disabled,
+  onReload,
+  onOpenStateChange,
+  onOutcome,
+}: {
+  competitionId: string;
+  seasonId: string;
+  seasonYear: number;
+  mapping: RosterMappingView;
+  requestedThroughWeek?: number | null;
+  disabled: boolean;
+  onReload: () => Promise<RosterMappingView | undefined>;
+  onOpenStateChange: (open: boolean) => void;
+  onOutcome: (outcome: ManualRefreshResponse) => void;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [drafts, setDrafts] = useState<Record<string, DraftChoice>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [mappingSaved, setMappingSaved] = useState(false);
+  const [refreshNeedsRetry, setRefreshNeedsRetry] = useState(false);
+  const mappingMutation = usePutRosterMappings(competitionId, seasonId);
+  const refreshMutation = useManualRefresh(competitionId, seasonId);
+  const pending = mappingMutation.isPending || refreshMutation.isPending;
+
+  const selectedExisting = useMemo(
+    () =>
+      new Map(
+        Object.entries(drafts).flatMap(([rosterId, draft]) =>
+          draft.choice.startsWith("existing:")
+            ? [[draft.choice.slice("existing:".length), rosterId] as const]
+            : [],
+        ),
+      ),
+    [drafts],
+  );
+
+  function handleOpenChange(nextOpen: boolean): void {
+    if (pending && !nextOpen) return;
+    setOpen(nextOpen);
+    onOpenStateChange(nextOpen);
+    if (nextOpen) {
+      setDrafts(mergeMappingDrafts(mapping));
+      mappingMutation.reset();
+      refreshMutation.reset();
+      setErrors({});
+      setMappingSaved(false);
+      setRefreshNeedsRetry(false);
+    }
+  }
+
+  async function runRefresh(): Promise<void> {
+    setRefreshNeedsRetry(false);
+    try {
+      const outcome = await refreshMutation.mutateAsync(
+        requestedThroughWeek ?? undefined,
+      );
+      onOutcome(outcome);
+      if (outcome.refresh.status === "succeeded") {
+        toast.success("Team setup and refresh completed");
+        handleOpenChange(false);
+      } else if (outcome.refresh.status === "partial") {
+        toast.warning("Teams saved; refresh completed partially");
+        setRefreshNeedsRetry(true);
+      } else {
+        toast.error("Teams saved; refresh failed");
+        setRefreshNeedsRetry(true);
+      }
+    } catch {
+      // The mapping is durable; the retry action remains in the sheet.
+      setRefreshNeedsRetry(true);
+    }
+  }
+
+  async function submit(
+    event: React.SyntheticEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+    const nextErrors: Record<string, string> = {};
+    for (const roster of mapping.rosters) {
+      const draft = drafts[roster.sleeper_roster_id];
+      if (!draft?.choice) {
+        nextErrors[roster.sleeper_roster_id] =
+          "Choose an existing team or create a new one.";
+      } else if (draft.choice === "new" && !draft.newName.trim()) {
+        nextErrors[roster.sleeper_roster_id] = "Enter a new team name.";
+      }
+    }
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    if (!mapping.source_api_request_id) return;
+
+    const assignments: PutRosterMappingsBody["assignments"] =
+      mapping.rosters.map((roster) => {
+        const draft = drafts[roster.sleeper_roster_id];
+        if (!draft)
+          throw new Error("validated roster mapping draft is missing");
+        if (draft.choice === "new") {
+          return {
+            sleeper_roster_id: roster.sleeper_roster_id,
+            target: { kind: "new", display_name: draft.newName.trim() },
+          };
+        }
+        return {
+          sleeper_roster_id: roster.sleeper_roster_id,
+          target: {
+            kind: "existing",
+            franchise_id: draft.choice.slice("existing:".length),
+          },
+        };
+      });
+
+    try {
+      await mappingMutation.mutateAsync({
+        source_api_request_id: mapping.source_api_request_id,
+        assignments,
+      });
+      setMappingSaved(true);
+      await runRefresh();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        error.code === "roster_mapping_source_stale"
+      ) {
+        const refreshedMapping = await onReload();
+        if (refreshedMapping) {
+          setDrafts((current) => mergeMappingDrafts(refreshedMapping, current));
+        }
+      }
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetTrigger asChild>
+        <Button disabled={disabled}>Set up teams</Button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-[min(42rem,96vw)] overflow-y-auto"
+      >
+        <SheetHeader>
+          <SheetTitle>Connect {seasonYear} teams</SheetTitle>
+          <SheetDescription>
+            Sleeper names and owners are evidence only. Explicitly connect each
+            roster to one existing team or create a new team.
+          </SheetDescription>
+        </SheetHeader>
+
+        {mappingSaved ? (
+          <div className="rounded-md border border-emerald-600/25 bg-emerald-500/5 p-4">
+            <p className="font-medium">Team mappings are saved.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The full Sleeper refresh still needs to complete. Retrying will
+              not reopen or change the saved mappings.
+            </p>
+            {refreshMutation.isPending ? (
+              <p className="mt-4 text-sm" role="status" aria-live="polite">
+                Refreshing Sleeper data…
+              </p>
+            ) : null}
+            {refreshNeedsRetry || refreshMutation.error ? (
+              <Button
+                className="mt-4"
+                variant="outline"
+                disabled={refreshMutation.isPending}
+                onClick={() => {
+                  void runRefresh();
+                }}
+              >
+                {refreshMutation.isPending ? "Refreshing…" : "Retry refresh"}
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <form onSubmit={(event) => void submit(event)} noValidate>
+            <div className="space-y-5">
+              {mapping.rosters.map((roster) => {
+                const draft = drafts[roster.sleeper_roster_id] ?? {
+                  choice: "",
+                  newName: roster.suggested_display_name,
+                };
+                const immutable = roster.franchise_id !== null;
+                return (
+                  <fieldset
+                    key={roster.sleeper_roster_id}
+                    className="rounded-lg border border-border p-4"
+                    disabled={pending || immutable}
+                  >
+                    <legend className="px-1 font-medium">
+                      Sleeper roster {roster.sleeper_roster_id}
+                    </legend>
+                    <p className="mt-1 text-sm font-medium">
+                      {roster.suggested_display_name}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {roster.managers.length > 0
+                        ? roster.managers
+                            .map(
+                              (manager) =>
+                                `${manager.display_name}${manager.role === "co_owner" ? " (co-owner)" : ""}`,
+                            )
+                            .join(", ")
+                        : "No Sleeper owner is currently listed."}
+                    </p>
+                    <div className="mt-4 space-y-2">
+                      <Label htmlFor={`mapping-${roster.sleeper_roster_id}`}>
+                        Competition team
+                      </Label>
+                      <select
+                        id={`mapping-${roster.sleeper_roster_id}`}
+                        className="block h-10 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+                        value={draft.choice}
+                        aria-invalid={
+                          errors[roster.sleeper_roster_id] ? true : undefined
+                        }
+                        onChange={(event) => {
+                          const choice = event.target.value;
+                          setDrafts((current) => ({
+                            ...current,
+                            [roster.sleeper_roster_id]: { ...draft, choice },
+                          }));
+                          setErrors((current) => ({
+                            ...current,
+                            [roster.sleeper_roster_id]: "",
+                          }));
+                        }}
+                      >
+                        <option value="">Choose a team…</option>
+                        <option value="new">Create a new team</option>
+                        {mapping.franchise_options.map((franchise) => {
+                          const selectedBy = selectedExisting.get(franchise.id);
+                          return (
+                            <option
+                              key={franchise.id}
+                              value={`existing:${franchise.id}`}
+                              disabled={
+                                selectedBy !== undefined &&
+                                selectedBy !== roster.sleeper_roster_id
+                              }
+                            >
+                              {franchise.display_name}
+                            </option>
+                          );
+                        })}
+                      </select>
+                    </div>
+                    {draft.choice === "new" ? (
+                      <div className="mt-3 space-y-2">
+                        <Label htmlFor={`new-team-${roster.sleeper_roster_id}`}>
+                          New team name
+                        </Label>
+                        <Input
+                          id={`new-team-${roster.sleeper_roster_id}`}
+                          value={draft.newName}
+                          onChange={(event) => {
+                            setDrafts((current) => ({
+                              ...current,
+                              [roster.sleeper_roster_id]: {
+                                ...draft,
+                                newName: event.target.value,
+                              },
+                            }));
+                          }}
+                        />
+                      </div>
+                    ) : null}
+                    {immutable ? (
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        This roster is already connected and cannot be remapped.
+                      </p>
+                    ) : null}
+                    {errors[roster.sleeper_roster_id] ? (
+                      <p className="mt-3 text-sm text-destructive">
+                        {errors[roster.sleeper_roster_id]}
+                      </p>
+                    ) : null}
+                  </fieldset>
+                );
+              })}
+            </div>
+
+            {mappingMutation.error ? (
+              <p
+                className="mt-5 rounded-md bg-destructive/10 p-4 text-sm text-destructive"
+                role="alert"
+              >
+                {mappingMutation.error instanceof ApiError
+                  ? mappingMutation.error.message
+                  : "The team mappings could not be saved."}
+              </p>
+            ) : null}
+
+            <div className="mt-8 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={pending}
+                onClick={() => {
+                  handleOpenChange(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={pending}>
+                {mappingMutation.isPending
+                  ? "Saving teams…"
+                  : refreshMutation.isPending
+                    ? "Refreshing…"
+                    : "Save teams and refresh"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/routes/competition-overview.tsx
+++ b/frontend/src/routes/competition-overview.tsx
@@ -12,6 +12,7 @@ import type { ManualRefreshResponse } from "@/features/refreshes/api";
 import { RefreshHistory } from "@/features/refreshes/refresh-history";
 import { RefreshOutcomePanel } from "@/features/refreshes/refresh-outcome";
 import { RefreshSheet } from "@/features/refreshes/refresh-sheet";
+import { RosterMappingPanel } from "@/features/roster-mappings/roster-mapping-panel";
 import { AddSeasonDialog } from "@/features/seasons/add-season-dialog";
 import type { CompetitionSeasonOverview } from "@/features/seasons/api";
 import { useSeasonDetail, useSeasonList } from "@/features/seasons/queries";
@@ -467,124 +468,143 @@ export function Component(): React.JSX.Element {
                   Try again
                 </Button>
               </div>
-            ) : detail ? (
-              <div className="grid gap-5 lg:grid-cols-[1.2fr_1fr]">
-                <article className="rounded-lg border border-border bg-card p-5">
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                        Sleeper league
-                      </p>
-                      <h3 className="mt-2 font-editorial text-2xl font-semibold">
-                        {detail.normalized_overview?.league_name ??
-                          "Awaiting first refresh"}
-                      </h3>
-                      <p className="mt-2 break-all text-sm text-muted-foreground">
-                        ID {detail.season.sleeper_league_id}
-                      </p>
+            ) : detail && selectedSeasonId && selectedSeason ? (
+              <>
+                <div className="grid gap-5 lg:grid-cols-[1.2fr_1fr]">
+                  <article className="rounded-lg border border-border bg-card p-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                          Sleeper league
+                        </p>
+                        <h3 className="mt-2 font-editorial text-2xl font-semibold">
+                          {detail.normalized_overview?.league_name ??
+                            "Awaiting first refresh"}
+                        </h3>
+                        <p className="mt-2 break-all text-sm text-muted-foreground">
+                          ID {detail.season.sleeper_league_id}
+                        </p>
+                      </div>
+                      {detail.normalized_overview?.status ? (
+                        <Badge variant="outline">
+                          {detail.normalized_overview.status}
+                        </Badge>
+                      ) : null}
                     </div>
-                    {detail.normalized_overview?.status ? (
-                      <Badge variant="outline">
-                        {detail.normalized_overview.status}
-                      </Badge>
-                    ) : null}
-                  </div>
-                  {detail.normalized_overview ? (
-                    <dl className="mt-6 grid grid-cols-2 gap-5 border-t border-border pt-5 text-sm sm:grid-cols-4">
-                      <div>
-                        <dt className="text-xs text-muted-foreground">
-                          Rosters
+                    {detail.normalized_overview ? (
+                      <dl className="mt-6 grid grid-cols-2 gap-5 border-t border-border pt-5 text-sm sm:grid-cols-4">
+                        <div>
+                          <dt className="text-xs text-muted-foreground">
+                            Rosters
+                          </dt>
+                          <dd className="mt-1 font-medium">
+                            {detail.normalized_overview.roster_count}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs text-muted-foreground">
+                            Playoff start
+                          </dt>
+                          <dd className="mt-1 font-medium">
+                            {detail.normalized_overview.playoff_start_week ??
+                              "—"}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs text-muted-foreground">
+                            Playoff teams
+                          </dt>
+                          <dd className="mt-1 font-medium">
+                            {detail.normalized_overview.playoff_team_count ??
+                              "—"}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs text-muted-foreground">
+                            League average match
+                          </dt>
+                          <dd className="mt-1 font-medium">
+                            {detail.normalized_overview.league_average_match ??
+                              "—"}
+                          </dd>
+                        </div>
+                      </dl>
+                    ) : (
+                      <p className="mt-6 border-t border-border pt-5 text-sm leading-6 text-muted-foreground">
+                        No normalized Sleeper observations exist yet. A manual
+                        refresh will load league settings, rosters, and the
+                        selected week boundary.
+                      </p>
+                    )}
+                  </article>
+
+                  <article className="rounded-lg border border-border bg-card p-5">
+                    <div className="flex items-center gap-2">
+                      <RefreshCw
+                        className="size-4 text-muted-foreground"
+                        aria-hidden="true"
+                      />
+                      <h3 className="font-semibold">Freshness</h3>
+                    </div>
+                    <dl className="mt-5 space-y-4 text-sm">
+                      <div className="flex items-start justify-between gap-4">
+                        <dt className="text-muted-foreground">
+                          Last refreshed
                         </dt>
-                        <dd className="mt-1 font-medium">
-                          {detail.normalized_overview.roster_count}
+                        <dd className="text-right">
+                          <DateTime
+                            value={
+                              detail.summary.latest_terminal_refresh
+                                ?.completed_at ?? null
+                            }
+                            showExact
+                          />
                         </dd>
                       </div>
-                      <div>
-                        <dt className="text-xs text-muted-foreground">
-                          Playoff start
+                      <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+                        <dt className="text-muted-foreground">
+                          Last successful refresh
                         </dt>
-                        <dd className="mt-1 font-medium">
-                          {detail.normalized_overview.playoff_start_week ?? "—"}
+                        <dd className="text-right">
+                          <DateTime
+                            value={detail.summary.latest_successful_refresh_at}
+                            showExact
+                          />
                         </dd>
                       </div>
-                      <div>
-                        <dt className="text-xs text-muted-foreground">
-                          Playoff teams
+                      <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+                        <dt className="text-muted-foreground">
+                          Latest generation snapshot
                         </dt>
-                        <dd className="mt-1 font-medium">
-                          {detail.normalized_overview.playoff_team_count ?? "—"}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className="text-xs text-muted-foreground">
-                          League average match
-                        </dt>
-                        <dd className="mt-1 font-medium">
-                          {detail.normalized_overview.league_average_match ??
-                            "—"}
+                        <dd className="text-right">
+                          <DateTime
+                            value={detail.summary.latest_ready_snapshot_at}
+                            empty="None built"
+                            showExact
+                          />
                         </dd>
                       </div>
                     </dl>
-                  ) : (
-                    <p className="mt-6 border-t border-border pt-5 text-sm leading-6 text-muted-foreground">
-                      No normalized Sleeper observations exist yet. A manual
-                      refresh will load league settings, rosters, and the
-                      selected week boundary.
+                    <p className="mt-5 border-t border-border pt-4 text-xs leading-5 text-muted-foreground">
+                      Snapshot time records when frozen generation input was
+                      built or reused. It is not Sleeper freshness.
                     </p>
-                  )}
-                </article>
-
-                <article className="rounded-lg border border-border bg-card p-5">
-                  <div className="flex items-center gap-2">
-                    <RefreshCw
-                      className="size-4 text-muted-foreground"
-                      aria-hidden="true"
-                    />
-                    <h3 className="font-semibold">Freshness</h3>
-                  </div>
-                  <dl className="mt-5 space-y-4 text-sm">
-                    <div className="flex items-start justify-between gap-4">
-                      <dt className="text-muted-foreground">Last refreshed</dt>
-                      <dd className="text-right">
-                        <DateTime
-                          value={
-                            detail.summary.latest_terminal_refresh
-                              ?.completed_at ?? null
-                          }
-                          showExact
-                        />
-                      </dd>
-                    </div>
-                    <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
-                      <dt className="text-muted-foreground">
-                        Last successful refresh
-                      </dt>
-                      <dd className="text-right">
-                        <DateTime
-                          value={detail.summary.latest_successful_refresh_at}
-                          showExact
-                        />
-                      </dd>
-                    </div>
-                    <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
-                      <dt className="text-muted-foreground">
-                        Latest generation snapshot
-                      </dt>
-                      <dd className="text-right">
-                        <DateTime
-                          value={detail.summary.latest_ready_snapshot_at}
-                          empty="None built"
-                          showExact
-                        />
-                      </dd>
-                    </div>
-                  </dl>
-                  <p className="mt-5 border-t border-border pt-4 text-xs leading-5 text-muted-foreground">
-                    Snapshot time records when frozen generation input was built
-                    or reused. It is not Sleeper freshness.
-                  </p>
-                </article>
-              </div>
+                  </article>
+                </div>
+                <RosterMappingPanel
+                  competitionId={competition.id}
+                  seasonId={selectedSeasonId}
+                  seasonYear={selectedSeason.season.season_year}
+                  requestedThroughWeek={
+                    detail.summary.latest_terminal_refresh
+                      ?.requested_through_week
+                  }
+                  disabled={archived}
+                  onOutcome={(outcome) => {
+                    setLatestOutcome({ seasonId: selectedSeasonId, outcome });
+                  }}
+                />
+              </>
             ) : null}
           </section>
 


### PR DESCRIPTION
## Summary

- add selected-season team identity readiness and typed roster-mapping transport
- add explicit responsive reconciliation using Sleeper team and owner evidence
- preserve choices across stale-source recovery and automatically refresh after
  a successful mapping commit
- keep committed mappings intact with an actionable retry when the follow-up
  refresh is partial, failed, or unavailable

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm api:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- manual FastAPI/PostgreSQL acceptance for bootstrap, later-season existing/new
  mapping, duplicate prevention, stale source, automatic refresh, durable retry,
  reload persistence, keyboard behavior, and mobile layout

Stacked on `codex/ui-6d-roster-identity-api`.
