### PR TITLE
fix(datalayer): ignore empty Sleeper lineup slots

### DIFF
--- a/backend/services/datalayer/sleeper/endpoints/weekly.py
+++ b/backend/services/datalayer/sleeper/endpoints/weekly.py
@@ -142,9 +142,13 @@ def _parse_matchups(payload: JsonValue, week: int) -> MatchupsEndpointRecords:
         )
         if len(player_ids) != len(set(player_ids)):
             reject(kind, "matchup_player_id_duplicate")
-        starters = identifier_list(
+        raw_starters = identifier_list(
             raw.get("starters"), kind, "matchup_starters_invalid"
         )
+        # Sleeper uses "0" for an unfilled starting-lineup slot. It is a
+        # placeholder rather than a player identifier and may occur more than
+        # once in the same lineup.
+        starters = tuple(player_id for player_id in raw_starters if player_id != "0")
         if len(starters) != len(set(starters)):
             reject(kind, "matchup_starter_id_duplicate")
         if not set(starters).issubset(player_ids):

--- a/backend/tests/services/datalayer/test_weekly_endpoints.py
+++ b/backend/tests/services/datalayer/test_weekly_endpoints.py
@@ -86,6 +86,26 @@ def test_matchup_fixture_preserves_exact_points_and_lineups() -> None:
     ]
 
 
+def test_matchup_ignores_sleeper_zero_starter_placeholders() -> None:
+    payload = [
+        {
+            "roster_id": 1,
+            "players": ["p1", "p2"],
+            "starters": ["p1", "0", "0"],
+            "players_points": {"p1": 12, "p2": 4},
+        }
+    ]
+    request = build_matchups_request(SEASON_ID, "123", 3)
+
+    assert validate_matchups_completeness(payload, request).is_complete
+    records = normalize_matchups(payload, request)
+
+    assert [
+        (row.sleeper_player_id, row.role)
+        for row in records.player_performances
+    ] == [("p1", "starter"), ("p2", "bench")]
+
+
 def test_matchups_are_deterministic_and_empty_week_is_authoritative() -> None:
     payload = _fixture("matchups_week1")
     assert isinstance(payload, list)


### PR DESCRIPTION
## Summary

- treat Sleeper starter token `"0"` as an empty lineup slot during weekly
  normalization
- retain strict validation for every nonzero starter and preserve defenses as
  normal player-like identities
- add a focused regression covering real 2024 matchup payloads

## Verification

- focused weekly endpoint tests
- real PostgreSQL refresh completed all 44 planned scopes during final review

Stacked on `codex/ui-10-operations`.
