### PR TITLE
fix(reporter): make missing credentials fatal and actionable

### DIFF
--- a/backend/services/generations/service.py
+++ b/backend/services/generations/service.py
@@ -77,6 +77,7 @@ from backend.services.reporter import (
 )
 from backend.services.reporter.runner.completion import (
     CompletionSettings,
+    ProviderConfigurationError,
     RetryPolicy,
 )
 
@@ -597,6 +598,8 @@ def _nonblank(value: str, field: str) -> str:
 
 
 def _failure_summary(category: str, exc: Exception) -> str:
+    if isinstance(exc, ProviderConfigurationError):
+        return exc.public_summary[:500]
     label = category.replace("_", " ").capitalize()
     return f"{label} failed ({type(exc).__name__})"[:500]
 

--- a/backend/services/reporter/runner/completion.py
+++ b/backend/services/reporter/runner/completion.py
@@ -393,7 +393,9 @@ def _normalize_provider_error(exc: Exception) -> Exception:
     message = str(exc).casefold()
     if (
         "openai_api_key" in message
-        and "api_key client option must be set" in message
+        and "missing credentials" in message
+        and "please pass" in message
+        and "api_key" in message
     ):
         return ProviderConfigurationError()
     return exc

--- a/backend/services/reporter/runner/completion.py
+++ b/backend/services/reporter/runner/completion.py
@@ -89,6 +89,17 @@ class CompletionRecordingError(RuntimeError):
     """Durable recording failed, so the provider operation cannot continue."""
 
 
+class ProviderConfigurationError(RuntimeError):
+    """A trusted provider configuration failure that must not be retried."""
+
+    public_summary = (
+        "Reporter execution cannot start because OPENAI_API_KEY is not configured"
+    )
+
+    def __init__(self) -> None:
+        super().__init__(self.public_summary)
+
+
 @dataclass(frozen=True)
 class RetryPolicy:
     max_retries: int = 3
@@ -295,17 +306,24 @@ class CompletionClient:
             )
             raise
         except Exception as exc:
-            status = "retryable_error" if is_retryable_error(exc) else "fatal_error"
+            provider_error = _normalize_provider_error(exc)
+            status = (
+                "retryable_error"
+                if is_retryable_error(provider_error)
+                else "fatal_error"
+            )
             self._finish_recorded_attempt(
                 attempt_id,
                 ModelAttemptFinish(
                     status=status,
                     actual_provider=error_provider(exc) or requested_provider,
                     actual_model=candidate,
-                    error=sanitize_provider_error(exc, requested_provider),
+                    error=sanitize_provider_error(provider_error, requested_provider),
                     provider_request_id=error_request_id(exc),
                 ),
             )
+            if provider_error is not exc:
+                raise provider_error from exc
             raise
 
         self._finish_recorded_attempt(
@@ -348,6 +366,9 @@ def make_completion_client(
 
 def is_retryable_error(exc: BaseException) -> bool:
     """Return True when the error looks transient / rate-limited."""
+    if isinstance(exc, ProviderConfigurationError):
+        return False
+
     type_name = type(exc).__name__
     if type_name in _RETRYABLE_TYPE_NAMES:
         return True
@@ -366,6 +387,16 @@ def is_retryable_error(exc: BaseException) -> bool:
 
     message = str(exc).lower()
     return any(fragment in message for fragment in _RETRYABLE_MESSAGE_FRAGMENTS)
+
+
+def _normalize_provider_error(exc: Exception) -> Exception:
+    message = str(exc).casefold()
+    if (
+        "openai_api_key" in message
+        and "api_key client option must be set" in message
+    ):
+        return ProviderConfigurationError()
+    return exc
 
 
 def retry_delay_seconds(

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -27,6 +27,7 @@ from backend.services.generations import (
 )
 from backend.services.memory import MemoryMutationResult
 from backend.services.reporter import ReporterOutput
+from backend.services.reporter.runner.completion import ProviderConfigurationError
 from backend.services.reporter.runner.recording import ArtifactMutation
 from backend.services.reporter.runner.schemas import ArtifactSnapshot
 
@@ -621,6 +622,27 @@ async def test_reporter_failure_or_cancellation_closes_and_discards_context(
     memory = reporter.calls[0][2]["memory_context"]
     with pytest.raises(GenerationMemoryContextClosedError):
         memory.take_completed_bundle()
+
+
+@pytest.mark.asyncio
+async def test_provider_configuration_failure_has_actionable_safe_summary(
+    tmp_path,
+) -> None:
+    service, manager, _, _, reporter, runtime, _ = _service(tmp_path)
+    reporter.error = ProviderConfigurationError()
+
+    result = await service.execute(_uuid(3))
+
+    assert runtime.closed is True
+    assert result.generation.status is GenerationStatus.FAILED
+    assert result.generation.failure_category == "reporter_execution"
+    assert (
+        result.generation.failure_summary
+        == ProviderConfigurationError.public_summary
+    )
+    assert manager.get(_uuid(3)).failure_summary == (
+        ProviderConfigurationError.public_summary
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/reporter/test_completion.py
+++ b/backend/tests/services/reporter/test_completion.py
@@ -291,8 +291,10 @@ def test_missing_openai_key_is_normalized_and_not_retried(monkeypatch) -> None:
     complete = SequenceCompletion(
         [
             InternalServerError(
-                "The api_key client option must be set either by passing api_key "
-                "to the client or by setting the OPENAI_API_KEY environment variable"
+                "litellm.InternalServerError: InternalServerError: "
+                "OpenAIException - Missing credentials. Please pass an `api_key`, "
+                "`workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` "
+                "or `OPENAI_ADMIN_KEY` environment variable."
             )
         ]
     )

--- a/backend/tests/services/reporter/test_completion.py
+++ b/backend/tests/services/reporter/test_completion.py
@@ -13,6 +13,7 @@ from backend.services.reporter.generator import _resolve_client
 from backend.services.reporter.runner.completion import (
     CompletionClient,
     CompletionSettings,
+    ProviderConfigurationError,
     RetryPolicy,
     is_retryable_error,
     retry_delay_seconds,
@@ -32,6 +33,10 @@ class RateLimitError(Exception):
     def __init__(self, message: str = "Rate limit exceeded", *, status_code: int = 429):
         super().__init__(message)
         self.status_code = status_code
+
+
+class InternalServerError(Exception):
+    """Stand-in for a provider HTTP 500 error."""
 
 
 class SequenceCompletion:
@@ -113,6 +118,7 @@ def make_client(
 def test_is_retryable_detects_rate_limit_by_type_and_status() -> None:
     assert is_retryable_error(RateLimitError())
     assert is_retryable_error(Exception("HTTP 429 too many requests"))
+    assert is_retryable_error(InternalServerError("provider unavailable"))
     assert not is_retryable_error(ValueError("bad request"))
 
 
@@ -270,6 +276,50 @@ def test_client_raises_non_retryable_immediately() -> None:
         run(client.complete(messages=[]))
 
     assert [req["model"] for req in complete.requests] == ["primary"]
+
+
+def test_missing_openai_key_is_normalized_and_not_retried(monkeypatch) -> None:
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(
+        "backend.services.reporter.runner.completion.asyncio.sleep",
+        fake_sleep,
+    )
+    complete = SequenceCompletion(
+        [
+            InternalServerError(
+                "The api_key client option must be set either by passing api_key "
+                "to the client or by setting the OPENAI_API_KEY environment variable"
+            )
+        ]
+    )
+    recorder = RecordingProbe()
+    client = make_client(
+        complete,
+        model="primary",
+        fallback_models=("fallback",),
+        retry=RetryPolicy(max_retries=3),
+        recorder=recorder,
+    )
+
+    with pytest.raises(
+        ProviderConfigurationError,
+        match="OPENAI_API_KEY is not configured",
+    ):
+        run(client.complete(turn_number=1, messages=[]))
+
+    assert [req["model"] for req in complete.requests] == ["primary"]
+    assert sleeps == []
+    assert len(recorder.finished) == 1
+    result = recorder.finished[0][1]
+    assert result.status == "fatal_error"
+    assert result.error == {
+        "type": "ProviderConfigurationError",
+        "message": ProviderConfigurationError.public_summary,
+    }
 
 
 def test_client_raises_after_all_models_exhausted(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- classify the observed missing `OPENAI_API_KEY` provider failure as a trusted,
  non-retryable configuration error
- record one fatal AI attempt without fallback churn or retry delays
- expose a bounded actionable generation failure summary without leaking raw
  provider error content
- match the exact LiteLLM error signature observed in the live review

## Verification

- focused reporter completion and generation service tests
- real PostgreSQL rerun recorded one fatal attempt and rendered the actionable
  configuration message during final review

Stacked on `codex/ui-review-fix-hydrate-fallback`.
