### PR TITLE
feat(ui): add generation form

### DIFF
--- a/backend/api/schemas/generations.py
+++ b/backend/api/schemas/generations.py
@@ -40,9 +40,13 @@ class SubmitGenerationBody(GenerationApiModel):
     settings: GenerationSettings = Field(default_factory=GenerationSettings)
 
     @model_validator(mode="after")
-    def validate_week_range(self) -> "SubmitGenerationBody":
+    def validate_submission(self) -> "SubmitGenerationBody":
         if self.week_start > self.week_end:
             raise ValueError("week_start cannot be after week_end")
+        if self.requested_primary_model in self.settings.model.fallback_models:
+            raise ValueError(
+                "requested_primary_model cannot duplicate a fallback model"
+            )
         return self
 
 

--- a/backend/tests/api/test_generation_routes.py
+++ b/backend/tests/api/test_generation_routes.py
@@ -363,6 +363,36 @@ async def test_submission_and_rerun_create_pending_requests_without_execution() 
 
 
 @pytest.mark.asyncio
+async def test_submission_rejects_primary_model_duplicated_in_fallbacks() -> None:
+    competition_id = uuid4()
+    season_id = uuid4()
+    dependencies = _dependencies(competition_id, season_id)
+    app, client = await _client(dependencies)
+    payload = {
+        "competition_season_id": str(season_id),
+        "kind": "live",
+        "request_text": "weekly recap",
+        "week_start": 8,
+        "week_end": 8,
+        "requested_primary_model": " gpt-test ",
+        "settings": {"model": {"fallback_models": ["gpt-test"]}},
+    }
+
+    async with app.router.lifespan_context(app), client:
+        response = await client.post(
+            f"/api/v1/generations/competitions/{competition_id}",
+            json=payload,
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["msg"] == (
+        "Value error, requested_primary_model cannot duplicate a fallback model"
+    )
+    assert dependencies.service.submissions == []
+    assert dependencies.dispatcher.dispatched == []
+
+
+@pytest.mark.asyncio
 async def test_polling_and_resource_routes_preserve_durable_payloads() -> None:
     competition_id = uuid4()
     season_id = uuid4()

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -21,7 +21,7 @@ Generation routes already exist under
 
 | Capability | Route | UI readiness |
 | --- | --- | --- |
-| Submit generation | `POST /generations/competitions/{competition_id}` | Implemented; body already includes kind, season, weeks, primary model, and nested settings |
+| Submit generation | `POST /generations/competitions/{competition_id}` | Implemented; body includes kind, season, explicit weeks, primary model, and nested settings, and rejects a primary model duplicated in the fallback chain |
 | Rerun exact request | `POST /generations/competitions/{competition_id}/{generation_id}/reruns` | Implemented |
 | Run history | `GET /generations/competitions/{competition_id}` | Implemented with season/kind/status/rerun filters |
 | Submitted article history | `GET /generations/competitions/{competition_id}/articles` | Implemented with season/kind filters |
@@ -32,10 +32,9 @@ Generation routes already exist under
 | Artifact list/detail | `GET .../{generation_id}/artifacts[/{artifact_id}]` | Implemented |
 | Artifact versions | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented |
 
-The current `backend/api/routes/data.py` registers only an empty `/data`
-router. Core competition/season persistence, refresh service, snapshot manager,
-and evaluation-workspace tables exist, but they do not yet have complete
-product resource/service/HTTP surfaces.
+Competition and season management plus refresh, overview, and snapshot-audit
+routes are implemented. Evaluation-workspace tables exist, but their product
+resource, service, and HTTP surfaces remain deferred to Layer 9.
 
 The existing generation route hierarchy is functional but inverted. Before a
 public client contract is stable, consider moving it to
@@ -203,11 +202,23 @@ described above remains authoritative.
 The existing generation contract is enough to create basic live and read-only
 backtest runs. These additions complete the planned UI:
 
+For Layer 7, the UI always submits explicit `week_start` and `week_end` values;
+it does not derive or imply a current week. Live mode is offered only for the
+latest attached season. Selecting an older season uses `backtest`, which pins
+historical memory at or before the requested cutoff and cannot write canonical
+memory. This latest-season restriction is currently a UI safety policy rather
+than an API invariant, so non-UI clients remain responsible for selecting the
+appropriate kind. Live runs may write canonical memory on success.
+
+Layer 7 does not expose an isolated or promotable simulation mode. That mode,
+its evaluation workspace, and promote/discard commands remain Layer 9 work;
+the available historical backtest is read-only.
+
 | Method and path | Purpose | Priority |
 | --- | --- | --- |
 | `POST .../{generation_id}/cancel` | Cancel a pending/running generation | Should-have; manager supports cancellation |
 | Extend article/run list query | Model, week overlap, completion range, request text | Later unless list size demands it |
-| Extend generation body | Explicit memory mode and optional `evaluation_workspace_id` for isolated simulation sequencing | Required for workspace promotion |
+| Extend generation body | Explicit memory mode and optional `evaluation_workspace_id` for isolated simulation sequencing | Layer 9; required for workspace promotion |
 | `GET .../{generation_id}/usage` | Aggregate tokens, latency, calls, and price quote | Required |
 | Optional `GET .../{generation_id}/audit` | One bounded detail projection for article + artifacts + calls | Optimization only; existing resources remain authoritative |
 

--- a/docs/ui/frontend-architecture.md
+++ b/docs/ui/frontend-architecture.md
@@ -180,18 +180,20 @@ still being discovered, so component snapshots, mocked API tests, and a browser
 suite would create maintenance cost while page structure and interactions are
 changing quickly.
 
-Each frontend layer instead has four required checks:
+Each frontend layer uses lightweight implementation checks:
 
 1. strict TypeScript compilation;
 2. lint and formatting checks;
 3. a successful production build; and
-4. a short manual acceptance pass through the affected journey against the real
-   local backend.
+4. targeted backend contract tests only when that layer changes backend
+   behavior.
 
-The manual pass is recorded in `.context/ui/log.md`, including the route,
-important states checked, and any known limitations. New backend resources and
-workflow invariants still receive targeted backend tests under `backend/tests`;
-the deferral applies only to frontend automated tests.
+Do not build elaborate temporary acceptance environments for each intermediate
+layer. After the complete initial UI stack is implemented, run one comprehensive
+review against the full local database and backend. That final pass covers all
+core journeys, real-data states, responsive behavior, keyboard/accessibility,
+reload and polling recovery, error states, and a clean browser console. Record
+that pass and any known limitations in `.context/ui/log.md`.
 
 Frontend tests can be introduced later where evidence makes them valuable—for
 example, a repeatedly broken generation-form mapping, polling lifecycle, cost
@@ -210,9 +212,9 @@ lint, typecheck, and the production build.
 
 Initial performance goals are pragmatic: route-level code splitting, no eager
 loading of artifact/call bodies, bounded list pages, and responsive interaction
-on ordinary league histories. Manual acceptance includes accessibility checks
-for dialogs, tabs, navigation, form errors, keyboard focus, and status updates
-until automated accessibility checks are justified.
+on ordinary league histories. The final full-stack review includes
+accessibility checks for dialogs, tabs, navigation, form errors, keyboard
+focus, and status updates until automated accessibility checks are justified.
 
 ## Deferred Choices
 

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -84,6 +84,18 @@ export function normalizeApiError(
 
   if (isRecord(payload)) {
     const detail = payload.detail;
+    if (isRecord(detail)) {
+      return new ApiError({
+        status,
+        code: asString(detail.code) ?? `http_${String(status)}`,
+        summary:
+          asString(detail.message) ??
+          asString(detail.summary) ??
+          "The request could not be completed.",
+        fieldErrors: parseFieldErrors(detail.field_errors),
+        correlationId: asString(detail.correlation_id) ?? responseCorrelationId,
+      });
+    }
     const fieldErrors = parseValidationErrors(detail);
     const isValidationError = Object.keys(fieldErrors).length > 0;
     return new ApiError({

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -3,6 +3,10 @@ export const queryKeys = {
     all: ["health"] as const,
     status: () => ["health", "status"] as const,
   },
+  models: {
+    all: ["models"] as const,
+    catalog: () => ["models", "catalog"] as const,
+  },
   competitions: {
     all: ["competitions"] as const,
     lists: () => ["competitions", "list"] as const,
@@ -65,5 +69,11 @@ export const queryKeys = {
         seasonId,
         "snapshots",
       ] as const,
+    generations: (competitionId: string) =>
+      ["competitions", competitionId, "generations"] as const,
+    generationSubmission: (competitionId: string) =>
+      ["competitions", competitionId, "generations", "submit"] as const,
+    generationDetail: (competitionId: string, generationId: string) =>
+      ["competitions", competitionId, "generations", generationId] as const,
   },
 } as const;

--- a/frontend/src/features/generations/api.ts
+++ b/frontend/src/features/generations/api.ts
@@ -1,0 +1,36 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type Generation = components["schemas"]["Generation"];
+export type GenerationBiasSettings =
+  components["schemas"]["GenerationBiasSettings"];
+export type GenerationKind = components["schemas"]["GenerationKind"];
+export type GenerationModelSettings =
+  components["schemas"]["GenerationModelSettings"];
+export type GenerationReportSettings =
+  components["schemas"]["GenerationReportSettings"];
+export type GenerationResponse = components["schemas"]["GenerationResponse"];
+export type GenerationRetrySettings =
+  components["schemas"]["GenerationRetrySettings"];
+export type GenerationRunnerSettings =
+  components["schemas"]["GenerationRunnerSettings"];
+export type GenerationSettings = components["schemas"]["GenerationSettings"];
+export type GenerationToneSettings =
+  components["schemas"]["GenerationToneSettings"];
+export type SubmitGenerationBody =
+  components["schemas"]["SubmitGenerationBody"];
+
+export interface SubmitGenerationInput {
+  competitionId: string;
+  body: SubmitGenerationBody;
+}
+
+export function submitGeneration({
+  competitionId,
+  body,
+}: SubmitGenerationInput): Promise<GenerationResponse> {
+  return apiRequest(`/api/v1/generations/competitions/${competitionId}`, {
+    method: "POST",
+    json: body,
+  });
+}

--- a/frontend/src/features/generations/draft.ts
+++ b/frontend/src/features/generations/draft.ts
@@ -1,0 +1,299 @@
+import { z } from "zod";
+
+import type { SubmitGenerationBody } from "@/features/generations/api";
+
+export const GENERATION_DRAFT_VERSION = 1 as const;
+export const GENERATION_WEEK_OPTIONS = Array.from(
+  { length: 18 },
+  (_, index) => index + 1,
+) as readonly number[];
+
+const trimmedListItemSchema = z
+  .string()
+  .trim()
+  .min(1, "Remove empty list items.");
+const humanReadableListSchema = z.array(trimmedListItemSchema);
+const controlLevelSchema = z.coerce
+  .number<number>()
+  .int()
+  .min(0, "Use a level from 0 through 3.")
+  .max(3, "Use a level from 0 through 3.");
+const weekSchema = z.coerce
+  .number<number>()
+  .int("Use a whole week from 1 through 18.")
+  .min(1, "Week must be from 1 through 18.")
+  .max(18, "Week must be from 1 through 18.");
+
+const generationDraftValuesSchema = z
+  .object({
+    competitionSeasonId: z.string(),
+    mode: z.enum(["live", "backtest"]),
+    requestText: z.string(),
+    weekStart: weekSchema,
+    weekEnd: weekSchema,
+    requestedPrimaryModel: z.string(),
+    report: z.object({
+      focusHints: humanReadableListSchema,
+      avoidTopics: humanReadableListSchema,
+      focusTeams: humanReadableListSchema,
+      voice: z.string(),
+      tone: z.object({
+        snarkLevel: controlLevelSchema,
+        hypeLevel: controlLevelSchema,
+        seriousness: controlLevelSchema,
+      }),
+      profanityPolicy: z.enum(["none", "mild", "unrestricted"]),
+      bias: z.object({
+        favoredTeams: humanReadableListSchema,
+        disfavoredTeams: humanReadableListSchema,
+        intensity: controlLevelSchema,
+      }),
+      lengthTarget: z.coerce
+        .number<number>()
+        .int("Length target must be a whole number.")
+        .min(1, "Length target must be at least 1."),
+      evidencePolicy: z.enum(["strict", "standard", "relaxed"]),
+    }),
+    model: z.object({
+      fallbackModels: humanReadableListSchema,
+      retry: z.object({
+        maxRetries: z.coerce
+          .number<number>()
+          .int("Retries must be a whole number.")
+          .min(0, "Retries cannot be negative."),
+        baseDelaySeconds: z.coerce
+          .number<number>()
+          .positive("Base delay must be greater than 0."),
+        maxDelaySeconds: z.coerce
+          .number<number>()
+          .positive("Maximum delay must be greater than 0."),
+      }),
+    }),
+    runner: z.object({
+      maxTurns: z.coerce
+        .number<number>()
+        .int("Maximum turns must be a whole number.")
+        .min(1, "Maximum turns must be at least 1."),
+      procedureHistoryMode: z.enum(["replace", "append"]),
+    }),
+  })
+  .superRefine((values, context) => {
+    if (values.weekStart > values.weekEnd) {
+      context.addIssue({
+        code: "custom",
+        message: "Start week cannot be after end week.",
+        path: ["weekEnd"],
+      });
+    }
+
+    if (
+      values.model.retry.maxDelaySeconds < values.model.retry.baseDelaySeconds
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Maximum delay must be at least the base delay.",
+        path: ["model", "retry", "maxDelaySeconds"],
+      });
+    }
+  });
+
+export const generationFormSchema = generationDraftValuesSchema.superRefine(
+  (values, context) => {
+    if (values.competitionSeasonId.trim().length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Select a season.",
+        path: ["competitionSeasonId"],
+      });
+    }
+    if (values.requestText.trim().length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Describe the reporter assignment.",
+        path: ["requestText"],
+      });
+    }
+    if (values.requestedPrimaryModel.trim().length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Select a primary model.",
+        path: ["requestedPrimaryModel"],
+      });
+    }
+    if (values.report.voice.trim().length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Enter a reporter voice.",
+        path: ["report", "voice"],
+      });
+    }
+
+    const modelChain = [
+      values.requestedPrimaryModel.trim(),
+      ...values.model.fallbackModels,
+    ];
+    if (new Set(modelChain).size !== modelChain.length) {
+      context.addIssue({
+        code: "custom",
+        message: "The primary and fallback models must all be unique.",
+        path: ["model", "fallbackModels"],
+      });
+    }
+  },
+);
+
+export type GenerationFormValues = z.output<typeof generationFormSchema>;
+
+export const generationDraftSchema = z.object({
+  version: z.literal(GENERATION_DRAFT_VERSION),
+  values: generationDraftValuesSchema,
+});
+export type GenerationDraft = z.output<typeof generationDraftSchema>;
+
+export function createGenerationFormDefaults(
+  primaryModel = "",
+  competitionSeasonId = "",
+): GenerationFormValues {
+  return {
+    competitionSeasonId,
+    mode: "live",
+    requestText: "",
+    weekStart: 1,
+    weekEnd: 1,
+    requestedPrimaryModel: primaryModel,
+    report: {
+      focusHints: [],
+      avoidTopics: [],
+      focusTeams: [],
+      voice: "sports columnist",
+      tone: { snarkLevel: 1, hypeLevel: 1, seriousness: 1 },
+      profanityPolicy: "none",
+      bias: { favoredTeams: [], disfavoredTeams: [], intensity: 1 },
+      lengthTarget: 1000,
+      evidencePolicy: "standard",
+    },
+    model: {
+      fallbackModels: [],
+      retry: { maxRetries: 3, baseDelaySeconds: 1, maxDelaySeconds: 30 },
+    },
+    runner: { maxTurns: 60, procedureHistoryMode: "replace" },
+  };
+}
+
+export function mapGenerationFormToSubmitBody(
+  unparsedValues: GenerationFormValues,
+): SubmitGenerationBody {
+  const values = generationFormSchema.parse(unparsedValues);
+  const hasBias =
+    values.report.bias.favoredTeams.length > 0 ||
+    values.report.bias.disfavoredTeams.length > 0;
+
+  return {
+    competition_season_id: values.competitionSeasonId.trim(),
+    kind: values.mode,
+    request_text: values.requestText.trim(),
+    week_start: values.weekStart,
+    week_end: values.weekEnd,
+    requested_primary_model: values.requestedPrimaryModel.trim(),
+    settings: {
+      report: {
+        focus_hints: values.report.focusHints,
+        avoid_topics: values.report.avoidTopics,
+        focus_teams: values.report.focusTeams,
+        voice: values.report.voice.trim(),
+        tone: {
+          snark_level: values.report.tone.snarkLevel,
+          hype_level: values.report.tone.hypeLevel,
+          seriousness: values.report.tone.seriousness,
+        },
+        profanity_policy: values.report.profanityPolicy,
+        ...(hasBias
+          ? {
+              bias: {
+                favored_teams: values.report.bias.favoredTeams,
+                disfavored_teams: values.report.bias.disfavoredTeams,
+                intensity: values.report.bias.intensity,
+              },
+            }
+          : {}),
+        length_target: values.report.lengthTarget,
+        evidence_policy: values.report.evidencePolicy,
+      },
+      model: {
+        fallback_models: values.model.fallbackModels,
+        retry: {
+          max_retries: values.model.retry.maxRetries,
+          base_delay_seconds: values.model.retry.baseDelaySeconds,
+          max_delay_seconds: values.model.retry.maxDelaySeconds,
+        },
+      },
+      runner: {
+        max_turns: values.runner.maxTurns,
+        procedure_history_mode: values.runner.procedureHistoryMode,
+      },
+    },
+  };
+}
+
+function draftStorageKey(competitionId: string): string {
+  return `aidam:generation-draft:${String(GENERATION_DRAFT_VERSION)}:${competitionId}`;
+}
+
+function browserStorage(): Storage | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadGenerationDraft(
+  competitionId: string,
+  storage: Storage | undefined = browserStorage(),
+): GenerationFormValues | undefined {
+  if (!storage) return undefined;
+  try {
+    const serialized = storage.getItem(draftStorageKey(competitionId));
+    if (!serialized) return undefined;
+    const parsed = generationDraftSchema.safeParse(
+      JSON.parse(serialized) as unknown,
+    );
+    return parsed.success ? parsed.data.values : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveGenerationDraft(
+  competitionId: string,
+  values: GenerationFormValues,
+  storage: Storage | undefined = browserStorage(),
+): void {
+  if (!storage) return;
+  const parsed = generationDraftValuesSchema.safeParse(values);
+  if (!parsed.success) return;
+  try {
+    storage.setItem(
+      draftStorageKey(competitionId),
+      JSON.stringify({
+        version: GENERATION_DRAFT_VERSION,
+        values: parsed.data,
+      }),
+    );
+  } catch {
+    // Draft persistence is best-effort; form submission remains available.
+  }
+}
+
+export function clearGenerationDraft(
+  competitionId: string,
+  storage: Storage | undefined = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(draftStorageKey(competitionId));
+  } catch {
+    // Draft persistence is best-effort; a stale draft is safe to ignore.
+  }
+}

--- a/frontend/src/features/generations/queries.ts
+++ b/frontend/src/features/generations/queries.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  submitGeneration,
+  type GenerationResponse,
+  type SubmitGenerationBody,
+} from "@/features/generations/api";
+
+export function useSubmitGeneration(competitionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: queryKeys.competitions.generationSubmission(competitionId),
+    mutationFn: (body: SubmitGenerationBody) =>
+      submitGeneration({ competitionId, body }),
+    onSuccess: async (response: GenerationResponse) => {
+      queryClient.setQueryData(
+        queryKeys.competitions.generationDetail(
+          competitionId,
+          response.generation.id,
+        ),
+        response,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.competitions.generations(competitionId),
+      });
+    },
+  });
+}

--- a/frontend/src/features/models/api.ts
+++ b/frontend/src/features/models/api.ts
@@ -1,0 +1,12 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type ModelCatalogItem = components["schemas"]["ModelCatalogItem"];
+export type ModelCatalogResponse =
+  components["schemas"]["ModelCatalogResponse"];
+
+export function getModelCatalog(
+  signal?: AbortSignal,
+): Promise<ModelCatalogResponse> {
+  return apiRequest("/api/v1/models", { signal });
+}

--- a/frontend/src/features/models/queries.ts
+++ b/frontend/src/features/models/queries.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getModelCatalog } from "@/features/models/api";
+
+export function useModelCatalog() {
+  return useQuery({
+    queryKey: queryKeys.models.catalog(),
+    queryFn: ({ signal }) => getModelCatalog(signal),
+  });
+}

--- a/frontend/src/routes/generate.tsx
+++ b/frontend/src/routes/generate.tsx
@@ -1,15 +1,1333 @@
-import { PlusCircle } from "lucide-react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  ArrowDown,
+  ArrowUp,
+  CircleAlert,
+  Clock3,
+  Database,
+  LoaderCircle,
+  Minus,
+  Plus,
+  Sparkles,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Controller,
+  type FieldError,
+  type FieldPath,
+  useForm,
+  useWatch,
+} from "react-hook-form";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router";
+import { toast } from "sonner";
 
-import { PlaceholderPage } from "@/components/shared/placeholder-page";
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCompetitionDetail } from "@/features/competitions/queries";
+import {
+  clearGenerationDraft,
+  createGenerationFormDefaults,
+  generationDraftSchema,
+  GENERATION_DRAFT_VERSION,
+  GENERATION_WEEK_OPTIONS,
+  generationFormSchema,
+  loadGenerationDraft,
+  mapGenerationFormToSubmitBody,
+  saveGenerationDraft,
+  type GenerationFormValues,
+} from "@/features/generations/draft";
+import { useSubmitGeneration } from "@/features/generations/queries";
+import { useModelCatalog } from "@/features/models/queries";
+import { useRosterMappings } from "@/features/roster-mappings/queries";
+import { useSeasonDetail, useSeasonList } from "@/features/seasons/queries";
+import { cn } from "@/lib/utils";
+
+const seasonListParameters = { limit: 200, offset: 0 } as const;
+const selectClassName =
+  "flex h-9 w-full rounded-md border border-border bg-background px-3 text-sm shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+const textareaClassName =
+  "min-h-28 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm shadow-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
+
+function FieldMessage({
+  id,
+  error,
+}: {
+  id?: string;
+  error?: FieldError;
+}): React.JSX.Element | null {
+  if (!error?.message) return null;
+  return (
+    <p id={id} className="mt-1 text-xs text-destructive">
+      {error.message}
+    </p>
+  );
+}
+
+const serverFieldPaths: Readonly<
+  Record<string, FieldPath<GenerationFormValues>>
+> = {
+  competition_season_id: "competitionSeasonId",
+  kind: "mode",
+  request_text: "requestText",
+  week_start: "weekStart",
+  week_end: "weekEnd",
+  requested_primary_model: "requestedPrimaryModel",
+  "settings.report.voice": "report.voice",
+  "settings.report.length_target": "report.lengthTarget",
+  "settings.model.fallback_models": "model.fallbackModels",
+  "settings.model.retry.max_retries": "model.retry.maxRetries",
+  "settings.model.retry.base_delay_seconds": "model.retry.baseDelaySeconds",
+  "settings.model.retry.max_delay_seconds": "model.retry.maxDelaySeconds",
+  "settings.runner.max_turns": "runner.maxTurns",
+  "settings.runner.procedure_history_mode": "runner.procedureHistoryMode",
+};
+
+function Section({
+  number,
+  title,
+  description,
+  children,
+}: {
+  number: string;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5 sm:p-6">
+      <div className="flex gap-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+          {number}
+        </span>
+        <div>
+          <h2 className="font-editorial text-2xl font-semibold">{title}</h2>
+          <p className="mt-1 text-sm leading-6 text-muted-foreground">
+            {description}
+          </p>
+        </div>
+      </div>
+      <div className="mt-6">{children}</div>
+    </section>
+  );
+}
+
+function StringListEditor({
+  value,
+  onChange,
+  placeholder,
+  label,
+}: {
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder: string;
+  label: string;
+}): React.JSX.Element {
+  const [draft, setDraft] = useState("");
+
+  function addValue(): void {
+    const next = draft.trim();
+    if (!next) return;
+    onChange([...value, next]);
+    setDraft("");
+  }
+
+  return (
+    <div>
+      <div className="flex gap-2">
+        <Input
+          value={draft}
+          placeholder={placeholder}
+          aria-label={label}
+          onChange={(event) => {
+            setDraft(event.target.value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            addValue();
+          }}
+        />
+        <Button type="button" variant="outline" onClick={addValue}>
+          <Plus className="size-4" aria-hidden="true" />
+          Add
+        </Button>
+      </div>
+      {value.length > 0 ? (
+        <ul
+          className="mt-3 flex flex-wrap gap-2"
+          aria-label={`${label} values`}
+        >
+          {value.map((item, index) => (
+            <li
+              key={`${item}-${String(index)}`}
+              className="flex items-center gap-1 rounded-full border border-border bg-muted px-3 py-1 text-xs"
+            >
+              <span>{item}</span>
+              <button
+                type="button"
+                className="rounded-full p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={`Remove ${item}`}
+                onClick={() => {
+                  onChange(value.filter((_, itemIndex) => itemIndex !== index));
+                }}
+              >
+                <Minus className="size-3" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function ToneControl({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}): React.JSX.Element {
+  return (
+    <label className="block text-sm font-medium">
+      <span className="flex items-center justify-between">
+        {label}
+        <span className="text-xs text-muted-foreground">{value} / 3</span>
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={3}
+        step={1}
+        value={value}
+        className="mt-2 w-full accent-[var(--primary)]"
+        onChange={(event) => {
+          onChange(Number(event.target.value));
+        }}
+      />
+    </label>
+  );
+}
+
+function PageSkeleton(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-5 py-10 sm:px-8 sm:py-14">
+      <Skeleton className="h-12 w-72" />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="space-y-5">
+          <Skeleton className="h-72 w-full" />
+          <Skeleton className="h-80 w-full" />
+        </div>
+        <Skeleton className="h-96 w-full" />
+      </div>
+    </div>
+  );
+}
 
 export function Component(): React.JSX.Element {
+  const { competitionId } = useParams();
+  const navigate = useNavigate();
+  const [searchParameters, setSearchParameters] = useSearchParams();
+  const resolvedCompetitionId = competitionId ?? "";
+  const competitionQuery = useCompetitionDetail(competitionId);
+  const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
+  const modelsQuery = useModelCatalog();
+  const submitGeneration = useSubmitGeneration(resolvedCompetitionId);
+  const storedDefaults = useMemo(
+    () =>
+      competitionId
+        ? (loadGenerationDraft(competitionId) ?? createGenerationFormDefaults())
+        : createGenerationFormDefaults(),
+    [competitionId],
+  );
+  const form = useForm<GenerationFormValues>({
+    resolver: zodResolver(generationFormSchema),
+    defaultValues: storedDefaults,
+    mode: "onBlur",
+  });
+  const selectedSeasonId = useWatch({
+    control: form.control,
+    name: "competitionSeasonId",
+  });
+  const selectedMode = useWatch({ control: form.control, name: "mode" });
+  const selectedPrimaryModel = useWatch({
+    control: form.control,
+    name: "requestedPrimaryModel",
+  });
+  const fallbackModels = useWatch({
+    control: form.control,
+    name: "model.fallbackModels",
+  });
+  const draftValues = useWatch({ control: form.control });
+  const seasonDetailQuery = useSeasonDetail(
+    competitionId,
+    selectedSeasonId || undefined,
+  );
+  const mappingsQuery = useRosterMappings(
+    competitionId,
+    selectedSeasonId || undefined,
+  );
+
+  const seasons = useMemo(
+    () => seasonsQuery.data?.page.items ?? [],
+    [seasonsQuery.data],
+  );
+  const latestSeason = seasons.reduce<(typeof seasons)[number] | undefined>(
+    (latest, candidate) =>
+      !latest ||
+      candidate.season.sequence_number > latest.season.sequence_number
+        ? candidate
+        : latest,
+    undefined,
+  );
+  const selectedSeason = seasons.find(
+    ({ season }) => season.id === selectedSeasonId,
+  );
+  const isLatestSeason =
+    selectedSeasonId.length > 0 && selectedSeasonId === latestSeason?.season.id;
+  const modelOptions = useMemo(
+    () => modelsQuery.data?.models ?? [],
+    [modelsQuery.data],
+  );
+  const validModelIds = useMemo(
+    () => new Set(modelOptions.map((model) => model.model)),
+    [modelOptions],
+  );
+  const selectedModel = modelOptions.find(
+    (model) => model.model === selectedPrimaryModel,
+  );
+  const modelSelectionValid =
+    validModelIds.has(selectedPrimaryModel) &&
+    fallbackModels.every(
+      (model) => model !== selectedPrimaryModel && validModelIds.has(model),
+    );
+  const lastSuccessfulRefresh =
+    seasonDetailQuery.data?.summary.latest_successful_refresh_at ?? null;
+  const mappingStatus = mappingsQuery.data?.mapping.status;
+  const hasNormalizedData = seasonDetailQuery.data?.normalized_overview != null;
+  const readyToGenerate =
+    Boolean(selectedSeason) &&
+    Boolean(lastSuccessfulRefresh) &&
+    hasNormalizedData &&
+    mappingStatus === "ready" &&
+    !competitionQuery.data?.competition.archived_at;
+
+  useEffect(() => {
+    if (!competitionId) return;
+    const parsed = generationDraftSchema.safeParse({
+      version: GENERATION_DRAFT_VERSION,
+      values: draftValues,
+    });
+    if (parsed.success) {
+      saveGenerationDraft(competitionId, parsed.data.values);
+    }
+  }, [competitionId, draftValues]);
+
+  useEffect(() => {
+    if (seasons.length === 0) return;
+    const requestedSeasonId = searchParameters.get("season");
+    const requestedSeason = seasons.find(
+      ({ season }) => season.id === requestedSeasonId,
+    );
+    const currentSeason = seasons.find(
+      ({ season }) => season.id === form.getValues("competitionSeasonId"),
+    );
+    const nextSeason = requestedSeason ?? currentSeason ?? latestSeason;
+    if (!nextSeason) return;
+    if (form.getValues("competitionSeasonId") !== nextSeason.season.id) {
+      form.setValue("competitionSeasonId", nextSeason.season.id);
+    }
+    if (requestedSeasonId !== nextSeason.season.id) {
+      const next = new URLSearchParams(searchParameters);
+      next.set("season", nextSeason.season.id);
+      setSearchParameters(next, { replace: true });
+    }
+  }, [form, latestSeason, searchParameters, seasons, setSearchParameters]);
+
+  useEffect(() => {
+    if (!selectedSeasonId || !latestSeason) return;
+    if (
+      selectedSeasonId !== latestSeason.season.id &&
+      selectedMode !== "backtest"
+    ) {
+      form.setValue("mode", "backtest", { shouldValidate: true });
+    }
+  }, [form, latestSeason, selectedMode, selectedSeasonId]);
+
+  useEffect(() => {
+    const defaultModel =
+      modelOptions.find((model) => model.is_default) ?? modelOptions[0];
+    if (!defaultModel) return;
+    const currentPrimary = form.getValues("requestedPrimaryModel");
+    const nextPrimary = validModelIds.has(currentPrimary)
+      ? currentPrimary
+      : defaultModel.model;
+    if (currentPrimary !== nextPrimary) {
+      form.setValue("requestedPrimaryModel", nextPrimary, {
+        shouldValidate: true,
+      });
+    }
+    const currentFallbacks = form.getValues("model.fallbackModels");
+    const nextFallbacks = currentFallbacks.filter(
+      (model) => model !== nextPrimary && validModelIds.has(model),
+    );
+    if (nextFallbacks.length !== currentFallbacks.length) {
+      form.setValue("model.fallbackModels", nextFallbacks, {
+        shouldValidate: true,
+      });
+    }
+  }, [form, modelOptions, validModelIds]);
+
+  useEffect(() => {
+    if (
+      !selectedPrimaryModel ||
+      !fallbackModels.includes(selectedPrimaryModel)
+    ) {
+      return;
+    }
+    form.setValue(
+      "model.fallbackModels",
+      fallbackModels.filter((model) => model !== selectedPrimaryModel),
+      { shouldDirty: true, shouldValidate: true },
+    );
+  }, [fallbackModels, form, selectedPrimaryModel]);
+
+  if (competitionQuery.isPending || seasonsQuery.isPending) {
+    return <PageSkeleton />;
+  }
+
+  if (competitionQuery.isError || seasonsQuery.isError || !competitionId) {
+    const error = competitionQuery.error ?? seasonsQuery.error;
+    return (
+      <div className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <CircleAlert className="size-8 text-destructive" aria-hidden="true" />
+        <h1 className="mt-4 font-editorial text-3xl font-semibold">
+          Generation setup unavailable
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          {error instanceof ApiError
+            ? error.message
+            : "The selected league and seasons could not be loaded."}
+        </p>
+        <Button
+          className="mt-6"
+          variant="outline"
+          onClick={() =>
+            void Promise.all([
+              competitionQuery.refetch(),
+              seasonsQuery.refetch(),
+            ])
+          }
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const competition = competitionQuery.data.competition;
+
+  if (seasons.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl px-5 py-16 text-center sm:px-8">
+        <Database
+          className="mx-auto size-9 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <p className="mt-5 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Reporter assignment
+        </p>
+        <h1 className="mt-3 font-editorial text-4xl font-semibold">
+          Add a season before generating
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-sm leading-6 text-muted-foreground">
+          A generation needs an attached Sleeper season, refreshed source data,
+          and complete team identity mappings.
+        </p>
+        <Link
+          className="mt-7 inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground outline-none hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring"
+          to={`/competitions/${competitionId}`}
+        >
+          Open league setup
+        </Link>
+      </div>
+    );
+  }
+
+  function selectSeason(seasonId: string): void {
+    form.setValue("competitionSeasonId", seasonId, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    const next = new URLSearchParams(searchParameters);
+    next.set("season", seasonId);
+    setSearchParameters(next);
+  }
+
+  const submit = form.handleSubmit(async (values) => {
+    if (!readyToGenerate) {
+      form.setError("root.server", {
+        message: "Finish the selected season's data setup before generating.",
+      });
+      return;
+    }
+    if (!modelSelectionValid) {
+      form.setError("requestedPrimaryModel", {
+        message: "Choose models from the current configured catalog.",
+      });
+      return;
+    }
+    form.clearErrors("root.server");
+    try {
+      const response = await submitGeneration.mutateAsync(
+        mapGenerationFormToSubmitBody(values),
+      );
+      clearGenerationDraft(competitionId);
+      toast.success("Generation queued");
+      await navigate(
+        `/competitions/${competitionId}/generations/${response.generation.id}`,
+      );
+    } catch (error) {
+      if (error instanceof ApiError) {
+        for (const [wirePath, messages] of Object.entries(error.fieldErrors)) {
+          const fieldPath = serverFieldPaths[wirePath];
+          if (!fieldPath || messages.length === 0) continue;
+          form.setError(fieldPath, {
+            type: "server",
+            message: messages.join(" "),
+          });
+        }
+      }
+      form.setError("root.server", {
+        message:
+          error instanceof ApiError
+            ? error.message
+            : "The generation could not be submitted.",
+      });
+    }
+  });
+
+  const selectableFallbacks = modelOptions.filter(
+    (model) =>
+      model.model !== selectedPrimaryModel &&
+      !fallbackModels.includes(model.model),
+  );
+
   return (
-    <PlaceholderPage
-      eyebrow="Reporter assignment"
-      title="Generate"
-      description="Configure the factual boundary, assignment, voice, and ordered model chain for a durable reporter run."
-      detail="The generation form and submission workflow will be added after league management."
-      icon={PlusCircle}
-    />
+    <div className="mx-auto w-full max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+          Reporter assignment
+        </p>
+        <h1 className="mt-3 font-editorial text-4xl font-semibold tracking-tight sm:text-5xl">
+          Generate an article
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">
+          Configure a reproducible reporter run for {competition.display_name}.
+          Submission creates a durable run record immediately.
+        </p>
+      </header>
+
+      <form
+        className="mt-9 grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]"
+        onSubmit={(event) => void submit(event)}
+      >
+        <div className="space-y-5">
+          <Section
+            number="1"
+            title="Scope"
+            description="Choose the factual boundary and whether memory may change."
+          >
+            <div className="grid gap-5 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <Label htmlFor="generation-season">Season</Label>
+                <select
+                  id="generation-season"
+                  className={cn(selectClassName, "mt-2")}
+                  value={selectedSeasonId}
+                  aria-invalid={Boolean(
+                    form.formState.errors.competitionSeasonId,
+                  )}
+                  aria-describedby="generation-season-error"
+                  onChange={(event) => {
+                    selectSeason(event.target.value);
+                  }}
+                >
+                  {seasons.map(({ season, summary }) => (
+                    <option key={season.id} value={season.id}>
+                      {season.season_year}
+                      {summary.league_name ? ` · ${summary.league_name}` : ""}
+                    </option>
+                  ))}
+                </select>
+                <FieldMessage
+                  id="generation-season-error"
+                  error={form.formState.errors.competitionSeasonId}
+                />
+              </div>
+              <div>
+                <Label htmlFor="week-start">Start week</Label>
+                <select
+                  id="week-start"
+                  className={cn(selectClassName, "mt-2")}
+                  aria-invalid={Boolean(form.formState.errors.weekStart)}
+                  aria-describedby="week-start-error"
+                  {...form.register("weekStart", { valueAsNumber: true })}
+                >
+                  {GENERATION_WEEK_OPTIONS.map((week) => (
+                    <option key={week} value={week}>
+                      Week {week}
+                    </option>
+                  ))}
+                </select>
+                <FieldMessage
+                  id="week-start-error"
+                  error={form.formState.errors.weekStart}
+                />
+              </div>
+              <div>
+                <Label htmlFor="week-end">End week</Label>
+                <select
+                  id="week-end"
+                  className={cn(selectClassName, "mt-2")}
+                  aria-invalid={Boolean(form.formState.errors.weekEnd)}
+                  aria-describedby="week-end-error"
+                  {...form.register("weekEnd", { valueAsNumber: true })}
+                >
+                  {GENERATION_WEEK_OPTIONS.map((week) => (
+                    <option key={week} value={week}>
+                      Week {week}
+                    </option>
+                  ))}
+                </select>
+                <FieldMessage
+                  id="week-end-error"
+                  error={form.formState.errors.weekEnd}
+                />
+              </div>
+            </div>
+
+            <fieldset className="mt-6">
+              <legend className="text-sm font-medium">Generation mode</legend>
+              <div className="mt-2 grid gap-3 sm:grid-cols-2">
+                <label
+                  className={cn(
+                    "rounded-md border p-4",
+                    selectedMode === "live"
+                      ? "border-primary bg-accent/45"
+                      : "border-border",
+                    !isLatestSeason && "cursor-not-allowed opacity-55",
+                  )}
+                >
+                  <span className="flex items-center gap-2 font-medium">
+                    <input
+                      type="radio"
+                      value="live"
+                      disabled={!isLatestSeason}
+                      {...form.register("mode")}
+                    />
+                    Live
+                  </span>
+                  <span className="mt-2 block text-xs leading-5 text-muted-foreground">
+                    Uses canonical reporter memory and may write memory on
+                    success.
+                  </span>
+                </label>
+                <label
+                  className={cn(
+                    "rounded-md border p-4",
+                    selectedMode === "backtest"
+                      ? "border-primary bg-accent/45"
+                      : "border-border",
+                  )}
+                >
+                  <span className="flex items-center gap-2 font-medium">
+                    <input
+                      type="radio"
+                      value="backtest"
+                      {...form.register("mode")}
+                    />
+                    Historical backtest
+                  </span>
+                  <span className="mt-2 block text-xs leading-5 text-muted-foreground">
+                    Pins historical data and memory without canonical memory
+                    writes.
+                  </span>
+                </label>
+              </div>
+              {!isLatestSeason ? (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Older seasons are evaluation-only and use historical backtest
+                  mode.
+                </p>
+              ) : null}
+            </fieldset>
+          </Section>
+
+          <Section
+            number="2"
+            title="Assignment"
+            description="Tell the reporter what to cover and which angles matter."
+          >
+            <Label htmlFor="request-text">Article request</Label>
+            <textarea
+              id="request-text"
+              className={cn(textareaClassName, "mt-2")}
+              placeholder="Write a sharp weekly recap focused on the playoff race…"
+              aria-invalid={Boolean(form.formState.errors.requestText)}
+              aria-describedby="request-text-error"
+              {...form.register("requestText")}
+            />
+            <FieldMessage
+              id="request-text-error"
+              error={form.formState.errors.requestText}
+            />
+            <div className="mt-5 grid gap-5 sm:grid-cols-2">
+              <div>
+                <Label>Focus teams</Label>
+                <Controller
+                  control={form.control}
+                  name="report.focusTeams"
+                  render={({ field }) => (
+                    <div className="mt-2">
+                      <StringListEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Team name"
+                        label="Focus team"
+                      />
+                    </div>
+                  )}
+                />
+              </div>
+              <div>
+                <Label>Focus topics</Label>
+                <Controller
+                  control={form.control}
+                  name="report.focusHints"
+                  render={({ field }) => (
+                    <div className="mt-2">
+                      <StringListEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Playoff race"
+                        label="Focus topic"
+                      />
+                    </div>
+                  )}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <Label>Topics to avoid</Label>
+                <Controller
+                  control={form.control}
+                  name="report.avoidTopics"
+                  render={({ field }) => (
+                    <div className="mt-2">
+                      <StringListEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Trade rumors"
+                        label="Topic to avoid"
+                      />
+                    </div>
+                  )}
+                />
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            number="3"
+            title="Voice"
+            description="Shape the editorial voice without changing the underlying facts."
+          >
+            <div className="grid gap-5 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <Label htmlFor="voice">Reporter voice</Label>
+                <Input
+                  id="voice"
+                  className="mt-2"
+                  aria-invalid={Boolean(form.formState.errors.report?.voice)}
+                  aria-describedby="voice-error"
+                  {...form.register("report.voice")}
+                />
+                <FieldMessage
+                  id="voice-error"
+                  error={form.formState.errors.report?.voice}
+                />
+              </div>
+              <div>
+                <Label htmlFor="length-target">Target words</Label>
+                <Input
+                  id="length-target"
+                  type="number"
+                  min={1}
+                  className="mt-2"
+                  aria-invalid={Boolean(
+                    form.formState.errors.report?.lengthTarget,
+                  )}
+                  aria-describedby="length-target-error"
+                  {...form.register("report.lengthTarget", {
+                    valueAsNumber: true,
+                  })}
+                />
+                <FieldMessage
+                  id="length-target-error"
+                  error={form.formState.errors.report?.lengthTarget}
+                />
+              </div>
+              <div>
+                <Label htmlFor="evidence-policy">Evidence policy</Label>
+                <select
+                  id="evidence-policy"
+                  className={cn(selectClassName, "mt-2")}
+                  {...form.register("report.evidencePolicy")}
+                >
+                  <option value="strict">Strict</option>
+                  <option value="standard">Standard</option>
+                  <option value="relaxed">Relaxed</option>
+                </select>
+              </div>
+              <div>
+                <Label htmlFor="profanity-policy">Profanity</Label>
+                <select
+                  id="profanity-policy"
+                  className={cn(selectClassName, "mt-2")}
+                  {...form.register("report.profanityPolicy")}
+                >
+                  <option value="none">None</option>
+                  <option value="mild">Mild</option>
+                  <option value="unrestricted">Unrestricted</option>
+                </select>
+              </div>
+              <div className="grid gap-4 rounded-md border border-border p-4 sm:col-span-2 sm:grid-cols-3">
+                <Controller
+                  control={form.control}
+                  name="report.tone.snarkLevel"
+                  render={({ field }) => (
+                    <ToneControl
+                      label="Snark"
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="report.tone.hypeLevel"
+                  render={({ field }) => (
+                    <ToneControl
+                      label="Hype"
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+                <Controller
+                  control={form.control}
+                  name="report.tone.seriousness"
+                  render={({ field }) => (
+                    <ToneControl
+                      label="Seriousness"
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+              </div>
+              <div>
+                <Label>Favored teams</Label>
+                <Controller
+                  control={form.control}
+                  name="report.bias.favoredTeams"
+                  render={({ field }) => (
+                    <div className="mt-2">
+                      <StringListEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Team name"
+                        label="Favored team"
+                      />
+                    </div>
+                  )}
+                />
+              </div>
+              <div>
+                <Label>Disfavored teams</Label>
+                <Controller
+                  control={form.control}
+                  name="report.bias.disfavoredTeams"
+                  render={({ field }) => (
+                    <div className="mt-2">
+                      <StringListEditor
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Team name"
+                        label="Disfavored team"
+                      />
+                    </div>
+                  )}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <Controller
+                  control={form.control}
+                  name="report.bias.intensity"
+                  render={({ field }) => (
+                    <ToneControl
+                      label="Bias intensity"
+                      value={field.value}
+                      onChange={field.onChange}
+                    />
+                  )}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Bias changes framing only. It never changes facts or numbers.
+                </p>
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            number="4"
+            title="Models"
+            description="Choose the primary model and an ordered, unique fallback chain."
+          >
+            {modelsQuery.isPending ? (
+              <Skeleton className="h-24 w-full" />
+            ) : modelsQuery.isError ? (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-4">
+                <p className="text-sm text-destructive">
+                  {modelsQuery.error instanceof ApiError
+                    ? modelsQuery.error.message
+                    : "The configured model catalog could not be loaded."}
+                </p>
+                <Button
+                  type="button"
+                  className="mt-3"
+                  variant="outline"
+                  onClick={() => void modelsQuery.refetch()}
+                >
+                  Retry model catalog
+                </Button>
+              </div>
+            ) : (
+              <>
+                <Label htmlFor="primary-model">Primary model</Label>
+                <select
+                  id="primary-model"
+                  className={cn(selectClassName, "mt-2")}
+                  aria-invalid={Boolean(
+                    form.formState.errors.requestedPrimaryModel,
+                  )}
+                  aria-describedby="primary-model-error"
+                  {...form.register("requestedPrimaryModel")}
+                >
+                  <option value="">Select a configured model</option>
+                  {modelOptions.map((model) => (
+                    <option key={model.model} value={model.model}>
+                      {model.display_name} · {model.provider}
+                      {model.is_default ? " · default" : ""}
+                    </option>
+                  ))}
+                </select>
+                <FieldMessage
+                  id="primary-model-error"
+                  error={form.formState.errors.requestedPrimaryModel}
+                />
+                {selectedModel ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {selectedModel.provider} · {selectedModel.model}
+                    {selectedModel.supports_reasoning
+                      ? " · reasoning supported"
+                      : ""}
+                  </p>
+                ) : null}
+
+                <div className="mt-6">
+                  <Label htmlFor="fallback-model">Fallback order</Label>
+                  <Controller
+                    control={form.control}
+                    name="model.fallbackModels"
+                    render={({ field }) => (
+                      <>
+                        <div className="mt-2 flex gap-2">
+                          <select
+                            id="fallback-model"
+                            className={selectClassName}
+                            defaultValue=""
+                          >
+                            <option value="">Choose a fallback</option>
+                            {selectableFallbacks.map((model) => (
+                              <option key={model.model} value={model.model}>
+                                {model.display_name} · {model.provider}
+                              </option>
+                            ))}
+                          </select>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={(event) => {
+                              const select = event.currentTarget
+                                .previousElementSibling as HTMLSelectElement | null;
+                              if (!select?.value) return;
+                              field.onChange([...field.value, select.value]);
+                              select.value = "";
+                            }}
+                          >
+                            <Plus className="size-4" aria-hidden="true" /> Add
+                          </Button>
+                        </div>
+                        {field.value.length > 0 ? (
+                          <ol className="mt-3 space-y-2">
+                            {field.value.map((modelId, index) => {
+                              const model = modelOptions.find(
+                                (item) => item.model === modelId,
+                              );
+                              return (
+                                <li
+                                  key={modelId}
+                                  className="flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm"
+                                >
+                                  <span className="flex size-6 items-center justify-center rounded-full bg-muted text-xs">
+                                    {index + 1}
+                                  </span>
+                                  <span className="min-w-0 flex-1 truncate">
+                                    {model?.display_name ?? modelId}
+                                  </span>
+                                  <Button
+                                    type="button"
+                                    size="icon"
+                                    variant="ghost"
+                                    disabled={index === 0}
+                                    aria-label={`Move ${modelId} up`}
+                                    onClick={() => {
+                                      const next = [...field.value];
+                                      const current = next[index];
+                                      const previous = next[index - 1];
+                                      if (!current || !previous) return;
+                                      next[index - 1] = current;
+                                      next[index] = previous;
+                                      field.onChange(next);
+                                    }}
+                                  >
+                                    <ArrowUp
+                                      className="size-4"
+                                      aria-hidden="true"
+                                    />
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="icon"
+                                    variant="ghost"
+                                    disabled={index === field.value.length - 1}
+                                    aria-label={`Move ${modelId} down`}
+                                    onClick={() => {
+                                      const next = [...field.value];
+                                      const current = next[index];
+                                      const following = next[index + 1];
+                                      if (!current || !following) return;
+                                      next[index] = following;
+                                      next[index + 1] = current;
+                                      field.onChange(next);
+                                    }}
+                                  >
+                                    <ArrowDown
+                                      className="size-4"
+                                      aria-hidden="true"
+                                    />
+                                  </Button>
+                                  <Button
+                                    type="button"
+                                    size="icon"
+                                    variant="ghost"
+                                    aria-label={`Remove ${modelId}`}
+                                    onClick={() => {
+                                      field.onChange(
+                                        field.value.filter(
+                                          (item) => item !== modelId,
+                                        ),
+                                      );
+                                    }}
+                                  >
+                                    <Minus
+                                      className="size-4"
+                                      aria-hidden="true"
+                                    />
+                                  </Button>
+                                </li>
+                              );
+                            })}
+                          </ol>
+                        ) : (
+                          <p className="mt-3 text-xs text-muted-foreground">
+                            No fallback models selected.
+                          </p>
+                        )}
+                      </>
+                    )}
+                  />
+                </div>
+              </>
+            )}
+          </Section>
+
+          <details className="rounded-lg border border-border bg-card p-5 sm:p-6">
+            <summary className="cursor-pointer font-editorial text-xl font-semibold outline-none focus-visible:ring-2 focus-visible:ring-ring">
+              Advanced execution
+            </summary>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Retry timing and runner limits. Defaults are appropriate for most
+              runs.
+            </p>
+            <div className="mt-5 grid gap-5 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="max-retries">Maximum retries</Label>
+                <Input
+                  id="max-retries"
+                  type="number"
+                  min={0}
+                  className="mt-2"
+                  aria-invalid={Boolean(
+                    form.formState.errors.model?.retry?.maxRetries,
+                  )}
+                  aria-describedby="max-retries-error"
+                  {...form.register("model.retry.maxRetries", {
+                    valueAsNumber: true,
+                  })}
+                />
+                <FieldMessage
+                  id="max-retries-error"
+                  error={form.formState.errors.model?.retry?.maxRetries}
+                />
+              </div>
+              <div>
+                <Label htmlFor="max-turns">Maximum turns</Label>
+                <Input
+                  id="max-turns"
+                  type="number"
+                  min={1}
+                  className="mt-2"
+                  aria-invalid={Boolean(form.formState.errors.runner?.maxTurns)}
+                  aria-describedby="max-turns-error"
+                  {...form.register("runner.maxTurns", {
+                    valueAsNumber: true,
+                  })}
+                />
+                <FieldMessage
+                  id="max-turns-error"
+                  error={form.formState.errors.runner?.maxTurns}
+                />
+              </div>
+              <div>
+                <Label htmlFor="base-delay">Base delay (seconds)</Label>
+                <Input
+                  id="base-delay"
+                  type="number"
+                  min={0.1}
+                  step={0.1}
+                  className="mt-2"
+                  aria-invalid={Boolean(
+                    form.formState.errors.model?.retry?.baseDelaySeconds,
+                  )}
+                  aria-describedby="base-delay-error"
+                  {...form.register("model.retry.baseDelaySeconds", {
+                    valueAsNumber: true,
+                  })}
+                />
+                <FieldMessage
+                  id="base-delay-error"
+                  error={form.formState.errors.model?.retry?.baseDelaySeconds}
+                />
+              </div>
+              <div>
+                <Label htmlFor="max-delay">Maximum delay (seconds)</Label>
+                <Input
+                  id="max-delay"
+                  type="number"
+                  min={0.1}
+                  step={0.1}
+                  className="mt-2"
+                  aria-invalid={Boolean(
+                    form.formState.errors.model?.retry?.maxDelaySeconds,
+                  )}
+                  aria-describedby="max-delay-error"
+                  {...form.register("model.retry.maxDelaySeconds", {
+                    valueAsNumber: true,
+                  })}
+                />
+                <FieldMessage
+                  id="max-delay-error"
+                  error={form.formState.errors.model?.retry?.maxDelaySeconds}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <Label htmlFor="procedure-history">Procedure history</Label>
+                <select
+                  id="procedure-history"
+                  className={cn(selectClassName, "mt-2")}
+                  {...form.register("runner.procedureHistoryMode")}
+                >
+                  <option value="replace">Replace each procedure view</option>
+                  <option value="append">Append procedure history</option>
+                </select>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <aside className="space-y-4 lg:sticky lg:top-24">
+          <section className="rounded-lg border border-border bg-card p-5">
+            <div className="flex items-center gap-2">
+              <Sparkles
+                className="size-4 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <h2 className="font-semibold">Run summary</h2>
+            </div>
+            <dl className="mt-5 space-y-4 text-sm">
+              <div className="flex items-start justify-between gap-3">
+                <dt className="text-muted-foreground">Season</dt>
+                <dd className="text-right font-medium">
+                  {selectedSeason?.season.season_year ?? "—"}
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-3 border-t border-border pt-4">
+                <dt className="text-muted-foreground">Mode</dt>
+                <dd>
+                  <Badge variant="outline">
+                    {selectedMode === "live" ? "Live" : "Backtest"}
+                  </Badge>
+                </dd>
+              </div>
+              <div className="flex items-start justify-between gap-3 border-t border-border pt-4">
+                <dt className="text-muted-foreground">Model chain</dt>
+                <dd className="text-right">
+                  {selectedPrimaryModel
+                    ? `${String(1 + fallbackModels.length)} model${fallbackModels.length === 0 ? "" : "s"}`
+                    : "—"}
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-5">
+            <div className="flex items-center gap-2">
+              <Clock3
+                className="size-4 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <h2 className="font-semibold">Data readiness</h2>
+            </div>
+            {seasonDetailQuery.isPending || mappingsQuery.isPending ? (
+              <Skeleton className="mt-4 h-20 w-full" />
+            ) : seasonDetailQuery.isError || mappingsQuery.isError ? (
+              <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-3">
+                <p className="text-sm text-destructive">
+                  Season readiness could not be loaded.
+                </p>
+                <Button
+                  type="button"
+                  className="mt-3"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    void Promise.all([
+                      seasonDetailQuery.refetch(),
+                      mappingsQuery.refetch(),
+                    ]);
+                  }}
+                >
+                  Retry readiness
+                </Button>
+              </div>
+            ) : (
+              <>
+                <p
+                  className={cn(
+                    "mt-4 text-sm font-medium",
+                    readyToGenerate ? "text-primary" : "text-destructive",
+                  )}
+                >
+                  {competition.archived_at
+                    ? "Archived league"
+                    : !hasNormalizedData
+                      ? "Sleeper data not loaded"
+                      : mappingStatus !== "ready"
+                        ? "Team identity setup required"
+                        : !lastSuccessfulRefresh
+                          ? "No successful refresh"
+                          : "Ready to generate"}
+                </p>
+                <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                  Last successful refresh:{" "}
+                  <DateTime value={lastSuccessfulRefresh} />
+                </p>
+                {!readyToGenerate ? (
+                  <Link
+                    className="mt-4 inline-flex text-sm font-medium text-primary underline-offset-4 hover:underline"
+                    to={`/competitions/${competitionId}?season=${selectedSeasonId}`}
+                  >
+                    Finish season setup
+                  </Link>
+                ) : null}
+              </>
+            )}
+            <p className="mt-4 border-t border-border pt-4 text-xs leading-5 text-muted-foreground">
+              Refresh and generation snapshots are separate. A same-day run may
+              reuse an earlier ready daily snapshot; snapshot time is shown on
+              the resulting run audit.
+            </p>
+          </section>
+
+          {form.formState.errors.root?.server ? (
+            <div
+              className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive"
+              role="alert"
+            >
+              {form.formState.errors.root.server.message}
+            </div>
+          ) : null}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={
+              !readyToGenerate ||
+              modelsQuery.isError ||
+              !modelSelectionValid ||
+              submitGeneration.isPending
+            }
+          >
+            {submitGeneration.isPending ? (
+              <LoaderCircle
+                className="size-4 animate-spin"
+                aria-hidden="true"
+              />
+            ) : (
+              <Sparkles className="size-4" aria-hidden="true" />
+            )}
+            {submitGeneration.isPending
+              ? "Creating durable run…"
+              : "Generate article"}
+          </Button>
+          <p
+            className="text-center text-xs leading-5 text-muted-foreground"
+            aria-live="polite"
+          >
+            The next page tracks pending, running, and terminal state. Reloading
+            will not lose the run.
+          </p>
+        </aside>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- add the complete competition-scoped generation form with explicit factual
  scope, live/backtest safety, reporter voice and bias controls, and advanced
  execution settings
- source primary and ordered fallback models from the backend catalog, preserve
  valid drafts, and reconcile stale model selections
- surface season refresh and roster-identity readiness while keeping refresh
  and immutable snapshot semantics distinct
- submit a durable generation and navigate immediately to its run URL
- harden server and frontend validation for duplicate model chains and legacy
  reporting error envelopes

## Verification

- `.venv\\Scripts\\python.exe -m pytest backend/tests/api/test_generation_routes.py backend/tests/api/test_openapi_export.py --basetemp=.test-tmp-ui7a` — 6 passed
- `pnpm install --frozen-lockfile`
- `pnpm api:check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- production Vite build using bundled Node 24 (Node 22.22 remains pinned)
- browser acceptance for latest/older season modes, explicit draft recovery,
  fallback ordering, durable navigation, and 390px responsive layout

Stacked on `codex/ui-6e-roster-identity-ui`.
