### PR TITLE
fix(ui): pluralize attempt count

### DIFF
--- a/frontend/src/features/execution/execution-timeline.tsx
+++ b/frontend/src/features/execution/execution-timeline.tsx
@@ -630,7 +630,10 @@ export function ExecutionTimeline({
               <span role="status">Updating summaries…</span>
             </>
           ) : (
-            <span>{query.data.page.total} attempts</span>
+            <span>
+              {query.data.page.total}{" "}
+              {query.data.page.total === 1 ? "attempt" : "attempts"}
+            </span>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- render `1 attempt` for singular execution totals and retain plural wording for
  all other counts

## Verification

- included in the pinned frontend format, lint, strict typecheck, and build gate
- confirmed against the one-attempt provider configuration failure

Stacked on `codex/ui-review-fix-provider-credentials`.
