### PR TITLE
feat(ui): add artifact version browser

### DIFF
--- a/backend/resources/reporting/artifacts/manager.py
+++ b/backend/resources/reporting/artifacts/manager.py
@@ -116,15 +116,48 @@ class ArtifactManager:
                     .where(*conditions)
                 ),
             )
-            rows = session.scalars(
-                sa.select(StoredArtifact)
+            version_summary = (
+                sa.select(
+                    StoredArtifactVersion.artifact_id.label("artifact_id"),
+                    sa.func.count(StoredArtifactVersion.id).label(
+                        "revision_count"
+                    ),
+                    sa.func.max(StoredArtifactVersion.created_at).label(
+                        "latest_version_at"
+                    ),
+                )
+                .where(
+                    StoredArtifactVersion.generation_id == query.generation_id
+                )
+                .group_by(StoredArtifactVersion.artifact_id)
+                .subquery()
+            )
+            rows = session.execute(
+                sa.select(
+                    StoredArtifact,
+                    sa.func.coalesce(version_summary.c.revision_count, 0).label(
+                        "revision_count"
+                    ),
+                    version_summary.c.latest_version_at,
+                )
+                .outerjoin(
+                    version_summary,
+                    version_summary.c.artifact_id == StoredArtifact.id,
+                )
                 .where(*conditions)
                 .order_by(StoredArtifact.path.asc(), StoredArtifact.id.asc())
                 .limit(query.limit)
                 .offset(query.offset)
             ).all()
             return ArtifactPage(
-                items=tuple(_decode_summary(row) for row in rows),
+                items=tuple(
+                    _decode_summary(
+                        row._mapping[StoredArtifact],
+                        revision_count=row._mapping["revision_count"],
+                        latest_version_at=row._mapping["latest_version_at"],
+                    )
+                    for row in rows
+                ),
                 total=total,
                 limit=query.limit,
                 offset=query.offset,
@@ -184,8 +217,19 @@ def _decode(stored: StoredArtifact) -> Artifact:
     )
 
 
-def _decode_summary(stored: StoredArtifact) -> ArtifactSummary:
-    return ArtifactSummary.model_validate(_decode(stored).model_dump())
+def _decode_summary(
+    stored: StoredArtifact,
+    *,
+    revision_count: int,
+    latest_version_at: datetime | None,
+) -> ArtifactSummary:
+    return ArtifactSummary.model_validate(
+        {
+            **_decode(stored).model_dump(),
+            "revision_count": revision_count,
+            "latest_version_at": latest_version_at,
+        }
+    )
 
 
 def _resolve_exact_artifact_version_in_session(

--- a/backend/resources/reporting/artifacts/objects.py
+++ b/backend/resources/reporting/artifacts/objects.py
@@ -78,7 +78,8 @@ class Artifact(ContractModel):
 
 
 class ArtifactSummary(Artifact):
-    pass
+    revision_count: NonNegativeInt
+    latest_version_at: AwareDatetime | None
 
 
 class ArtifactPage(ContractModel):

--- a/backend/tests/api/test_generation_routes.py
+++ b/backend/tests/api/test_generation_routes.py
@@ -272,7 +272,13 @@ def _dependencies(competition_id: UUID, season_id: UUID) -> SimpleNamespace:
         finalized_at=NOW,
         created_at=NOW,
     )
-    artifact_summary = ArtifactSummary.model_validate(artifact.model_dump())
+    artifact_summary = ArtifactSummary.model_validate(
+        {
+            **artifact.model_dump(),
+            "revision_count": 2,
+            "latest_version_at": NOW,
+        }
+    )
     version = ArtifactVersion(
         id=version_id,
         artifact_id=artifact_id,
@@ -504,6 +510,11 @@ async def test_polling_and_resource_routes_preserve_durable_payloads() -> None:
     }
     assert tool_call.json()["tool_call"]["full_result_text"] == '{"found":true}'
     assert artifacts.json()["page"]["items"][0]["path"] == "article.md"
+    assert artifacts.json()["page"]["items"][0]["revision_count"] == 2
+    assert (
+        artifacts.json()["page"]["items"][0]["latest_version_at"]
+        == "2026-08-23T09:30:00Z"
+    )
     assert versions.json()["page"]["items"][0]["revision_number"] == 2
     assert version.json()["version"]["content_hash"] == "b" * 64
     assert dependencies.articles.queries[0].competition_season_id is None

--- a/backend/tests/resources/reporting/artifacts/test_manager.py
+++ b/backend/tests/resources/reporting/artifacts/test_manager.py
@@ -111,11 +111,18 @@ def test_list_orders_paths_and_filters_finalized_artifacts(
     version_manager = ArtifactVersionManager(
         session_factory, generation_context(generation_domain)
     )
+    version_manager.append_artifact_version(
+        AppendArtifactVersion(
+            artifact_id=article.id,
+            content="# Article draft",
+            content_hash=_hash("# Article draft"),
+        )
+    )
     version = version_manager.append_artifact_version(
         AppendArtifactVersion(
             artifact_id=article.id,
-            content="# Article",
-            content_hash=_hash("# Article"),
+            content="# Article final",
+            content_hash=_hash("# Article final"),
         )
     )
     artifact_manager.finalize_artifact(
@@ -126,6 +133,10 @@ def test_list_orders_paths_and_filters_finalized_artifacts(
         "article.md",
         "research/brief.md",
     ]
+    assert page.items[0].revision_count == 2
+    assert page.items[0].latest_version_at == version.created_at
+    assert page.items[1].revision_count == 0
+    assert page.items[1].latest_version_at is None
     finalized = artifact_manager.list(
         ArtifactQuery(generation_id=generation_id, finalized=True)
     )

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -29,7 +29,7 @@ Generation routes already exist under
 | Submitted article | `GET /generations/competitions/{competition_id}/{generation_id}/article` | Implemented and returns the exact generation, artifact, and version |
 | AI call list/detail | `GET .../{generation_id}/ai-calls[/{ai_call_id}]` | Implemented |
 | Tool call list/detail | `GET .../{generation_id}/tool-calls[/{tool_call_id}]` | Implemented |
-| Artifact list/detail | `GET .../{generation_id}/artifacts[/{artifact_id}]` | Implemented |
+| Artifact list/detail | `GET .../{generation_id}/artifacts[/{artifact_id}]` | Implemented; list summaries include revision count and latest-version time |
 | Artifact versions | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented |
 
 Competition and season management plus refresh, overview, and snapshot-audit

--- a/docs/ui/frontend-architecture.md
+++ b/docs/ui/frontend-architecture.md
@@ -181,7 +181,9 @@ still being discovered, so component snapshots, mocked API tests, and a browser
 suite would create maintenance cost while page structure and interactions are
 changing quickly.
 
-Each frontend layer uses lightweight implementation checks:
+Each frontend PR uses one lightweight implementation check immediately before
+commit. Subagents do not independently repeat these commands after their
+contributions. The single final pass includes:
 
 1. strict TypeScript compilation;
 2. lint and formatting checks;
@@ -189,8 +191,9 @@ Each frontend layer uses lightweight implementation checks:
 4. targeted backend contract tests only when that layer changes backend
    behavior.
 
-Do not build elaborate temporary acceptance environments for each intermediate
-layer. After the complete initial UI stack is implemented, run one comprehensive
+Do not run the gate after individual edits or subagent contributions, and do
+not build elaborate temporary acceptance environments for each intermediate
+PR. After the complete initial UI stack is implemented, run one comprehensive
 review against the full local database and backend. That final pass covers all
 core journeys, real-data states, responsive behavior, keyboard/accessibility,
 reload and polling recovery, error states, and a clean browser console. Record

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1160,10 +1160,14 @@ export interface components {
              * Format: uuid
              */
             id: string;
+            /** Latest Version At */
+            latest_version_at: string | null;
             /** Media Type */
             media_type: string;
             /** Path */
             path: string;
+            /** Revision Count */
+            revision_count: number;
         };
         /** ArtifactVersion */
         ArtifactVersion: {

--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -95,5 +95,76 @@ export const queryKeys = {
         generationId,
         "article",
       ] as const,
+    artifactLists: (competitionId: string, generationId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "artifacts",
+        "list",
+      ] as const,
+    artifactList: (
+      competitionId: string,
+      generationId: string,
+      parameters: Readonly<object>,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "artifacts",
+        "list",
+        parameters,
+      ] as const,
+    artifactVersionLists: (
+      competitionId: string,
+      generationId: string,
+      artifactId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "artifacts",
+        artifactId,
+        "versions",
+        "list",
+      ] as const,
+    artifactVersionList: (
+      competitionId: string,
+      generationId: string,
+      artifactId: string,
+      parameters: Readonly<object>,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "artifacts",
+        artifactId,
+        "versions",
+        "list",
+        parameters,
+      ] as const,
+    artifactVersionDetail: (
+      competitionId: string,
+      generationId: string,
+      artifactId: string,
+      versionId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "artifacts",
+        artifactId,
+        "versions",
+        versionId,
+      ] as const,
   },
 } as const;

--- a/frontend/src/components/shared/artifact-content-viewer.tsx
+++ b/frontend/src/components/shared/artifact-content-viewer.tsx
@@ -1,0 +1,178 @@
+import { Check, Copy, FileWarning } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { MarkdownArticle } from "@/components/shared/markdown-article";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const MARKDOWN_MEDIA_TYPES = new Set([
+  "application/markdown",
+  "text/markdown",
+  "text/x-markdown",
+]);
+
+const TEXT_APPLICATION_MEDIA_TYPES = new Set([
+  "application/graphql",
+  "application/javascript",
+  "application/sql",
+  "application/x-httpd-php",
+  "application/x-javascript",
+  "application/x-sh",
+  "application/x-yaml",
+  "application/xml",
+  "application/yaml",
+]);
+
+type CopyStatus = "idle" | "copied" | "failed";
+type PreviewKind = "json" | "markdown" | "source" | "unsupported";
+
+function normalizedMediaType(mediaType: string): string {
+  return mediaType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
+function previewKind(mediaType: string): PreviewKind {
+  if (MARKDOWN_MEDIA_TYPES.has(mediaType)) return "markdown";
+  if (mediaType === "application/json" || mediaType.endsWith("+json")) {
+    return "json";
+  }
+  if (
+    mediaType.startsWith("text/") ||
+    mediaType.endsWith("+xml") ||
+    TEXT_APPLICATION_MEDIA_TYPES.has(mediaType)
+  ) {
+    return "source";
+  }
+  return "unsupported";
+}
+
+function prettyJson(content: string): string {
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    return content;
+  }
+}
+
+function SourcePreview({ content }: { content: string }): React.JSX.Element {
+  if (content.length === 0) {
+    return (
+      <p className="px-5 py-8 text-sm text-muted-foreground">
+        This artifact version is empty.
+      </p>
+    );
+  }
+
+  return (
+    <pre className="max-h-[70vh] max-w-full overflow-auto p-5 font-mono text-sm leading-6 whitespace-pre">
+      <code>{content}</code>
+    </pre>
+  );
+}
+
+export interface ArtifactContentViewerProps {
+  className?: string;
+  content: string;
+  mediaType: string;
+}
+
+export function ArtifactContentViewer({
+  className,
+  content,
+  mediaType,
+}: ArtifactContentViewerProps): React.JSX.Element {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const normalizedType = normalizedMediaType(mediaType);
+  const kind = previewKind(normalizedType);
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== undefined) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  async function copyContent(): Promise<void> {
+    if (resetTimer.current !== undefined) clearTimeout(resetTimer.current);
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("failed");
+    }
+    resetTimer.current = setTimeout(() => {
+      setCopyStatus("idle");
+    }, 2_000);
+  }
+
+  return (
+    <section className={cn("min-w-0", className)}>
+      <div className="mb-3 flex min-h-9 flex-wrap items-center justify-between gap-3">
+        <p className="font-mono text-xs text-muted-foreground">
+          {normalizedType || "Unknown media type"}
+        </p>
+        <div className="flex items-center gap-2">
+          <span aria-live="polite" className="text-xs text-muted-foreground">
+            {copyStatus === "failed" ? "Copy unavailable" : null}
+          </span>
+          <Button
+            aria-label={
+              copyStatus === "copied"
+                ? "Artifact content copied"
+                : "Copy exact artifact content"
+            }
+            onClick={() => void copyContent()}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {copyStatus === "copied" ? (
+              <Check className="size-3.5" aria-hidden="true" />
+            ) : (
+              <Copy className="size-3.5" aria-hidden="true" />
+            )}
+            {copyStatus === "copied" ? "Copied" : "Copy content"}
+          </Button>
+        </div>
+      </div>
+
+      {kind === "markdown" ? (
+        <div className="min-w-0 rounded-md border border-border bg-card p-5 sm:p-8">
+          {content.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              This artifact version is empty.
+            </p>
+          ) : (
+            <MarkdownArticle content={content} />
+          )}
+        </div>
+      ) : null}
+
+      {kind === "json" || kind === "source" ? (
+        <div className="min-w-0 overflow-hidden rounded-md border border-border bg-muted/40">
+          <SourcePreview
+            content={kind === "json" ? prettyJson(content) : content}
+          />
+        </div>
+      ) : null}
+
+      {kind === "unsupported" ? (
+        <div className="flex gap-3 rounded-md border border-border bg-muted/40 p-5">
+          <FileWarning
+            className="mt-0.5 size-5 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <div>
+            <p className="text-sm font-medium">Preview unavailable</p>
+            <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+              This media type is not rendered in the browser. You can still copy
+              the exact stored content for inspection in an appropriate tool.
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/features/artifacts/api.ts
+++ b/frontend/src/features/artifacts/api.ts
@@ -1,0 +1,65 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type Artifact = components["schemas"]["Artifact"];
+export type ArtifactSummary = components["schemas"]["ArtifactSummary"];
+export type ArtifactPageResponse =
+  components["schemas"]["ArtifactPageResponse"];
+export type ArtifactVersion = components["schemas"]["ArtifactVersion"];
+export type ArtifactVersionSummary =
+  components["schemas"]["ArtifactVersionSummary"];
+export type ArtifactVersionPageResponse =
+  components["schemas"]["ArtifactVersionPageResponse"];
+export type ArtifactVersionResponse =
+  components["schemas"]["ArtifactVersionResponse"];
+
+export interface PageParameters {
+  limit: number;
+  offset: number;
+}
+
+export function listArtifacts(
+  competitionId: string,
+  generationId: string,
+  parameters: PageParameters,
+  signal?: AbortSignal,
+): Promise<ArtifactPageResponse> {
+  const query = new URLSearchParams({
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}/artifacts?${query.toString()}`,
+    { signal },
+  );
+}
+
+export function listArtifactVersions(
+  competitionId: string,
+  generationId: string,
+  artifactId: string,
+  parameters: PageParameters,
+  signal?: AbortSignal,
+): Promise<ArtifactVersionPageResponse> {
+  const query = new URLSearchParams({
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}/artifacts/${artifactId}/versions?${query.toString()}`,
+    { signal },
+  );
+}
+
+export function getArtifactVersion(
+  competitionId: string,
+  generationId: string,
+  artifactId: string,
+  versionId: string,
+  signal?: AbortSignal,
+): Promise<ArtifactVersionResponse> {
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}/artifacts/${artifactId}/versions/${versionId}`,
+    { signal },
+  );
+}

--- a/frontend/src/features/artifacts/artifact-browser.tsx
+++ b/frontend/src/features/artifacts/artifact-browser.tsx
@@ -1,0 +1,655 @@
+import {
+  ArrowLeft,
+  ArrowRight,
+  CircleAlert,
+  FileArchive,
+  FileText,
+} from "lucide-react";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
+
+import { ApiError } from "@/api/errors";
+import { ArtifactContentViewer } from "@/components/shared/artifact-content-viewer";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSubmittedArticle } from "@/features/articles/queries";
+import type {
+  Artifact,
+  ArtifactSummary,
+  ArtifactVersionSummary,
+} from "@/features/artifacts/api";
+import {
+  useArtifactList,
+  useArtifactVersion,
+  useArtifactVersionList,
+} from "@/features/artifacts/queries";
+import { cn } from "@/lib/utils";
+
+const ARTIFACT_PAGE_SIZE = 25;
+const VERSION_PAGE_SIZE = 25;
+
+interface ArtifactBrowserProps {
+  competitionId: string;
+  generationId: string;
+  submittedVersionId: string | null;
+  active: boolean;
+}
+
+function positivePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function pageCount(total: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+function artifactIsSummary(
+  artifact: Artifact | ArtifactSummary,
+): artifact is ArtifactSummary {
+  return "revision_count" in artifact;
+}
+
+function artifactRevisionCount(
+  artifact: Artifact | ArtifactSummary,
+  versionTotal: number | undefined,
+): string {
+  const count = artifactIsSummary(artifact)
+    ? artifact.revision_count
+    : versionTotal;
+  if (count === undefined) return "Revisions unavailable";
+  return `${String(count)} revision${count === 1 ? "" : "s"}`;
+}
+
+function BrowserSkeleton(): React.JSX.Element {
+  return (
+    <div className="grid gap-6 lg:grid-cols-[19rem_minmax(0,1fr)]">
+      <div className="space-y-3">
+        {[0, 1, 2].map((item) => (
+          <Skeleton key={item} className="h-28 w-full rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-[32rem] w-full rounded-lg" />
+    </div>
+  );
+}
+
+function InlineError({
+  title,
+  error,
+  onRetry,
+}: {
+  title: string;
+  error: unknown;
+  onRetry: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+      <CircleAlert className="size-6 text-destructive" aria-hidden="true" />
+      <h3 className="mt-3 font-semibold">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        {error instanceof ApiError
+          ? error.message
+          : "This durable artifact resource could not be loaded."}
+      </p>
+      <Button className="mt-4" variant="outline" onClick={onRetry}>
+        Try again
+      </Button>
+    </div>
+  );
+}
+
+function Pager({
+  label,
+  page,
+  totalPages,
+  total,
+  onPageChange,
+}: {
+  label: string;
+  page: number;
+  totalPages: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}): React.JSX.Element | null {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4 text-xs">
+      <span className="text-muted-foreground">
+        {label} page {page} of {totalPages} · {total} total
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1}
+          aria-label={`Previous ${label.toLowerCase()} page`}
+          onClick={() => {
+            onPageChange(page - 1);
+          }}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages}
+          aria-label={`Next ${label.toLowerCase()} page`}
+          onClick={() => {
+            onPageChange(page + 1);
+          }}
+        >
+          Next
+          <ArrowRight className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ArtifactChoice({
+  artifact,
+  selected,
+  submitted,
+  onSelect,
+}: {
+  artifact: ArtifactSummary;
+  selected: boolean;
+  submitted: boolean;
+  onSelect: () => void;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "w-full rounded-lg border border-border bg-card p-4 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
+        selected && "border-primary/50 bg-accent/55",
+      )}
+      aria-pressed={selected}
+      onClick={onSelect}
+    >
+      <span className="flex flex-wrap items-center gap-2">
+        {submitted ? <Badge>Submitted</Badge> : null}
+        {artifact.finalized_version_id ? (
+          <Badge variant="outline">Finalized</Badge>
+        ) : (
+          <Badge variant="secondary">Draft</Badge>
+        )}
+      </span>
+      <span className="mt-3 block break-all font-mono text-sm font-medium">
+        {artifact.path}
+      </span>
+      <span className="mt-2 block text-xs text-muted-foreground">
+        {artifact.media_type} · {artifactRevisionCount(artifact, undefined)}
+      </span>
+      <span className="mt-1 block text-xs text-muted-foreground">
+        Updated <DateTime value={artifact.latest_version_at} />
+      </span>
+    </button>
+  );
+}
+
+function VersionChoice({
+  version,
+  selected,
+  submitted,
+  finalized,
+  onSelect,
+}: {
+  version: ArtifactVersionSummary;
+  selected: boolean;
+  submitted: boolean;
+  finalized: boolean;
+  onSelect: () => void;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "w-full rounded-md border border-border bg-background p-3 text-left outline-none transition-colors hover:bg-muted/55 focus-visible:ring-2 focus-visible:ring-ring",
+        selected && "border-primary/50 bg-accent/55",
+      )}
+      aria-pressed={selected}
+      onClick={onSelect}
+    >
+      <span className="flex flex-wrap items-center gap-2">
+        <span className="font-medium">Revision {version.revision_number}</span>
+        {submitted ? <Badge>Submitted</Badge> : null}
+        {finalized ? <Badge variant="outline">Finalized</Badge> : null}
+      </span>
+      <span className="mt-2 block text-xs text-muted-foreground">
+        <DateTime value={version.created_at} showExact />
+      </span>
+      {version.source_ai_call_id || version.source_tool_call_id ? (
+        <span className="mt-2 block text-xs text-muted-foreground">
+          Source: {version.source_tool_call_id ? "tool call" : "AI call"}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+export function ArtifactBrowser({
+  competitionId,
+  generationId,
+  submittedVersionId,
+  active,
+}: ArtifactBrowserProps): React.JSX.Element {
+  const [searchParameters, setSearchParameters] = useSearchParams();
+  const artifactPage = positivePage(searchParameters.get("artifactPage"));
+  const requestedArtifactId = searchParameters.get("artifact") ?? undefined;
+  const requestedVersionId = searchParameters.get("version") ?? undefined;
+  const submittedArticleQuery = useSubmittedArticle(
+    competitionId,
+    generationId,
+    active && submittedVersionId !== null,
+  );
+  const artifactsQuery = useArtifactList(
+    competitionId,
+    generationId,
+    {
+      limit: ARTIFACT_PAGE_SIZE,
+      offset: (artifactPage - 1) * ARTIFACT_PAGE_SIZE,
+    },
+    active,
+  );
+  const artifacts = artifactsQuery.data?.page.items ?? [];
+  const submittedArtifact = submittedArticleQuery.data?.artifact;
+  const submittedArtifactId = submittedArtifact?.id;
+  const selectionReady =
+    submittedVersionId === null || !submittedArticleQuery.isPending;
+  const requestedArtifact = artifacts.find(
+    (artifact) => artifact.id === requestedArtifactId,
+  );
+  const selectedArtifactId = selectionReady
+    ? (requestedArtifact?.id ??
+      (requestedArtifactId === submittedArtifactId
+        ? submittedArtifactId
+        : undefined) ??
+      submittedArtifactId ??
+      artifacts[0]?.id)
+    : undefined;
+  const selectedArtifact =
+    artifacts.find((artifact) => artifact.id === selectedArtifactId) ??
+    (submittedArtifact?.id === selectedArtifactId
+      ? submittedArtifact
+      : undefined);
+  const submittedRevision = submittedArticleQuery.data?.version;
+  const implicitSubmittedVersionPage =
+    submittedRevision && selectedArtifactId === submittedArtifactId
+      ? Math.max(
+          1,
+          Math.ceil(submittedRevision.revision_number / VERSION_PAGE_SIZE),
+        )
+      : 1;
+  const versionPageParameter = searchParameters.get("versionPage");
+  const versionPage = versionPageParameter
+    ? positivePage(versionPageParameter)
+    : implicitSubmittedVersionPage;
+  const versionsQuery = useArtifactVersionList(
+    competitionId,
+    generationId,
+    selectedArtifactId,
+    {
+      limit: VERSION_PAGE_SIZE,
+      offset: (versionPage - 1) * VERSION_PAGE_SIZE,
+    },
+    active && selectedArtifactId !== undefined,
+  );
+  const versions = versionsQuery.data?.page.items ?? [];
+  const requestedVersion = versions.find(
+    (version) => version.id === requestedVersionId,
+  );
+  const requestedSubmittedVersion =
+    requestedVersionId === submittedVersionId &&
+    selectedArtifactId === submittedArtifactId
+      ? submittedRevision
+      : undefined;
+  const selectedVersionId =
+    requestedVersion?.id ??
+    requestedSubmittedVersion?.id ??
+    (selectedArtifactId === submittedArtifactId
+      ? (submittedVersionId ?? undefined)
+      : (selectedArtifact?.finalized_version_id ?? versions.at(-1)?.id));
+  const selectedSubmittedVersion =
+    selectedVersionId === submittedVersionId &&
+    selectedArtifactId === submittedArtifactId
+      ? submittedRevision
+      : undefined;
+  const selectedVersionQuery = useArtifactVersion(
+    competitionId,
+    generationId,
+    selectedArtifactId,
+    selectedVersionId,
+    active && selectedSubmittedVersion === undefined,
+  );
+  const selectedVersion =
+    selectedSubmittedVersion ?? selectedVersionQuery.data?.version;
+  const artifactTotalPages = pageCount(
+    artifactsQuery.data?.page.total ?? 0,
+    ARTIFACT_PAGE_SIZE,
+  );
+  const versionTotalPages = pageCount(
+    versionsQuery.data?.page.total ?? 0,
+    VERSION_PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    if (!active || !artifactsQuery.data || artifactPage <= artifactTotalPages)
+      return;
+    const next = new URLSearchParams(searchParameters);
+    if (artifactTotalPages === 1) next.delete("artifactPage");
+    else next.set("artifactPage", String(artifactTotalPages));
+    next.delete("artifact");
+    next.delete("version");
+    next.delete("versionPage");
+    setSearchParameters(next, { replace: true });
+  }, [
+    active,
+    artifactPage,
+    artifactTotalPages,
+    artifactsQuery.data,
+    searchParameters,
+    setSearchParameters,
+  ]);
+
+  useEffect(() => {
+    if (!active || !selectedArtifactId) return;
+    const next = new URLSearchParams(searchParameters);
+    let changed = false;
+    if (next.get("artifact") !== selectedArtifactId) {
+      next.set("artifact", selectedArtifactId);
+      changed = true;
+    }
+    if (!versionPageParameter && implicitSubmittedVersionPage > 1) {
+      next.set("versionPage", String(implicitSubmittedVersionPage));
+      changed = true;
+    }
+    if (selectedVersionId && next.get("version") !== selectedVersionId) {
+      next.set("version", selectedVersionId);
+      changed = true;
+    }
+    if (changed) setSearchParameters(next, { replace: true });
+  }, [
+    active,
+    implicitSubmittedVersionPage,
+    searchParameters,
+    selectedArtifactId,
+    selectedVersionId,
+    setSearchParameters,
+    versionPageParameter,
+  ]);
+
+  useEffect(() => {
+    if (!active || !versionsQuery.data || versionPage <= versionTotalPages)
+      return;
+    const next = new URLSearchParams(searchParameters);
+    if (versionTotalPages === 1) next.delete("versionPage");
+    else next.set("versionPage", String(versionTotalPages));
+    next.delete("version");
+    setSearchParameters(next, { replace: true });
+  }, [
+    active,
+    searchParameters,
+    setSearchParameters,
+    versionPage,
+    versionTotalPages,
+    versionsQuery.data,
+  ]);
+
+  function selectArtifact(artifactId: string): void {
+    const next = new URLSearchParams(searchParameters);
+    next.set("artifact", artifactId);
+    next.delete("version");
+    next.delete("versionPage");
+    setSearchParameters(next);
+  }
+
+  function selectVersion(versionId: string): void {
+    const next = new URLSearchParams(searchParameters);
+    next.set("version", versionId);
+    setSearchParameters(next);
+  }
+
+  function setArtifactPage(nextPage: number): void {
+    const next = new URLSearchParams(searchParameters);
+    if (nextPage === 1) next.delete("artifactPage");
+    else next.set("artifactPage", String(nextPage));
+    next.delete("artifact");
+    next.delete("version");
+    next.delete("versionPage");
+    setSearchParameters(next);
+  }
+
+  function setVersionPage(nextPage: number): void {
+    const next = new URLSearchParams(searchParameters);
+    if (nextPage === 1) next.delete("versionPage");
+    else next.set("versionPage", String(nextPage));
+    setSearchParameters(next);
+  }
+
+  if (artifactsQuery.isPending || !selectionReady) return <BrowserSkeleton />;
+
+  if (artifactsQuery.isError) {
+    return (
+      <InlineError
+        title="Artifact history unavailable"
+        error={artifactsQuery.error}
+        onRetry={() => void artifactsQuery.refetch()}
+      />
+    );
+  }
+
+  if (artifacts.length === 0 && artifactPage === 1) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/60 p-8 text-center sm:p-12">
+        <FileArchive
+          className="mx-auto size-8 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <h3 className="mt-5 font-editorial text-2xl font-semibold">
+          No artifacts recorded
+        </h3>
+        <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
+          This generation has no durable work products to inspect.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-w-0 items-start gap-6 lg:grid-cols-[19rem_minmax(0,1fr)]">
+      <section aria-labelledby="artifact-list-heading" className="min-w-0">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h3 id="artifact-list-heading" className="font-semibold">
+            Artifacts
+          </h3>
+          <span className="text-xs text-muted-foreground">
+            {artifactsQuery.data.page.total} total
+          </span>
+        </div>
+        <div className="space-y-3">
+          {artifacts.map((artifact) => (
+            <ArtifactChoice
+              key={artifact.id}
+              artifact={artifact}
+              selected={artifact.id === selectedArtifactId}
+              submitted={artifact.id === submittedArtifactId}
+              onSelect={() => {
+                selectArtifact(artifact.id);
+              }}
+            />
+          ))}
+        </div>
+        <div className="mt-4">
+          <Pager
+            label="Artifacts"
+            page={artifactPage}
+            totalPages={artifactTotalPages}
+            total={artifactsQuery.data.page.total}
+            onPageChange={setArtifactPage}
+          />
+        </div>
+      </section>
+
+      <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-card">
+        {selectedArtifact ? (
+          <>
+            <header className="border-b border-border px-5 py-5 sm:px-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    Selected artifact
+                  </p>
+                  <h3 className="mt-2 break-all font-mono text-base font-semibold">
+                    {selectedArtifact.path}
+                  </h3>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {selectedArtifact.media_type} ·{" "}
+                    {artifactRevisionCount(
+                      selectedArtifact,
+                      versionsQuery.data?.page.total,
+                    )}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {selectedArtifact.id === submittedArtifactId ? (
+                    <Badge>Submitted artifact</Badge>
+                  ) : null}
+                  {selectedArtifact.finalized_version_id ? (
+                    <Badge variant="outline">Finalized</Badge>
+                  ) : (
+                    <Badge variant="secondary">Draft</Badge>
+                  )}
+                </div>
+              </div>
+            </header>
+
+            <div className="grid min-w-0 gap-6 p-5 sm:p-6 xl:grid-cols-[15rem_minmax(0,1fr)]">
+              <div className="min-w-0">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <h4 className="font-semibold">Versions</h4>
+                  {versionsQuery.isFetching && !versionsQuery.isPending ? (
+                    <span
+                      className="text-xs text-muted-foreground"
+                      role="status"
+                    >
+                      Updating…
+                    </span>
+                  ) : null}
+                </div>
+                {versionsQuery.isPending ? (
+                  <div className="space-y-2">
+                    <Skeleton className="h-20 w-full" />
+                    <Skeleton className="h-20 w-full" />
+                  </div>
+                ) : versionsQuery.isError ? (
+                  <InlineError
+                    title="Version history unavailable"
+                    error={versionsQuery.error}
+                    onRetry={() => void versionsQuery.refetch()}
+                  />
+                ) : versions.length === 0 ? (
+                  <p className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+                    This artifact has no recorded versions.
+                  </p>
+                ) : (
+                  <>
+                    <div className="space-y-2">
+                      {versions.map((version) => (
+                        <VersionChoice
+                          key={version.id}
+                          version={version}
+                          selected={version.id === selectedVersionId}
+                          submitted={version.id === submittedVersionId}
+                          finalized={
+                            version.id === selectedArtifact.finalized_version_id
+                          }
+                          onSelect={() => {
+                            selectVersion(version.id);
+                          }}
+                        />
+                      ))}
+                    </div>
+                    <div className="mt-4">
+                      <Pager
+                        label="Versions"
+                        page={versionPage}
+                        totalPages={versionTotalPages}
+                        total={versionsQuery.data.page.total}
+                        onPageChange={setVersionPage}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+
+              <div className="min-w-0">
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                  <h4 className="font-semibold">
+                    {selectedVersion
+                      ? `Revision ${String(selectedVersion.revision_number)}`
+                      : "Version content"}
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedVersion?.id === submittedVersionId ? (
+                      <Badge>Submitted</Badge>
+                    ) : null}
+                    {selectedVersion?.id ===
+                    selectedArtifact.finalized_version_id ? (
+                      <Badge variant="outline">Finalized</Badge>
+                    ) : null}
+                  </div>
+                </div>
+                {selectedVersionId !== undefined &&
+                selectedVersionQuery.isPending &&
+                !selectedSubmittedVersion ? (
+                  <Skeleton className="h-80 w-full rounded-lg" />
+                ) : selectedVersionQuery.isError ? (
+                  <InlineError
+                    title="Version content unavailable"
+                    error={selectedVersionQuery.error}
+                    onRetry={() => void selectedVersionQuery.refetch()}
+                  />
+                ) : selectedVersion ? (
+                  <>
+                    <div className="mb-3 flex flex-wrap gap-x-4 gap-y-2 text-xs text-muted-foreground">
+                      <span>
+                        Created <DateTime value={selectedVersion.created_at} />
+                      </span>
+                      <span className="break-all font-mono">
+                        SHA-256 {selectedVersion.content_hash}
+                      </span>
+                    </div>
+                    <ArtifactContentViewer
+                      key={selectedVersion.id}
+                      content={selectedVersion.content}
+                      mediaType={selectedArtifact.media_type}
+                    />
+                  </>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-border p-8 text-center">
+                    <FileText
+                      className="mx-auto size-6 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                    <p className="mt-3 text-sm text-muted-foreground">
+                      Select a version to inspect its exact stored content.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="p-8 text-center text-sm text-muted-foreground">
+            Select an artifact to inspect its versions.
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/artifacts/queries.ts
+++ b/frontend/src/features/artifacts/queries.ts
@@ -1,0 +1,88 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  getArtifactVersion,
+  listArtifacts,
+  listArtifactVersions,
+  type PageParameters,
+} from "@/features/artifacts/api";
+
+export function useArtifactList(
+  competitionId: string,
+  generationId: string,
+  parameters: PageParameters,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.artifactList(
+      competitionId,
+      generationId,
+      parameters,
+    ),
+    queryFn: ({ signal }) =>
+      listArtifacts(competitionId, generationId, parameters, signal),
+    enabled: enabled && competitionId.length > 0 && generationId.length > 0,
+  });
+}
+
+export function useArtifactVersionList(
+  competitionId: string,
+  generationId: string,
+  artifactId: string | undefined,
+  parameters: PageParameters,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.artifactVersionList(
+      competitionId,
+      generationId,
+      artifactId ?? "missing",
+      parameters,
+    ),
+    queryFn: ({ signal }) =>
+      listArtifactVersions(
+        competitionId,
+        generationId,
+        artifactId ?? "",
+        parameters,
+        signal,
+      ),
+    enabled:
+      enabled &&
+      competitionId.length > 0 &&
+      generationId.length > 0 &&
+      artifactId !== undefined,
+  });
+}
+
+export function useArtifactVersion(
+  competitionId: string,
+  generationId: string,
+  artifactId: string | undefined,
+  versionId: string | undefined,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.artifactVersionDetail(
+      competitionId,
+      generationId,
+      artifactId ?? "missing",
+      versionId ?? "missing",
+    ),
+    queryFn: ({ signal }) =>
+      getArtifactVersion(
+        competitionId,
+        generationId,
+        artifactId ?? "",
+        versionId ?? "",
+        signal,
+      ),
+    enabled:
+      enabled &&
+      competitionId.length > 0 &&
+      generationId.length > 0 &&
+      artifactId !== undefined &&
+      versionId !== undefined,
+  });
+}

--- a/frontend/src/routes/generation-detail.tsx
+++ b/frontend/src/routes/generation-detail.tsx
@@ -20,6 +20,7 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SubmittedArticlePanel } from "@/features/articles/submitted-article-panel";
+import { ArtifactBrowser } from "@/features/artifacts/artifact-browser";
 import {
   createGenerationFormValuesFromDetail,
   saveGenerationDraft,
@@ -159,6 +160,8 @@ export function Component(): React.JSX.Element {
     next.set("tab", nextTab);
     next.delete("artifact");
     next.delete("version");
+    next.delete("artifactPage");
+    next.delete("versionPage");
     next.delete("page");
     setSearchParameters(next, { replace: true });
   }
@@ -457,9 +460,12 @@ export function Component(): React.JSX.Element {
             />
           </TabsContent>
           <TabsContent value="artifacts">
-            <DeferredAuditPanel
-              title="Artifact history"
-              description="Version browsing and intermediate work products land in the next article-audit slice."
+            <ArtifactBrowser
+              key={resolvedGenerationId}
+              competitionId={resolvedCompetitionId}
+              generationId={resolvedGenerationId}
+              submittedVersionId={generation.submitted_artifact_version_id}
+              active={activeTab === "artifacts"}
             />
           </TabsContent>
           <TabsContent value="execution">


### PR DESCRIPTION
# PR 8b — Artifact and Version Browser

## Summary

- enrich artifact summaries with revision count and latest-version time
- add bounded URL-backed artifact and version selection
- lazily fetch exact selected content and distinguish submitted, finalized, and
  draft work
- render Markdown, JSON, HTML source, and other textual artifacts inertly

## Verification

One final lightweight gate: format, lint, strict typecheck/production build,
generated API drift, and narrowly targeted artifact API tests. Comprehensive
browser and full-database review remains deferred until the stack is complete.
