### PR TITLE
fix(memory): bootstrap empty canonical root

### DIFF
--- a/backend/resources/memory/revisions/manager.py
+++ b/backend/resources/memory/revisions/manager.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
+from backend.database.models.core import Competition
 from backend.database.models.memory import (
     CurrentRevision,
     MemoryItem,
@@ -73,6 +74,65 @@ class RevisionManager:
         if row is None:
             raise RevisionNotFoundError(self._competition_id)
         return _to_revision(row)
+
+    def ensure_current(self) -> CanonicalRevision:
+        """Return the current revision, creating the canonical empty root if needed."""
+
+        with transaction_session(self._session_factory) as session:
+            competition_id = session.scalar(
+                sa.select(Competition.id)
+                .where(Competition.id == self._competition_id)
+                .with_for_update()
+            )
+            if competition_id is None:
+                raise RevisionNotFoundError(self._competition_id)
+
+            current = session.scalar(
+                sa.select(MemoryRevision)
+                .join(
+                    CurrentRevision,
+                    sa.and_(
+                        CurrentRevision.current_revision_id == MemoryRevision.id,
+                        CurrentRevision.competition_id == MemoryRevision.competition_id,
+                    ),
+                )
+                .where(CurrentRevision.competition_id == self._competition_id)
+            )
+            if current is not None:
+                return _to_revision(current)
+
+            has_history = session.scalar(
+                sa.select(MemoryRevision.id)
+                .where(MemoryRevision.competition_id == self._competition_id)
+                .limit(1)
+            )
+            if has_history is not None:
+                raise RevisionNotFoundError(self._competition_id)
+
+            root = MemoryRevision(
+                id=uuid4(),
+                competition_id=self._competition_id,
+                sequence_number=0,
+                previous_revision_id=None,
+                producing_generation_id=None,
+                competition_season_id=None,
+                week=None,
+                knowledge_cutoff_at=None,
+                state_content_hash=compute_state_content_hash(
+                    self._competition_id, ()
+                ),
+            )
+            session.add(root)
+            session.flush((root,))
+            session.add(
+                CurrentRevision(
+                    competition_id=self._competition_id,
+                    current_revision_id=root.id,
+                    lock_version=0,
+                )
+            )
+            session.flush()
+            return _to_revision(root)
 
     def pin(self, revision_id: UUID) -> CanonicalRevision:
         """Resolve one exact revision without leaking cross-competition state."""

--- a/backend/services/generations/service.py
+++ b/backend/services/generations/service.py
@@ -400,8 +400,9 @@ class GenerationService:
         return GenerationExecutionResult(generation=generation)
 
     def _select_memory_revision(self, generation: Generation) -> CanonicalRevision:
+        current = self._revisions.ensure_current()
         if generation.kind is GenerationKind.LIVE:
-            return self._revisions.current()
+            return current
         if generation.week_end is None:
             raise ValueError("backtest memory selection requires a cutoff week")
         history = self._revisions.history()

--- a/backend/tests/resources/memory/test_revision_manager.py
+++ b/backend/tests/resources/memory/test_revision_manager.py
@@ -19,7 +19,11 @@ from backend.database.models.memory import (
 from backend.database.models.reporting import Generation
 from backend.database.sessions import create_session_factory
 from backend.resources.context import CompetitionScope, ManagerContext
-from backend.resources.memory.common import StaleCanonicalRevisionError
+from backend.resources.memory.common import (
+    RevisionNotFoundError,
+    StaleCanonicalRevisionError,
+)
+from backend.resources.memory.revisions.hashing import compute_state_content_hash
 from backend.resources.memory.revisions.manager import RevisionManager
 from backend.resources.memory.revisions.shared import visible_versions_statement
 from backend.resources.memory.revisions.writers import lock_current_revision
@@ -239,6 +243,79 @@ def _manager(database_engine: Engine, competition_id: UUID) -> RevisionManager:
         }
     )
     return RevisionManager(create_session_factory(database_engine), context)
+
+
+def test_ensure_current_creates_one_canonical_empty_root(
+    database_engine: Engine,
+) -> None:
+    competition_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Empty Memory League"},
+        )
+    manager = _manager(database_engine, competition_id)
+
+    first = manager.ensure_current()
+    second = manager.ensure_current()
+
+    assert first == second
+    assert first.sequence_number == 0
+    assert first.previous_revision_id is None
+    assert first.producing_generation_id is None
+    assert first.competition_season_id is None
+    assert first.week is None
+    assert first.knowledge_cutoff_at is None
+    assert first.state_content_hash == compute_state_content_hash(competition_id, ())
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemoryRevision)
+            .where(MemoryRevision.competition_id == competition_id)
+        ) == 1
+        assert connection.scalar(
+            sa.select(CurrentRevision.current_revision_id).where(
+                CurrentRevision.competition_id == competition_id
+            )
+        ) == first.revision_id
+
+
+def test_ensure_current_does_not_mask_history_without_pointer(
+    database_engine: Engine,
+) -> None:
+    competition_id = uuid4()
+    revision_id = uuid4()
+    with database_engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Broken Memory League"},
+        )
+        connection.execute(
+            sa.insert(MemoryRevision),
+            {
+                "id": revision_id,
+                "competition_id": competition_id,
+                "sequence_number": 0,
+                "state_content_hash": compute_state_content_hash(
+                    competition_id, ()
+                ),
+            },
+        )
+
+    with pytest.raises(RevisionNotFoundError):
+        _manager(database_engine, competition_id).ensure_current()
+
+    with database_engine.connect() as connection:
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(MemoryRevision)
+            .where(MemoryRevision.competition_id == competition_id)
+        ) == 1
+        assert connection.scalar(
+            sa.select(sa.func.count())
+            .select_from(CurrentRevision)
+            .where(CurrentRevision.competition_id == competition_id)
+        ) == 0
 
 
 def test_revision_manager_reads_current_pin_and_history(

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -178,6 +178,11 @@ class FakeRevisions:
         self.current_calls += 1
         return self.current_revision
 
+    def ensure_current(self):
+        self.events.append("memory")
+        self.current_calls += 1
+        return self.current_revision
+
     def history(self):
         self.events.append("memory")
         self.history_calls += 1
@@ -503,7 +508,7 @@ async def test_backtest_selects_latest_same_season_revision_and_is_read_only(
 
     result = await service.execute(_uuid(3))
 
-    assert revisions.current_calls == 0
+    assert revisions.current_calls == 1
     assert revisions.history_calls == 1
     assert manager.starts[0].input_memory_revision_id == _uuid(102)
     assert manager.starts[0].knowledge_cutoff_at == cutoff


### PR DESCRIPTION
## Summary

- lazily create the canonical sequence-zero memory root for competitions with
  no revision history
- serialize first-run initialization with a competition-row lock and reject
  history-without-pointer corruption
- make both live and historical read-only generation input selection work from
  a genuinely empty database

## Verification

- focused revision-manager and generation-service tests
- real PostgreSQL live and backtest submissions both resolved the same
  canonical sequence-zero root during final review

Stacked on `codex/ui-review-fix-matchup-starters`.
