### PR TITLE
fix(datalayer): reconcile stale refresh runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,22 @@ The one-shot worker command remains available for manual execution and recovery:
 uv run --env-file .env aidam-worker execute --competition-id <uuid> --generation-id <uuid>
 uv run --env-file .env aidam-worker reconcile-stale --competition-id <uuid> \
   --stale-before 2026-08-23T09:00:00Z --limit 100
+uv run --env-file .env aidam-worker reconcile-stale-refreshes \
+  --competition-id <uuid> --stale-before 2026-08-23T09:00:00Z --limit 100
 ```
 
 The initial API is single-local-user and does not claim durable per-user
 ownership. Background dispatch runs in the API process with worker-scoped
 dependencies and is not durable across a hard API-process failure. There is no
 queue, lease, heartbeat, or automatic resume.
+
+A hard process failure during a Sleeper refresh can likewise leave a refresh in
+`running`. After confirming that no refresh process still owns the work, an
+operator can run `reconcile-stale-refreshes` with an explicit timezone-aware
+cutoff. The command does not refetch or resume work: it derives each terminal
+status from the refresh plan and its latest durable API attempts, using a bounded
+competition-scoped batch. Because refreshes do not have a lease or heartbeat,
+this recovery is deliberately manual rather than age-triggered at API startup.
 
 ## Frontend
 

--- a/backend/resources/sleeper_data/refreshes/manager.py
+++ b/backend/resources/sleeper_data/refreshes/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 from typing import cast
 from uuid import UUID
@@ -74,54 +75,64 @@ class RefreshRunManager:
             refresh = self._load(session, refresh_id, lock=True)
             if refresh.status != RefreshStatus.RUNNING.value:
                 return decode_refresh(refresh)
-            plan = decode_endpoint_scope(refresh.endpoint_scope)
             attempts = session.scalars(
                 sa.select(StoredApiRequest).where(
                     StoredApiRequest.refresh_run_id == refresh.id
                 )
             ).all()
-            latest: dict[str, StoredApiRequest] = {}
-            for attempt in attempts:
-                current = latest.get(attempt.scope_key)
-                if current is None or _request_order(attempt) > _request_order(
-                    current
-                ):
-                    latest[attempt.scope_key] = attempt
-
-            succeeded = 0
-            required_successes = 0
-            required_failures = 0
-            failed_scopes: list[str] = []
-            for planned in plan:
-                attempt = latest.get(planned.scope_key.value)
-                successful = attempt is not None and _request_is_normalized(attempt)
-                if successful:
-                    succeeded += 1
-                    if planned.required:
-                        required_successes += 1
-                else:
-                    failed_scopes.append(planned.scope_key.value)
-                    if planned.required:
-                        required_failures += 1
-
-            if required_failures == 0:
-                status = RefreshStatus.SUCCEEDED
-            elif required_successes:
-                status = RefreshStatus.PARTIAL
-            else:
-                status = RefreshStatus.FAILED
-            refresh.status = status.value
-            refresh.completed_at = sa.func.now()
-            refresh.request_count = len(plan)
-            refresh.succeeded_request_count = succeeded
-            refresh.failed_request_count = len(plan) - succeeded
-            refresh.error_summary = (
-                None
-                if not failed_scopes
-                else {"code": "refresh_scopes_failed", "scope_keys": failed_scopes}
-            )
+            _finish_running_refresh(refresh, attempts)
             session.flush()
             return decode_refresh(refresh)
+
+    def finish_stale_running(
+        self,
+        *,
+        stale_before: datetime,
+        limit: int,
+    ) -> tuple[RefreshRun, ...]:
+        """Finish one bounded, competition-scoped batch of stale refreshes."""
+
+        if stale_before.tzinfo is None or stale_before.utcoffset() is None:
+            raise ValueError("stale_before must be timezone-aware")
+        if limit < 1 or limit > 200:
+            raise ValueError("stale reconciliation limit must be between 1 and 200")
+        with transaction_session(self._session_factory) as session:
+            refreshes = session.scalars(
+                sa.select(StoredRefreshRun)
+                .where(
+                    StoredRefreshRun.competition_id == self._competition_id,
+                    StoredRefreshRun.status == RefreshStatus.RUNNING.value,
+                    StoredRefreshRun.started_at < stale_before,
+                )
+                .order_by(
+                    StoredRefreshRun.started_at.asc(),
+                    StoredRefreshRun.id.asc(),
+                )
+                .limit(limit)
+                .with_for_update(skip_locked=True)
+            ).all()
+            if not refreshes:
+                return ()
+
+            refresh_ids = [refresh.id for refresh in refreshes]
+            attempts = session.scalars(
+                sa.select(StoredApiRequest).where(
+                    StoredApiRequest.refresh_run_id.in_(refresh_ids)
+                )
+            ).all()
+            attempts_by_refresh: dict[UUID, list[StoredApiRequest]] = {
+                refresh_id: [] for refresh_id in refresh_ids
+            }
+            for attempt in attempts:
+                attempts_by_refresh[attempt.refresh_run_id].append(attempt)
+
+            for refresh in refreshes:
+                _finish_running_refresh(
+                    refresh,
+                    attempts_by_refresh[refresh.id],
+                )
+            session.flush()
+            return tuple(decode_refresh(refresh) for refresh in refreshes)
 
     def get_refresh(self, refresh_id: UUID) -> RefreshRun:
         with read_only_session(self._session_factory) as session:
@@ -224,4 +235,49 @@ def _request_is_normalized(request: StoredApiRequest) -> bool:
         request.status == RequestStatus.SUCCEEDED.value
         and request.is_complete
         and request.normalization_status == NormalizationStatus.SUCCEEDED.value
+    )
+
+
+def _finish_running_refresh(
+    refresh: StoredRefreshRun,
+    attempts: Sequence[StoredApiRequest],
+) -> None:
+    plan = decode_endpoint_scope(refresh.endpoint_scope)
+    latest: dict[str, StoredApiRequest] = {}
+    for attempt in attempts:
+        current = latest.get(attempt.scope_key)
+        if current is None or _request_order(attempt) > _request_order(current):
+            latest[attempt.scope_key] = attempt
+
+    succeeded = 0
+    required_successes = 0
+    required_failures = 0
+    failed_scopes: list[str] = []
+    for planned in plan:
+        attempt = latest.get(planned.scope_key.value)
+        successful = attempt is not None and _request_is_normalized(attempt)
+        if successful:
+            succeeded += 1
+            if planned.required:
+                required_successes += 1
+        else:
+            failed_scopes.append(planned.scope_key.value)
+            if planned.required:
+                required_failures += 1
+
+    if required_failures == 0:
+        status = RefreshStatus.SUCCEEDED
+    elif required_successes:
+        status = RefreshStatus.PARTIAL
+    else:
+        status = RefreshStatus.FAILED
+    refresh.status = status.value
+    refresh.completed_at = sa.func.now()
+    refresh.request_count = len(plan)
+    refresh.succeeded_request_count = succeeded
+    refresh.failed_request_count = len(plan) - succeeded
+    refresh.error_summary = (
+        None
+        if not failed_scopes
+        else {"code": "refresh_scopes_failed", "scope_keys": failed_scopes}
     )

--- a/backend/tests/resources/sleeper_data/test_refresh_run_manager.py
+++ b/backend/tests/resources/sleeper_data/test_refresh_run_manager.py
@@ -254,3 +254,117 @@ def test_finish_refresh_derives_partial_and_failed_required_plans(
     outcome = refresh_manager.finish_refresh(failed.id)
     assert outcome.status is RefreshStatus.FAILED
     assert (outcome.succeeded_request_count, outcome.failed_request_count) == (0, 1)
+
+
+def test_finish_stale_running_is_bounded_scoped_and_uses_durable_attempts(
+    database_engine: Engine,
+    domain: Domain,
+    refresh_manager: RefreshRunManager,
+    request_manager: ApiRequestManager,
+    session_factory: SessionFactory,
+) -> None:
+    league = build_league_request(domain.season_id, domain.sleeper_league_id)
+    users = build_league_users_request(domain.season_id, domain.sleeper_league_id)
+    cutoff = datetime(2026, 8, 23, 12, tzinfo=UTC)
+
+    failed = start_refresh(refresh_manager, domain, league)
+    partial = start_refresh(refresh_manager, domain, league, users)
+    succeeded = start_refresh(refresh_manager, domain, league)
+    recent = start_refresh(refresh_manager, domain, league)
+    terminal = start_refresh(refresh_manager, domain, league)
+
+    partial_request = _record_success(
+        request_manager,
+        partial.id,
+        league,
+        cutoff - timedelta(hours=1),
+    )
+    _mark_normalized(session_factory, partial_request.id)
+    _record_failure(
+        request_manager,
+        partial.id,
+        users,
+        cutoff - timedelta(minutes=59),
+    )
+    succeeded_request = _record_success(
+        request_manager,
+        succeeded.id,
+        league,
+        cutoff - timedelta(minutes=30),
+    )
+    _mark_normalized(session_factory, succeeded_request.id)
+    refresh_manager.finish_refresh(terminal.id)
+
+    other = seed_domain(database_engine, label="Other stale refresh")
+    other_manager, _, _ = _managers(database_engine, other)
+    other_endpoint = build_league_request(
+        other.season_id,
+        other.sleeper_league_id,
+    )
+    other_refresh = start_refresh(other_manager, other, other_endpoint)
+
+    started_at = {
+        failed.id: cutoff - timedelta(hours=4),
+        partial.id: cutoff - timedelta(hours=3),
+        succeeded.id: cutoff - timedelta(hours=2),
+        recent.id: cutoff,
+        terminal.id: cutoff - timedelta(hours=5),
+        other_refresh.id: cutoff - timedelta(hours=6),
+    }
+    with database_engine.begin() as connection:
+        for refresh_id, timestamp in started_at.items():
+            connection.execute(
+                sa.update(StoredRefreshRun)
+                .where(StoredRefreshRun.id == refresh_id)
+                .values(started_at=timestamp)
+            )
+
+    first_batch = refresh_manager.finish_stale_running(
+        stale_before=cutoff,
+        limit=2,
+    )
+
+    assert [refresh.id for refresh in first_batch] == [failed.id, partial.id]
+    assert [refresh.status for refresh in first_batch] == [
+        RefreshStatus.FAILED,
+        RefreshStatus.PARTIAL,
+    ]
+    assert first_batch[0].error == {
+        "code": "refresh_scopes_failed",
+        "scope_keys": [league.scope_key.value],
+    }
+    assert (
+        first_batch[1].request_count,
+        first_batch[1].succeeded_request_count,
+        first_batch[1].failed_request_count,
+    ) == (2, 1, 1)
+
+    second_batch = refresh_manager.finish_stale_running(
+        stale_before=cutoff,
+        limit=2,
+    )
+
+    assert [refresh.id for refresh in second_batch] == [succeeded.id]
+    assert second_batch[0].status is RefreshStatus.SUCCEEDED
+    assert second_batch[0].completed_at is not None
+    assert refresh_manager.get_refresh(recent.id).status is RefreshStatus.RUNNING
+    assert other_manager.get_refresh(other_refresh.id).status is RefreshStatus.RUNNING
+    assert refresh_manager.finish_stale_running(stale_before=cutoff, limit=2) == ()
+
+
+@pytest.mark.parametrize("limit", [0, 201])
+def test_finish_stale_running_validates_cutoff_and_limit(
+    refresh_manager: RefreshRunManager,
+    limit: int,
+) -> None:
+    with pytest.raises(ValueError, match="limit"):
+        refresh_manager.finish_stale_running(
+            stale_before=datetime.now(UTC),
+            limit=limit,
+        )
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        refresh_manager.finish_stale_running(
+            stale_before=datetime.now(),
+            limit=1,
+        )

--- a/backend/tests/worker/test_main.py
+++ b/backend/tests/worker/test_main.py
@@ -11,6 +11,7 @@ from backend.resources.reporting.generations import (
     GenerationKind,
     GenerationStatus,
 )
+from backend.services.datalayer.contracts import RefreshStatus
 from backend.services.generations import ReconcileResult
 from backend.worker.main import run
 
@@ -54,6 +55,24 @@ class StubService:
             stale_before=policy.stale_before,
             generations=(self.generation,),
         )
+
+
+class StubRefreshManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[datetime, int]] = []
+        self.refreshes = (
+            SimpleNamespace(id=uuid4(), status=RefreshStatus.PARTIAL),
+            SimpleNamespace(id=uuid4(), status=RefreshStatus.FAILED),
+        )
+
+    def finish_stale_running(
+        self,
+        *,
+        stale_before: datetime,
+        limit: int,
+    ) -> tuple[object, ...]:
+        self.calls.append((stale_before, limit))
+        return self.refreshes
 
 
 def _generation(status: GenerationStatus) -> Generation:
@@ -179,6 +198,52 @@ def test_reconcile_stale_delegates_explicit_cutoff_and_limit() -> None:
     assert service.policies[0].limit == 25
     assert payload["count"] == 1
     assert runtime.closed is True
+
+
+def test_reconcile_stale_refreshes_delegates_and_reports_terminal_derivation() -> None:
+    runtime = StubRuntime()
+    manager = StubRefreshManager()
+    competition_id = uuid4()
+    captured_competitions: list[UUID] = []
+    stdout = StringIO()
+
+    def refresh_manager_factory(
+        _runtime: object,
+        scoped_competition_id: UUID,
+    ) -> StubRefreshManager:
+        captured_competitions.append(scoped_competition_id)
+        return manager
+
+    exit_code = run(
+        [
+            "reconcile-stale-refreshes",
+            "--competition-id",
+            str(competition_id),
+            "--stale-before",
+            "2026-08-23T09:00:00Z",
+            "--limit",
+            "25",
+        ],
+        runtime_factory=lambda: runtime,
+        refresh_manager_factory=refresh_manager_factory,  # type: ignore[arg-type]
+        stdout=stdout,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    cutoff = datetime(2026, 8, 23, 9, 0, tzinfo=UTC)
+    assert exit_code == 0
+    assert runtime.ready is True
+    assert runtime.closed is True
+    assert captured_competitions == [competition_id]
+    assert manager.calls == [(cutoff, 25)]
+    assert payload == {
+        "stale_before": cutoff.isoformat(),
+        "count": 2,
+        "refresh_ids": [str(refresh.id) for refresh in manager.refreshes],
+        "statuses": {
+            str(refresh.id): refresh.status.value for refresh in manager.refreshes
+        },
+    }
 
 
 def test_worker_failures_are_sanitized_and_runtime_is_closed() -> None:

--- a/backend/worker/dependencies.py
+++ b/backend/worker/dependencies.py
@@ -12,6 +12,7 @@ from backend.resources.context import (
     ManagerContext,
     SystemProcessActor,
 )
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
 
 
 def build_worker_generation_dependencies(
@@ -28,4 +29,20 @@ def build_worker_generation_dependencies(
         correlation_id=correlation_id or uuid4(),
     )
     return build_generation_dependencies(runtime.session_factory, context)
+
+
+def build_worker_refresh_manager(
+    runtime: GenerationRuntimeDependencies,
+    competition_id: UUID,
+    *,
+    correlation_id: UUID | None = None,
+) -> RefreshRunManager:
+    """Build a scoped refresh manager for explicit worker recovery."""
+
+    context = ManagerContext[CompetitionScope](
+        actor=SystemProcessActor(process_name="refresh-recovery-worker"),
+        scope=CompetitionScope(competition_id=competition_id),
+        correlation_id=correlation_id or uuid4(),
+    )
+    return RefreshRunManager(runtime.session_factory, context)
 

--- a/backend/worker/main.py
+++ b/backend/worker/main.py
@@ -6,13 +6,17 @@ from collections.abc import Sequence
 from datetime import datetime
 import json
 import sys
-from typing import TextIO
+from typing import Protocol, TextIO
 from uuid import UUID
 
-from backend.composition import build_worker_runtime
+from backend.composition import GenerationRuntimeDependencies, build_worker_runtime
 from backend.resources.reporting.generations import GenerationStatus
+from backend.resources.sleeper_data.refreshes import RefreshRunManager
 from backend.services.generations import StaleGenerationPolicy
-from backend.worker.dependencies import build_worker_generation_dependencies
+from backend.worker.dependencies import (
+    build_worker_generation_dependencies,
+    build_worker_refresh_manager,
+)
 from backend.worker.execution import (
     DependencyFactory,
     RuntimeFactory,
@@ -20,11 +24,22 @@ from backend.worker.execution import (
 )
 
 
+class RefreshManagerFactory(Protocol):
+    def __call__(
+        self,
+        runtime: GenerationRuntimeDependencies,
+        competition_id: UUID,
+        *,
+        correlation_id: UUID | None = None,
+    ) -> RefreshRunManager: ...
+
+
 def run(
     argv: Sequence[str] | None = None,
     *,
     runtime_factory: RuntimeFactory = build_worker_runtime,
     dependency_factory: DependencyFactory = build_worker_generation_dependencies,
+    refresh_manager_factory: RefreshManagerFactory = build_worker_refresh_manager,
     stdout: TextIO = sys.stdout,
     stderr: TextIO = sys.stderr,
 ) -> int:
@@ -48,6 +63,28 @@ def run(
         return 2
     try:
         runtime.assert_ready()
+        if arguments.command == "reconcile-stale-refreshes":
+            refreshes = refresh_manager_factory(
+                runtime,
+                arguments.competition_id,
+            ).finish_stale_running(
+                stale_before=arguments.stale_before,
+                limit=arguments.limit,
+            )
+            _write_json(
+                stdout,
+                {
+                    "stale_before": arguments.stale_before.isoformat(),
+                    "count": len(refreshes),
+                    "refresh_ids": [str(refresh.id) for refresh in refreshes],
+                    "statuses": {
+                        str(refresh.id): refresh.status.value
+                        for refresh in refreshes
+                    },
+                },
+            )
+            return 0
+
         dependencies = dependency_factory(runtime, arguments.competition_id)
         result = dependencies.service.reconcile_stale(
             StaleGenerationPolicy(
@@ -128,6 +165,20 @@ def _parser() -> argparse.ArgumentParser:
     reconcile.add_argument("--competition-id", type=UUID, required=True)
     reconcile.add_argument("--stale-before", type=_aware_datetime, required=True)
     reconcile.add_argument("--limit", type=int, default=100, choices=range(1, 201))
+
+    reconcile_refreshes = commands.add_parser("reconcile-stale-refreshes")
+    reconcile_refreshes.add_argument("--competition-id", type=UUID, required=True)
+    reconcile_refreshes.add_argument(
+        "--stale-before",
+        type=_aware_datetime,
+        required=True,
+    )
+    reconcile_refreshes.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        choices=range(1, 201),
+    )
     return parser
 
 

--- a/docs/ui/release-checklist.md
+++ b/docs/ui/release-checklist.md
@@ -82,6 +82,12 @@ they make a failure reproducible.
 - [ ] Run **Refresh Sleeper data** against the real source.
 - [ ] Confirm the refresh reaches its terminal state and history records the
       attempt, timestamps, scope, and any partial/rejected observations.
+- [ ] If a refresh was interrupted by a hard process failure, first confirm no
+      refresh process remains active, then run the bounded operator recovery:
+      `uv run --env-file .env aidam-worker reconcile-stale-refreshes
+      --competition-id <uuid> --stale-before <aware-ISO-timestamp> --limit 100`.
+      Confirm the command reports the expected refresh IDs and statuses derived
+      from durable attempts; it must not refetch or resume Sleeper work.
 - [ ] Confirm the competition overview and generation form show consistent data
       freshness and readiness.
 - [ ] Reload the page and confirm the persisted competition, season, identities,
@@ -240,6 +246,10 @@ than described.
 - Generation execution is dispatched by the API process. A hard API-process
   failure can leave work requiring manual recovery because there is no durable
   queue, lease, heartbeat, or automatic resume.
+- Sleeper refreshes have no durable lease or heartbeat. A hard process failure
+  can leave a `running` row that requires the explicit, cutoff-based
+  `reconcile-stale-refreshes` operator command; the API and application startup
+  do not automatically classify refreshes as stale.
 - Writable simulations, evaluation workspaces, promotion/discard, merge/rebase,
   and historical-memory promotion are intentionally absent.
 - The initial application is a trusted local single-operator product without


### PR DESCRIPTION
## Summary

- add bounded, competition-scoped reconciliation for refresh runs left
  `running` after hard API process loss
- expose an explicit worker CLI command with truthful terminal derivation,
  readiness checks, and operator output
- document local recovery and add focused manager and CLI coverage

## Verification

- focused refresh-manager and worker CLI tests
- reconciled an intentionally hard-killed PostgreSQL refresh to a durable
  terminal failure during final review

Stacked on `codex/ui-review-fix-empty-memory`.
