### PR TITLE
docs(ui): align article filter checklist

### DIFF
--- a/docs/ui/release-checklist.md
+++ b/docs/ui/release-checklist.md
@@ -135,7 +135,7 @@ Backtest generation ID: `____________________________`
 
 - [ ] The article library contains only successful generations with an explicit
       submitted artifact version.
-- [ ] Season, live/backtest, and week filters produce the expected persisted rows.
+- [ ] Season and live/backtest filters produce the expected persisted rows.
 - [ ] Each row presents its derived title, completion time, assignment excerpt,
       scope, requested/actual model summary, token total, and estimated cost when
       available.


### PR DESCRIPTION
## Summary

- align the release checklist with the accepted article-library contract by
  requiring season and live/backtest filters only
- remove the deferred week-filter requirement from initial-release signoff

## Verification

- documentation diff reviewed against the Layer 8 design and API query schema

Stacked on `codex/ui-review-fix-attempt-label`.
