### PR TITLE
chore(ui): add local release operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ SLEEPER_WEEK_OVERRIDE=12  # Optional: override current week for testing
 OPENAI_API_KEY=your_openai_api_key_here
 
 # Reporter Configuration
-REPORTER_MODEL=deepseek/deepseek-v4-pro
+REPORTER_MODEL=gpt-5-mini
 # Comma-separated LiteLLM model IDs tried after primary retries are exhausted
 REPORTER_FALLBACK_MODELS=gpt-5.6-luna
 # Retries per model on rate limits / transient errors (exponential backoff)
@@ -15,10 +15,12 @@ REPORTER_OUTPUT_DIR=.output
 REPORTER_TRACING=true
 
 # Product database (runtime and migration credentials must be distinct)
-AIDAM_DATABASE_URL=postgresql+psycopg://aidam_api:password@localhost:54329/aidam
-AIDAM_WORKER_DATABASE_URL=postgresql+psycopg://aidam_worker:password@localhost:54329/aidam
-AIDAM_MIGRATION_DATABASE_URL=postgresql+psycopg://aidam_migrator:password@localhost:54329/aidam
-AIDAM_DATABASE_CA_FILE=/path/to/supabase-root.crt
+AIDAM_DATABASE_URL=postgresql+psycopg://aidam_api:aidam_local_api@127.0.0.1:54329/aidam
+AIDAM_WORKER_DATABASE_URL=postgresql+psycopg://aidam_worker:aidam_local_worker@127.0.0.1:54329/aidam
+AIDAM_MIGRATION_DATABASE_URL=postgresql+psycopg://aidam_migrator:aidam_local_migrator@127.0.0.1:54329/aidam
+# TLS is intentionally disabled only for the isolated local Compose database.
+AIDAM_DATABASE_REQUIRE_TLS=false
+AIDAM_MIGRATION_REQUIRE_TLS=false
 AIDAM_DATABASE_POOL_SIZE=5
 AIDAM_DATABASE_MAX_OVERFLOW=5
 AIDAM_DATABASE_STATEMENT_TIMEOUT_MS=30000

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,62 @@
+name: Frontend
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - "backend/**"
+      - ".github/workflows/frontend.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+      - "backend/**"
+      - ".github/workflows/frontend.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.5"
+          python-version: "3.11"
+          enable-cache: true
+      - name: Install Python project
+        run: uv sync --locked
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.19.0
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.node-version
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install frontend
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+      - name: Check generated API types
+        working-directory: frontend
+        run: pnpm api:check
+      - name: Check formatting
+        working-directory: frontend
+        run: pnpm format:check
+      - name: Lint
+        working-directory: frontend
+        run: pnpm lint
+      - name: Typecheck
+        working-directory: frontend
+        run: pnpm typecheck
+      - name: Build production frontend
+        working-directory: frontend
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # AIdamShefter-v2
 
-AI-powered fantasy football reporter. Fetches Sleeper league data, loads it into
-an in-memory SQLite database, uses persistent reporter memory for narrative
-continuity, and writes data-grounded articles with the reporter v2 runner.
+AI-powered fantasy football reporter. It refreshes Sleeper league data into a
+durable PostgreSQL product database, maintains narrative memory, and writes
+data-grounded articles through the reporter generation service.
 
 ## Setup
 
 ```bash
 uv python install
-uv sync
+uv sync --locked
+corepack enable
+corepack install --global pnpm@11.19.0
+pnpm --dir frontend install --frozen-lockfile
 ```
 
 `uv` reads `.python-version`, creates the project-local `.venv`, and installs
@@ -19,6 +22,18 @@ the exact dependency versions recorded in `uv.lock`. Copy `.env.example` to
 SLEEPER_LEAGUE_ID=<league_id>
 OPENAI_API_KEY=<key>
 ```
+
+The checked-in database values are for the isolated local Compose service. Start
+it and apply the current schema before starting the application:
+
+```bash
+docker compose -f compose.database.yml up --detach --wait
+uv run --env-file .env alembic -c backend/migrations/alembic.ini upgrade head
+```
+
+The Compose database stores its data in a temporary filesystem and starts empty
+after the service is recreated. It is intended for local development and release
+review, not durable deployment.
 
 ## Quick Start
 
@@ -41,9 +56,7 @@ generation boundary. Generation submission creates a pending row and schedules
 worker-scoped execution as a FastAPI background task after sending the response.
 
 ```bash
-export AIDAM_DATABASE_URL=postgresql+psycopg://aidam_api:password@localhost/aidam
-export AIDAM_DATABASE_REQUIRE_TLS=false  # isolated local PostgreSQL only
-uv run aidam-api
+uv run --env-file .env aidam-api
 ```
 
 The server listens on `127.0.0.1:8000` by default. Override that with
@@ -51,14 +64,20 @@ The server listens on `127.0.0.1:8000` by default. Override that with
 `/health/live`; readiness at `/health/ready` also verifies the configured
 database name, runtime role, and TLS policy.
 
+Confirm both checks before opening the frontend:
+
+```bash
+curl http://127.0.0.1:8000/health/live
+curl http://127.0.0.1:8000/health/ready
+```
+
 Submit a generation under
 `/api/v1/generations/competitions/{competition_id}` to schedule it automatically.
 The one-shot worker command remains available for manual execution and recovery:
 
 ```bash
-export AIDAM_WORKER_DATABASE_URL=postgresql+psycopg://aidam_worker:password@localhost/aidam
-uv run aidam-worker execute --competition-id <uuid> --generation-id <uuid>
-uv run aidam-worker reconcile-stale --competition-id <uuid> \
+uv run --env-file .env aidam-worker execute --competition-id <uuid> --generation-id <uuid>
+uv run --env-file .env aidam-worker reconcile-stale --competition-id <uuid> \
   --stale-before 2026-08-23T09:00:00Z --limit 100
 ```
 
@@ -70,24 +89,30 @@ queue, lease, heartbeat, or automatic resume.
 ## Frontend
 
 The local operator frontend lives under `frontend/` and requires Node.js
-22.22.x plus pnpm 11.19.0. With the API listening on `127.0.0.1:8000`:
+22.22.x plus pnpm 11.19.0. Keep the API command above running in one terminal,
+then start Vite from a second terminal:
 
 ```bash
-cd frontend
-pnpm install --frozen-lockfile
-pnpm dev
+pnpm --dir frontend dev
 ```
 
 Vite serves the application on `http://127.0.0.1:5173` and proxies `/api` and
-`/health` to the local API. Set `AIDAM_API_PROXY_TARGET` to use another
-development API origin. `VITE_API_BASE_URL` is optional and defaults to
-same-origin requests.
+`/health` to the local API. The default configuration needs no frontend `.env`.
+To use a different local API port, copy `frontend/.env.example` to
+`frontend/.env` and change `AIDAM_API_PROXY_TARGET`. Leave
+`VITE_API_BASE_URL` blank so browser requests remain same-origin.
+
+This initial release is supported only as a single-operator application bound
+to loopback. FastAPI intentionally does not enable CORS, and the Vite development
+server is the supported frontend serving path. Remote access, public deployment,
+TLS termination, authentication, and production static-asset hosting require a
+separate deployment design and are not supported by this release.
 
 The committed TypeScript API contract is generated directly from FastAPI:
 
 ```bash
-pnpm api:generate
-pnpm api:check
+pnpm --dir frontend api:generate
+pnpm --dir frontend api:check
 ```
 
 Set `AIDAM_PYTHON` only when the generator cannot discover the repository's

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -1,6 +1,6 @@
 # Product UI Design
 
-**Status:** Proposed product and frontend contract
+**Status:** Implemented initial-release product and frontend contract
 
 **Scope:** Competition management, article generation, generated-article
 inspection, execution audit, and usage/cost visibility
@@ -32,6 +32,7 @@ not part of this UI slice.
 | [`user-journeys.md`](user-journeys.md) | Information architecture, page inventory, flows, and user-visible states |
 | [`application-contracts.md`](application-contracts.md) | Required HTTP surface, implemented coverage, gaps, and transport semantics |
 | [`frontend-architecture.md`](frontend-architecture.md) | TypeScript application structure, libraries, data flow, quality gates, and delivery |
+| [`release-checklist.md`](release-checklist.md) | Final clean-start, real-data journey, cross-cutting review, and release signoff |
 
 The dependency-ordered implementation plan is intentionally local and mutable
 under `.context/ui/stack.md`, following the existing datalayer, memory, and
@@ -52,7 +53,7 @@ The UI must use the backend's domain words consistently:
 | Artifact | A versioned Markdown work product created during a generation |
 | Live generation | A run using the requested current-season boundary and canonical memory |
 | Backtest | A historical, cutoff-aware run isolated from canonical memory writes |
-| Evaluation workspace | Isolated simulated memory state that may be explicitly discarded or fast-forward promoted |
+| Evaluation workspace | Deferred concept for isolated writable memory; not exposed in the initial release |
 
 In particular, the league screen says **Refresh Sleeper data**, not “create a
 snapshot.” A refresh calls Sleeper; a snapshot is a separate reproducibility
@@ -78,14 +79,12 @@ durable cross-season identity.
   polls that page until the run is terminal and survives browser reloads.
 - Advanced reporter controls are available but visually secondary to season,
   week range, mode, request, and model chain.
-- Generation intent has two dimensions: current versus historical factual time,
-  and canonical versus isolated memory effects. Current canonical work is a
-  live generation; current isolated work is a simulation that may be
-  fast-forward promoted; historical work is a backtest and is evaluation-only
-  under the accepted memory contract.
-- Isolated memory never changes canonical memory merely because a run
-  succeeded. Promotion is a separate, confirmed command available only when
-  the workspace started from the still-current canonical revision.
+- The initial release exposes live generation and historical backtest only.
+  Live work may advance canonical memory; backtests pin historical canonical
+  memory and are strictly read-only.
+- Writable simulations, evaluation workspaces, and promotion/discard are
+  deferred until a separate memory-architecture decision compares
+  revision-native draft lineages with serialized workspace artifacts.
 - Article content is rendered from the exact submitted artifact version.
   Intermediate artifacts and later/earlier versions never replace it by path
   convention.
@@ -104,17 +103,10 @@ The first useful release includes:
 - model catalog and generation form;
 - polling-oriented run state;
 - article history and article/run detail;
-- artifacts, AI calls, tool calls, aggregate token usage, and cost estimate; and
-- isolated one-workspace-at-a-time current simulation and fast-forward
-  promotion if the backend workspace service lands in the same release.
+- artifacts, AI calls, tool calls, aggregate token usage, and cost estimate.
 
-Memory browsing/editing, comparisons, scheduled generation, templates, public
-publishing, dashboards across competitions, and streaming execution logs are
-deliberately deferred.
-
-The requested ability to promote memory from a historical backtest conflicts
-with the accepted backend invariant that an old-base workspace is
-evaluation-only. Supporting that behavior would require an explicit memory
-architecture change (merge/rebase or a different meaning of “backtest”), not
-just a UI control. The safe initial product promotes current-based simulations
-and keeps historical backtests isolated.
+Memory browsing/editing, writable simulations, promotion, comparisons,
+scheduled generation, templates, public publishing, dashboards across
+competitions, and streaming execution logs are deliberately deferred. Existing
+evaluation-workspace database seams remain unused for this release and do not
+constitute an accepted future architecture.

--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -33,8 +33,9 @@ Generation routes already exist under
 | Artifact versions | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented |
 
 Competition and season management plus refresh, overview, and snapshot-audit
-routes are implemented. Evaluation-workspace tables exist, but their product
-resource, service, and HTTP surfaces remain deferred to Layer 9.
+routes are implemented. Evaluation-workspace tables exist, but writable
+simulations and their product/API surfaces are explicitly deferred beyond the
+initial release pending a new memory-architecture decision.
 
 The existing generation route hierarchy is functional but inverted. Before a
 public client contract is stable, consider moving it to
@@ -210,15 +211,15 @@ memory. This latest-season restriction is currently a UI safety policy rather
 than an API invariant, so non-UI clients remain responsible for selecting the
 appropriate kind. Live runs may write canonical memory on success.
 
-Layer 7 does not expose an isolated or promotable simulation mode. That mode,
-its evaluation workspace, and promote/discard commands remain Layer 9 work;
-the available historical backtest is read-only.
+The initial release does not expose an isolated or promotable simulation mode.
+Evaluation-workspace and promote/discard contracts are deferred; the available
+historical backtest is read-only.
 
 | Method and path | Purpose | Priority |
 | --- | --- | --- |
 | `POST .../{generation_id}/cancel` | Cancel a pending/running generation | Should-have; manager supports cancellation |
 | Extend article/run list query | Model, week overlap, completion range, request text | Later unless list size demands it |
-| Extend generation body | Explicit memory mode and optional `evaluation_workspace_id` for isolated simulation sequencing | Layer 9; required for workspace promotion |
+| Extend generation body | Explicit writable draft-memory mode | Deferred pending memory architecture decision |
 | `GET .../{generation_id}/usage` | Aggregate tokens, latency, calls, and price quote | Required |
 | Optional `GET .../{generation_id}/audit` | One bounded detail projection for article + artifacts + calls | Optimization only; existing resources remain authoritative |
 
@@ -269,10 +270,21 @@ backend uses the current LiteLLM price map and may fall back to the map bundled
 with the installed LiteLLM package when the remote map is unavailable.
 Historical price reproduction and persisted dollar cost are not required.
 
-## Evaluation Workspace and Promotion API
+## Deferred Writable Simulation and Promotion
 
-The database schema anticipates workspaces, but a public manager/service/API is
-missing. Promotable current simulations and longitudinal evaluations require:
+The initial release intentionally adds no evaluation-workspace manager,
+service, route, or UI. Existing database seams remain unused and must not be
+treated as an accepted serialized-artifact architecture.
+
+Before adding writable simulations, compare revision-native draft lineages
+against serialized reporting-owned workspace artifacts. The preferred option to
+evaluate lets live generations advance canonical memory, backtests advance an
+isolated draft lineage, and promotion publish only a draft whose base remains
+the canonical head. This requires adapting or replacing the current linear
+introduced/retired visibility model, which is not branch-safe.
+
+The following route shapes are historical design candidates, not committed
+initial-release contracts:
 
 | Method and path | Purpose |
 | --- | --- |
@@ -281,23 +293,9 @@ missing. Promotable current simulations and longitudinal evaluations require:
 | `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/promote` | Fast-forward isolated memory into one new canonical revision |
 | `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/discard` | Close without canonical mutation |
 
-Workspace creation accepts the competition season/use case but does not accept
-an arbitrary untrusted canonical base from the browser; the service resolves and
-returns it. Generation submission accepts the resulting workspace ID only for
-an isolated memory mode. The service allocates sequence numbers and pins the
-workspace's current memory artifact.
-
-Promotion is an atomic command with an expected workspace/current-artifact
-version. It succeeds only when the workspace is active, its final memory
-artifact is complete, and the canonical head still equals its base revision.
-Otherwise it returns a typed `409 workspace_base_stale` or lifecycle conflict.
-No automatic merge or partial promotion is allowed. Consequently, a current
-simulation may be promotable and a historical old-base backtest is
-evaluation-only.
-
-Until these contracts exist, the UI must accurately offer basic read-only
-backtests and hide promotion rather than exposing a control that cannot preserve
-simulated memory.
+Until a replacement architecture is accepted, the UI offers only live canonical
+generation and read-only historical backtests and hides all workspace and
+promotion controls.
 
 ## Article List Projection
 

--- a/docs/ui/frontend-architecture.md
+++ b/docs/ui/frontend-architecture.md
@@ -20,7 +20,7 @@ The frontend is a standalone TypeScript application under `frontend/`:
 | Frontend automated tests | Deferred until the UI stabilizes or regressions justify them |
 | Formatting/linting | Prettier + ESLint with type-aware rules |
 
-Vite is appropriate because this is an authenticated/local product console, not
+Vite is appropriate because this is a local product console, not
 an SEO-dependent publishing site. Server rendering would add a deployment and
 data-loading model without helping the initial journeys. The backend remains a
 separately runnable FastAPI process.
@@ -107,10 +107,13 @@ Do not duplicate complete API response interfaces by hand. Zod schemas remain
 appropriate for form state because form inputs have UI-specific coercion and
 cross-field validation that differ from wire types.
 
-Development proxies `/api` and health requests to the local FastAPI port. The
-production hosting decision should preserve same-origin `/api` when possible;
-otherwise the backend needs an explicit allowlisted CORS configuration rather
-than `*`.
+Development proxies `/api` and health requests to the loopback FastAPI port.
+The initial release is a local-only operator application: Vite binds to
+`127.0.0.1`, the browser uses same-origin paths through the development proxy,
+and FastAPI remains loopback-bound without CORS. The production build remains a
+quality gate, not a supported deployment command. Remote or multi-user hosting
+requires a separate authentication, TLS, static-hosting, reverse-proxy, and
+allowlisted-CORS decision.
 
 ## Server State and Polling
 
@@ -139,7 +142,7 @@ refresh-history, competition-summary, and relevant generation-readiness keys.
 
 Mutations use server-returned resources and targeted invalidation. Optimistic
 updates are reserved for reversible presentation changes; competition creation,
-refresh, generation, promotion, and discard wait for server confirmation.
+refresh and generation wait for server confirmation.
 
 ## Form Model
 
@@ -201,8 +204,8 @@ that pass and any known limitations in `.context/ui/log.md`.
 
 Frontend tests can be introduced later where evidence makes them valuable—for
 example, a repeatedly broken generation-form mapping, polling lifecycle, cost
-calculation presentation, or canonical-memory promotion flow. No test framework
-is installed preemptively.
+calculation presentation, or another repeatedly broken product journey. No test
+framework is installed preemptively.
 
 ## Delivery and Quality Gates
 
@@ -222,10 +225,11 @@ focus, and status updates until automated accessibility checks are justified.
 
 ## Deferred Choices
 
-- frontend hosting and FastAPI static-asset ownership;
+- remote frontend hosting, reverse-proxy topology, and static-asset ownership;
 - authentication/session transport;
 - websocket or server-sent progress;
 - rich-text article editing;
+- writable simulations, evaluation workspaces, and memory promotion;
 - public article rendering/SEO;
 - multi-competition analytics;
 - a shared JavaScript monorepo/package layer; and

--- a/docs/ui/release-checklist.md
+++ b/docs/ui/release-checklist.md
@@ -1,0 +1,291 @@
+# UI Release Checklist
+
+Use this checklist for the final comprehensive review of the local operator UI
+against the real PostgreSQL database, FastAPI backend, Sleeper data, and model
+provider. Run it after the complete initial UI stack is built, not after each
+intermediate layer.
+
+Writable simulations, evaluation workspaces, promotion, and discard are outside
+this release. Do not enable or test those deferred flows here.
+
+## Review Metadata
+
+| Field | Value |
+| --- | --- |
+| Date and time | |
+| Reviewer | |
+| Commit | |
+| Branch | |
+| Operating system | |
+| Browser and version | |
+| Desktop viewport | |
+| Mobile viewport or device | |
+| Database identity/environment | |
+| Competition and season reviewed | |
+| Sleeper league ID | |
+| Primary and fallback models | |
+| API base URL | |
+| Frontend URL | |
+
+Never paste database passwords, provider keys, full connection URLs, or private
+model payloads into this record.
+
+## Clean Bootstrap and Automated Gates
+
+Start from a clean checkout with no existing frontend dependencies or running
+application processes. The database may contain the full intended review data,
+but the application must not depend on untracked code or stale generated files.
+
+- [ ] Install the Python version pinned by the repository.
+- [ ] Install Python dependencies from the locked dependency graph.
+- [ ] Start the local PostgreSQL service and wait for its health check.
+- [ ] Apply the complete Alembic history to head with the migrator role.
+- [ ] Start FastAPI with the documented local environment.
+- [ ] Confirm `/health/live` reports the process alive.
+- [ ] Confirm `/health/ready` reports the database-backed service ready.
+- [ ] Install the pinned pnpm version and use Node.js 22.22.x.
+- [ ] Run `pnpm install --frozen-lockfile` in `frontend/`.
+- [ ] Confirm the committed OpenAPI TypeScript contract has no drift.
+- [ ] Confirm frontend formatting passes.
+- [ ] Confirm frontend lint passes without warnings.
+- [ ] Confirm strict TypeScript compilation passes.
+- [ ] Confirm the production frontend build succeeds.
+- [ ] Start the frontend through the documented local proxy configuration.
+- [ ] Open the application through the documented frontend URL.
+
+| Bootstrap or gate evidence | Result | Notes |
+| --- | --- | --- |
+| PostgreSQL and Alembic head | Pending | |
+| API liveness and readiness | Pending | |
+| Frozen frontend install | Pending | |
+| Generated API drift | Pending | |
+| Format, lint, and typecheck | Pending | |
+| Production build | Pending | |
+
+## Full Real-Database Journey
+
+Use real persisted application rows and a real Sleeper refresh. Do not replace
+the backend with a stub server. Capture generation IDs and concise notes where
+they make a failure reproducible.
+
+### Competition, Season, and Refresh
+
+- [ ] The application opens on the competition list without console errors.
+- [ ] The competition list handles its loading, empty, populated, and recoverable
+      error states.
+- [ ] Create or select the review competition.
+- [ ] Create or select its season with the correct Sleeper league ID.
+- [ ] Complete first-season roster identity onboarding, or confirm the existing
+      durable identities are ready.
+- [ ] If reconciliation is required, map every observed Sleeper roster to the
+      intended franchise and retry safely after any stale-source response.
+- [ ] Run **Refresh Sleeper data** against the real source.
+- [ ] Confirm the refresh reaches its terminal state and history records the
+      attempt, timestamps, scope, and any partial/rejected observations.
+- [ ] Confirm the competition overview and generation form show consistent data
+      freshness and readiness.
+- [ ] Reload the page and confirm the persisted competition, season, identities,
+      refresh history, and freshness remain correct.
+
+### Live Generation
+
+- [ ] Open **Generate** for the latest attached season.
+- [ ] Confirm live mode clearly describes canonical memory behavior.
+- [ ] Select an explicit week or week range.
+- [ ] Enter the assignment and review reporter voice, tone, bias, length, evidence,
+      retry, turn-limit, primary-model, and ordered-fallback settings.
+- [ ] Confirm the primary model cannot be duplicated in the fallback chain and
+      fallbacks cannot repeat.
+- [ ] Submit the generation and confirm navigation to its durable run page.
+- [ ] Confirm pending/running status shows useful stage, turn, elapsed time,
+      assignment, scope, and model-chain context.
+- [ ] Reload while the run is active and confirm polling resumes from durable
+      backend state.
+- [ ] Move the browser to the background and restore it; confirm polling pauses and
+      resumes appropriately without creating another generation.
+- [ ] Confirm polling stops when the generation becomes terminal.
+- [ ] If the run fails, confirm the failure is actionable and **Rerun** plus
+      **Edit settings and try again** preserve the intended configuration.
+- [ ] For the successful run, record the generation ID below.
+
+Live generation ID: `____________________________`
+
+### Historical Read-Only Backtest
+
+- [ ] Select an older attached season or historical boundary and confirm the UI
+      changes the run to backtest mode.
+- [ ] Confirm the historical week cutoff and read-only memory behavior are explicit
+      before submission.
+- [ ] Confirm no current-simulation, workspace, promotion, discard, merge, or
+      automatic-promotion control appears.
+- [ ] Submit the backtest and confirm the durable status/reload/polling behavior
+      matches the live run.
+- [ ] Confirm a successful backtest produces an inspectable article without
+      offering any canonical-memory promotion action.
+
+Backtest generation ID: `____________________________`
+
+### Article Library and Exact Article
+
+- [ ] The article library contains only successful generations with an explicit
+      submitted artifact version.
+- [ ] Season, live/backtest, and week filters produce the expected persisted rows.
+- [ ] Each row presents its derived title, completion time, assignment excerpt,
+      scope, requested/actual model summary, token total, and estimated cost when
+      available.
+- [ ] Open the live article and confirm the rendered Markdown is the exact submitted
+      version identified by the generation, not a path-selected intermediate draft.
+- [ ] Repeat the exact-version check for the backtest article.
+- [ ] Confirm headings, lists, links, tables, code, and long lines remain readable
+      and contained.
+- [ ] Confirm raw HTML in Markdown does not execute.
+- [ ] Confirm **Copy Markdown** copies the exact submitted content and provides
+      visible feedback.
+- [ ] Confirm article metadata matches the generation request, dates, mode, model
+      chain, data snapshot, memory input, and manifest hash.
+
+### Artifact and Version Audit
+
+- [ ] The artifact list shows path, media type, finalization state, revision count,
+      and modified time for the selected generation.
+- [ ] Artifact and version pagination does not lose the active selection or alter
+      the URL-backed tab state.
+- [ ] Selecting an artifact loads its version history without eagerly loading every
+      version body.
+- [ ] Selecting a version loads that exact content and visibly marks submitted and
+      finalized versions correctly.
+- [ ] Markdown artifacts use the safe renderer; valid JSON is pretty-printed;
+      textual HTML and other text appear only as escaped source.
+- [ ] Unknown or binary media types do not execute in the browser.
+- [ ] Copying artifact content copies the exact stored version rather than its
+      presentation-only formatting.
+
+### Execution Audit
+
+- [ ] AI attempts appear in chronological turn/attempt order with requested and
+      actual models, status, latency, finish reason, and token usage.
+- [ ] AI-call pagination reaches every recorded attempt without duplicates.
+- [ ] Tool calls are nested under the correct AI attempt and ordered by tool
+      ordinal.
+- [ ] Expanding an AI or tool call lazy-loads its large request, response, result,
+      and error payloads; collapsed rows do not load those bodies unnecessarily.
+- [ ] Structured objects are pretty-printed, text is escaped, overflow is contained,
+      and disclosure controls work by keyboard.
+- [ ] Copy controls copy the exact displayed payload and announce success or
+      failure inline.
+- [ ] Provider errors, failed tools, missing fields, and empty payloads remain
+      understandable without exposing an unsafe renderer.
+
+### Usage and Estimated Cost
+
+- [ ] Usage shows aggregate input, cached input, output, reasoning, and total tokens.
+- [ ] Attempt count and summed latency agree with the execution audit.
+- [ ] Provider/model breakdowns agree with the actual attempts, including retries
+      and fallbacks.
+- [ ] Cost is always labeled **Estimated cost** with currency and quote time.
+- [ ] The frontend performs no independent price calculation.
+- [ ] A complete estimate is distinguishable from an incomplete estimate.
+- [ ] When an affected real run is available, missing-usage and unpriced call IDs
+      are visible and traceable to execution details.
+- [ ] Missing cost is not displayed as zero.
+
+## Cross-Cutting UI Review
+
+### Responsive Layout
+
+- [ ] Review every primary route at the recorded desktop viewport.
+- [ ] Review every primary route at the recorded mobile viewport or device.
+- [ ] Navigation, forms, metadata rails, tables, timelines, code, and article prose
+      remain usable without unintended page-width overflow.
+- [ ] Important actions remain visible and do not depend on hover.
+
+### Keyboard and Accessibility
+
+- [ ] Complete primary navigation and the generation form using only the keyboard.
+- [ ] Focus order follows visual and task order.
+- [ ] Focus indicators remain visible on links, buttons, tabs, disclosures, fields,
+      dialogs, and scrollable regions.
+- [ ] Tabs, dialogs, menus, sheets, and disclosure controls expose their expected
+      keyboard behavior and return focus sensibly.
+- [ ] Every form field has an accessible name; validation and server errors are
+      associated with the relevant field.
+- [ ] Loading, submission, copy, polling, and terminal-status feedback is available
+      without relying only on color or a transient toast.
+- [ ] Status badges and destructive/error colors retain readable contrast.
+
+### Reload, Connectivity, and Errors
+
+- [ ] Directly loading every primary route restores the intended persisted state.
+- [ ] Browser back/forward navigation preserves URL-backed filters, tabs, pages, and
+      selections.
+- [ ] Active generation polling recovers after reload, tab visibility changes, and
+      temporary offline/online transitions.
+- [ ] Recoverable request failures provide an inline explanation and retry path.
+- [ ] Empty lists, missing resources, invalid IDs, archived competitions, stale
+      roster observations, partial refreshes, failed generations, and incomplete
+      cost data have understandable states.
+- [ ] The browser console contains no uncaught exceptions, failed React keys,
+      accessibility warnings, or unexpected network loops during the journey.
+- [ ] The network panel shows bounded pagination and lazy detail loading rather than
+      unbounded or repeated child requests.
+
+## Known Limitations
+
+These are accepted release boundaries unless the review uncovers behavior worse
+than described.
+
+- A same-day manual refresh can reuse an earlier matching daily generation
+  snapshot. The UI surfaces the distinction but does not redesign snapshot
+  identity.
+- Generation execution is dispatched by the API process. A hard API-process
+  failure can leave work requiring manual recovery because there is no durable
+  queue, lease, heartbeat, or automatic resume.
+- Writable simulations, evaluation workspaces, promotion/discard, merge/rebase,
+  and historical-memory promotion are intentionally absent.
+- The initial application is a trusted local single-operator product without
+  authentication, durable per-user ownership, or public publishing.
+- An incomplete-cost state depends on recorded provider usage/pricing gaps. If the
+  full review database contains no naturally affected run, record that case as not
+  observed rather than mutating durable production-like history to manufacture it.
+
+Additional known limitations:
+
+- 
+
+## Findings and Outcome
+
+Record defects with a reproducible route, generation or resource ID, expected
+behavior, actual behavior, severity, and evidence location. Do not include secrets
+or full private model payloads.
+
+| ID | Severity | Area | Result | Evidence or notes | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| UI-001 | | | | | |
+
+| Review area | Outcome | Notes |
+| --- | --- | --- |
+| Clean bootstrap and automated gates | Pending | |
+| Competition, season, and refresh | Pending | |
+| Live generation | Pending | |
+| Historical read-only backtest | Pending | |
+| Article and artifacts | Pending | |
+| Execution and usage | Pending | |
+| Responsive and accessibility | Pending | |
+| Reload, errors, and console | Pending | |
+
+Final decision: **Pending / Pass / Pass with accepted limitations / Fail**
+
+Release-blocking findings:
+
+- 
+
+Accepted follow-up findings:
+
+- 
+
+Reviewer signoff: `____________________________`
+
+Signoff date: `____________________________`
+
+After completion, add a concise result summary and remaining limitations to
+`.context/ui/log.md`.

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -148,13 +148,11 @@ explicitly chooses `Use these settings` on that run.
 
 ### Generation modes
 
-The form presents three product modes while preserving the backend's existing
-`live`/`backtest` kind where applicable:
+The initial form presents the backend's two supported product modes:
 
 | Mode | Factual boundary | Memory effect | Promotion |
 | --- | --- | --- | --- |
 | Live | Selected current boundary | Writes canonical memory on success | Not applicable; already canonical |
-| Current simulation | Selected current boundary | Writes only an evaluation workspace | Eligible for explicit fast-forward promotion while its base remains current |
 | Historical backtest | Historical week cutoff | Historical pinned memory, isolated/read-only | Not eligible under the accepted architecture |
 
 Live mode is described as “generate from the selected current season boundary
@@ -163,31 +161,17 @@ warns when no usable observations exist. Because generation currently never
 refreshes implicitly, the warning provides a `Refresh now` action and returns
 to the preserved form afterward.
 
-### Simulation and backtest behavior
+### Backtest behavior
 
 Backtest mode makes the historical boundary prominent and explains that future
 Sleeper data is physically excluded from the frozen snapshot. It also explains
-the memory limitation accurately: the existing simple backtest path pins an
-earlier canonical revision and disables writes; promotable simulated memory
-requires an evaluation workspace.
+the memory limitation accurately: the backtest path pins an earlier canonical
+revision and disables writes.
 
-When evaluation workspaces are available, submitting a current simulation
-creates or selects the competition's active workspace and records the run in
-that workspace. The form does not offer an “automatically promote on success”
-checkbox. After a successful workspace run, the generation page offers:
-
-- `Promote memory`, enabled only if the workspace is complete and its base is
-  still the canonical head; and
-- `Discard simulation`, which closes the workspace without canonical changes.
-
-Promotion shows the base revision, proposed resulting revision, run count, and
-a confirmation warning. A stale-base conflict instructs the user to discard or
-restart the simulation; it never silently merges competing memory.
-
-A historical workspace started from an old memory revision remains useful for
-longitudinal evaluation, but promotion is disabled with an explanation. If the
-product must promote historical results, that decision first changes the
-durable memory policy; the frontend must not imply that a merge/rebase exists.
+The initial product does not expose current simulation, writable backtest,
+workspace, promotion, discard, merge, rebase, or stale-workspace recovery
+controls. Those behaviors require a separate memory-architecture decision and
+must not be inferred from unused database scaffolding.
 
 ### Model selection
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,6 @@
-# Leave blank for same-origin production requests.
+# Leave blank for the supported local release. Browser requests stay on the
+# Vite origin and the development server proxies them to FastAPI.
 VITE_API_BASE_URL=
 
-# Development-only Vite proxy target.
+# Optional local FastAPI proxy override.
 AIDAM_API_PROXY_TARGET=http://127.0.0.1:8000

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      host: "127.0.0.1",
+      port: 5173,
+      strictPort: true,
       proxy: {
         "/api": { target: apiTarget, changeOrigin: true },
         "/health": { target: apiTarget, changeOrigin: true },


### PR DESCRIPTION
## Summary

- add frontend CI for frozen pnpm installation, OpenAPI drift, formatting,
  linting, strict typechecking, and production builds on pinned runtimes
- document the complete local PostgreSQL bootstrap, migration, API health, and
  two-terminal frontend/backend workflow
- pin the supported Vite development server to loopback and document the
  local-only, no-CORS initial release boundary
- add the comprehensive real-database UI release checklist

## Verification

- frozen pnpm install
- OpenAPI drift check
- frontend format, lint, strict typecheck, and production build

Stacked on `codex/ui-8c-execution-usage`. Layer 9 writable workspaces and
promotion are intentionally deferred by the accepted promotion-deferral
decision.
