### PR TITLE
feat(ui): add generation run state

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -73,6 +73,14 @@ export const queryKeys = {
       ["competitions", competitionId, "generations"] as const,
     generationSubmission: (competitionId: string) =>
       ["competitions", competitionId, "generations", "submit"] as const,
+    generationRerun: (competitionId: string, generationId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "rerun",
+      ] as const,
     generationDetail: (competitionId: string, generationId: string) =>
       ["competitions", competitionId, "generations", generationId] as const,
   },

--- a/frontend/src/features/generations/api.ts
+++ b/frontend/src/features/generations/api.ts
@@ -4,6 +4,9 @@ import type { components } from "@/api/generated/schema";
 export type Generation = components["schemas"]["Generation"];
 export type GenerationBiasSettings =
   components["schemas"]["GenerationBiasSettings"];
+export type GenerationDetail = components["schemas"]["GenerationDetail"];
+export type GenerationDetailResponse =
+  components["schemas"]["GenerationDetailResponse"];
 export type GenerationKind = components["schemas"]["GenerationKind"];
 export type GenerationModelSettings =
   components["schemas"]["GenerationModelSettings"];
@@ -15,6 +18,7 @@ export type GenerationRetrySettings =
 export type GenerationRunnerSettings =
   components["schemas"]["GenerationRunnerSettings"];
 export type GenerationSettings = components["schemas"]["GenerationSettings"];
+export type GenerationStatus = components["schemas"]["GenerationStatus"];
 export type GenerationToneSettings =
   components["schemas"]["GenerationToneSettings"];
 export type SubmitGenerationBody =
@@ -33,4 +37,25 @@ export function submitGeneration({
     method: "POST",
     json: body,
   });
+}
+
+export function getGeneration(
+  competitionId: string,
+  generationId: string,
+  signal?: AbortSignal,
+): Promise<GenerationDetailResponse> {
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}`,
+    { signal },
+  );
+}
+
+export function rerunGeneration(
+  competitionId: string,
+  generationId: string,
+): Promise<GenerationResponse> {
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}/reruns`,
+    { method: "POST" },
+  );
 }

--- a/frontend/src/features/generations/draft.ts
+++ b/frontend/src/features/generations/draft.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import type { SubmitGenerationBody } from "@/features/generations/api";
+import type {
+  GenerationDetail,
+  SubmitGenerationBody,
+} from "@/features/generations/api";
 
 export const GENERATION_DRAFT_VERSION = 1 as const;
 export const GENERATION_WEEK_OPTIONS = Array.from(
@@ -143,6 +146,162 @@ export const generationFormSchema = generationDraftValuesSchema.superRefine(
 );
 
 export type GenerationFormValues = z.output<typeof generationFormSchema>;
+
+const persistedNonBlankStringSchema = z
+  .string()
+  .min(1)
+  .refine((value) => value === value.trim());
+const persistedStringListSchema = z.array(persistedNonBlankStringSchema);
+const persistedControlLevelSchema = z.number().int().min(0).max(3);
+
+export const persistedGenerationSettingsSchema = z
+  .object({
+    schema_version: z.literal(1),
+    report: z
+      .object({
+        focus_hints: persistedStringListSchema,
+        avoid_topics: persistedStringListSchema,
+        focus_teams: persistedStringListSchema,
+        voice: persistedNonBlankStringSchema,
+        tone: z
+          .object({
+            snark_level: persistedControlLevelSchema,
+            hype_level: persistedControlLevelSchema,
+            seriousness: persistedControlLevelSchema,
+          })
+          .strict(),
+        profanity_policy: z.enum(["none", "mild", "unrestricted"]),
+        bias: z
+          .object({
+            favored_teams: persistedStringListSchema,
+            disfavored_teams: persistedStringListSchema,
+            intensity: persistedControlLevelSchema,
+          })
+          .strict()
+          .nullable(),
+        length_target: z.number().int().min(1),
+        evidence_policy: z.enum(["strict", "standard", "relaxed"]),
+      })
+      .strict(),
+    model: z
+      .object({
+        fallback_models: persistedStringListSchema,
+        retry: z
+          .object({
+            max_retries: z.number().int().min(0),
+            base_delay_seconds: z.number().positive(),
+            max_delay_seconds: z.number().positive(),
+          })
+          .strict(),
+      })
+      .strict(),
+    runner: z
+      .object({
+        max_turns: z.number().int().min(1),
+        procedure_history_mode: z.enum(["replace", "append"]),
+      })
+      .strict(),
+    input_policy: z
+      .object({
+        snapshot_refresh: z.literal("never"),
+        snapshot_as_of_date: z.literal("execution_utc_date"),
+        backtest_memory: z.literal("latest_same_season_at_or_before_week"),
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((settings, context) => {
+    if (
+      settings.model.retry.max_delay_seconds <
+      settings.model.retry.base_delay_seconds
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Maximum delay must be at least the base delay.",
+        path: ["model", "retry", "max_delay_seconds"],
+      });
+    }
+
+    if (
+      new Set(settings.model.fallback_models).size !==
+      settings.model.fallback_models.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Fallback models must be unique.",
+        path: ["model", "fallback_models"],
+      });
+    }
+  });
+export type PersistedGenerationSettings = z.output<
+  typeof persistedGenerationSettingsSchema
+>;
+
+const generationEditSourceSchema = z.object({
+  competition_season_id: z.uuid(),
+  kind: z.enum(["live", "backtest"]),
+  request_text: persistedNonBlankStringSchema,
+  week_start: z.number().int().min(1).max(18),
+  week_end: z.number().int().min(1).max(18),
+  requested_primary_model: persistedNonBlankStringSchema,
+  settings: persistedGenerationSettingsSchema,
+});
+
+/**
+ * Reconstruct an editable form only from a complete, supported persisted run.
+ * Undefined means the run is unsafe to copy; callers should leave existing
+ * drafts untouched and explain that the saved settings cannot be edited.
+ */
+export function createGenerationFormValuesFromDetail(
+  generation: GenerationDetail,
+): GenerationFormValues | undefined {
+  const sourceResult = generationEditSourceSchema.safeParse(generation);
+  if (!sourceResult.success) return undefined;
+
+  const source = sourceResult.data;
+  const settings = source.settings;
+  const valuesResult = generationFormSchema.safeParse({
+    competitionSeasonId: source.competition_season_id,
+    mode: source.kind,
+    requestText: source.request_text,
+    weekStart: source.week_start,
+    weekEnd: source.week_end,
+    requestedPrimaryModel: source.requested_primary_model,
+    report: {
+      focusHints: settings.report.focus_hints,
+      avoidTopics: settings.report.avoid_topics,
+      focusTeams: settings.report.focus_teams,
+      voice: settings.report.voice,
+      tone: {
+        snarkLevel: settings.report.tone.snark_level,
+        hypeLevel: settings.report.tone.hype_level,
+        seriousness: settings.report.tone.seriousness,
+      },
+      profanityPolicy: settings.report.profanity_policy,
+      bias: {
+        favoredTeams: settings.report.bias?.favored_teams ?? [],
+        disfavoredTeams: settings.report.bias?.disfavored_teams ?? [],
+        intensity: settings.report.bias?.intensity ?? 1,
+      },
+      lengthTarget: settings.report.length_target,
+      evidencePolicy: settings.report.evidence_policy,
+    },
+    model: {
+      fallbackModels: settings.model.fallback_models,
+      retry: {
+        maxRetries: settings.model.retry.max_retries,
+        baseDelaySeconds: settings.model.retry.base_delay_seconds,
+        maxDelaySeconds: settings.model.retry.max_delay_seconds,
+      },
+    },
+    runner: {
+      maxTurns: settings.runner.max_turns,
+      procedureHistoryMode: settings.runner.procedure_history_mode,
+    },
+  });
+
+  return valuesResult.success ? valuesResult.data : undefined;
+}
 
 export const generationDraftSchema = z.object({
   version: z.literal(GENERATION_DRAFT_VERSION),

--- a/frontend/src/features/generations/queries.ts
+++ b/frontend/src/features/generations/queries.ts
@@ -1,11 +1,28 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { queryKeys } from "@/api/query-keys";
 import {
+  getGeneration,
+  rerunGeneration,
   submitGeneration,
+  type GenerationDetailResponse,
   type GenerationResponse,
+  type GenerationStatus,
   type SubmitGenerationBody,
 } from "@/features/generations/api";
+
+const GENERATION_POLL_INTERVAL_MS = 2_000;
+
+function isActiveGeneration(status: GenerationStatus | undefined): boolean {
+  return status === "pending" || status === "running";
+}
+
+function canPollInBrowser(): boolean {
+  return (
+    typeof document === "undefined" ||
+    (document.visibilityState === "visible" && navigator.onLine)
+  );
+}
 
 export function useSubmitGeneration(competitionId: string) {
   const queryClient = useQueryClient();
@@ -16,6 +33,62 @@ export function useSubmitGeneration(competitionId: string) {
       submitGeneration({ competitionId, body }),
     onSuccess: async (response: GenerationResponse) => {
       queryClient.setQueryData(
+        queryKeys.competitions.generationDetail(
+          competitionId,
+          response.generation.id,
+        ),
+        response,
+      );
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.competitions.generations(competitionId),
+      });
+    },
+  });
+}
+
+export function useGenerationDetail(
+  competitionId: string,
+  generationId: string | undefined,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.generationDetail(
+      competitionId,
+      generationId ?? "missing",
+    ),
+    queryFn: ({ signal }) =>
+      getGeneration(competitionId, generationId ?? "", signal),
+    enabled: generationId !== undefined,
+    refetchInterval: (query) =>
+      isActiveGeneration(query.state.data?.generation.status) &&
+      canPollInBrowser()
+        ? GENERATION_POLL_INTERVAL_MS
+        : false,
+    refetchIntervalInBackground: false,
+    refetchOnReconnect: (query) =>
+      isActiveGeneration(query.state.data?.generation.status)
+        ? "always"
+        : false,
+    refetchOnWindowFocus: (query) =>
+      isActiveGeneration(query.state.data?.generation.status)
+        ? "always"
+        : false,
+  });
+}
+
+export function useRerunGeneration(
+  competitionId: string,
+  generationId: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: queryKeys.competitions.generationRerun(
+      competitionId,
+      generationId,
+    ),
+    mutationFn: () => rerunGeneration(competitionId, generationId),
+    onSuccess: async (response: GenerationResponse) => {
+      queryClient.setQueryData<GenerationDetailResponse>(
         queryKeys.competitions.generationDetail(
           competitionId,
           response.generation.id,

--- a/frontend/src/routes/generation-detail.tsx
+++ b/frontend/src/routes/generation-detail.tsx
@@ -1,17 +1,413 @@
-import { FileText } from "lucide-react";
-import { useParams } from "react-router";
+import {
+  ArrowLeft,
+  CircleAlert,
+  CircleCheck,
+  CircleX,
+  Clock3,
+  FileText,
+  LoaderCircle,
+  Pencil,
+  RefreshCw,
+  RotateCcw,
+} from "lucide-react";
+import { Link, useNavigate, useParams } from "react-router";
+import { toast } from "sonner";
 
-import { PlaceholderPage } from "@/components/shared/placeholder-page";
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  createGenerationFormValuesFromDetail,
+  saveGenerationDraft,
+} from "@/features/generations/draft";
+import {
+  useGenerationDetail,
+  useRerunGeneration,
+} from "@/features/generations/queries";
+import { useSeasonList } from "@/features/seasons/queries";
+import { cn } from "@/lib/utils";
+
+const seasonListParameters = { limit: 200, offset: 0 } as const;
+
+function titleCase(value: string): string {
+  return value
+    .split(/[_\-.\s]+/u)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function elapsedLabel(start: string, end?: string | null): string {
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor(
+      (new Date(end ?? Date.now()).getTime() - new Date(start).getTime()) /
+        1_000,
+    ),
+  );
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  if (minutes < 1) return `${String(seconds)}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 1) return `${String(minutes)}m ${String(seconds)}s`;
+  return `${String(hours)}h ${String(minutes % 60)}m`;
+}
+
+function statusVariant(
+  status: "pending" | "running" | "succeeded" | "failed" | "cancelled",
+): "default" | "outline" | "destructive" {
+  if (status === "failed") return "destructive";
+  if (status === "succeeded") return "default";
+  return "outline";
+}
+
+function DetailSkeleton(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 px-5 py-10 sm:px-8 sm:py-14">
+      <Skeleton className="h-10 w-72" />
+      <Skeleton className="h-44 w-full" />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <Skeleton className="h-72 w-full" />
+        <Skeleton className="h-72 w-full" />
+      </div>
+    </div>
+  );
+}
 
 export function Component(): React.JSX.Element {
-  const { generationId } = useParams();
+  const { competitionId, generationId } = useParams();
+  const navigate = useNavigate();
+  const resolvedCompetitionId = competitionId ?? "";
+  const resolvedGenerationId = generationId ?? "";
+  const detailQuery = useGenerationDetail(resolvedCompetitionId, generationId);
+  const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
+  const rerun = useRerunGeneration(resolvedCompetitionId, resolvedGenerationId);
+
+  if (detailQuery.isPending) return <DetailSkeleton />;
+
+  if (detailQuery.isError || !competitionId || !generationId) {
+    const missing =
+      detailQuery.error instanceof ApiError && detailQuery.error.status === 404;
+    return (
+      <div className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <CircleAlert className="size-8 text-destructive" aria-hidden="true" />
+        <h1 className="mt-4 font-editorial text-3xl font-semibold">
+          {missing ? "Run not found" : "Run detail unavailable"}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          {detailQuery.error instanceof ApiError
+            ? detailQuery.error.message
+            : "The durable generation record could not be loaded."}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          {!missing ? (
+            <Button
+              variant="outline"
+              onClick={() => void detailQuery.refetch()}
+            >
+              Try again
+            </Button>
+          ) : null}
+          <Link
+            className={buttonVariants({ variant: "ghost" })}
+            to={
+              competitionId
+                ? `/competitions/${competitionId}/generate`
+                : "/competitions"
+            }
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            Back to Generate
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const generation = detailQuery.data.generation;
+  const terminal = ["succeeded", "failed", "cancelled"].includes(
+    generation.status,
+  );
+  const active =
+    generation.status === "pending" || generation.status === "running";
+  const editableValues = createGenerationFormValuesFromDetail(generation);
+  const season = seasonsQuery.data?.page.items.find(
+    (item) => item.season.id === generation.competition_season_id,
+  );
+  const fallbackModels = editableValues?.model.fallbackModels ?? [];
+  const progressStart = generation.started_at ?? generation.created_at;
+
+  async function rerunGeneration(): Promise<void> {
+    try {
+      const response = await rerun.mutateAsync();
+      toast.success("Rerun queued");
+      await navigate(
+        `/competitions/${resolvedCompetitionId}/generations/${response.generation.id}`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof ApiError
+          ? error.message
+          : "The rerun could not be queued.",
+      );
+    }
+  }
+
+  function editSettings(): void {
+    if (!editableValues) return;
+    saveGenerationDraft(resolvedCompetitionId, editableValues);
+    void navigate(
+      `/competitions/${resolvedCompetitionId}/generate?season=${generation.competition_season_id}`,
+    );
+  }
+
   return (
-    <PlaceholderPage
-      eyebrow="Generation record"
-      title="Run detail"
-      description="Durable run status, the submitted article, artifacts, execution, and usage will be inspected here."
-      detail={`Generation scope: ${generationId ?? "unknown"}`}
-      icon={FileText}
-    />
+    <div className="mx-auto w-full max-w-6xl px-5 py-10 sm:px-8 sm:py-14">
+      <header className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Generation record
+            </p>
+            <Badge variant={statusVariant(generation.status)}>
+              {titleCase(generation.status)}
+            </Badge>
+          </div>
+          <h1 className="mt-3 font-editorial text-4xl font-semibold tracking-tight sm:text-5xl">
+            {generation.status === "succeeded"
+              ? "Article ready"
+              : generation.status === "failed"
+                ? "Generation failed"
+                : generation.status === "cancelled"
+                  ? "Generation cancelled"
+                  : "Generating article"}
+          </h1>
+          <p className="mt-3 max-w-2xl break-words text-sm leading-6 text-muted-foreground">
+            {generation.request_text}
+          </p>
+        </div>
+        {terminal ? (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              disabled={rerun.isPending}
+              onClick={() => void rerunGeneration()}
+            >
+              {rerun.isPending ? (
+                <LoaderCircle
+                  className="size-4 animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <RotateCcw className="size-4" aria-hidden="true" />
+              )}
+              Rerun exact request
+            </Button>
+            <Button
+              variant="outline"
+              disabled={!editableValues}
+              onClick={editSettings}
+            >
+              <Pencil className="size-4" aria-hidden="true" />
+              Edit settings
+            </Button>
+          </div>
+        ) : null}
+      </header>
+
+      {active ? (
+        <section
+          className="mt-9 overflow-hidden rounded-lg border border-primary/25 bg-card"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <div className="flex items-start gap-4 p-5 sm:p-6">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              {generation.status === "running" ? (
+                <RefreshCw className="size-5 animate-spin" aria-hidden="true" />
+              ) : (
+                <Clock3 className="size-5" aria-hidden="true" />
+              )}
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                {generation.status === "pending"
+                  ? "Waiting for worker"
+                  : "Reporter running"}
+              </p>
+              <h2 className="mt-2 font-editorial text-2xl font-semibold">
+                {generation.current_stage
+                  ? titleCase(generation.current_stage)
+                  : "Preparing durable inputs"}
+              </h2>
+              <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+                <span>Turn {generation.current_turn}</span>
+                <span>Elapsed {elapsedLabel(progressStart)}</span>
+                {generation.progress_updated_at ? (
+                  <span>
+                    Updated <DateTime value={generation.progress_updated_at} />
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <div className="h-1 overflow-hidden bg-muted">
+            <div className="h-full w-1/3 animate-pulse bg-primary" />
+          </div>
+        </section>
+      ) : null}
+
+      {generation.status === "succeeded" ? (
+        <section className="mt-9 rounded-lg border border-primary/25 bg-primary/5 p-5 sm:p-6">
+          <div className="flex gap-4">
+            <CircleCheck
+              className="mt-0.5 size-6 shrink-0 text-primary"
+              aria-hidden="true"
+            />
+            <div>
+              <h2 className="font-editorial text-2xl font-semibold">
+                Submitted article recorded
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                The exact submitted artifact version is attached to this durable
+                run. Article rendering and audit tabs land in Layer 8.
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {generation.status === "failed" || generation.status === "cancelled" ? (
+        <section className="mt-9 rounded-lg border border-destructive/30 bg-destructive/5 p-5 sm:p-6">
+          <div className="flex gap-4">
+            <CircleX
+              className="mt-0.5 size-6 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+            <div>
+              <h2 className="font-editorial text-2xl font-semibold">
+                {generation.status === "failed"
+                  ? "Run did not complete"
+                  : "Run was cancelled"}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {generation.failure_summary ??
+                  "No additional failure detail was recorded for this run."}
+              </p>
+              {generation.failure_category ? (
+                <p className="mt-3 font-mono text-xs text-muted-foreground">
+                  {generation.failure_category}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <div className="mt-6 grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <section className="rounded-lg border border-border bg-card p-5 sm:p-6">
+          <div className="flex items-center gap-2">
+            <FileText
+              className="size-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <h2 className="font-editorial text-2xl font-semibold">
+              Assignment
+            </h2>
+          </div>
+          <p className="mt-5 whitespace-pre-wrap text-sm leading-7">
+            {generation.request_text}
+          </p>
+          <dl className="mt-6 grid gap-5 border-t border-border pt-5 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="text-xs text-muted-foreground">Primary model</dt>
+              <dd className="mt-1 break-all font-medium">
+                {generation.requested_primary_model}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Fallback chain</dt>
+              <dd className="mt-1 font-medium">
+                {editableValues
+                  ? fallbackModels.length > 0
+                    ? fallbackModels.join(" → ")
+                    : "None"
+                  : "Saved settings schema unsupported"}
+              </dd>
+            </div>
+          </dl>
+          {!editableValues ? (
+            <p className="mt-5 rounded-md border border-border bg-muted/60 p-4 text-xs leading-5 text-muted-foreground">
+              These saved settings cannot be safely decoded by this frontend, so
+              Edit settings is disabled. Exact rerun remains available for
+              terminal runs because the backend owns that copy operation.
+            </p>
+          ) : null}
+        </section>
+
+        <aside className="rounded-lg border border-border bg-card p-5">
+          <h2 className="font-semibold">Run metadata</h2>
+          <dl className="mt-5 space-y-4 text-sm">
+            <div className="flex items-start justify-between gap-4">
+              <dt className="text-muted-foreground">Season</dt>
+              <dd className="text-right font-medium">
+                {season?.season.season_year ?? generation.competition_season_id}
+              </dd>
+            </div>
+            <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+              <dt className="text-muted-foreground">Weeks</dt>
+              <dd className="text-right font-medium">
+                {generation.week_start === generation.week_end
+                  ? `Week ${String(generation.week_start ?? "—")}`
+                  : `${String(generation.week_start ?? "—")}–${String(generation.week_end ?? "—")}`}
+              </dd>
+            </div>
+            <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+              <dt className="text-muted-foreground">Mode</dt>
+              <dd className="text-right font-medium">
+                {titleCase(generation.kind)}
+              </dd>
+            </div>
+            <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+              <dt className="text-muted-foreground">Created</dt>
+              <dd className="text-right">
+                <DateTime value={generation.created_at} showExact />
+              </dd>
+            </div>
+            <div className="flex items-start justify-between gap-4 border-t border-border pt-4">
+              <dt className="text-muted-foreground">Elapsed</dt>
+              <dd className="text-right font-medium">
+                {elapsedLabel(progressStart, generation.completed_at)}
+              </dd>
+            </div>
+            {generation.rerun_of_generation_id ? (
+              <div className="border-t border-border pt-4">
+                <dt className="text-muted-foreground">Rerun of</dt>
+                <dd className="mt-1 break-all">
+                  <Link
+                    className="text-primary underline-offset-4 hover:underline"
+                    to={`/competitions/${resolvedCompetitionId}/generations/${generation.rerun_of_generation_id}`}
+                  >
+                    {generation.rerun_of_generation_id}
+                  </Link>
+                </dd>
+              </div>
+            ) : null}
+          </dl>
+        </aside>
+      </div>
+
+      <div className="mt-8">
+        <Link
+          className={cn(buttonVariants({ variant: "ghost" }), "px-0")}
+          to={`/competitions/${resolvedCompetitionId}/generate?season=${generation.competition_season_id}`}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to Generate
+        </Link>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- add durable generation detail reads with active-state-only polling and
  focus/reconnect recovery
- present pending, running, succeeded, failed, and cancelled run states with
  scope, progress, assignment, model, and timing metadata
- add exact terminal reruns through the backend command and navigate to the new
  durable run
- decode supported persisted settings explicitly for edit-settings recovery and
  fail closed for unknown schemas

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- production Vite build using bundled Node 24 (Node 22.22 remains pinned)

Comprehensive UI and real-database acceptance is deferred until the full stack
is implemented.

Stacked on `codex/ui-7a-generation-form`.
