### PR TITLE
feat(ui): add recent generation runs

### DIFF
--- a/frontend/src/api/query-keys.ts
+++ b/frontend/src/api/query-keys.ts
@@ -71,6 +71,14 @@ export const queryKeys = {
       ] as const,
     generations: (competitionId: string) =>
       ["competitions", competitionId, "generations"] as const,
+    generationList: (competitionId: string, parameters: Readonly<object>) =>
+      [
+        "competitions",
+        competitionId,
+        "generations",
+        "list",
+        parameters,
+      ] as const,
     generationSubmission: (competitionId: string) =>
       ["competitions", competitionId, "generations", "submit"] as const,
     generationRerun: (competitionId: string, generationId: string) =>

--- a/frontend/src/features/generations/api.ts
+++ b/frontend/src/features/generations/api.ts
@@ -10,6 +10,8 @@ export type GenerationDetailResponse =
 export type GenerationKind = components["schemas"]["GenerationKind"];
 export type GenerationModelSettings =
   components["schemas"]["GenerationModelSettings"];
+export type GenerationPageResponse =
+  components["schemas"]["GenerationPageResponse"];
 export type GenerationReportSettings =
   components["schemas"]["GenerationReportSettings"];
 export type GenerationResponse = components["schemas"]["GenerationResponse"];
@@ -19,6 +21,7 @@ export type GenerationRunnerSettings =
   components["schemas"]["GenerationRunnerSettings"];
 export type GenerationSettings = components["schemas"]["GenerationSettings"];
 export type GenerationStatus = components["schemas"]["GenerationStatus"];
+export type GenerationSummary = components["schemas"]["GenerationSummary"];
 export type GenerationToneSettings =
   components["schemas"]["GenerationToneSettings"];
 export type SubmitGenerationBody =
@@ -27,6 +30,12 @@ export type SubmitGenerationBody =
 export interface SubmitGenerationInput {
   competitionId: string;
   body: SubmitGenerationBody;
+}
+
+export interface GenerationHistoryParameters {
+  competitionSeasonId: string;
+  limit: number;
+  offset: number;
 }
 
 export function submitGeneration({
@@ -46,6 +55,22 @@ export function getGeneration(
 ): Promise<GenerationDetailResponse> {
   return apiRequest(
     `/api/v1/generations/competitions/${competitionId}/${generationId}`,
+    { signal },
+  );
+}
+
+export function getGenerationHistory(
+  competitionId: string,
+  parameters: GenerationHistoryParameters,
+  signal?: AbortSignal,
+): Promise<GenerationPageResponse> {
+  const query = new URLSearchParams({
+    competition_season_id: parameters.competitionSeasonId,
+    limit: String(parameters.limit),
+    offset: String(parameters.offset),
+  });
+  return apiRequest(
+    `/api/v1/generations/competitions/${competitionId}?${query.toString()}`,
     { signal },
   );
 }

--- a/frontend/src/features/generations/queries.ts
+++ b/frontend/src/features/generations/queries.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/api/query-keys";
 import {
   getGeneration,
+  getGenerationHistory,
   rerunGeneration,
   submitGeneration,
   type GenerationDetailResponse,
@@ -72,6 +73,25 @@ export function useGenerationDetail(
       isActiveGeneration(query.state.data?.generation.status)
         ? "always"
         : false,
+  });
+}
+
+export function useGenerationHistory(
+  competitionId: string,
+  seasonId: string | undefined,
+  limit = 5,
+) {
+  const parameters = {
+    competitionSeasonId: seasonId ?? "",
+    limit,
+    offset: 0,
+  } as const;
+  return useQuery({
+    queryKey: queryKeys.competitions.generationList(competitionId, parameters),
+    queryFn: ({ signal }) =>
+      getGenerationHistory(competitionId, parameters, signal),
+    enabled:
+      competitionId.length > 0 && seasonId !== undefined && seasonId.length > 0,
   });
 }
 

--- a/frontend/src/features/generations/recent-runs.tsx
+++ b/frontend/src/features/generations/recent-runs.tsx
@@ -1,0 +1,271 @@
+import { CircleAlert } from "lucide-react";
+import { Link } from "react-router";
+
+import { ApiError } from "@/api/errors";
+import type { components } from "@/api/generated/schema";
+import { DateTime } from "@/components/shared/date-time";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useGenerationHistory } from "@/features/generations/queries";
+
+type GenerationSummary = components["schemas"]["GenerationSummary"];
+
+function titleCase(value: string): string {
+  return value
+    .split(/[_\-.\s]+/u)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function statusVariant(
+  status: GenerationSummary["status"],
+): "default" | "outline" | "secondary" | "destructive" {
+  if (status === "failed") return "destructive";
+  if (status === "succeeded") return "default";
+  if (status === "running") return "secondary";
+  return "outline";
+}
+
+function weekLabel(run: GenerationSummary): string {
+  if (run.week_start === null || run.week_end === null) {
+    return "Weeks not resolved";
+  }
+  if (run.week_start === run.week_end) return `Week ${String(run.week_start)}`;
+  return `Weeks ${String(run.week_start)}–${String(run.week_end)}`;
+}
+
+function RunTime({ run }: { run: GenerationSummary }): React.JSX.Element {
+  const label = run.completed_at
+    ? "Completed"
+    : run.started_at
+      ? "Started"
+      : "Created";
+  const value = run.completed_at ?? run.started_at ?? run.created_at;
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="mt-1">
+        <DateTime value={value} />
+      </div>
+    </div>
+  );
+}
+
+function RunProgress({ run }: { run: GenerationSummary }): React.JSX.Element {
+  if (run.failure_summary) {
+    return (
+      <div>
+        <p className="break-words text-sm text-destructive">
+          {run.failure_summary}
+        </p>
+        {run.failure_category ? (
+          <p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+            {run.failure_category}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (run.status === "pending") {
+    return <span className="text-sm text-muted-foreground">Queued</span>;
+  }
+
+  if (run.current_stage) {
+    return (
+      <div>
+        <p className="break-words text-sm">{titleCase(run.current_stage)}</p>
+        {run.status === "running" ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Turn {String(run.current_turn)}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <span className="text-sm text-muted-foreground">No stage recorded</span>
+  );
+}
+
+function DesktopRuns({
+  competitionId,
+  items,
+}: {
+  competitionId: string;
+  items: GenerationSummary[];
+}): React.JSX.Element {
+  return (
+    <div className="hidden overflow-hidden rounded-lg border border-border bg-card md:block">
+      <table className="w-full table-fixed border-collapse text-left text-sm">
+        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
+          <tr>
+            <th className="w-32 px-5 py-3 font-semibold">Status</th>
+            <th className="w-36 px-4 py-3 font-semibold">Scope</th>
+            <th className="px-4 py-3 font-semibold">Assignment</th>
+            <th className="w-48 px-4 py-3 font-semibold">Stage</th>
+            <th className="w-36 px-4 py-3 font-semibold">Time</th>
+            <th className="w-24 px-4 py-3 text-right font-semibold">Run</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {items.map((run) => (
+            <tr key={run.id} className="align-top">
+              <td className="px-5 py-4">
+                <Badge variant={statusVariant(run.status)}>
+                  {titleCase(run.status)}
+                </Badge>
+              </td>
+              <td className="px-4 py-4">
+                <p className="font-medium">{titleCase(run.kind)}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {weekLabel(run)}
+                </p>
+              </td>
+              <td className="min-w-0 px-4 py-4">
+                <p className="line-clamp-2 break-words leading-6">
+                  {run.request_text}
+                </p>
+              </td>
+              <td className="min-w-0 px-4 py-4">
+                <RunProgress run={run} />
+              </td>
+              <td className="px-4 py-4">
+                <RunTime run={run} />
+              </td>
+              <td className="px-4 py-4 text-right">
+                <Link
+                  className="font-medium text-primary underline-offset-4 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+                  to={`/competitions/${competitionId}/generations/${run.id}`}
+                >
+                  Open
+                  <span className="sr-only"> generation run</span>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MobileRuns({
+  competitionId,
+  items,
+}: {
+  competitionId: string;
+  items: GenerationSummary[];
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3 md:hidden">
+      {items.map((run) => (
+        <article
+          key={run.id}
+          className="min-w-0 overflow-hidden rounded-lg border border-border bg-card p-4"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={statusVariant(run.status)}>
+              {titleCase(run.status)}
+            </Badge>
+            <Badge variant="outline">{titleCase(run.kind)}</Badge>
+            <span className="text-xs text-muted-foreground">
+              {weekLabel(run)}
+            </span>
+          </div>
+          <p className="mt-4 line-clamp-3 break-words text-sm leading-6">
+            {run.request_text}
+          </p>
+          <div className="mt-4 border-t border-border pt-4">
+            <RunProgress run={run} />
+          </div>
+          <div className="mt-4 flex flex-wrap items-end justify-between gap-4 border-t border-border pt-4">
+            <RunTime run={run} />
+            <Link
+              className="font-medium text-primary underline-offset-4 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+              to={`/competitions/${competitionId}/generations/${run.id}`}
+            >
+              Open run
+            </Link>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+export function RecentRuns({
+  competitionId,
+  seasonId,
+}: {
+  competitionId: string;
+  seasonId: string;
+}): React.JSX.Element {
+  const query = useGenerationHistory(competitionId, seasonId, 5);
+
+  if (query.isPending) {
+    return (
+      <div className="space-y-3" aria-label="Loading recent generation runs">
+        {[0, 1, 2].map((item) => (
+          <Skeleton key={item} className="h-24 w-full rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+        <CircleAlert className="size-6 text-destructive" aria-hidden="true" />
+        <p className="mt-3 text-sm text-destructive">
+          {query.error instanceof ApiError
+            ? query.error.message
+            : "Recent generation runs could not be loaded."}
+        </p>
+        <Button
+          className="mt-4"
+          variant="outline"
+          onClick={() => void query.refetch()}
+        >
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const items = query.data.page.items.slice(0, 5);
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/60 p-8 text-center">
+        <p className="font-medium">No generation runs recorded</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Live and historical runs for this season will appear here after they
+          are submitted.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex min-h-5 items-center justify-between gap-4">
+        <span className="text-xs text-muted-foreground">
+          Showing {String(items.length)} newest
+          {query.data.page.total > items.length
+            ? ` of ${String(query.data.page.total)}`
+            : ""}
+        </span>
+        {query.isFetching ? (
+          <span className="text-xs text-muted-foreground" role="status">
+            Updating…
+          </span>
+        ) : null}
+      </div>
+      <DesktopRuns competitionId={competitionId} items={items} />
+      <MobileRuns competitionId={competitionId} items={items} />
+    </div>
+  );
+}

--- a/frontend/src/routes/competition-overview.tsx
+++ b/frontend/src/routes/competition-overview.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCompetitionDetail } from "@/features/competitions/queries";
+import { RecentRuns } from "@/features/generations/recent-runs";
 import type { ManualRefreshResponse } from "@/features/refreshes/api";
 import { RefreshHistory } from "@/features/refreshes/refresh-history";
 import { RefreshOutcomePanel } from "@/features/refreshes/refresh-outcome";
@@ -610,6 +611,27 @@ export function Component(): React.JSX.Element {
 
           {latestOutcome && latestOutcome.seasonId === selectedSeasonId ? (
             <RefreshOutcomePanel outcome={latestOutcome.outcome} />
+          ) : null}
+
+          {selectedSeasonId ? (
+            <section className="mt-10" aria-labelledby="recent-runs-heading">
+              <h2
+                id="recent-runs-heading"
+                className="font-editorial text-2xl font-semibold"
+              >
+                Recent runs
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                The five newest live and historical generation attempts for the
+                selected season, including active and failed runs.
+              </p>
+              <div className="mt-5">
+                <RecentRuns
+                  competitionId={competition.id}
+                  seasonId={selectedSeasonId}
+                />
+              </div>
+            </section>
           ) : null}
 
           {selectedSeasonId ? (


### PR DESCRIPTION
## Summary

- add a bounded selected-season generation history query and cache keys
- surface the five newest runs directly on the competition overview across all
  statuses and both supported modes
- provide direct detail links plus active progress or actionable failure context
  in desktop and mobile presentations

## Verification

- included in the pinned frontend format, lint, strict typecheck, and build gate
- reviewed against real PostgreSQL live/backtest failures on desktop and mobile

Stacked on `codex/ui-review-fix-checklist-filters`.
