### PR TITLE
feat(ui): add execution and usage audit

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -166,5 +166,97 @@ export const queryKeys = {
         "versions",
         versionId,
       ] as const,
+    generationUsage: (competitionId: string, generationId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "usage",
+      ] as const,
+    aiCallLists: (competitionId: string, generationId: string) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        "list",
+      ] as const,
+    aiCallList: (
+      competitionId: string,
+      generationId: string,
+      parameters: Readonly<object>,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        "list",
+        parameters,
+      ] as const,
+    aiCallDetail: (
+      competitionId: string,
+      generationId: string,
+      aiCallId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        aiCallId,
+      ] as const,
+    toolCallLists: (
+      competitionId: string,
+      generationId: string,
+      aiCallId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        aiCallId,
+        "tool-calls",
+        "list",
+      ] as const,
+    toolCallList: (
+      competitionId: string,
+      generationId: string,
+      aiCallId: string,
+      parameters: Readonly<object>,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        aiCallId,
+        "tool-calls",
+        "list",
+        parameters,
+      ] as const,
+    toolCallDetail: (
+      competitionId: string,
+      generationId: string,
+      aiCallId: string,
+      toolCallId: string,
+    ) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        generationId,
+        "ai-calls",
+        aiCallId,
+        "tool-calls",
+        toolCallId,
+      ] as const,
   },
 } as const;

--- a/frontend/src/components/shared/structured-content-viewer.tsx
+++ b/frontend/src/components/shared/structured-content-viewer.tsx
@@ -1,0 +1,114 @@
+import { Check, ChevronRight, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type CopyStatus = "idle" | "copied" | "failed";
+
+function serializedContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (content === undefined) return "";
+  return JSON.stringify(content, null, 2);
+}
+
+export interface StructuredContentViewerProps {
+  className?: string;
+  content: unknown;
+  defaultOpen?: boolean;
+  title: string;
+}
+
+export function StructuredContentViewer({
+  className,
+  content,
+  defaultOpen = false,
+  title,
+}: StructuredContentViewerProps): React.JSX.Element {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const hasContent = content !== undefined;
+  const displayContent = serializedContent(content);
+  const contentKind = typeof content === "string" ? "Text" : "JSON";
+
+  useEffect(
+    () => () => {
+      if (resetTimer.current !== undefined) clearTimeout(resetTimer.current);
+    },
+    [],
+  );
+
+  async function copyContent(): Promise<void> {
+    if (!hasContent) return;
+    if (resetTimer.current !== undefined) clearTimeout(resetTimer.current);
+    try {
+      await navigator.clipboard.writeText(displayContent);
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("failed");
+    }
+    resetTimer.current = setTimeout(() => {
+      setCopyStatus("idle");
+    }, 2_000);
+  }
+
+  return (
+    <details
+      className={cn(
+        "group min-w-0 overflow-hidden rounded-md border border-border bg-card",
+        className,
+      )}
+      open={defaultOpen || undefined}
+    >
+      <summary className="flex min-h-11 cursor-pointer list-none items-center gap-2 px-4 py-2 text-sm outline-none transition-colors hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+        <ChevronRight
+          className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90"
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
+        <span className="shrink-0 font-mono text-[0.7rem] uppercase tracking-wide text-muted-foreground">
+          {hasContent ? contentKind : "Empty"}
+        </span>
+      </summary>
+
+      <div className="min-w-0 border-t border-border">
+        <div className="flex min-h-10 flex-wrap items-center justify-end gap-2 border-b border-border bg-muted/30 px-3 py-1.5">
+          <span aria-live="polite" className="text-xs text-muted-foreground">
+            {copyStatus === "failed" ? "Copy unavailable" : null}
+          </span>
+          <Button
+            aria-label={
+              copyStatus === "copied"
+                ? `${title} copied`
+                : `Copy exact ${title.toLowerCase()}`
+            }
+            disabled={!hasContent}
+            onClick={() => void copyContent()}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {copyStatus === "copied" ? (
+              <Check className="size-3.5" aria-hidden="true" />
+            ) : (
+              <Copy className="size-3.5" aria-hidden="true" />
+            )}
+            {copyStatus === "copied" ? "Copied" : "Copy"}
+          </Button>
+        </div>
+
+        {hasContent ? (
+          <pre className="max-h-[32rem] max-w-full overflow-auto bg-muted/20 p-4 font-mono text-xs leading-5 whitespace-pre">
+            <code>{displayContent}</code>
+          </pre>
+        ) : (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No payload was recorded.
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/frontend/src/features/execution/api.ts
+++ b/frontend/src/features/execution/api.ts
@@ -1,0 +1,82 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type AICall = components["schemas"]["AICall"];
+export type AICallPageResponse = components["schemas"]["AICallPageResponse"];
+export type AICallResponse = components["schemas"]["AICallResponse"];
+export type AICallStatus = components["schemas"]["AICallStatus"];
+export type AICallSummary = components["schemas"]["AICallSummary"];
+export type TokenUsage = components["schemas"]["TokenUsage"];
+export type ToolCall = components["schemas"]["ToolCall"];
+export type ToolCallPageResponse =
+  components["schemas"]["ToolCallPageResponse"];
+export type ToolCallResponse = components["schemas"]["ToolCallResponse"];
+export type ToolCallStatus = components["schemas"]["ToolCallStatus"];
+export type ToolCallSummary = components["schemas"]["ToolCallSummary"];
+
+export interface ExecutionPageParameters {
+  limit: number;
+  offset: number;
+}
+
+function generationPath(competitionId: string, generationId: string): string {
+  return `/api/v1/generations/competitions/${competitionId}/${generationId}`;
+}
+
+function pageQuery(parameters: ExecutionPageParameters): URLSearchParams {
+  return new URLSearchParams({
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+}
+
+export function listAICalls(
+  competitionId: string,
+  generationId: string,
+  parameters: ExecutionPageParameters,
+  signal?: AbortSignal,
+): Promise<AICallPageResponse> {
+  return apiRequest(
+    `${generationPath(competitionId, generationId)}/ai-calls?${pageQuery(parameters).toString()}`,
+    { signal },
+  );
+}
+
+export function getAICall(
+  competitionId: string,
+  generationId: string,
+  aiCallId: string,
+  signal?: AbortSignal,
+): Promise<AICallResponse> {
+  return apiRequest(
+    `${generationPath(competitionId, generationId)}/ai-calls/${aiCallId}`,
+    { signal },
+  );
+}
+
+export function listToolCalls(
+  competitionId: string,
+  generationId: string,
+  aiCallId: string,
+  parameters: ExecutionPageParameters,
+  signal?: AbortSignal,
+): Promise<ToolCallPageResponse> {
+  const query = pageQuery(parameters);
+  query.set("ai_call_id", aiCallId);
+  return apiRequest(
+    `${generationPath(competitionId, generationId)}/tool-calls?${query.toString()}`,
+    { signal },
+  );
+}
+
+export function getToolCall(
+  competitionId: string,
+  generationId: string,
+  toolCallId: string,
+  signal?: AbortSignal,
+): Promise<ToolCallResponse> {
+  return apiRequest(
+    `${generationPath(competitionId, generationId)}/tool-calls/${toolCallId}`,
+    { signal },
+  );
+}

--- a/frontend/src/features/execution/execution-timeline.tsx
+++ b/frontend/src/features/execution/execution-timeline.tsx
@@ -1,0 +1,659 @@
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronDown,
+  ChevronRight,
+  CircleAlert,
+  Cpu,
+  LoaderCircle,
+  Wrench,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { StructuredContentViewer } from "@/components/shared/structured-content-viewer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type {
+  AICallStatus,
+  AICallSummary,
+  TokenUsage,
+  ToolCallStatus,
+  ToolCallSummary,
+} from "@/features/execution/api";
+import {
+  useAICallDetail,
+  useAICallList,
+  useToolCallDetail,
+  useToolCallList,
+} from "@/features/execution/queries";
+
+const EXECUTION_PAGE_SIZE = 25;
+const TOOL_PAGE_SIZE = 25;
+
+interface ExecutionTimelineProps {
+  competitionId: string;
+  generationId: string;
+  active: boolean;
+  generationActive: boolean;
+}
+
+type BadgeVariant = "outline" | "secondary" | "destructive";
+
+function positivePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function pageCount(total: number, pageSize: number): number {
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+function formatDuration(milliseconds: number | null): string {
+  if (milliseconds === null) return "In progress";
+  if (milliseconds < 1_000) return `${String(milliseconds)} ms`;
+  return `${(milliseconds / 1_000).toFixed(milliseconds < 10_000 ? 1 : 0)} s`;
+}
+
+function modelLabel(provider: string | null, model: string): string {
+  return provider ? `${provider}/${model}` : model;
+}
+
+function aiStatus(status: AICallStatus): {
+  label: string;
+  variant: BadgeVariant;
+} {
+  if (status === "succeeded") return { label: "Succeeded", variant: "outline" };
+  if (status === "retryable_error")
+    return { label: "Retryable error", variant: "destructive" };
+  if (status === "fatal_error")
+    return { label: "Fatal error", variant: "destructive" };
+  if (status === "cancelled") return { label: "Cancelled", variant: "outline" };
+  if (status === "started") return { label: "Running", variant: "secondary" };
+  return { label: "Unknown outcome", variant: "secondary" };
+}
+
+function toolStatus(status: ToolCallStatus): {
+  label: string;
+  variant: BadgeVariant;
+} {
+  if (status === "succeeded") return { label: "Succeeded", variant: "outline" };
+  if (status === "failed") return { label: "Failed", variant: "destructive" };
+  if (status === "cancelled") return { label: "Cancelled", variant: "outline" };
+  return { label: "Running", variant: "secondary" };
+}
+
+function TokenSummary({ usage }: { usage: TokenUsage }): React.JSX.Element {
+  const values = [
+    ["Total", usage.total_tokens],
+    ["Input", usage.input_tokens],
+    ["Cached", usage.cached_input_tokens],
+    ["Output", usage.output_tokens],
+    ["Reasoning", usage.reasoning_tokens],
+  ] as const;
+  return (
+    <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+      {values.map(([label, value]) => (
+        <div key={label} className="flex gap-1">
+          <dt>{label}</dt>
+          <dd className="font-medium tabular-nums text-foreground">
+            {value ?? "—"}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function InlineError({
+  title,
+  error,
+  onRetry,
+}: {
+  title: string;
+  error: unknown;
+  onRetry: () => void;
+}): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-5">
+      <CircleAlert className="size-5 text-destructive" aria-hidden="true" />
+      <h4 className="mt-3 font-semibold">{title}</h4>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        {error instanceof ApiError
+          ? error.message
+          : "This durable execution resource could not be loaded."}
+      </p>
+      <Button className="mt-3" variant="outline" size="sm" onClick={onRetry}>
+        Try again
+      </Button>
+    </div>
+  );
+}
+
+function Pager({
+  label,
+  page,
+  totalPages,
+  total,
+  onPageChange,
+}: {
+  label: string;
+  page: number;
+  totalPages: number;
+  total: number;
+  onPageChange: (page: number) => void;
+}): React.JSX.Element | null {
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4 text-xs">
+      <span className="text-muted-foreground">
+        {label} page {page} of {totalPages} · {total} total
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page <= 1}
+          aria-label={`Previous ${label.toLowerCase()} page`}
+          onClick={() => {
+            onPageChange(page - 1);
+          }}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={page >= totalPages}
+          aria-label={`Next ${label.toLowerCase()} page`}
+          onClick={() => {
+            onPageChange(page + 1);
+          }}
+        >
+          Next
+          <ArrowRight className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ToolCallRow({
+  competitionId,
+  generationId,
+  aiCallId,
+  summary,
+}: {
+  competitionId: string;
+  generationId: string;
+  aiCallId: string;
+  summary: ToolCallSummary;
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const detailQuery = useToolCallDetail(
+    competitionId,
+    generationId,
+    aiCallId,
+    summary.id,
+    expanded,
+  );
+  const presentation = toolStatus(summary.status);
+  const regionId = `tool-call-${summary.id}`;
+
+  return (
+    <li className="rounded-lg border border-border bg-background">
+      <button
+        type="button"
+        className="flex w-full items-start gap-3 p-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        aria-expanded={expanded}
+        aria-controls={regionId}
+        onClick={() => {
+          setExpanded((value) => !value);
+        }}
+      >
+        {expanded ? (
+          <ChevronDown className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+        )}
+        <span className="min-w-0 flex-1">
+          <span className="flex flex-wrap items-center gap-2">
+            <span className="break-all font-mono text-sm font-medium">
+              {summary.tool_name}
+            </span>
+            <Badge variant={presentation.variant}>{presentation.label}</Badge>
+          </span>
+          <span className="mt-2 block text-xs text-muted-foreground">
+            Tool {summary.tool_ordinal} · {formatDuration(summary.duration_ms)}{" "}
+            · {summary.implementation_version}
+          </span>
+        </span>
+      </button>
+
+      {expanded ? (
+        <div id={regionId} className="border-t border-border p-4">
+          {detailQuery.isPending ? (
+            <div className="space-y-2">
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-14 w-full" />
+            </div>
+          ) : detailQuery.isError ? (
+            <InlineError
+              title="Tool-call detail unavailable"
+              error={detailQuery.error}
+              onRetry={() => void detailQuery.refetch()}
+            />
+          ) : (
+            <div className="grid min-w-0 gap-3 xl:grid-cols-2">
+              <StructuredContentViewer
+                title="Arguments"
+                content={detailQuery.data.tool_call.arguments}
+              />
+              <StructuredContentViewer
+                title="Structured result"
+                content={
+                  detailQuery.data.tool_call.structured_result ?? undefined
+                }
+              />
+              <StructuredContentViewer
+                title="Full result text"
+                content={
+                  detailQuery.data.tool_call.full_result_text ?? undefined
+                }
+              />
+              <StructuredContentViewer
+                title="Error"
+                content={
+                  detailQuery.data.tool_call.error ??
+                  detailQuery.data.tool_call.error_text ??
+                  undefined
+                }
+              />
+            </div>
+          )}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function ToolCallsPanel({
+  competitionId,
+  generationId,
+  aiCallId,
+}: {
+  competitionId: string;
+  generationId: string;
+  aiCallId: string;
+}): React.JSX.Element {
+  const [page, setPage] = useState(1);
+  const query = useToolCallList(
+    competitionId,
+    generationId,
+    aiCallId,
+    {
+      limit: TOOL_PAGE_SIZE,
+      offset: (page - 1) * TOOL_PAGE_SIZE,
+    },
+    true,
+  );
+  const totalPages = pageCount(query.data?.page.total ?? 0, TOOL_PAGE_SIZE);
+
+  return (
+    <section
+      className="mt-5 border-t border-border pt-5"
+      aria-labelledby={`tools-${aiCallId}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h4
+          id={`tools-${aiCallId}`}
+          className="flex items-center gap-2 font-semibold"
+        >
+          <Wrench className="size-4 text-muted-foreground" aria-hidden="true" />
+          Tool calls
+        </h4>
+        {query.isFetching && !query.isPending ? (
+          <span className="text-xs text-muted-foreground" role="status">
+            Updating…
+          </span>
+        ) : null}
+      </div>
+
+      {query.isPending ? (
+        <div className="mt-3 space-y-2">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : query.isError ? (
+        <div className="mt-3">
+          <InlineError
+            title="Tool-call history unavailable"
+            error={query.error}
+            onRetry={() => void query.refetch()}
+          />
+        </div>
+      ) : query.data.page.items.length === 0 ? (
+        <p className="mt-3 rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+          This AI attempt recorded no tool calls.
+        </p>
+      ) : (
+        <>
+          <ol className="mt-3 space-y-2">
+            {query.data.page.items.map((toolCall) => (
+              <ToolCallRow
+                key={toolCall.id}
+                competitionId={competitionId}
+                generationId={generationId}
+                aiCallId={aiCallId}
+                summary={toolCall}
+              />
+            ))}
+          </ol>
+          <div className="mt-4">
+            <Pager
+              label="Tool calls"
+              page={page}
+              totalPages={totalPages}
+              total={query.data.page.total}
+              onPageChange={setPage}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function AICallBody({
+  competitionId,
+  generationId,
+  summary,
+}: {
+  competitionId: string;
+  generationId: string;
+  summary: AICallSummary;
+}): React.JSX.Element {
+  const detailQuery = useAICallDetail(
+    competitionId,
+    generationId,
+    summary.id,
+    true,
+  );
+  return (
+    <div className="border-t border-border bg-muted/20 p-4 sm:p-5">
+      {detailQuery.isPending ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      ) : detailQuery.isError ? (
+        <InlineError
+          title="AI-call detail unavailable"
+          error={detailQuery.error}
+          onRetry={() => void detailQuery.refetch()}
+        />
+      ) : (
+        <div className="grid min-w-0 gap-3 xl:grid-cols-2">
+          <StructuredContentViewer
+            title="Request parameters"
+            content={detailQuery.data.ai_call.request_parameters}
+          />
+          <StructuredContentViewer
+            title="Input messages"
+            content={detailQuery.data.ai_call.input_messages}
+          />
+          <StructuredContentViewer
+            title="Tool definitions"
+            content={detailQuery.data.ai_call.tool_definitions}
+          />
+          <StructuredContentViewer
+            title="Provider response"
+            content={detailQuery.data.ai_call.provider_response ?? undefined}
+          />
+          <StructuredContentViewer
+            title="Error"
+            content={detailQuery.data.ai_call.error ?? undefined}
+          />
+        </div>
+      )}
+      <ToolCallsPanel
+        competitionId={competitionId}
+        generationId={generationId}
+        aiCallId={summary.id}
+      />
+    </div>
+  );
+}
+
+function AICallRow({
+  competitionId,
+  generationId,
+  summary,
+}: {
+  competitionId: string;
+  generationId: string;
+  summary: AICallSummary;
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const presentation = aiStatus(summary.status);
+  const actualModel = summary.actual_model
+    ? modelLabel(summary.actual_provider, summary.actual_model)
+    : "Not resolved";
+  const regionId = `ai-call-${summary.id}`;
+
+  return (
+    <li className="overflow-hidden rounded-lg border border-border bg-card">
+      <button
+        type="button"
+        className="w-full p-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:p-5"
+        aria-expanded={expanded}
+        aria-controls={regionId}
+        onClick={() => {
+          setExpanded((value) => !value);
+        }}
+      >
+        <span className="flex items-start gap-3">
+          {expanded ? (
+            <ChevronDown
+              className="mt-0.5 size-5 shrink-0"
+              aria-hidden="true"
+            />
+          ) : (
+            <ChevronRight
+              className="mt-0.5 size-5 shrink-0"
+              aria-hidden="true"
+            />
+          )}
+          <span className="min-w-0 flex-1">
+            <span className="flex flex-wrap items-center gap-2">
+              <span className="font-semibold">
+                Turn {summary.turn_number} · Attempt{" "}
+                {summary.attempt_number + 1}
+              </span>
+              <Badge variant={presentation.variant}>{presentation.label}</Badge>
+            </span>
+            <span className="mt-3 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+              <span className="min-w-0">
+                <span className="block text-muted-foreground">Model</span>
+                <span className="mt-1 block break-all font-mono">
+                  {modelLabel(
+                    summary.requested_provider,
+                    summary.requested_model,
+                  )}{" "}
+                  → {actualModel}
+                </span>
+              </span>
+              <span>
+                <span className="block text-muted-foreground">Timing</span>
+                <span className="mt-1 block">
+                  <DateTime value={summary.started_at} /> ·{" "}
+                  {formatDuration(summary.latency_ms)}
+                </span>
+              </span>
+              <span>
+                <span className="block text-muted-foreground">
+                  Finish reason
+                </span>
+                <span className="mt-1 block">
+                  {summary.finish_reason ?? "—"}
+                </span>
+              </span>
+            </span>
+            <span className="mt-3 block">
+              <TokenSummary usage={summary.usage} />
+            </span>
+          </span>
+        </span>
+      </button>
+      {expanded ? (
+        <div id={regionId}>
+          <AICallBody
+            competitionId={competitionId}
+            generationId={generationId}
+            summary={summary}
+          />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function TimelineSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-3">
+      {[0, 1, 2].map((item) => (
+        <Skeleton key={item} className="h-36 w-full rounded-lg" />
+      ))}
+    </div>
+  );
+}
+
+export function ExecutionTimeline({
+  competitionId,
+  generationId,
+  active,
+  generationActive,
+}: ExecutionTimelineProps): React.JSX.Element | null {
+  const [searchParameters, setSearchParameters] = useSearchParams();
+  const page = positivePage(searchParameters.get("page"));
+  const query = useAICallList(
+    competitionId,
+    generationId,
+    {
+      limit: EXECUTION_PAGE_SIZE,
+      offset: (page - 1) * EXECUTION_PAGE_SIZE,
+    },
+    active,
+    generationActive,
+  );
+  const totalPages = pageCount(
+    query.data?.page.total ?? 0,
+    EXECUTION_PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    if (!active || !query.data || page <= totalPages) return;
+    const next = new URLSearchParams(searchParameters);
+    if (totalPages === 1) next.delete("page");
+    else next.set("page", String(totalPages));
+    setSearchParameters(next, { replace: true });
+  }, [
+    active,
+    page,
+    query.data,
+    searchParameters,
+    setSearchParameters,
+    totalPages,
+  ]);
+
+  if (!active) return null;
+  if (query.isPending) return <TimelineSkeleton />;
+  if (query.isError) {
+    return (
+      <InlineError
+        title="Execution history unavailable"
+        error={query.error}
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+  if (query.data.page.items.length === 0 && page === 1) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/60 p-8 text-center sm:p-12">
+        <Cpu
+          className="mx-auto size-8 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <h3 className="mt-5 font-editorial text-2xl font-semibold">
+          No AI attempts recorded
+        </h3>
+        <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
+          This generation has not recorded a model attempt yet.
+        </p>
+      </div>
+    );
+  }
+
+  function setPage(nextPage: number): void {
+    const next = new URLSearchParams(searchParameters);
+    if (nextPage === 1) next.delete("page");
+    else next.set("page", String(nextPage));
+    setSearchParameters(next);
+  }
+
+  return (
+    <section aria-labelledby="execution-timeline-heading" className="min-w-0">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3
+            id="execution-timeline-heading"
+            className="font-editorial text-2xl font-semibold"
+          >
+            Model attempts
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Durable turn and retry order, with tool activity nested under each
+            attempt.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {query.isFetching ? (
+            <>
+              <LoaderCircle
+                className="size-3 animate-spin"
+                aria-hidden="true"
+              />
+              <span role="status">Updating summaries…</span>
+            </>
+          ) : (
+            <span>{query.data.page.total} attempts</span>
+          )}
+        </div>
+      </div>
+
+      <ol className="space-y-3">
+        {query.data.page.items.map((call) => (
+          <AICallRow
+            key={call.id}
+            competitionId={competitionId}
+            generationId={generationId}
+            summary={call}
+          />
+        ))}
+      </ol>
+      <div className="mt-5">
+        <Pager
+          label="AI attempts"
+          page={page}
+          totalPages={totalPages}
+          total={query.data.page.total}
+          onPageChange={setPage}
+        />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/execution/queries.ts
+++ b/frontend/src/features/execution/queries.ts
@@ -1,0 +1,119 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import {
+  getAICall,
+  getToolCall,
+  listAICalls,
+  listToolCalls,
+  type ExecutionPageParameters,
+} from "@/features/execution/api";
+
+const ACTIVE_SUMMARY_POLL_MS = 2_000;
+
+function browserCanPoll(): boolean {
+  return (
+    typeof document === "undefined" ||
+    (document.visibilityState === "visible" && navigator.onLine)
+  );
+}
+
+export function useAICallList(
+  competitionId: string,
+  generationId: string,
+  parameters: ExecutionPageParameters,
+  enabled: boolean,
+  generationActive: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      ...queryKeys.competitions.aiCallList(
+        competitionId,
+        generationId,
+        parameters,
+      ),
+      generationActive,
+    ] as const,
+    queryFn: ({ signal }) =>
+      listAICalls(competitionId, generationId, parameters, signal),
+    enabled: enabled && competitionId.length > 0 && generationId.length > 0,
+    placeholderData: keepPreviousData,
+    refetchInterval:
+      enabled && generationActive && browserCanPoll()
+        ? ACTIVE_SUMMARY_POLL_MS
+        : false,
+    refetchIntervalInBackground: false,
+  });
+}
+
+export function useAICallDetail(
+  competitionId: string,
+  generationId: string,
+  aiCallId: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.aiCallDetail(
+      competitionId,
+      generationId,
+      aiCallId,
+    ),
+    queryFn: ({ signal }) =>
+      getAICall(competitionId, generationId, aiCallId, signal),
+    enabled:
+      enabled &&
+      competitionId.length > 0 &&
+      generationId.length > 0 &&
+      aiCallId.length > 0,
+  });
+}
+
+export function useToolCallList(
+  competitionId: string,
+  generationId: string,
+  aiCallId: string,
+  parameters: ExecutionPageParameters,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.toolCallList(
+      competitionId,
+      generationId,
+      aiCallId,
+      parameters,
+    ),
+    queryFn: ({ signal }) =>
+      listToolCalls(competitionId, generationId, aiCallId, parameters, signal),
+    enabled:
+      enabled &&
+      competitionId.length > 0 &&
+      generationId.length > 0 &&
+      aiCallId.length > 0,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useToolCallDetail(
+  competitionId: string,
+  generationId: string,
+  aiCallId: string,
+  toolCallId: string,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: queryKeys.competitions.toolCallDetail(
+      competitionId,
+      generationId,
+      aiCallId,
+      toolCallId,
+    ),
+    queryFn: ({ signal }) =>
+      getToolCall(competitionId, generationId, toolCallId, signal),
+    enabled:
+      enabled &&
+      competitionId.length > 0 &&
+      generationId.length > 0 &&
+      aiCallId.length > 0 &&
+      toolCallId.length > 0,
+  });
+}

--- a/frontend/src/features/usage/api.ts
+++ b/frontend/src/features/usage/api.ts
@@ -1,0 +1,19 @@
+import { apiRequest } from "@/api/client";
+import type { components } from "@/api/generated/schema";
+
+export type GenerationUsage = components["schemas"]["GenerationUsage"];
+export type GenerationUsageResponse =
+  components["schemas"]["GenerationUsageResponse"];
+export type ModelUsageBreakdown = components["schemas"]["ModelUsageBreakdown"];
+export type TokenTotals = components["schemas"]["TokenTotals"];
+
+export function getGenerationUsage(
+  competitionId: string,
+  generationId: string,
+  signal?: AbortSignal,
+): Promise<GenerationUsageResponse> {
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}/${generationId}/usage`,
+    { signal },
+  );
+}

--- a/frontend/src/features/usage/queries.ts
+++ b/frontend/src/features/usage/queries.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { queryKeys } from "@/api/query-keys";
+import { getGenerationUsage } from "@/features/usage/api";
+
+export function useGenerationUsage(
+  competitionId: string,
+  generationId: string,
+  enabled: boolean,
+  provisional: boolean,
+) {
+  return useQuery({
+    queryKey: [
+      ...queryKeys.competitions.generationUsage(competitionId, generationId),
+      provisional,
+    ] as const,
+    queryFn: ({ signal }) =>
+      getGenerationUsage(competitionId, generationId, signal),
+    enabled: enabled && competitionId.length > 0 && generationId.length > 0,
+    refetchInterval:
+      enabled &&
+      provisional &&
+      (typeof document === "undefined" ||
+        (document.visibilityState === "visible" && navigator.onLine))
+        ? 5_000
+        : false,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/frontend/src/features/usage/usage-panel.tsx
+++ b/frontend/src/features/usage/usage-panel.tsx
@@ -1,0 +1,371 @@
+import { CircleAlert, Clock3, Coins, Cpu } from "lucide-react";
+
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ModelUsageBreakdown, TokenTotals } from "@/features/usage/api";
+import { useGenerationUsage } from "@/features/usage/queries";
+
+interface UsagePanelProps {
+  competitionId: string;
+  generationId: string;
+  active: boolean;
+  provisional: boolean;
+}
+
+function numberLabel(value: number): string {
+  return value.toLocaleString();
+}
+
+function costLabel(value: string | null, currency: string): string {
+  return value === null ? "Unavailable" : `${currency} ${value}`;
+}
+
+function modelLabel(breakdown: ModelUsageBreakdown): string {
+  const identity = [breakdown.provider, breakdown.model]
+    .filter(Boolean)
+    .join(" / ");
+  return identity || "Provider or model not recorded";
+}
+
+function TokenSummary({ tokens }: { tokens: TokenTotals }): React.JSX.Element {
+  const categories = [
+    { label: "Input", value: tokens.input_tokens },
+    { label: "Cached input", value: tokens.cached_input_tokens },
+    { label: "Output", value: tokens.output_tokens },
+    { label: "Reasoning", value: tokens.reasoning_tokens },
+    { label: "Total", value: tokens.total_tokens },
+  ];
+  return (
+    <dl className="grid grid-cols-2 gap-x-6 gap-y-5 sm:grid-cols-3 xl:grid-cols-5">
+      {categories.map((category) => (
+        <div key={category.label}>
+          <dt className="text-xs text-muted-foreground">{category.label}</dt>
+          <dd className="mt-1 font-mono text-lg font-semibold tabular-nums">
+            {numberLabel(category.value)}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function BreakdownTable({
+  breakdowns,
+}: {
+  breakdowns: ModelUsageBreakdown[];
+}): React.JSX.Element {
+  return (
+    <div className="hidden overflow-hidden rounded-lg border border-border lg:block">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3 font-semibold">Provider / model</th>
+            <th className="px-4 py-3 font-semibold">Attempts</th>
+            <th className="px-4 py-3 font-semibold">Tokens</th>
+            <th className="px-4 py-3 font-semibold">Latency</th>
+            <th className="px-4 py-3 font-semibold">Estimated cost</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {breakdowns.map((breakdown, index) => (
+            <tr
+              key={`${breakdown.provider ?? "unknown"}:${breakdown.model ?? "unknown"}:${String(index)}`}
+            >
+              <td className="max-w-64 px-4 py-4">
+                <p className="break-all font-medium">{modelLabel(breakdown)}</p>
+                {!breakdown.complete ? (
+                  <Badge className="mt-2" variant="secondary">
+                    Incomplete
+                  </Badge>
+                ) : null}
+              </td>
+              <td className="px-4 py-4 font-mono tabular-nums">
+                {numberLabel(breakdown.attempt_count)}
+              </td>
+              <td className="px-4 py-4 font-mono tabular-nums">
+                {numberLabel(breakdown.tokens.total_tokens)}
+              </td>
+              <td className="px-4 py-4 font-mono tabular-nums">
+                {numberLabel(breakdown.latency_ms)} ms
+              </td>
+              <td className="px-4 py-4 font-mono tabular-nums">
+                {costLabel(breakdown.estimated_cost, breakdown.currency)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function BreakdownCards({
+  breakdowns,
+}: {
+  breakdowns: ModelUsageBreakdown[];
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3 lg:hidden">
+      {breakdowns.map((breakdown, index) => (
+        <article
+          key={`${breakdown.provider ?? "unknown"}:${breakdown.model ?? "unknown"}:${String(index)}`}
+          className="rounded-lg border border-border bg-card p-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <h4 className="break-all font-medium">{modelLabel(breakdown)}</h4>
+            {!breakdown.complete ? (
+              <Badge variant="secondary">Incomplete</Badge>
+            ) : null}
+          </div>
+          <dl className="mt-4 grid grid-cols-2 gap-4 border-t border-border pt-4 text-sm sm:grid-cols-4">
+            <div>
+              <dt className="text-xs text-muted-foreground">Attempts</dt>
+              <dd className="mt-1 font-mono tabular-nums">
+                {numberLabel(breakdown.attempt_count)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Tokens</dt>
+              <dd className="mt-1 font-mono tabular-nums">
+                {numberLabel(breakdown.tokens.total_tokens)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Latency</dt>
+              <dd className="mt-1 font-mono tabular-nums">
+                {numberLabel(breakdown.latency_ms)} ms
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-muted-foreground">Estimated cost</dt>
+              <dd className="mt-1 break-all font-mono tabular-nums">
+                {costLabel(breakdown.estimated_cost, breakdown.currency)}
+              </dd>
+            </div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function AffectedCalls({
+  title,
+  ids,
+}: {
+  title: string;
+  ids: string[];
+}): React.JSX.Element | null {
+  if (ids.length === 0) return null;
+  return (
+    <div>
+      <h4 className="text-sm font-medium">{title}</h4>
+      <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-md border border-border bg-background p-3">
+        {ids.map((id) => (
+          <li key={id} className="break-all font-mono text-xs">
+            {id}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function UsageSkeleton(): React.JSX.Element {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-36 w-full rounded-lg" />
+      <Skeleton className="h-64 w-full rounded-lg" />
+    </div>
+  );
+}
+
+export function UsagePanel({
+  competitionId,
+  generationId,
+  active,
+  provisional,
+}: UsagePanelProps): React.JSX.Element {
+  const usageQuery = useGenerationUsage(
+    competitionId,
+    generationId,
+    active,
+    provisional,
+  );
+
+  if (!active) return <></>;
+  if (usageQuery.isPending) return <UsageSkeleton />;
+
+  if (usageQuery.isError) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+        <CircleAlert className="size-6 text-destructive" aria-hidden="true" />
+        <h3 className="mt-3 font-semibold">Usage unavailable</h3>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          {usageQuery.error instanceof ApiError
+            ? usageQuery.error.message
+            : "The aggregate generation usage could not be loaded."}
+        </p>
+        <Button
+          className="mt-4"
+          variant="outline"
+          onClick={() => void usageQuery.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const usage = usageQuery.data.usage;
+  const incomplete = !usage.complete;
+
+  return (
+    <div className="min-w-0 space-y-6">
+      {provisional ? (
+        <div className="rounded-lg border border-primary/25 bg-primary/5 p-4 text-sm leading-6">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">Provisional</Badge>
+            <span className="font-medium">This run is still active.</span>
+          </div>
+          <p className="mt-2 text-muted-foreground">
+            Recorded attempts are included now. Totals and the current estimate
+            may change as more calls finish.
+          </p>
+        </div>
+      ) : null}
+
+      {incomplete ? (
+        <section
+          className="rounded-lg border border-destructive/30 bg-destructive/5 p-5"
+          aria-labelledby="incomplete-usage-heading"
+        >
+          <div className="flex items-start gap-3">
+            <CircleAlert
+              className="mt-0.5 size-5 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+            <div>
+              <h3 id="incomplete-usage-heading" className="font-semibold">
+                Estimate is incomplete
+              </h3>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                One or more attempts lacked reported usage or current pricing.
+                Unavailable cost is not treated as zero.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            <AffectedCalls
+              title="Calls missing usage"
+              ids={usage.missing_usage_call_ids}
+            />
+            <AffectedCalls
+              title="Calls without current pricing"
+              ids={usage.unpriced_call_ids}
+            />
+          </div>
+        </section>
+      ) : null}
+
+      <section
+        className="rounded-lg border border-border bg-card p-5 sm:p-6"
+        aria-labelledby="usage-summary-heading"
+      >
+        <div className="flex flex-col gap-5 border-b border-border pb-5 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <Coins
+                className="size-5 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <h3
+                id="usage-summary-heading"
+                className="font-editorial text-2xl font-semibold"
+              >
+                Usage summary
+              </h3>
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              All recorded provider attempts, including fallbacks and failures
+              when usage was reported.
+            </p>
+          </div>
+          <div className="sm:text-right">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              Estimated cost
+            </p>
+            <p className="mt-1 break-all font-mono text-2xl font-semibold tabular-nums">
+              {costLabel(usage.estimated_cost, usage.currency)}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Current quote · <DateTime value={usage.quoted_at} showExact />
+            </p>
+          </div>
+        </div>
+
+        <div className="pt-5">
+          <TokenSummary tokens={usage.tokens} />
+        </div>
+        <dl className="mt-6 grid gap-4 border-t border-border pt-5 text-sm sm:grid-cols-2">
+          <div className="flex items-center gap-3">
+            <Cpu className="size-4 text-muted-foreground" aria-hidden="true" />
+            <div>
+              <dt className="text-xs text-muted-foreground">Attempts</dt>
+              <dd className="mt-1 font-mono font-medium tabular-nums">
+                {numberLabel(usage.attempt_count)}
+              </dd>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Clock3
+              className="size-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <div>
+              <dt className="text-xs text-muted-foreground">
+                Aggregate latency
+              </dt>
+              <dd className="mt-1 font-mono font-medium tabular-nums">
+                {numberLabel(usage.latency_ms)} ms
+              </dd>
+            </div>
+          </div>
+        </dl>
+      </section>
+
+      <section aria-labelledby="model-usage-heading">
+        <div className="mb-4 flex items-end justify-between gap-3">
+          <div>
+            <h3
+              id="model-usage-heading"
+              className="font-editorial text-2xl font-semibold"
+            >
+              Provider and model breakdown
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Backend-recorded actual provider/model usage and current estimate.
+            </p>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {usage.breakdowns.length} model group
+            {usage.breakdowns.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        {usage.breakdowns.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-card/60 p-7 text-sm text-muted-foreground">
+            No provider/model usage has been recorded for this run.
+          </div>
+        ) : (
+          <>
+            <BreakdownTable breakdowns={usage.breakdowns} />
+            <BreakdownCards breakdowns={usage.breakdowns} />
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/routes/generation-detail.tsx
+++ b/frontend/src/routes/generation-detail.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SubmittedArticlePanel } from "@/features/articles/submitted-article-panel";
 import { ArtifactBrowser } from "@/features/artifacts/artifact-browser";
+import { ExecutionTimeline } from "@/features/execution/execution-timeline";
 import {
   createGenerationFormValuesFromDetail,
   saveGenerationDraft,
@@ -30,6 +31,7 @@ import {
   useRerunGeneration,
 } from "@/features/generations/queries";
 import { useSeasonList } from "@/features/seasons/queries";
+import { UsagePanel } from "@/features/usage/usage-panel";
 import { cn } from "@/lib/utils";
 
 const seasonListParameters = { limit: 200, offset: 0 } as const;
@@ -469,15 +471,21 @@ export function Component(): React.JSX.Element {
             />
           </TabsContent>
           <TabsContent value="execution">
-            <DeferredAuditPanel
-              title="Execution timeline"
-              description="The durable run status remains above. Turn, AI-call, and nested tool-call inspection lands in the execution audit slice."
+            <ExecutionTimeline
+              key={resolvedGenerationId}
+              competitionId={resolvedCompetitionId}
+              generationId={resolvedGenerationId}
+              active={activeTab === "execution"}
+              generationActive={active}
             />
           </TabsContent>
           <TabsContent value="usage">
-            <DeferredAuditPanel
-              title="Usage and estimated cost"
-              description="Backend-owned token and cost estimates land with the execution audit slice."
+            <UsagePanel
+              key={resolvedGenerationId}
+              competitionId={resolvedCompetitionId}
+              generationId={resolvedGenerationId}
+              active={activeTab === "usage"}
+              provisional={active}
             />
           </TabsContent>
         </Tabs>
@@ -492,23 +500,6 @@ export function Component(): React.JSX.Element {
           Back to Generate
         </Link>
       </div>
-    </div>
-  );
-}
-
-function DeferredAuditPanel({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}): React.JSX.Element {
-  return (
-    <div className="rounded-lg border border-dashed border-border bg-card/60 p-7 sm:p-9">
-      <h3 className="font-editorial text-2xl font-semibold">{title}</h3>
-      <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-        {description}
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
# PR 8c — Execution and Usage Audit

## Summary

- add paginated durable AI attempt history with nested lazy tool calls
- load request/response/result/error bodies only after expansion and render them
  as escaped structured content
- add backend-authoritative usage, provider/model breakdowns, quote time,
  provisional values, and explicit incomplete-cost states
- complete the unified generation detail tabs

## Verification

One consolidated pre-commit frontend pass: format, lint, strict typecheck, and
production build. No backend contract changed, so no backend test command was
needed. Comprehensive UI and full-database review remains deferred until the
stack is complete.
