### PR TITLE
feat(models): curate provider-aware catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,18 @@
 SLEEPER_LEAGUE_ID=your_league_id_here
 SLEEPER_WEEK_OVERRIDE=12  # Optional: override current week for testing
 
-# OpenAI Configuration (required for reporter)
+# Reporter provider credentials. OpenAI is required for the default model;
+# DeepSeek and Meta add their curated models to the product catalog.
 OPENAI_API_KEY=your_openai_api_key_here
+# DEEPSEEK_API_KEY=
+# META_API_KEY=
 
 # Reporter Configuration
-REPORTER_MODEL=gpt-5-mini
-# Comma-separated LiteLLM model IDs tried after primary retries are exhausted
-REPORTER_FALLBACK_MODELS=gpt-5.6-luna
+REPORTER_MODEL=gpt-5.6-luna
+# When unset, the catalog derives curated choices from the provider credentials
+# above. Set an explicit comma-separated list (including an empty value) to
+# override those additional LiteLLM model IDs.
+# REPORTER_FALLBACK_MODELS=
 # Retries per model on rate limits / transient errors (exponential backoff)
 REPORTER_V2_MAX_RETRIES=3
 REPORTER_OUTPUT_DIR=.output

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ SLEEPER_LEAGUE_ID=<league_id>
 OPENAI_API_KEY=<key>
 ```
 
+`gpt-5.6-luna` is the default reporter model. Adding `DEEPSEEK_API_KEY` and
+`META_API_KEY` exposes the curated DeepSeek V4 and Meta Muse Spark choices in
+the product model catalog. Set `REPORTER_FALLBACK_MODELS` only when you need to
+replace that credential-derived selection with an explicit comma-separated
+list of LiteLLM model IDs.
+
 The checked-in database values are for the isolated local Compose service. Start
 it and apply the current schema before starting the application:
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,33 @@ from typing import Literal
 from backend.database.engine import EngineSettings
 
 
+DEFAULT_REPORTER_MODEL = "gpt-5.6-luna"
+
+# Curated tool-capable chat models for credentials supported by the local
+# product. Premium/pro-priced model families are intentionally omitted. An
+# explicit REPORTER_FALLBACK_MODELS value remains authoritative.
+_MODEL_CATALOG_BY_CREDENTIAL: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "OPENAI_API_KEY",
+        (
+            "gpt-5.6-luna",
+            "gpt-5.6-terra",
+            "gpt-5.6-sol",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
+        ),
+    ),
+    (
+        "DEEPSEEK_API_KEY",
+        (
+            "deepseek/deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro",
+        ),
+    ),
+    ("META_API_KEY", ("meta/muse-spark-1.1",)),
+)
+
+
 def _boolean(name: str, default: bool) -> bool:
     raw_value = os.getenv(name)
     if raw_value is None:
@@ -134,13 +161,18 @@ class ModelCatalogSettings:
 
     @classmethod
     def from_environment(cls) -> "ModelCatalogSettings":
-        primary = os.getenv("REPORTER_MODEL", "gpt-5-mini").strip()
+        primary = os.getenv("REPORTER_MODEL", DEFAULT_REPORTER_MODEL).strip()
         if not primary:
             raise ValueError("REPORTER_MODEL must not be empty")
-        raw_fallbacks = os.getenv("REPORTER_FALLBACK_MODELS", "")
+        raw_fallbacks = os.getenv("REPORTER_FALLBACK_MODELS")
+        candidates = (
+            raw_fallbacks.split(",")
+            if raw_fallbacks is not None
+            else _models_for_configured_credentials()
+        )
         ordered: list[str] = []
         seen = {primary}
-        for raw_model in raw_fallbacks.split(","):
+        for raw_model in candidates:
             model = raw_model.strip()
             if model and model not in seen:
                 seen.add(model)
@@ -149,6 +181,14 @@ class ModelCatalogSettings:
 
     def model_chain(self) -> tuple[str, ...]:
         return (self.primary_model, *self.fallback_models)
+
+
+def _models_for_configured_credentials() -> tuple[str, ...]:
+    models: list[str] = []
+    for credential_name, provider_models in _MODEL_CATALOG_BY_CREDENTIAL:
+        if os.getenv(credential_name, "").strip():
+            models.extend(provider_models)
+    return tuple(models)
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/tests/services/model_usage/test_catalog.py
+++ b/backend/tests/services/model_usage/test_catalog.py
@@ -17,6 +17,73 @@ MODEL_MAP = {
 }
 
 
+def test_settings_default_to_luna_and_configured_provider_models(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    monkeypatch.delenv("REPORTER_FALLBACK_MODELS", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-test-key")
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+
+    settings = ModelCatalogSettings.from_environment()
+
+    assert settings.model_chain() == (
+        "gpt-5.6-luna",
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+        "meta/muse-spark-1.1",
+    )
+
+
+def test_settings_only_include_models_for_configured_credentials(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    monkeypatch.delenv("REPORTER_FALLBACK_MODELS", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("META_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-test-key")
+
+    settings = ModelCatalogSettings.from_environment()
+
+    assert settings.model_chain() == (
+        "gpt-5.6-luna",
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+    )
+
+
+def test_explicit_empty_fallback_catalog_disables_derived_models(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    monkeypatch.setenv("REPORTER_FALLBACK_MODELS", "")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+
+    settings = ModelCatalogSettings.from_environment()
+
+    assert settings.model_chain() == ("gpt-5.6-luna",)
+
+
+def test_curated_models_are_tool_capable_litellm_ids(monkeypatch) -> None:
+    monkeypatch.delenv("REPORTER_MODEL", raising=False)
+    monkeypatch.delenv("REPORTER_FALLBACK_MODELS", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-test-key")
+    monkeypatch.setenv("META_API_KEY", "meta-test-key")
+    settings = ModelCatalogSettings.from_environment()
+
+    def offline() -> dict[str, object]:
+        raise OSError("offline")
+
+    registry = LiteLLMModelRegistry(remote_loader=offline)
+
+    for model in settings.model_chain():
+        info = registry.model_info(model)
+        assert info is not None, model
+        assert info.get("mode") == "chat", model
+        assert info.get("supports_function_calling") is True, model
+
+
 def test_settings_build_ordered_deduplicated_model_chain(monkeypatch) -> None:
     monkeypatch.setenv("REPORTER_MODEL", "deepseek/deepseek-v4-pro")
     monkeypatch.setenv(


### PR DESCRIPTION
## Summary

- make `gpt-5.6-luna` the default reporter model
- derive a curated tool-capable model catalog from configured OpenAI,
  DeepSeek, and Meta provider credentials
- use exact LiteLLM IDs for GPT-5.6/5.4, DeepSeek V4, and Meta Muse Spark
- preserve `REPORTER_FALLBACK_MODELS` as an explicit catalog override
- document provider-key behavior and omit premium/pro-priced model families

## Verification

- `backend/tests/services/model_usage/test_catalog.py` — 7 passed
- OpenAPI generated-type drift check
- frontend format, lint, strict typecheck, and production build on Node 22.22
- credential-safe local projection returned the expected eight-model catalog

The local ignored `.env` was also corrected from `gpt-5-6-luna` to the valid
`gpt-5.6-luna`; no credential values are included in this PR.
