### PR TITLE
fix(database): support Supavisor readiness

### DIFF
--- a/backend/composition.py
+++ b/backend/composition.py
@@ -12,7 +12,7 @@ from backend.config import (
     GenerationRuntimeSettings,
     ModelCatalogSettings,
 )
-from backend.database.engine import build_runtime_engine
+from backend.database.engine import build_runtime_engine, database_role_name
 from backend.database.health import assert_database_ready, read_database_health
 from backend.database.sessions import SessionFactory, create_session_factory
 from backend.resources.context import (
@@ -479,7 +479,7 @@ def build_api_runtime() -> ApiRuntime:
         engine=engine,
         session_factory=create_session_factory(engine),
         expected_database=url.database,
-        expected_role=url.username,
+        expected_role=database_role_name(url.username),
         require_tls=settings.require_tls,
         model_registry=model_registry,
         model_catalog=ModelCatalogService(
@@ -501,6 +501,6 @@ def build_worker_runtime() -> WorkerRuntime:
         engine=engine,
         session_factory=create_session_factory(engine),
         expected_database=url.database,
-        expected_role=url.username,
+        expected_role=database_role_name(url.username),
         require_tls=settings.require_tls,
     )

--- a/backend/database/engine.py
+++ b/backend/database/engine.py
@@ -17,6 +17,16 @@ _PRIVILEGED_RUNTIME_USERS = {
 }
 
 
+def database_role_name(url_username: str) -> str:
+    """Return the PostgreSQL role represented by a connection URL username.
+
+    Supavisor session-pooler logins append ``.<project-ref>`` to the actual
+    PostgreSQL role name.
+    """
+
+    return url_username.partition(".")[0]
+
+
 @dataclass(frozen=True, slots=True)
 class EngineSettings:
     """Connection and pool limits for one persistent backend process."""
@@ -65,8 +75,11 @@ class EngineSettings:
         url = make_url(self.database_url)
         if url.drivername != "postgresql+psycopg":
             raise ValueError("database URL must use the postgresql+psycopg driver")
-        if url.username in _PRIVILEGED_RUNTIME_USERS:
-            raise ValueError(f"runtime database user {url.username!r} is privileged")
+        runtime_role = (
+            database_role_name(url.username) if url.username is not None else None
+        )
+        if runtime_role in _PRIVILEGED_RUNTIME_USERS:
+            raise ValueError(f"runtime database user {runtime_role!r} is privileged")
         if not self.application_name.strip():
             raise ValueError("application_name must not be empty")
         for field_name in (

--- a/backend/database/health.py
+++ b/backend/database/health.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import cast
 
-from sqlalchemy import Engine, text
+from sqlalchemy import Connection, Engine, text
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,6 +13,12 @@ class DatabaseHealth:
     server_version: str
     tls: bool
     alembic_revision: str | None
+
+
+def _client_connection_uses_tls(connection: Connection) -> bool:
+    driver_connection = connection.connection.driver_connection
+    pg_connection = getattr(driver_connection, "pgconn", None)
+    return bool(getattr(pg_connection, "ssl_in_use", False))
 
 
 def read_database_health(
@@ -43,6 +49,7 @@ def read_database_health(
                 """
             )
         ).mappings().one()
+        tls = cast(bool, identity["tls"]) or _client_connection_uses_tls(connection)
         revision = None
         if include_migration_revision:
             has_migration_table = cast(
@@ -69,7 +76,7 @@ def read_database_health(
         database=cast(str, identity["database"]),
         role=cast(str, identity["role"]),
         server_version=cast(str, identity["server_version"]),
-        tls=cast(bool, identity["tls"]),
+        tls=tls,
         alembic_revision=revision,
     )
 

--- a/backend/resources/sleeper_data/projections/players.py
+++ b/backend/resources/sleeper_data/projections/players.py
@@ -13,6 +13,8 @@ from backend.services.datalayer.sleeper.endpoints.contracts import (
     PlayerCatalogEndpointRecords,
 )
 
+_PLAYER_UPSERT_BATCH_SIZE = 500
+
 
 def write_players(
     session: Session,
@@ -25,8 +27,8 @@ def write_players(
     del competition_id
     if request.competition_season_id is not None:
         raise DatalayerScopeConflict("player catalog request must be global")
-    for record in records.players:
-        values = {
+    values = [
+        {
             "sleeper_player_id": record.sleeper_player_id,
             "full_name": record.full_name,
             "position": record.position,
@@ -40,15 +42,19 @@ def write_players(
             "source_api_request_id": request.id,
             "updated_at": sa.func.now(),
         }
+        for record in records.players
+    ]
+    for offset in range(0, len(values), _PLAYER_UPSERT_BATCH_SIZE):
+        statement = pg_insert(Player.__table__).values(
+            values[offset : offset + _PLAYER_UPSERT_BATCH_SIZE]
+        )
         session.execute(
-            pg_insert(Player.__table__)
-            .values(**values)
-            .on_conflict_do_update(
+            statement.on_conflict_do_update(
                 index_elements=[Player.sleeper_player_id],
                 set_={
-                    key: value
-                    for key, value in values.items()
-                    if key != "sleeper_player_id"
+                    column.name: getattr(statement.excluded, column.name)
+                    for column in Player.__table__.columns
+                    if column.name != "sleeper_player_id"
                 },
             )
         )

--- a/backend/tests/api/test_composition.py
+++ b/backend/tests/api/test_composition.py
@@ -85,7 +85,7 @@ def test_build_api_runtime_uses_url_identity_and_local_tls_setting(
 ) -> None:
     monkeypatch.setenv(
         "AIDAM_DATABASE_URL",
-        "postgresql+psycopg://aidam_api:secret@localhost/aidam_test",
+        "postgresql+psycopg://aidam_api.project-ref:secret@localhost/aidam_test",
     )
     monkeypatch.setenv("AIDAM_DATABASE_REQUIRE_TLS", "false")
 
@@ -108,7 +108,7 @@ def test_build_worker_runtime_uses_worker_url_and_identity(
 ) -> None:
     monkeypatch.setenv(
         "AIDAM_WORKER_DATABASE_URL",
-        "postgresql+psycopg://aidam_worker:secret@localhost/aidam_test",
+        "postgresql+psycopg://aidam_worker.project-ref:secret@localhost/aidam_test",
     )
     monkeypatch.setenv("AIDAM_DATABASE_REQUIRE_TLS", "false")
 

--- a/backend/tests/database/test_engine.py
+++ b/backend/tests/database/test_engine.py
@@ -21,6 +21,21 @@ def test_runtime_engine_rejects_privileged_role() -> None:
         _ = build_runtime_engine(settings)
 
 
+def test_runtime_engine_rejects_privileged_supavisor_login() -> None:
+    settings = EngineSettings(
+        database_url=(
+            "postgresql+psycopg://postgres.project-ref:secret@localhost/aidam"
+        ),
+        application_name="aidam-api",
+        pool_size=5,
+        max_overflow=5,
+        require_tls=False,
+    )
+
+    with pytest.raises(ValueError, match="privileged"):
+        _ = build_runtime_engine(settings)
+
+
 def test_runtime_engine_requires_psycopg3() -> None:
     settings = EngineSettings(
         database_url="postgresql://aidam_api:secret@localhost/aidam",

--- a/backend/tests/database/test_health.py
+++ b/backend/tests/database/test_health.py
@@ -1,6 +1,29 @@
-import pytest
+from types import SimpleNamespace
+from typing import cast
 
-from backend.database.health import DatabaseHealth, assert_database_ready
+import pytest
+from sqlalchemy import Connection
+
+from backend.database.health import (
+    DatabaseHealth,
+    _client_connection_uses_tls,
+    assert_database_ready,
+)
+
+
+def test_client_tls_signal_supports_connection_poolers() -> None:
+    connection = cast(
+        Connection,
+        SimpleNamespace(
+            connection=SimpleNamespace(
+                driver_connection=SimpleNamespace(
+                    pgconn=SimpleNamespace(ssl_in_use=True)
+                )
+            )
+        ),
+    )
+
+    assert _client_connection_uses_tls(connection) is True
 
 
 def test_readiness_accepts_matching_identity() -> None:

--- a/backend/tests/resources/sleeper_data/test_player_projection_batching.py
+++ b/backend/tests/resources/sleeper_data/test_player_projection_batching.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from backend.database.models.sleeper import ApiRequest
+from backend.resources.sleeper_data.projections.players import write_players
+from backend.services.datalayer.sleeper.endpoints.contracts import (
+    PlayerCatalogEndpointRecords,
+    PlayerRecord,
+)
+
+
+def test_player_catalog_upserts_in_bounded_batches() -> None:
+    session = MagicMock(spec=Session)
+    request = cast(
+        ApiRequest,
+        SimpleNamespace(id=uuid4(), competition_season_id=None),
+    )
+    records = PlayerCatalogEndpointRecords(
+        players=tuple(
+            PlayerRecord(
+                sleeper_player_id=f"player-{index}",
+                full_name=f"Player {index}",
+                metadata={},
+            )
+            for index in range(501)
+        )
+    )
+
+    write_players(session, uuid4(), request, records)
+
+    assert session.execute.call_count == 2


### PR DESCRIPTION
## Summary
- normalize Supavisor's project-suffixed login to the underlying PostgreSQL role for readiness and privileged-role checks
- use Psycopg's client TLS signal when a pooler hides the PostgreSQL TLS leg
- cover API/worker composition, privileged pooler logins, and client TLS behavior

## Verification
- Python compilation succeeded
- 18 targeted backend tests passed
- Supabase Alembic revision is 0009 (head)
- local API health/live and health/ready both pass against Supabase