### PR TITLE
Allow live generation for historical weeks

### DIFF
--- a/docs/ui/application-contracts.md
+++ b/docs/ui/application-contracts.md
@@ -19,18 +19,18 @@
 Generation routes already exist under
 `/api/v1/generations/competitions/{competition_id}`:
 
-| Capability | Route | UI readiness |
-| --- | --- | --- |
-| Submit generation | `POST /generations/competitions/{competition_id}` | Implemented; body includes kind, season, explicit weeks, primary model, and nested settings, and rejects a primary model duplicated in the fallback chain |
-| Rerun exact request | `POST /generations/competitions/{competition_id}/{generation_id}/reruns` | Implemented |
-| Run history | `GET /generations/competitions/{competition_id}` | Implemented with season/kind/status/rerun filters |
-| Submitted article history | `GET /generations/competitions/{competition_id}/articles` | Implemented with season/kind filters and a set-based article/usage projection |
-| Run detail | `GET /generations/competitions/{competition_id}/{generation_id}` | Implemented |
-| Submitted article | `GET /generations/competitions/{competition_id}/{generation_id}/article` | Implemented and returns the exact generation, artifact, and version |
-| AI call list/detail | `GET .../{generation_id}/ai-calls[/{ai_call_id}]` | Implemented |
-| Tool call list/detail | `GET .../{generation_id}/tool-calls[/{tool_call_id}]` | Implemented |
-| Artifact list/detail | `GET .../{generation_id}/artifacts[/{artifact_id}]` | Implemented; list summaries include revision count and latest-version time |
-| Artifact versions | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented |
+| Capability                | Route                                                                     | UI readiness                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Submit generation         | `POST /generations/competitions/{competition_id}`                         | Implemented; body includes kind, season, explicit weeks, primary model, and nested settings, and rejects a primary model duplicated in the fallback chain |
+| Rerun exact request       | `POST /generations/competitions/{competition_id}/{generation_id}/reruns`  | Implemented                                                                                                                                               |
+| Run history               | `GET /generations/competitions/{competition_id}`                          | Implemented with season/kind/status/rerun filters                                                                                                         |
+| Submitted article history | `GET /generations/competitions/{competition_id}/articles`                 | Implemented with season/kind filters and a set-based article/usage projection                                                                             |
+| Run detail                | `GET /generations/competitions/{competition_id}/{generation_id}`          | Implemented                                                                                                                                               |
+| Submitted article         | `GET /generations/competitions/{competition_id}/{generation_id}/article`  | Implemented and returns the exact generation, artifact, and version                                                                                       |
+| AI call list/detail       | `GET .../{generation_id}/ai-calls[/{ai_call_id}]`                         | Implemented                                                                                                                                               |
+| Tool call list/detail     | `GET .../{generation_id}/tool-calls[/{tool_call_id}]`                     | Implemented                                                                                                                                               |
+| Artifact list/detail      | `GET .../{generation_id}/artifacts[/{artifact_id}]`                       | Implemented; list summaries include revision count and latest-version time                                                                                |
+| Artifact versions         | `GET .../{generation_id}/artifacts/{artifact_id}/versions[/{version_id}]` | Implemented                                                                                                                                               |
 
 Competition and season management plus refresh, overview, and snapshot-audit
 routes are implemented. Evaluation-workspace tables exist, but writable
@@ -47,16 +47,16 @@ hide that path irregularity from feature code.
 
 Recommended routes:
 
-| Method and path | Purpose | Status |
-| --- | --- | --- |
-| `GET /competitions` | List active competitions with season/freshness/article summary | Implemented |
-| `POST /competitions` | Create `{display_name}` | Implemented |
-| `GET /competitions/{competition_id}` | Competition detail and summary | Implemented |
-| `PATCH /competitions/{competition_id}` | Rename or archive through explicit allowed fields | Implemented |
-| `GET /competitions/{competition_id}/seasons` | Ordered season list | Implemented |
-| `POST /competitions/{competition_id}/seasons` | Attach `{season_year, sleeper_league_id}` and derive sequence | Implemented |
-| `GET /competitions/{competition_id}/seasons/{season_id}` | Season identity plus normalized league overview when present | Implemented |
-| `GET /competitions/{competition_id}/seasons/{season_id}/roster-mappings` | Read roster-identity readiness and observed mapping evidence | Implemented |
+| Method and path                                                          | Purpose                                                              | Status      |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------- | ----------- |
+| `GET /competitions`                                                      | List active competitions with season/freshness/article summary       | Implemented |
+| `POST /competitions`                                                     | Create `{display_name}`                                              | Implemented |
+| `GET /competitions/{competition_id}`                                     | Competition detail and summary                                       | Implemented |
+| `PATCH /competitions/{competition_id}`                                   | Rename or archive through explicit allowed fields                    | Implemented |
+| `GET /competitions/{competition_id}/seasons`                             | Ordered season list                                                  | Implemented |
+| `POST /competitions/{competition_id}/seasons`                            | Attach `{season_year, sleeper_league_id}` and derive sequence        | Implemented |
+| `GET /competitions/{competition_id}/seasons/{season_id}`                 | Season identity plus normalized league overview when present         | Implemented |
+| `GET /competitions/{competition_id}/seasons/{season_id}/roster-mappings` | Read roster-identity readiness and observed mapping evidence         | Implemented |
 | `PUT /competitions/{competition_id}/seasons/{season_id}/roster-mappings` | Atomically map every observed roster to an existing or new franchise | Implemented |
 
 Example creation response:
@@ -76,13 +76,13 @@ Example creation response:
 `PATCH /competitions/{competition_id}` accepts exactly one sparse change:
 
 ```json
-{"display_name": "Renamed League"}
+{ "display_name": "Renamed League" }
 ```
 
 or:
 
 ```json
-{"archived": true}
+{ "archived": true }
 ```
 
 Empty bodies, null values, `archived: false`, combined changes, and unknown
@@ -107,7 +107,7 @@ Typed competition errors use the new product envelope:
   "error": {
     "code": "competition_season_year_exists",
     "summary": "that season year is already attached to this competition",
-    "field_errors": {"season_year": ["Already attached to this competition."]}
+    "field_errors": { "season_year": ["Already attached to this competition."] }
   }
 }
 ```
@@ -139,13 +139,13 @@ roster. Existing season-roster mappings are immutable.
 
 ## Required Refresh and Data Audit API
 
-| Method and path | Purpose | Status |
-| --- | --- | --- |
-| `POST /data/competitions/{competition_id}/seasons/{season_id}/refreshes` | Run manual refresh with optional `{through_week}` | Implemented |
-| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes` | Page refresh history | Implemented |
-| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes/{refresh_id}` | Read terminal/running refresh and counts | Implemented |
-| `GET /data/competitions/{competition_id}/seasons/{season_id}/overview` | Normalized league metadata/current overview | Implemented |
-| `GET /data/competitions/{competition_id}/seasons/{season_id}/snapshots` | Page snapshot audit metadata | Implemented |
+| Method and path                                                                      | Purpose                                           | Status      |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
+| `POST /data/competitions/{competition_id}/seasons/{season_id}/refreshes`             | Run manual refresh with optional `{through_week}` | Implemented |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes`              | Page refresh history                              | Implemented |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/refreshes/{refresh_id}` | Read terminal/running refresh and counts          | Implemented |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/overview`               | Normalized league metadata/current overview       | Implemented |
+| `GET /data/competitions/{competition_id}/seasons/{season_id}/snapshots`              | Page snapshot audit metadata                      | Implemented |
 
 V1 manual refresh may be synchronous because the implemented refresh service is
 synchronous and the existing datalayer plan explicitly calls for a synchronous
@@ -204,23 +204,24 @@ The existing generation contract is enough to create basic live and read-only
 backtest runs. These additions complete the planned UI:
 
 For Layer 7, the UI always submits explicit `week_start` and `week_end` values;
-it does not derive or imply a current week. Live mode is offered only for the
-latest attached season. Selecting an older season uses `backtest`, which pins
-historical memory at or before the requested cutoff and cannot write canonical
-memory. This latest-season restriction is currently a UI safety policy rather
-than an API invariant, so non-UI clients remain responsible for selecting the
-appropriate kind. Live runs may write canonical memory on success.
+it does not derive or imply a current week. Live mode is available for any
+attached season and selected week boundary. A live run pins the current
+canonical memory head and may append a new revision on success; it does not
+rewind memory to the selected season or week. Rebuilding a completed season
+cleanly therefore requires empty canonical memory and chronological live runs.
+Backtest pins historical memory at or before the requested cutoff and cannot
+write canonical memory.
 
 The initial release does not expose an isolated or promotable simulation mode.
 Evaluation-workspace and promote/discard contracts are deferred; the available
 historical backtest is read-only.
 
-| Method and path | Purpose | Priority |
-| --- | --- | --- |
-| `POST .../{generation_id}/cancel` | Cancel a pending/running generation | Should-have; manager supports cancellation |
-| Extend article/run list query | Model, week overlap, completion range, request text | Later unless list size demands it |
-| Extend generation body | Explicit writable draft-memory mode | Deferred pending memory architecture decision |
-| `GET .../{generation_id}/usage` | Aggregate tokens, latency, calls, and price quote | Required |
+| Method and path                          | Purpose                                                       | Priority                                                   |
+| ---------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------- |
+| `POST .../{generation_id}/cancel`        | Cancel a pending/running generation                           | Should-have; manager supports cancellation                 |
+| Extend article/run list query            | Model, week overlap, completion range, request text           | Later unless list size demands it                          |
+| Extend generation body                   | Explicit writable draft-memory mode                           | Deferred pending memory architecture decision              |
+| `GET .../{generation_id}/usage`          | Aggregate tokens, latency, calls, and price quote             | Required                                                   |
 | Optional `GET .../{generation_id}/audit` | One bounded detail projection for article + artifacts + calls | Optimization only; existing resources remain authoritative |
 
 The UI polls run detail. WebSockets or server-sent events are not required for
@@ -286,12 +287,12 @@ introduced/retired visibility model, which is not branch-safe.
 The following route shapes are historical design candidates, not committed
 initial-release contracts:
 
-| Method and path | Purpose |
-| --- | --- |
-| `POST /competitions/{competition_id}/evaluation-workspaces` | Create an active workspace pinned to a server-selected canonical base revision |
-| `GET /competitions/{competition_id}/evaluation-workspaces/{workspace_id}` | Status, base/current artifact, generations, and promotion eligibility |
-| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/promote` | Fast-forward isolated memory into one new canonical revision |
-| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/discard` | Close without canonical mutation |
+| Method and path                                                                    | Purpose                                                                        |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `POST /competitions/{competition_id}/evaluation-workspaces`                        | Create an active workspace pinned to a server-selected canonical base revision |
+| `GET /competitions/{competition_id}/evaluation-workspaces/{workspace_id}`          | Status, base/current artifact, generations, and promotion eligibility          |
+| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/promote` | Fast-forward isolated memory into one new canonical revision                   |
+| `POST /competitions/{competition_id}/evaluation-workspaces/{workspace_id}/discard` | Close without canonical mutation                                               |
 
 Until a replacement architecture is accepted, the UI offers only live canonical
 generation and read-only historical backtests and hides all workspace and
@@ -320,7 +321,7 @@ New routes should converge on:
   "error": {
     "code": "stable_machine_code",
     "summary": "Safe operator-facing summary",
-    "field_errors": {"sleeper_league_id": ["Already attached"]},
+    "field_errors": { "sleeper_league_id": ["Already attached"] },
     "correlation_id": "optional-id"
   }
 }

--- a/docs/ui/release-checklist.md
+++ b/docs/ui/release-checklist.md
@@ -10,22 +10,22 @@ this release. Do not enable or test those deferred flows here.
 
 ## Review Metadata
 
-| Field | Value |
-| --- | --- |
-| Date and time | |
-| Reviewer | |
-| Commit | |
-| Branch | |
-| Operating system | |
-| Browser and version | |
-| Desktop viewport | |
-| Mobile viewport or device | |
-| Database identity/environment | |
-| Competition and season reviewed | |
-| Sleeper league ID | |
-| Primary and fallback models | |
-| API base URL | |
-| Frontend URL | |
+| Field                           | Value |
+| ------------------------------- | ----- |
+| Date and time                   |       |
+| Reviewer                        |       |
+| Commit                          |       |
+| Branch                          |       |
+| Operating system                |       |
+| Browser and version             |       |
+| Desktop viewport                |       |
+| Mobile viewport or device       |       |
+| Database identity/environment   |       |
+| Competition and season reviewed |       |
+| Sleeper league ID               |       |
+| Primary and fallback models     |       |
+| API base URL                    |       |
+| Frontend URL                    |       |
 
 Never paste database passwords, provider keys, full connection URLs, or private
 model payloads into this record.
@@ -53,14 +53,14 @@ but the application must not depend on untracked code or stale generated files.
 - [ ] Start the frontend through the documented local proxy configuration.
 - [ ] Open the application through the documented frontend URL.
 
-| Bootstrap or gate evidence | Result | Notes |
-| --- | --- | --- |
-| PostgreSQL and Alembic head | Pending | |
-| API liveness and readiness | Pending | |
-| Frozen frontend install | Pending | |
-| Generated API drift | Pending | |
-| Format, lint, and typecheck | Pending | |
-| Production build | Pending | |
+| Bootstrap or gate evidence  | Result  | Notes |
+| --------------------------- | ------- | ----- |
+| PostgreSQL and Alembic head | Pending |       |
+| API liveness and readiness  | Pending |       |
+| Frozen frontend install     | Pending |       |
+| Generated API drift         | Pending |       |
+| Format, lint, and typecheck | Pending |       |
+| Production build            | Pending |       |
 
 ## Full Real-Database Journey
 
@@ -85,7 +85,7 @@ they make a failure reproducible.
 - [ ] If a refresh was interrupted by a hard process failure, first confirm no
       refresh process remains active, then run the bounded operator recovery:
       `uv run --env-file .env aidam-worker reconcile-stale-refreshes
-      --competition-id <uuid> --stale-before <aware-ISO-timestamp> --limit 100`.
+    --competition-id <uuid> --stale-before <aware-ISO-timestamp> --limit 100`.
       Confirm the command reports the expected refresh IDs and statuses derived
       from durable attempts; it must not refetch or resume Sleeper work.
 - [ ] Confirm the competition overview and generation form show consistent data
@@ -95,7 +95,7 @@ they make a failure reproducible.
 
 ### Live Generation
 
-- [ ] Open **Generate** for the latest attached season.
+- [ ] Open **Generate** for the intended attached season and week boundary.
 - [ ] Confirm live mode clearly describes canonical memory behavior.
 - [ ] Select an explicit week or week range.
 - [ ] Enter the assignment and review reporter voice, tone, bias, length, evidence,
@@ -260,7 +260,7 @@ than described.
 
 Additional known limitations:
 
-- 
+-
 
 ## Findings and Outcome
 
@@ -268,30 +268,30 @@ Record defects with a reproducible route, generation or resource ID, expected
 behavior, actual behavior, severity, and evidence location. Do not include secrets
 or full private model payloads.
 
-| ID | Severity | Area | Result | Evidence or notes | Disposition |
-| --- | --- | --- | --- | --- | --- |
-| UI-001 | | | | | |
+| ID     | Severity | Area | Result | Evidence or notes | Disposition |
+| ------ | -------- | ---- | ------ | ----------------- | ----------- |
+| UI-001 |          |      |        |                   |             |
 
-| Review area | Outcome | Notes |
-| --- | --- | --- |
-| Clean bootstrap and automated gates | Pending | |
-| Competition, season, and refresh | Pending | |
-| Live generation | Pending | |
-| Historical read-only backtest | Pending | |
-| Article and artifacts | Pending | |
-| Execution and usage | Pending | |
-| Responsive and accessibility | Pending | |
-| Reload, errors, and console | Pending | |
+| Review area                         | Outcome | Notes |
+| ----------------------------------- | ------- | ----- |
+| Clean bootstrap and automated gates | Pending |       |
+| Competition, season, and refresh    | Pending |       |
+| Live generation                     | Pending |       |
+| Historical read-only backtest       | Pending |       |
+| Article and artifacts               | Pending |       |
+| Execution and usage                 | Pending |       |
+| Responsive and accessibility        | Pending |       |
+| Reload, errors, and console         | Pending |       |
 
 Final decision: **Pending / Pass / Pass with accepted limitations / Fail**
 
 Release-blocking findings:
 
-- 
+-
 
 Accepted follow-up findings:
 
-- 
+-
 
 Reviewer signoff: `____________________________`
 

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -44,14 +44,14 @@ requiring horizontal scrolling for core actions.
 
 ## Route and Page Inventory
 
-| Route | Page | Primary responsibility |
-| --- | --- | --- |
-| `/` | Redirect | Continue to `/competitions` or the last valid competition |
-| `/competitions` | Competition list | Browse, create, archive, and choose a competition |
-| `/competitions/:competitionId` | Competition overview | Seasons, freshness, refresh history, and recent runs |
-| `/competitions/:competitionId/articles` | Article history | Filter and browse submitted articles for one competition |
-| `/competitions/:competitionId/generate` | Generate article | Configure, validate, and submit a generation |
-| `/competitions/:competitionId/generations/:generationId` | Generation detail | Article/run status plus artifacts, execution, and usage tabs |
+| Route                                                    | Page                 | Primary responsibility                                       |
+| -------------------------------------------------------- | -------------------- | ------------------------------------------------------------ |
+| `/`                                                      | Redirect             | Continue to `/competitions` or the last valid competition    |
+| `/competitions`                                          | Competition list     | Browse, create, archive, and choose a competition            |
+| `/competitions/:competitionId`                           | Competition overview | Seasons, freshness, refresh history, and recent runs         |
+| `/competitions/:competitionId/articles`                  | Article history      | Filter and browse submitted articles for one competition     |
+| `/competitions/:competitionId/generate`                  | Generate article     | Configure, validate, and submit a generation                 |
+| `/competitions/:competitionId/generations/:generationId` | Generation detail    | Article/run status plus artifacts, execution, and usage tabs |
 
 Creation stays in a dialog or sheet on `/competitions`; it does not need a
 dedicated route in v1. Season creation is a dialog on the competition overview.
@@ -150,16 +150,18 @@ explicitly chooses `Use these settings` on that run.
 
 The initial form presents the backend's two supported product modes:
 
-| Mode | Factual boundary | Memory effect | Promotion |
-| --- | --- | --- | --- |
-| Live | Selected current boundary | Writes canonical memory on success | Not applicable; already canonical |
+| Mode                | Factual boundary       | Memory effect                                | Promotion                                    |
+| ------------------- | ---------------------- | -------------------------------------------- | -------------------------------------------- |
+| Live                | Selected week boundary | Writes canonical memory on success           | Not applicable; already canonical            |
 | Historical backtest | Historical week cutoff | Historical pinned memory, isolated/read-only | Not eligible under the accepted architecture |
 
-Live mode is described as “generate from the selected current season boundary
-and canonical reporter memory.” The page shows the last successful refresh and
-warns when no usable observations exist. Because generation currently never
-refreshes implicitly, the warning provides a `Refresh now` action and returns
-to the preserved form afterward.
+Live mode is described as “generate from the selected week boundary and current
+canonical reporter memory.” It is available for every attached season, including
+completed seasons, but does not rewind canonical memory. The form advises users
+to start from empty memory and run chronologically when rebuilding a season. The
+page shows the last successful refresh and warns when no usable observations
+exist. Because generation currently never refreshes implicitly, the warning
+provides a `Refresh now` action and returns to the preserved form afterward.
 
 ### Backtest behavior
 

--- a/frontend/src/routes/generate.tsx
+++ b/frontend/src/routes/generate.tsx
@@ -305,8 +305,6 @@ export function Component(): React.JSX.Element {
   const selectedSeason = seasons.find(
     ({ season }) => season.id === selectedSeasonId,
   );
-  const isLatestSeason =
-    selectedSeasonId.length > 0 && selectedSeasonId === latestSeason?.season.id;
   const modelOptions = useMemo(
     () => modelsQuery.data?.models ?? [],
     [modelsQuery.data],
@@ -365,16 +363,6 @@ export function Component(): React.JSX.Element {
       setSearchParameters(next, { replace: true });
     }
   }, [form, latestSeason, searchParameters, seasons, setSearchParameters]);
-
-  useEffect(() => {
-    if (!selectedSeasonId || !latestSeason) return;
-    if (
-      selectedSeasonId !== latestSeason.season.id &&
-      selectedMode !== "backtest"
-    ) {
-      form.setValue("mode", "backtest", { shouldValidate: true });
-    }
-  }, [form, latestSeason, selectedMode, selectedSeasonId]);
 
   useEffect(() => {
     const defaultModel =
@@ -638,14 +626,12 @@ export function Component(): React.JSX.Element {
                     selectedMode === "live"
                       ? "border-primary bg-accent/45"
                       : "border-border",
-                    !isLatestSeason && "cursor-not-allowed opacity-55",
                   )}
                 >
                   <span className="flex items-center gap-2 font-medium">
                     <input
                       type="radio"
                       value="live"
-                      disabled={!isLatestSeason}
                       {...form.register("mode")}
                     />
                     Live
@@ -677,10 +663,11 @@ export function Component(): React.JSX.Element {
                   </span>
                 </label>
               </div>
-              {!isLatestSeason ? (
+              {selectedMode === "live" ? (
                 <p className="mt-2 text-xs text-muted-foreground">
-                  Older seasons are evaluation-only and use historical backtest
-                  mode.
+                  Live runs append to current canonical memory; they do not
+                  rewind it. For a clean historical rebuild, start with empty
+                  memory and run weeks in chronological order.
                 </p>
               ) : null}
             </fieldset>


### PR DESCRIPTION
Removes the latest-season-only UI guard for Live generation. Historical Live runs remain explicit about appending to current canonical memory and recommend chronological runs from empty memory for clean rebuilds. Updates the durable UI contract and release checklist. Verification: frontend format, lint, strict typecheck, and production build passed.