### PR TITLE
fix(ui): add router hydration fallback

### DIFF
--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -7,6 +7,7 @@ export const router = createBrowserRouter([
   {
     path: "/",
     Component: AppShell,
+    HydrateFallback: AppShell,
     ErrorBoundary: RouteErrorBoundary,
     children: [
       { index: true, element: <Navigate to="/competitions" replace /> },


### PR DESCRIPTION
## Summary

- provide the application shell as the root data-router hydration fallback
- remove the development-only missing-fallback warning on cold lazy routes

## Verification

- included in the pinned frontend format, lint, strict typecheck, and build gate
- cold-loaded a lazy generation detail route with a clean browser console

Stacked on `codex/ui-review-fix-stale-refresh`.
