### PR TITLE
Make reporter procedures adaptive

### DIFF
--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -240,8 +240,11 @@ def _build_user_message(config: ReportConfig) -> str:
     lines.extend(
         [
             "",
-            "Start by loading the `research` procedure. Build the brief as you go, "
-            "then use the storyline, drafting, and verification procedures as needed.",
+            "Begin with the action that will reduce the most important uncertainty. "
+            "A broad league-data call is often useful, and the `research` procedure "
+            "is available when its detailed checklist would help. Treat research, "
+            "storyline mining, drafting, and verification as interleavable activities; "
+            "do not load the four procedures as a fixed sequence.",
         ]
     )
     return "\n".join(lines)

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -1,26 +1,28 @@
 # Drafting Procedure
 
-You are writing the publishable article from the brief artifact. Use `read_artifact(path="research/brief.md")`, then create or edit the article with artifact tools. Choose one stable normalized Markdown path for the draft; `article.md` is the default, not a requirement. Do not call datalayer tools while drafting unless you discover the brief is missing a required fact; if that happens, switch back to `research`.
+Use this procedure for sustained composition and revision of the publishable article. Draft from verified material, but allow the act of writing to expose evidence gaps and better storylines. Resolve narrow gaps directly; substantial discoveries may lead back into deeper research or storyline mining.
 
 ## Operating Rules
 
-- The brief is the source of truth. Use only saved facts, storylines, outline, style, and bias.
+- The brief is the source of factual truth. Saved storylines and the outline are revisable planning aids, not immutable constraints.
 - Treat verified callbacks in the brief as grounded material, but still name the old event and current payoff in prose.
 - Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
 - Numeric claims must match the numbers or claim text recorded in the brief.
-- Follow the outline unless later research made it incomplete. If it needs refreshing, switch to `storyline` before writing.
+- Treat the outline as a working plan, not a constraint. Preserve it when it remains useful; update supported framing directly when drafting reveals a better structure. Load `storyline` only for substantial narrative rethinking.
+- For a narrow missing fact, make the targeted datalayer call, record the verified result in the brief, and resume drafting. Load `research` only when the gap requires broad exploration.
+- Continue mining storylines while writing. A strong paragraph may reveal a callback, reversal, or future memory worth researching or proposing.
 - Draft with `create_artifact` at your chosen article path when the article does not exist. Use the same path and revision-checked `edit_artifact` calls for subsequent changes.
-- Do not submit the article from this procedure unless verification is explicitly skipped by the user or guardrails force wrap-up.
+- Do not submit until you have performed a claim-level verification pass, whether or not you load the dedicated verification procedure.
 
 ## Drafting Flow
 
-1. Read `research/brief.md`.
-2. Confirm its storylines and outline reflect the saved facts. If not, switch to `storyline` before writing.
-3. Identify the lead storyline and section order from the outline.
-4. Create a coherent Markdown draft at one stable path, or read the existing draft before continuing it.
-5. Read the chosen draft artifact after major additions to inspect flow and coverage.
+1. Read `research/brief.md` when its current content is not already available.
+2. Identify the strongest supported lead and draft the sections with the clearest evidence first.
+3. After meaningful additions, ask whether the prose exposed a factual gap, a weak storyline, or a stronger callback. Resolve only the gaps that matter to the article.
+4. Create a coherent Markdown draft at one stable path, or continue from the current draft content and revision.
+5. Read an artifact again only when its current state is unknown or when a full-document review is needed.
 6. Use exact `edit_artifact` replacements for local improvements. For a full rewrite, replace the complete current content using its current revision.
-7. Switch to `verification` when the draft is complete.
+7. When the draft is complete, perform a claim-level audit. Load `verification` if its detailed checklist would improve that audit.
 
 ## Writing Standards
 
@@ -67,4 +69,4 @@ Use stable, descriptive Markdown headings for article sections, such as:
 - Playoff picture
 - Closing
 
-Before switching to verification, make sure each required outline fact appears in the article and the document has a coherent opening, body, and close.
+Before submission, make sure each required outline fact appears in the article and the document has a coherent opening, body, and close.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -1,32 +1,39 @@
 # Research Procedure
 
-You are gathering verified fantasy football facts for the article brief. Use datalayer tools to inspect the league, then record only confirmed claims in `research/brief.md`. Do not draft article prose in this procedure.
+Use this procedure for substantial discovery, evidence repair, and callback investigation. Gather verified fantasy football facts while continuously mining for narrative meaning. Research may begin a run or interrupt outlining, drafting, or verification; it does not have to be completed in one block.
 
 ## Artifact Editing
 
-- Call `read_artifact(path="research/brief.md")` before editing and retain its revision.
+- Do not read the pre-created brief before initial research merely to inspect an empty workspace. When you have a useful batch of verified material, read `research/brief.md` if you do not already hold its current content and revision.
 - Add material with `edit_artifact`, passing the current revision and replacing a unique insertion marker with the new Markdown plus the same marker.
+- Batch related facts and callbacks into coherent edits instead of spending one turn per fact. Reuse the content and revision returned by successful artifact operations.
 - If the edit reports a revision conflict or a non-unique match, read the brief again and retry from current content.
 - Every fact entry should have a stable ID, precise claim, exact numbers, category, and source references naming the supporting tool calls.
 
 ## Operating Rules
 
-- If you are returning to research after another procedure has run, read the brief first so you know which facts already exist.
+- If you are repairing a gap found during drafting or verification, inspect the relevant brief and draft material, then research only what is missing.
 - Start broad, then drill down. Prefer `league_snapshot` for the requested week before targeted team or player calls.
 - Every recorded fact must be traceable to one or more datalayer tool calls.
 - Save specific, reusable facts rather than commentary. The article voice comes later.
 - Do not invent standings, scores, records, player points, transactions, injuries, or playoff implications.
 - Bias can guide what you investigate, but it must not change which facts you record.
-- If `search_memory` is available and the request may depend on league history, retrieve relevant typed memory as research leads only.
+- When `search_memory` is available, perform one lightweight storyline scan after the broad current-week inventory unless the request is purely factual and narrow. Deepen the scan only when current teams, players, transactions, opponents, or stakes create a plausible callback.
 - Hydrated memory is not a fact source. Verify both the older claim and the current-week payoff against frozen datalayer results before recording a callback.
-- If the runner announces the hard tool limit, stop researching and move directly toward submitting the best article possible with the artifacts already available.
+- A narrow evidence gap does not require a procedure change. Make the targeted datalayer call, update the brief, and resume the work that exposed the gap.
 
-## Default Research Flow
+## Adaptive Research Loop
 
-1. Establish the request scope: week or week range, focus teams, focus topics, article type, target tone, and any teams to favor or roast.
-2. Call `league_snapshot(week=N)` for a single-week article, or use the available week and standings tools for a multi-week request.
-3. Inspect the main scoreboard and standings movement. Look for upsets, blowouts, close games, streaks, playoff movement, and season-best or season-worst performances.
-4. Run the memory scout loop when the request or data suggests long-running context:
+Repeat these activities in the order the evidence demands:
+
+1. Orient: establish the week range, focus, article type, target tone, and any teams to favor or roast.
+2. Discover: use `league_snapshot(week=N)` or the relevant multi-week tools to map scores, standings movement, transactions, and obvious outliers.
+3. Mine hypotheses: ask which results changed meaning, contradicted expectations, continued an arc, or created future stakes. Treat these as questions until verified.
+4. Verify the strongest hypotheses with targeted team, player, transaction, standings, playoff, SQL, or memory calls.
+5. Record useful evidence in the brief in batches, then reassess coverage and narrative strength.
+6. If an outline or draft already exists, test new evidence against it. Preserve what still works and revise only what the evidence changed.
+
+Run the memory scout loop when the request or data suggests long-running context:
    - Extract the current-week fact map: scores, margins, standings movement, playoff stakes, current matchups, top players, transactions, focus teams, and requested framing.
    - Generate narrative hypotheses from the current week. Ask what changed meaning, reversed, paid off, collapsed, became funny, or now has stakes.
    - Call `search_memory` with text, current team keys, tags, and typed filters. Request exact or stable expansions when linked evidence or storylines matter.
@@ -35,15 +42,18 @@ You are gathering verified fantasy football facts for the article brief. Use dat
    - Record old-event and current-event facts plus the verified callback in the brief.
    - Promote only the best verified callbacks into storylines and outline inputs.
    - Buffer durable changes with the relevant typed `propose_*` or `replace_*` tools when an arc should matter later. Use IDs returned by proposal tools for same-bundle relationships.
-5. Call targeted tools for the strongest leads:
+
+Useful targeted tools include:
    - `team_game(roster_key, week=N)` for player-level detail in a specific matchup.
    - `team_dossier(roster_key, week=N)` for recent form, record, and broader context.
    - `week_player_leaderboard(week=N, limit=10)` for top performers.
    - `transactions(week_from=N, week_to=N)` or `team_transactions(...)` for trade, waiver, or roster-move angles.
    - `player_weekly_log(...)` or `player_summary(...)` for trend checks on a featured player.
    - `playoff_bracket(...)` and `team_playoff_path(...)` when the article has playoff stakes.
-6. Record the strongest facts in the brief. Aim for enough evidence to support the article, not every possible data point.
-7. When the evidence base is ready, switch to `storyline` to organize facts into narrative threads and an outline.
+
+Treat a league snapshot as an inventory, not sufficient research for a featured storyline. Each major section should have targeted context that tests its interpretation or adds relevant team, player, transaction, historical, standings, or playoff detail.
+
+Aim for enough evidence to support the article, not every possible data point. When research is sufficient, continue with whichever activity is most useful: synthesize storylines, draft a supported section, verify an existing draft, or investigate one remaining high-value uncertainty. Load another procedure only if its detailed guidance is needed.
 
 ## Memory Scout Requirements
 
@@ -90,12 +100,12 @@ Use stable IDs that describe the fact. Prefer categories such as `score`, `stand
 - Continuing arcs: previous storylines that changed, intensified, or resolved.
 - Playoff pressure: seed movement, elimination risk, byes, and bracket paths.
 
-## Stopping Criteria
+## Sufficiency Criteria
 
-Move to `storyline` when you have enough verified facts to support the requested article:
+Research is sufficient when you have enough verified facts to support the requested article and no unresolved high-value lead is likely to change its central framing:
 
 - Short focused article: 5-8 strong facts.
 - Standard weekly recap: 10-20 strong facts.
 - Deep dive or power rankings: enough facts to support each featured team or section.
 
-If tool limits are approaching, stop researching, record the best facts you already have, and switch to `storyline`. If the hard limit has already been reached, do not make more research calls.
+Fact counts are diagnostics, not stopping targets. Continue when another call could materially change the lead, correct an important claim, or unlock a strong callback. Stop when additional calls would mostly add interchangeable detail.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -1,20 +1,30 @@
 # Storyline Procedure
 
-You are turning verified facts into a usable article plan. Read `research/brief.md`, create storylines from its saved facts, record style and bias, and build an outline in the same Markdown artifact. Do not draft final article prose here.
+Use this procedure for deliberate storyline mining and narrative synthesis. Storyline work may happen after a broad scan, between targeted research calls, while reshaping a draft, or during verification. It is not a mandatory bridge between research and drafting.
 
 ## Operating Rules
 
-- Use `read_artifact(path="research/brief.md")` first unless you just saved all relevant facts in the immediately preceding turn.
-- Every storyline must be supported by existing fact IDs. If a needed fact is missing, switch back to `research` and get it.
+- Read `research/brief.md` when you do not already hold its current content and revision.
+- Every storyline recorded as verified must be supported by existing fact IDs. A promising unsupported angle is a research hypothesis: make the narrow calls needed to prove or reject it before recording it.
 - Storyline summaries may interpret the data, but they must not add new factual claims.
 - Record the outline after the main storylines. If later research changes the facts or storylines, refresh the affected plan in the brief.
 - Bias is framing only. Preserve the user's framing preferences without altering scores, records, or outcomes.
-- Callback storylines must be supported by both an old-event fact or verified memory receipt and a current-event fact.
+- A callback used in the article must point to two saved brief facts: one old-event fact reverified against frozen data and one current-event fact. Retrieved memory is only the lead that prompted the investigation.
 - Apply changes with `edit_artifact`, using an exact, unique replacement and the current brief revision. Preserve reusable insertion anchors when adding more material later.
+- A small evidence gap does not require loading the research procedure. Investigate it directly, update the brief, and continue mining the angle. Load `research` only when the gap opens a substantial new investigation.
+- Inspecting or drafting a paragraph can be a useful test of whether a storyline has enough specificity. If prose exposes a weak premise, strengthen or drop the angle rather than forcing it into the outline.
 
-## Storyline Creation
+## Storyline Mining Loop
 
-Create 3-6 storylines for a standard weekly recap and fewer for narrow requests. Record each narrative thread under the brief's storyline heading.
+For a standard weekly recap, 3-6 developed angles is a useful range rather than a quota; use fewer for narrow requests. Prefer fewer well-supported storylines over filling slots. Record each narrative thread under the brief's storyline heading.
+
+For each candidate angle:
+
+1. Name the change or tension, not merely the result.
+2. Identify the supporting facts already present and the exact evidence gaps.
+3. Check current-week data and memory for reversal, payoff, continuity, irony, or future stakes.
+4. Verify high-value gaps and reject angles that remain vague or incidental.
+5. Rank surviving storylines by reader value and article fit, then update the outline or draft as appropriate.
 
 Priority guidance:
 
@@ -60,7 +70,7 @@ Create the writing plan under the brief's outline heading. Each section should i
 - `required_fact_ids`: exact facts the writer must use.
 - `storyline_ids`: storylines that belong in the section.
 
-Default weekly recap structure:
+A possible weekly recap structure:
 
 1. Opening hook: lead with the priority-1 storyline and set the week's theme.
 2. Lead story: give the strongest matchup or narrative enough room.
@@ -69,11 +79,11 @@ Default weekly recap structure:
 5. Standings or outlook: playoff implications, next-week stakes, or season trajectory.
 6. Closing: resolve the article with the strongest takeaway.
 
-For power rankings, build one section per rank or rank tier. For team deep dives, build sections around record, recent games, roster strengths or weaknesses, transactions, and outlook.
+For power rankings, one section per rank or tier may work. For team deep dives, useful sections often include record, recent games, roster strengths or weaknesses, transactions, and outlook. Build only as much outline as the article needs, and revise it when new evidence changes the article's shape.
 
 ## Typed Memory Proposals
 
-If typed memory proposal tools are available, buffer narrative state before drafting:
+If typed memory proposal tools are available, buffer durable narrative state when it becomes clear; do not wait for a separate pre-drafting checkpoint:
 
 - Use `propose_storyline` for new durable arcs and `replace_storyline` only for canonical items returned by `search_memory` with an exact expected revision.
 - Use `propose_event` for inferred matchup or trade evidence and `propose_trigger` for typed rematch or trade-evaluation callbacks.
@@ -107,4 +117,4 @@ Next callback trigger: Team A faces Team B, Player X faces Team A, or either sid
 Verification needed before use: confirm original trade receipt and current payoff with saved brief facts.
 ```
 
-When the brief has facts, storylines, outline, style, and bias ready, switch to `drafting`.
+When the narrative plan is useful, continue with the action that most improves the article. That may be drafting, targeted research, verification, or further storyline mining. Do not load `drafting` solely to announce a phase transition.

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,15 +1,16 @@
 # Verification Procedure
 
-You are checking the chosen publishable draft artifact against `research/brief.md`. Your job is to find unsupported or incorrect claims, correct them with revision-checked exact edits, and submit only when the article is grounded.
+Use this procedure for a detailed claim-level audit of the chosen publishable draft against `research/brief.md`. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
 
 ## Operating Rules
 
-- Use `list_artifacts` when needed to identify the draft path, then call `read_artifact` for both that draft and `research/brief.md` before judging it. Do not infer an application role from the filename.
+- Use `list_artifacts` only when the draft path is unknown. Read the draft or brief only when you do not already hold its current content and revision.
 - Verify every numeric or factual claim against saved facts.
 - Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
-- If the brief is missing evidence for a necessary claim, switch to `research` instead of guessing.
-- If later research left the outline or storylines incomplete, switch to `storyline` before final verification.
+- If the brief is missing evidence for a necessary claim, investigate the narrow gap directly and update the brief. Load `research` only when the problem requires substantial exploration.
+- If verification exposes a weak or unsupported framing choice, revise it directly. Load `storyline` only when the article needs broader narrative restructuring.
 - Treat callback claims as factual claims. They need evidence for both the older event and the current event.
+- Before submission, perform a deliberate memory harvest when proposal tools are available. Review the final lead storylines, verified callbacks, meaningful transactions, reversals, playoff stakes, and future rematch or evaluation conditions. Buffer only items with plausible future callback value or season-long significance; routine results do not need to persist.
 
 ## Claims To Check
 
@@ -39,17 +40,17 @@ For every callback paragraph:
 
 ## Verification Flow
 
-1. Read the chosen publishable draft and retain its path and current revision.
-2. Read `research/brief.md`.
-3. Extract each factual claim from the article section by section.
-4. Match each claim to a fact ID and use the exact saved numbers.
-5. Classify issues:
+1. Establish the current draft path, content, and revision, and the current brief content and revision. Reuse state returned by recent artifact operations when available.
+2. Extract each factual claim from the article section by section.
+3. Match each claim to a fact ID and use the exact saved numbers.
+4. Classify issues:
    - `error`: wrong score, winner, record, player points, transaction, or other critical fact.
    - `warning`: unsupported superlative, ambiguous rounding, or overstatement.
    - `info`: stylistic claim that is not directly factual but may be too strong.
-6. Correct `error` issues with exact, single-match `edit_artifact` calls.
-7. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
-8. After each edit, use its returned revision for the next edit. Read the article again after all corrections.
+5. Correct `error` issues with exact, single-match `edit_artifact` calls.
+6. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
+7. When a correction requires new evidence or reframing, resolve it and continue the audit from the affected section; do not restart the entire workflow.
+8. After each edit, use its returned content and revision for the next check. Perform one final whole-article review after substantive corrections.
 9. Call `submit_artifact(path=<draft_path>, expected_revision=<current>)` only after the draft passes verification.
 
 ## Correction Policy

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -9,23 +9,31 @@ Core rules:
 - Use typed generation memory only as narrative research leads, never as article-ready truth.
 - Treat retrieved memories as candidate callbacks. Re-verify old-event receipts and current-week payoffs before drafting from them.
 - Dormant storylines are valuable when this week's events create a meaningful reversal, payoff, revenge angle, regret arc, or stakes change.
-- You may move backward in the workflow when needed. If drafting reveals a gap, return to research.
+- Research, storyline mining, drafting, and verification are activities you may interleave, not mandatory sequential phases. Choose the next action that resolves the most important uncertainty or improves the article most.
+- Mine storylines throughout the run. After meaningful research or drafting discoveries, ask what changed, reversed, paid off, collapsed, became funny, or gained stakes.
+- Drafting may expose research gaps, and verification may expose better storylines. Follow those leads, update the brief, and then continue from the most useful point.
 
 Artifact rules:
 - Artifacts are raw Markdown addressed by logical path.
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` to work with them.
-- Before editing, read the artifact and pass its current revision. Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
+- `research/brief.md` is pre-created for the run. Do not list or read it merely to recover request details already present in the user message. Research first, then read it when you have a useful batch of verified material to add.
+- Before editing an artifact, know its current content and revision. A successful read, create, or edit returns both; reuse that state instead of rereading after every write. Reread when the revision is unknown, another operation may have changed it, or an edit conflicts.
+- Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
 - Keep verified facts, callbacks, storylines, style, bias, and outline in `research/brief.md`.
 - Choose a stable normalized Markdown path for the publishable article.
   `article.md` is the default convention, not a required application identity.
 
-Workflow:
-- Load procedures as needed with `load_procedure()`.
+Working method:
+- Procedures are optional operating guides, not workflow gates or a checklist. Load one when its detailed instructions will materially help the current work.
+- Do not load all four procedures just to move through named stages. You may skip a procedure, revisit one, or handle a narrow research, storyline, drafting, or verification task without changing the active procedure.
+- Use `research` for substantial exploration or evidence repair, `storyline` for deliberate narrative synthesis, `drafting` for sustained composition, and `verification` for a detailed final audit.
 - Use datalayer tools for Sleeper league facts.
 - Use `search_memory`, when available, for revision-pinned hydrated memory leads.
-- Use explicit `propose_*` and `replace_*` tools to buffer typed memory changes. These proposals are not visible to searches in the same run and are not committed by the reporter.
+- Use explicit `propose_*` and `replace_*` tools to buffer typed memory changes for generation finalization. These proposals do not become visible to searches during the same run.
 - Verify remembered claims with frozen datalayer tools and record the verified evidence in `research/brief.md`; there are no memory access-history or verification-record tools.
 - Record verified callbacks in `research/brief.md` after both old and current facts are present.
+- Consider durable memory whenever a meaningful arc emerges; do not postpone all memory work to a separate storyline phase.
+- Before submission, deliberately review the final storylines and callbacks for durable memory value. It is valid to propose nothing after a real review when the run contains only routine results.
 
 Available procedure names:
 - `research`

--- a/backend/services/reporter/runner/tools/procedure_tools.py
+++ b/backend/services/reporter/runner/tools/procedure_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
 VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
-PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "2"
+PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "3"
 
 PROCEDURE_TOOL_SPECS: list[ToolDef] = [
     {
@@ -21,8 +21,9 @@ PROCEDURE_TOOL_SPECS: list[ToolDef] = [
         "function": {
             "name": "load_procedure",
             "description": (
-                "Load the current operating procedure. Use this before research, "
-                "storyline synthesis, drafting, and verification work."
+                "Load optional detailed guidance for one kind of reporter work. "
+                "Procedures are reference playbooks, not exclusive workflow stages; "
+                "they need not be loaded in sequence or all within one run."
             ),
             "parameters": {
                 "type": "object",

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -486,7 +486,7 @@ async def test_live_execution_pins_inputs_before_reporter_and_closes_runtime(
         entry["name"]: entry["version"]
         for entry in manifest["tools"]["implementations"]
     }
-    assert procedure_versions["load_procedure"] == "2"
+    assert procedure_versions["load_procedure"] == "3"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -187,9 +187,13 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
         custom_instructions="End with one clean callback.",
     )
 
-    assert copied_user_message(config) == legacy_user_message(
+    copied_message = copied_user_message(config)
+    legacy_message = legacy_user_message(
         LegacyReportConfig.model_validate(config.model_dump(mode="json"))
     )
+    assert copied_message != legacy_message
+    assert "interleavable activities" in copied_message
+    assert "fixed sequence" in copied_message
     assert copied_system_prompt() != legacy_system_prompt()
     assert "research/brief.md" in copied_system_prompt()
     assert "submit_artifact" in copied_system_prompt()
@@ -209,7 +213,10 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
         "submit_artifact",
     ]
     assert set(copied_artifact_names).isdisjoint(legacy_artifact_names)
-    assert COPIED_PROCEDURE_TOOLS == LEGACY_PROCEDURE_TOOLS
+    assert COPIED_PROCEDURE_TOOLS != LEGACY_PROCEDURE_TOOLS
+    assert "reference playbooks" in COPIED_PROCEDURE_TOOLS[0]["function"][
+        "description"
+    ]
     assert [spec["function"]["name"] for spec in COPIED_MEMORY_TOOLS] == [
         "search_memory",
         "propose_fact",
@@ -236,11 +243,19 @@ def test_prompt_and_procedure_assets_document_intentional_artifact_divergence() 
         "procedures/drafting.md": "create_artifact",
         "procedures/verification.md": "submit_artifact",
     }
+    flexibility_markers = {
+        "prompts/system.md": "not mandatory sequential phases",
+        "procedures/research.md": "Adaptive Research Loop",
+        "procedures/storyline.md": "not a mandatory bridge",
+        "procedures/drafting.md": "act of writing to expose",
+        "procedures/verification.md": "not a one-way terminal phase",
+    }
     for relative_path, marker in expected_markers.items():
         copied_text = (copied / relative_path).read_text(encoding="utf-8")
         legacy_text = (legacy / relative_path).read_text(encoding="utf-8")
         assert copied_text != legacy_text
         assert marker in copied_text
+        assert flexibility_markers[relative_path] in copied_text
 
 
 def test_generator_preserves_article_result_across_artifact_contract_divergence() -> None:

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -40,7 +40,7 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
     assert registry.tool_implementation_versions == [
         (tool.name, tool.implementation_version) for tool in definition.tools
     ]
-    assert PROCEDURE_TOOL_IMPLEMENTATION_VERSION == "2"
+    assert PROCEDURE_TOOL_IMPLEMENTATION_VERSION == "3"
     assert {procedure.name for procedure in definition.procedures} == {
         "drafting",
         "research",

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -214,11 +214,6 @@ def test_generate_article_end_to_end_tool_loop() -> None:
             ),
             make_response(
                 tool_calls=[
-                    tool_call("load_procedure", {"name": "storyline"}, "call_5")
-                ]
-            ),
-            make_response(
-                tool_calls=[
                     tool_call(
                         "edit_artifact",
                         {
@@ -232,20 +227,6 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                             "expected_revision": 2,
                         },
                         "call_6",
-                    )
-                ]
-            ),
-            make_response(
-                tool_calls=[
-                    tool_call("load_procedure", {"name": "drafting"}, "call_7")
-                ]
-            ),
-            make_response(
-                tool_calls=[
-                    tool_call(
-                        "read_artifact",
-                        {"path": "research/brief.md"},
-                        "call_8",
                     )
                 ]
             ),
@@ -270,13 +251,6 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                 tool_calls=[
                     tool_call(
                         "load_procedure", {"name": "verification"}, "call_10"
-                    )
-                ]
-            ),
-            make_response(
-                tool_calls=[
-                    tool_call(
-                        "read_artifact", {"path": "article.md"}, "call_11"
                     )
                 ]
             ),
@@ -337,10 +311,9 @@ def test_generate_article_end_to_end_tool_loop() -> None:
     ].content
     assert "Taco Takes Control" in artifacts["research/brief.md"].content
     assert output.run_log_summary["submitted"] is True
+    assert output.run_log_summary["total_turns"] == 9
     assert output.run_log_summary["procedures_loaded"] == [
         "research",
-        "storyline",
-        "drafting",
         "verification",
     ]
     assert any(

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -1,0 +1,85 @@
+
+# Reporter Research Pipeline Design
+
+**Status:** Proposed
+
+## Purpose
+
+Restore deep, evidence-backed reporter research without reintroducing a rigid phase
+machine. The work is deliberately split so the structured research substrate can
+ship and be evaluated before a separate model is trusted to curate persistent
+memory.
+
+## Scope
+
+This design owns the backend reporter's research state, research-facing tools,
+article artifact boundary, and the future handoff from a completed generation to
+memory curation. It refines the broader contracts in
+[`../generation/README.md`](../generation/README.md) and
+[`../memory/README.md`](../memory/README.md).
+
+It does not change the datalayer, generation job lifecycle, or the legacy
+`reporter_v2` package.
+
+## Documents
+
+| Document | Owns |
+| --- | --- |
+| [`architecture.md`](architecture.md) | Component boundaries, dependencies, lifecycle, and failure behavior |
+| [`application-contracts.md`](application-contracts.md) | Structured brief, tools, invariants, errors, and acceptance coverage |
+
+## Delivery Sequence
+
+1. **Baseline prompt PR:** make procedures optional reference playbooks and allow
+   research, drafting, verification, and storyline mining to interleave. This is
+   the base for the implementation milestones, not M1 itself.
+2. **M1 — structured research brief:** restore a runtime-owned, typed brief and
+   specialized brief tools. Keep generic Markdown artifacts for the publishable
+   article and expose the brief as a deterministic read-only projection for
+   observability.
+3. **M1 evaluation gate:** ship and test representative live runs across article
+   types and supported models. Compare research depth, factual coverage, article
+   accuracy, turn cost, and storyline coverage with the prompt-only baseline.
+4. **M2 — memory curation pass:** only after the M1 gate is accepted, add a
+   separate model pass that converts the verified brief and selected article into
+   typed memory proposals.
+
+## Settled Direction
+
+- Flexible orchestration and structured research are complementary. Prompts decide
+  what to investigate next; typed tools preserve what has been verified.
+- The structured brief is the source of truth for research state. Generic artifact
+  text must never be parsed back into authoritative facts.
+- `research/brief.md` is a runtime-rendered projection. Generic artifact tools
+  cannot create, edit, delete, submit, or replace it.
+- The article remains a generic Markdown artifact so the writer retains freedom
+  over form, tone, and revision strategy.
+- M1 does not introduce a second model call or change persistent-memory
+  finalization. Existing memory behavior remains available while research quality
+  is evaluated independently.
+- M2 consumes a bounded, typed curation packet. It produces proposals for the
+  existing deterministic validator/finalizer and never writes memory directly.
+- Reporter memory search remains available during research; curation is not a
+  substitute for loading relevant historical context.
+
+## Non-Goals
+
+- Implementing M1 or M2 in the baseline prompt PR.
+- Reconstructing structured facts by parsing Markdown or model prose.
+- Treating the entire raw tool-call transcript as the curator's primary input.
+- Replacing frozen league-data reads, the generation service lifecycle, or the
+  existing memory store.
+- Forcing a fixed research → storyline → draft → verification procedure sequence.
+- Migrating or modifying the legacy `reporter_v2` implementation.
+
+## Open Questions
+
+The following are deliberately deferred until the M1 evaluation gate. They do not
+block M1, but must be settled before M2 implementation starts:
+
+- Whether curation runs synchronously before generation finalization or as a
+  retryable follow-up job.
+- The curator's retry, timeout, and partial-failure contract.
+- The exact canonical receipt/source-reference shape passed from M1 to M2.
+- Whether writer-facing direct memory-proposal tools remain as a fallback after M2
+  proves reliable.

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -1,0 +1,179 @@
+# Reporter Research Pipeline Application Contracts
+
+## Vocabulary and Ownership
+
+- **Research brief:** runtime-owned typed state for verified research. Owned by the
+  reporter runner for one run.
+- **Brief projection:** deterministic Markdown rendering of the research brief at
+  `research/brief.md`. Owned by the brief renderer.
+- **Article artifact:** model-authored Markdown eligible for submission. Owned by
+  the existing artifact store.
+- **Source reference:** traceable description of the data or memory read that
+  supports a fact. M1 preserves traceability; M2 may strengthen this into canonical
+  receipt identifiers.
+- **Readiness:** computed diagnostics indicating whether the current brief can
+  support a defensible article. It is not procedure progress.
+- **Curation packet/proposal bundle:** preliminary M2 input/output contracts. The
+  memory finalizer, not the curator, owns persistent writes.
+
+## M1 Public Contracts
+
+The exact Python representation may use frozen dataclasses, Pydantic models, or the
+repository's established schema mechanism, but it must preserve these semantics.
+
+```text
+BriefSourceRef
+  tool_name: non-empty string
+  arguments: normalized mapping
+  result_ref: optional receipt/result identifier
+
+BriefFact
+  id: stable run-local identifier
+  claim: non-empty factual statement
+  category: non-empty string
+  sources: one or more BriefSourceRef
+  numbers: optional normalized mapping
+
+BriefCallback
+  id: stable run-local identifier
+  current_fact_id: existing BriefFact identifier
+  historical_fact_id: existing BriefFact identifier
+  connection: non-empty explanation
+
+BriefStoryline
+  id: stable run-local identifier
+  headline: non-empty string
+  summary: non-empty string
+  supporting_fact_ids: one or more existing BriefFact identifiers
+  priority: bounded integer or enum
+  tags: zero or more strings
+
+BriefOutline
+  sections: ordered sections with optional fact/storyline references
+
+ResearchBrief
+  facts, callbacks, storylines, outline, style, bias, readiness, revision
+```
+
+Model-facing tool capabilities are:
+
+- `save_fact`
+- `save_memory_callback`
+- `save_storyline`
+- `set_outline`
+- `set_style`
+- `set_bias`
+- `read_brief`
+
+Names may be adjusted to local conventions, but handlers must remain specialized
+typed operations. A generic `write_brief_markdown` capability is not equivalent.
+
+The existing generic artifact capabilities remain available for article creation
+and revision. They must reject the reserved `research/brief.md` path.
+
+## M1 Lifecycle and State Transitions
+
+1. A run starts with a new empty `ResearchBrief` revision and no model-authored
+   brief artifact.
+2. Successful brief mutations increment the revision, recompute readiness and
+   dependent staleness, render the projection, and emit research-log metadata.
+3. Failed mutations leave the revision and projection unchanged.
+4. Article artifacts may be created or revised at any brief revision.
+5. Submission selects a non-empty article artifact and captures the final brief
+   revision/readiness in reporter output.
+6. A run-scoped brief is immutable after reporter completion.
+
+Idempotent replay of the same normalized mutation returns the existing logical
+item or a no-op result instead of adding a duplicate.
+
+## M1 Invariants
+
+- Every fact has at least one source reference.
+- Every callback references two existing facts.
+- Every storyline has at least one existing supporting fact.
+- Every outline fact/storyline reference resolves within the current brief.
+- Removing or materially replacing supporting state marks dependent state stale or
+  requires it to be updated; stale dependencies cannot silently appear ready.
+- The rendered projection is a deterministic function of the structured brief and
+  revision.
+- Generic artifact operations cannot mutate, submit, or shadow the brief
+  projection.
+- Procedures do not gate brief, data, memory, artifact, or submission tools.
+- Bias changes framing and emphasis only; it cannot alter factual brief state.
+- The selected article remains the publishable output. The brief remains research
+  evidence and is not selected as the article.
+
+## M1 Error Semantics
+
+Brief tool failures distinguish at least:
+
+- invalid arguments;
+- unknown or stale reference;
+- duplicate/idempotent mutation;
+- reserved artifact path; and
+- projection/render failure.
+
+Validation failures are model-correctable and remain within the agent loop.
+Internal render/storage failures follow the runner's existing fatal tool-error
+policy. Error payloads must be concise and must not expose secrets or raw internal
+exceptions.
+
+## Compatibility and Transition
+
+- Reporter output continues to expose `research/brief.md` among observable
+  artifacts, but its producer changes from the model-facing generic artifact store
+  to the renderer.
+- Article artifact selection, run persistence, streaming events, and generation
+  API shapes remain compatible.
+- Existing direct memory proposal/finalization behavior remains unchanged during
+  M1 so research quality can be evaluated without conflating a new curator.
+- The legacy `reporter_v2` package is not part of the migration.
+- The prompt-only baseline PR must merge before M1 so the brief implementation is
+  evaluated under adaptive orchestration rather than fixed procedure sequencing.
+
+## M1 Acceptance Coverage
+
+Focused tests must cover:
+
+- schema validation and stable/idempotent identifiers;
+- fact, callback, storyline, outline, style, and bias mutations;
+- cross-reference rejection and dependent staleness;
+- deterministic projection at every successful revision;
+- atomic behavior when projection fails;
+- rejection of generic artifact operations on `research/brief.md`;
+- compatible reporter output and article selection;
+- adaptive interleaving and backtracking without procedure gating;
+- no empty seed-artifact create/read turns; and
+- current memory finalization compatibility.
+
+The live M1 gate uses representative weeks, report types, and supported models. It
+records research depth, verified fact/storyline coverage, factual accuracy,
+research-to-drafting interleaving, total turns, latency, and token usage against
+the prompt-only baseline. M2 cannot begin until the results and an explicit go/no-go
+decision are recorded.
+
+## Preliminary M2 Contracts
+
+These contracts establish the boundary but are not implementation-ready until the
+deferred M2 decisions are resolved.
+
+```text
+MemoryCurationInput
+  generation_id
+  league_id and season scope
+  final ResearchBrief
+  selected article
+  relevant pinned memory
+  bounded evidence/receipt catalog
+
+MemoryProposalBundle
+  proposal identities
+  typed storyline/fact/event/context mutations
+  evidence references
+  confidence and rationale metadata
+```
+
+The curator may return zero proposals. It may not execute memory writes. The
+existing validator/finalizer owns authorization, referential integrity,
+idempotency, and persistence. Curator failure never invalidates a successful
+article.

--- a/docs/reporter-research-pipeline/architecture.md
+++ b/docs/reporter-research-pipeline/architecture.md
@@ -1,0 +1,179 @@
+# Reporter Research Pipeline Architecture
+
+## Context and Goals
+
+The current reporter exposes generic path-addressed Markdown artifacts for both
+research and finished writing. That maximizes flexibility, but it also makes
+research completeness, evidence relationships, and storyline extraction optional
+properties of prose. Prompt-driven procedure calls can improve behavior, but they
+cannot provide durable structure or deterministic validation.
+
+The target keeps one adaptive agent loop while separating three kinds of state:
+
+1. frozen league data and reporter-memory context used as evidence;
+2. a typed, runtime-owned research brief used as verified working state; and
+3. generic Markdown article artifacts used for authored output.
+
+M2 later adds a separate memory curator, but only after the M1 research substrate
+has been evaluated in live runs.
+
+## System Boundary
+
+### Reporter runner
+
+Owns orchestration, model/tool turns, the structured brief, generic article
+artifacts, and final submission. It may interleave research, storyline mining,
+drafting, and verification in any order.
+
+### Frozen league data
+
+Remains the authoritative per-run source for current league facts. Existing data
+tools and guarded SQL remain unchanged.
+
+### Reporter memory
+
+Remains the authoritative source for historical narrative context and the target
+for validated memory mutations. M1 does not change its schema or finalizer.
+
+### Generation service
+
+Continues to own run creation, persistence, lifecycle, and output selection. It
+must not learn brief internals beyond the reporter's existing output contract.
+
+### Forbidden coupling
+
+- Generic artifact handlers must not mutate structured brief state.
+- Brief state must not depend on parsing rendered Markdown.
+- The future curator must not write the memory database directly.
+- Procedure progress/logging must not become a phase gate for tool availability.
+
+## Component Model
+
+### `ResearchBriefStore` (M1)
+
+Holds typed facts, callbacks, storylines, outline, style, bias, and readiness state
+for one reporter run. It validates cross-references and assigns stable IDs.
+
+### Brief tools (M1)
+
+Expose narrow model actions such as saving a verified fact, connecting current and
+historical facts, saving a storyline, setting an outline, and reading current
+brief state. Tool handlers are the only model-facing mutation boundary.
+
+### `ResearchBriefRenderer` (M1)
+
+Deterministically renders current structured state to `research/brief.md`. The
+projection is included in reporter output and logs for observability, but is not an
+independent writable artifact.
+
+### `ArtifactStore` (existing)
+
+Continues to own generic Markdown artifacts, especially candidate and selected
+articles. It reserves `research/brief.md` for the renderer.
+
+### `MemoryCurator` (M2)
+
+Receives a bounded typed packet containing the verified brief, selected article,
+relevant pinned memory, and an evidence/receipt catalog. It returns typed memory
+proposals for deterministic validation and finalization.
+
+## Data and Control Flow
+
+### Baseline prompt PR
+
+The agent loads only the procedure playbooks relevant to its current uncertainty.
+It may move directly among data tools, memory search, brief/artifact work, and
+verification. Procedure state remains observability metadata, not a runner-enforced
+workflow state machine.
+
+### M1 generation
+
+1. The generation service creates frozen league data and current reporter-memory
+   context as it does today.
+2. The runner creates an empty in-memory `ResearchBriefStore` and reserves the
+   rendered brief path. It does not create an empty generic artifact that the
+   model must load and read.
+3. The agent explores data and memory adaptively. Verified findings are captured
+   through brief tools at the point they become useful.
+4. Every successful brief mutation validates references, updates readiness or
+   staleness, renders the projection, and records the mutation in the research log.
+5. The agent creates and revises one or more generic article artifacts. Drafting
+   can begin before research is complete; new findings can update both brief and
+   draft later.
+6. Submission validates that a non-empty publishable article is selected and
+   records brief readiness diagnostics. The reporter returns the article plus the
+   rendered brief through its compatible output shape.
+7. Existing generation-memory finalization behavior remains unchanged in M1.
+
+The structured mutation and its rendered projection are one logical operation. A
+projection failure fails the tool call and leaves neither side advanced.
+
+### M2 curation
+
+After the M1 evaluation gate is accepted, the completed run builds a typed curation
+packet. The curator may mine storylines and other durable context from the verified
+brief and article, but its output is only a proposal bundle. Existing deterministic
+validation, idempotency, and finalization boundaries decide what is persisted.
+
+The precise synchronous/asynchronous placement is intentionally deferred. Either
+choice must preserve a successful article when curation fails.
+
+## Failure and Recovery Semantics
+
+### M1
+
+- Invalid or missing brief references return a typed tool error and do not mutate
+  state.
+- Repeating an idempotent tool mutation must not duplicate the same logical item.
+- A projection/render failure makes the originating brief mutation fail
+  atomically.
+- Generic artifact operations targeting the reserved brief path fail clearly.
+- Missing brief readiness is visible at submission. The exact hard/soft submission
+  policy is contract-tested rather than inferred from procedure order.
+- Reporter failure and retry continue to follow the generation service's existing
+  lifecycle.
+
+### M2
+
+- Curator failure cannot invalidate or discard an otherwise successful article.
+- Curator output is untrusted until the existing validator accepts it.
+- Retries must be idempotent by generation/run identity and proposal identity.
+- Timeout and retry policy must be settled before M2 implementation.
+
+## Observability
+
+M1 records brief mutations and readiness alongside the existing research log. Live
+evaluation should report at least:
+
+- data, memory-search, brief-tool, artifact, and procedure call counts;
+- number of verified facts, supported storylines, callbacks, and outline sections;
+- unsupported-reference validation failures;
+- turns to first useful fact, first storyline, first draft, and submission;
+- factual-correction count during verification; and
+- total turns, latency, and token usage.
+
+M2 adds curator outcome, duration, proposal counts, validation rejections, retries,
+and persisted mutation counts.
+
+## Security and Privacy
+
+All model output is untrusted at the tool boundary. Existing league/season scoping,
+SQL guards, memory authorization, and data masking remain authoritative. The
+curation packet contains only run-scoped data already available to the reporter;
+it must not include secrets or unbounded internal logs.
+
+## Architecture Decisions
+
+- Use one adaptive writer/researcher loop rather than a runner-enforced phase
+  machine.
+- Restore typed research state instead of trying to solve missing structure with
+  stronger prompt sequencing.
+- Keep article artifacts generic and reserve the brief projection path.
+- Evaluate M1 independently before adding M2 cost, latency, and failure modes.
+- Give a future curator verified state and evidence metadata, not a transcript to
+  rediscover the run from scratch.
+
+## Open Questions
+
+Only M2 placement, retries, receipt shape, and fallback writer-proposal behavior
+remain open. They are owned by the M2 design checkpoint after M1 evaluation.


### PR DESCRIPTION
## Summary

- Treat reporter procedures as optional reference playbooks instead of fixed sequential phases.
- Allow research, storyline mining, drafting, and verification to interleave and remove redundant empty-artifact reads from the canonical loop.
- Add the tracked design contract that sequences M1 structured brief/tools before a separately evaluated M2 memory-curation pass.

## Verification

- `python -m py_compile` passed for all changed Python files.
- `git diff --check` passed.
- Targeted pytest modules were not run locally because this workspace has neither `uv` nor `pytest`; CI should run the affected reporter and generation tests.

## Follow-up

After this baseline merges, M1 restores the runtime-owned structured verified brief and specialized tools. M2 remains gated on shipped live M1 evaluation results.