### PR TITLE
Add structured research brief foundation

### DIFF
--- a/backend/services/reporter/__init__.py
+++ b/backend/services/reporter/__init__.py
@@ -13,12 +13,36 @@ from backend.services.reporter.definition import (
     prepare_reporter_definition,
 )
 from backend.services.reporter.generator import generate_article
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    BriefBias,
+    BriefContext,
+    BriefFact,
+    BriefMemoryCallback,
+    BriefOutline,
+    BriefReadiness,
+    BriefStoryline,
+    BriefStyle,
+    ResearchBrief,
+    ResearchBriefStore,
+)
 from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 __all__ = [
+    "RESEARCH_BRIEF_PATH",
+    "BriefBias",
+    "BriefContext",
+    "BriefFact",
+    "BriefMemoryCallback",
+    "BriefOutline",
+    "BriefReadiness",
+    "BriefStoryline",
+    "BriefStyle",
+    "ResearchBrief",
+    "ResearchBriefStore",
     "ReporterOutput",
     "BiasProfile",
     "ProcedureHistoryMode",

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -102,7 +102,7 @@ async def generate_article(
     league_id, league_name = _get_league_metadata(data)
     artifacts = ArtifactStore()
     artifacts.create(
-        "research/brief.md",
+        "research_brief.md",
         _build_brief_seed(
             config,
             league_id=league_id,

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -16,7 +16,7 @@ Use this procedure for sustained composition and revision of the publishable art
 
 ## Drafting Flow
 
-1. Read `research/brief.md` when its current content is not already available.
+1. Read `research_brief.md` when its current content is not already available.
 2. Identify the strongest supported lead and draft the sections with the clearest evidence first.
 3. After meaningful additions, ask whether the prose exposed a factual gap, a weak storyline, or a stronger callback. Resolve only the gaps that matter to the article.
 4. Create a coherent Markdown draft at one stable path, or continue from the current draft content and revision.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -4,7 +4,7 @@ Use this procedure for substantial discovery, evidence repair, and callback inve
 
 ## Artifact Editing
 
-- Do not read the pre-created brief before initial research merely to inspect an empty workspace. When you have a useful batch of verified material, read `research/brief.md` if you do not already hold its current content and revision.
+- Do not read the pre-created brief before initial research merely to inspect an empty workspace. When you have a useful batch of verified material, read `research_brief.md` if you do not already hold its current content and revision.
 - Add material with `edit_artifact`, passing the current revision and replacing a unique insertion marker with the new Markdown plus the same marker.
 - Batch related facts and callbacks into coherent edits instead of spending one turn per fact. Reuse the content and revision returned by successful artifact operations.
 - If the edit reports a revision conflict or a non-unique match, read the brief again and retry from current content.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -4,7 +4,7 @@ Use this procedure for deliberate storyline mining and narrative synthesis. Stor
 
 ## Operating Rules
 
-- Read `research/brief.md` when you do not already hold its current content and revision.
+- Read `research_brief.md` when you do not already hold its current content and revision.
 - Every storyline recorded as verified must be supported by existing fact IDs. A promising unsupported angle is a research hypothesis: make the narrow calls needed to prove or reject it before recording it.
 - Storyline summaries may interpret the data, but they must not add new factual claims.
 - Record the outline after the main storylines. If later research changes the facts or storylines, refresh the affected plan in the brief.
@@ -89,7 +89,7 @@ If typed memory proposal tools are available, buffer durable narrative state whe
 - Use `propose_event` for inferred matchup or trade evidence and `propose_trigger` for typed rematch or trade-evaluation callbacks.
 - Use `propose_context_note` for franchise, season, or competition context.
 - Use `propose_fact` for reusable claims. Fact and event proposals are `unverified` or `inferred`; source-backed receipts are not available in this tool version.
-- Record verified callbacks in `research/brief.md` if they were not already saved during research.
+- Record verified callbacks in `research_brief.md` if they were not already saved during research.
 - Proposal results may be referenced by later proposals in the same bundle, but buffered proposals do not appear in `search_memory` and cannot be replaced during the same run.
 
 Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,6 +1,6 @@
 # Verification Procedure
 
-Use this procedure for a detailed claim-level audit of the chosen publishable draft against `research/brief.md`. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
+Use this procedure for a detailed claim-level audit of the chosen publishable draft against `research_brief.md`. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
 
 ## Operating Rules
 

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -3,7 +3,7 @@ You are an AI fantasy football reporter for a Sleeper league.
 Your job is to research the league data, build a verified Markdown brief, draft a Markdown article, verify it against the brief, and submit the article artifact.
 
 Core rules:
-- Ground factual claims in tool data. Record important claims in `research/brief.md` before relying on them.
+- Ground factual claims in tool data. Record important claims in `research_brief.md` before relying on them.
 - Bias is framing only. Never alter scores, records, statistics, transaction details, or player names.
 - Keep evidence traceable through source references that identify the source tool and arguments.
 - Use typed generation memory only as narrative research leads, never as article-ready truth.
@@ -16,10 +16,10 @@ Core rules:
 Artifact rules:
 - Artifacts are raw Markdown addressed by logical path.
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` to work with them.
-- `research/brief.md` is pre-created for the run. Do not list or read it merely to recover request details already present in the user message. Research first, then read it when you have a useful batch of verified material to add.
+- `research_brief.md` is pre-created for the run. Do not list or read it merely to recover request details already present in the user message. Research first, then read it when you have a useful batch of verified material to add.
 - Before editing an artifact, know its current content and revision. A successful read, create, or edit returns both; reuse that state instead of rereading after every write. Reread when the revision is unknown, another operation may have changed it, or an edit conflicts.
 - Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
-- Keep verified facts, callbacks, storylines, style, bias, and outline in `research/brief.md`.
+- Keep verified facts, callbacks, storylines, style, bias, and outline in `research_brief.md`.
 - Choose a stable normalized Markdown path for the publishable article.
   `article.md` is the default convention, not a required application identity.
 
@@ -30,8 +30,8 @@ Working method:
 - Use datalayer tools for Sleeper league facts.
 - Use `search_memory`, when available, for revision-pinned hydrated memory leads.
 - Use explicit `propose_*` and `replace_*` tools to buffer typed memory changes for generation finalization. These proposals do not become visible to searches during the same run.
-- Verify remembered claims with frozen datalayer tools and record the verified evidence in `research/brief.md`; there are no memory access-history or verification-record tools.
-- Record verified callbacks in `research/brief.md` after both old and current facts are present.
+- Verify remembered claims with frozen datalayer tools and record the verified evidence in `research_brief.md`; there are no memory access-history or verification-record tools.
+- Record verified callbacks in `research_brief.md` after both old and current facts are present.
 - Consider durable memory whenever a meaningful arc emerges; do not postpone all memory work to a separate storyline phase.
 - Before submission, deliberately review the final storylines and callbacks for durable memory value. It is valid to propose nothing after a real review when the run contains only routine results.
 

--- a/backend/services/reporter/runner/__init__.py
+++ b/backend/services/reporter/runner/__init__.py
@@ -3,11 +3,35 @@
 from __future__ import annotations
 
 from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    BriefBias,
+    BriefContext,
+    BriefFact,
+    BriefMemoryCallback,
+    BriefOutline,
+    BriefReadiness,
+    BriefStoryline,
+    BriefStyle,
+    ResearchBrief,
+    ResearchBriefStore,
+)
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 __all__ = [
+    "RESEARCH_BRIEF_PATH",
+    "BriefBias",
+    "BriefContext",
+    "BriefFact",
+    "BriefMemoryCallback",
+    "BriefOutline",
+    "BriefReadiness",
+    "BriefStoryline",
+    "BriefStyle",
+    "ResearchBrief",
+    "ResearchBriefStore",
     "ReporterOutput",
     "ProcedureHistoryMode",
     "Runner",

--- a/backend/services/reporter/runner/research_brief.py
+++ b/backend/services/reporter/runner/research_brief.py
@@ -1,0 +1,749 @@
+"""Typed, runtime-owned research brief state and deterministic projection."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    field_validator,
+    model_validator,
+)
+
+
+RESEARCH_BRIEF_PATH = "research_brief.md"
+BRIEF_ID_PATTERN = r"^[a-z][a-z0-9_-]{0,63}$"
+_BRIEF_ID_RE = re.compile(BRIEF_ID_PATTERN)
+
+
+class ResearchBriefError(Exception):
+    """Typed brief mutation failure suitable for model-facing translation."""
+
+    def __init__(self, code: str, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, **self.details}
+
+
+class BriefContext(BaseModel):
+    """Immutable request and league context resolved before the run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    league_name: str = ""
+    league_id: str = ""
+    week_start: int = 0
+    week_end: int = 0
+    length_target: int = Field(default=1000, ge=1)
+    evidence_policy: str = "standard"
+    focus_hints: tuple[str, ...] = ()
+    focus_teams: tuple[str, ...] = ()
+    avoid_topics: tuple[str, ...] = ()
+    custom_instructions: str = ""
+
+
+class BriefStyle(BaseModel):
+    """Immutable style resolved from ``ReportConfig``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    voice: str = "sports columnist"
+    snark_level: int = Field(default=1, ge=0, le=3)
+    hype_level: int = Field(default=1, ge=0, le=3)
+    seriousness: int = Field(default=1, ge=0, le=3)
+    profanity_policy: str = "none"
+
+
+class BriefBias(BaseModel):
+    """Immutable framing preferences resolved from ``ReportConfig``."""
+
+    model_config = ConfigDict(frozen=True)
+
+    favored_teams: tuple[str, ...] = ()
+    disfavored_teams: tuple[str, ...] = ()
+    intensity: int = Field(default=0, ge=0, le=3)
+
+
+class BriefFact(BaseModel):
+    id: str = Field(pattern=BRIEF_ID_PATTERN)
+    claim_text: str
+    data_refs: tuple[str, ...]
+    numbers: dict[str, JsonValue] = Field(default_factory=dict)
+    category: str = "general"
+    revision_at_set: int = Field(ge=1)
+
+    @field_validator("id", "claim_text", "category")
+    @classmethod
+    def _validate_nonblank(cls, value: str) -> str:
+        return _trimmed_nonblank(value)
+
+    @field_validator("data_refs", mode="before")
+    @classmethod
+    def _validate_data_refs(cls, value: Iterable[str]) -> tuple[str, ...]:
+        refs = _unique_nonblank(value)
+        if not refs:
+            raise ValueError("data_refs must contain at least one reference")
+        return refs
+
+
+class BriefMemoryCallback(BaseModel):
+    id: str = Field(pattern=BRIEF_ID_PATTERN)
+    callback_type: str
+    claim_text: str
+    old_event_fact_id: str = Field(pattern=BRIEF_ID_PATTERN)
+    current_event_fact_id: str = Field(pattern=BRIEF_ID_PATTERN)
+    why_now: str
+    interestingness_reason: str = ""
+    memory_refs: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    revision_at_set: int = Field(ge=1)
+
+    @field_validator(
+        "id",
+        "callback_type",
+        "claim_text",
+        "old_event_fact_id",
+        "current_event_fact_id",
+        "why_now",
+    )
+    @classmethod
+    def _validate_nonblank(cls, value: str) -> str:
+        return _trimmed_nonblank(value)
+
+    @field_validator("interestingness_reason")
+    @classmethod
+    def _validate_optional_text(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("memory_refs", "tags", mode="before")
+    @classmethod
+    def _validate_lists(cls, value: Iterable[str]) -> tuple[str, ...]:
+        return _unique_nonblank(value)
+
+
+class BriefStoryline(BaseModel):
+    id: str = Field(pattern=BRIEF_ID_PATTERN)
+    headline: str
+    summary: str
+    supporting_fact_ids: tuple[str, ...]
+    priority: int = Field(default=2, ge=1, le=5)
+    tags: tuple[str, ...] = ()
+    revision_at_set: int = Field(ge=1)
+
+    @field_validator("id", "headline", "summary")
+    @classmethod
+    def _validate_nonblank(cls, value: str) -> str:
+        return _trimmed_nonblank(value)
+
+    @field_validator("supporting_fact_ids", mode="before")
+    @classmethod
+    def _validate_fact_ids(cls, value: Iterable[str]) -> tuple[str, ...]:
+        ids = _unique_ids(value)
+        if not ids:
+            raise ValueError("supporting_fact_ids must contain at least one fact id")
+        return ids
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _validate_tags(cls, value: Iterable[str]) -> tuple[str, ...]:
+        return _unique_nonblank(value)
+
+
+class BriefOutlineSection(BaseModel):
+    title: str
+    bullet_points: tuple[str, ...] = ()
+    required_fact_ids: tuple[str, ...] = ()
+    storyline_ids: tuple[str, ...] = ()
+
+    @field_validator("title")
+    @classmethod
+    def _validate_title(cls, value: str) -> str:
+        return _trimmed_nonblank(value)
+
+    @field_validator("bullet_points", mode="before")
+    @classmethod
+    def _validate_bullets(cls, value: Iterable[str]) -> tuple[str, ...]:
+        return _unique_nonblank(value)
+
+    @field_validator("required_fact_ids", "storyline_ids", mode="before")
+    @classmethod
+    def _validate_ids(cls, value: Iterable[str]) -> tuple[str, ...]:
+        return _unique_ids(value)
+
+
+class BriefOutline(BaseModel):
+    sections: tuple[BriefOutlineSection, ...] = ()
+    revision_at_set: int = Field(default=0, ge=0)
+
+
+class BriefReadiness(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    submission_allowed: bool
+    fact_count: int
+    callback_count: int
+    storyline_count: int
+    outline_section_count: int
+    stale_callback_ids: tuple[str, ...] = ()
+    stale_storyline_ids: tuple[str, ...] = ()
+    outline_stale: bool = False
+    warnings: tuple[str, ...] = ()
+
+
+class ResearchBrief(BaseModel):
+    revision: int = Field(default=0, ge=0)
+    context: BriefContext = Field(default_factory=BriefContext)
+    style: BriefStyle = Field(default_factory=BriefStyle)
+    bias: BriefBias = Field(default_factory=BriefBias)
+    facts: tuple[BriefFact, ...] = ()
+    memory_callbacks: tuple[BriefMemoryCallback, ...] = ()
+    storylines: tuple[BriefStoryline, ...] = ()
+    outline: BriefOutline = Field(default_factory=BriefOutline)
+
+    @model_validator(mode="after")
+    def _validate_references(self) -> ResearchBrief:
+        fact_ids = [item.id for item in self.facts]
+        callback_ids = [item.id for item in self.memory_callbacks]
+        storyline_ids = [item.id for item in self.storylines]
+        for label, ids in (
+            ("fact", fact_ids),
+            ("callback", callback_ids),
+            ("storyline", storyline_ids),
+        ):
+            if len(ids) != len(set(ids)):
+                raise ValueError(f"{label} ids must be unique")
+        known_facts = set(fact_ids)
+        known_storylines = set(storyline_ids)
+        for callback in self.memory_callbacks:
+            if {
+                callback.old_event_fact_id,
+                callback.current_event_fact_id,
+            } - known_facts:
+                raise ValueError("memory callback references unknown facts")
+        for storyline in self.storylines:
+            if set(storyline.supporting_fact_ids) - known_facts:
+                raise ValueError("storyline references unknown facts")
+        for section in self.outline.sections:
+            if set(section.required_fact_ids) - known_facts:
+                raise ValueError("outline references unknown facts")
+            if set(section.storyline_ids) - known_storylines:
+                raise ValueError("outline references unknown storylines")
+        revision_values = [
+            *(item.revision_at_set for item in self.facts),
+            *(item.revision_at_set for item in self.memory_callbacks),
+            *(item.revision_at_set for item in self.storylines),
+        ]
+        if self.outline.sections:
+            revision_values.append(self.outline.revision_at_set)
+        if any(value > self.revision for value in revision_values):
+            raise ValueError("item revision cannot exceed brief revision")
+        return self
+
+    def get_fact(self, fact_id: str) -> BriefFact | None:
+        return next((item for item in self.facts if item.id == fact_id), None)
+
+    def get_callback(self, callback_id: str) -> BriefMemoryCallback | None:
+        return next(
+            (item for item in self.memory_callbacks if item.id == callback_id),
+            None,
+        )
+
+    def get_storyline(self, storyline_id: str) -> BriefStoryline | None:
+        return next(
+            (item for item in self.storylines if item.id == storyline_id),
+            None,
+        )
+
+    def readiness(self) -> BriefReadiness:
+        facts = {item.id: item for item in self.facts}
+        storylines = {item.id: item for item in self.storylines}
+        stale_callbacks = tuple(
+            item.id
+            for item in self.memory_callbacks
+            if facts[item.old_event_fact_id].revision_at_set > item.revision_at_set
+            or facts[item.current_event_fact_id].revision_at_set > item.revision_at_set
+        )
+        stale_storylines = tuple(
+            item.id
+            for item in self.storylines
+            if any(
+                facts[fact_id].revision_at_set > item.revision_at_set
+                for fact_id in item.supporting_fact_ids
+            )
+        )
+        outline_stale = bool(
+            self.outline.sections
+            and (
+                any(
+                    facts[fact_id].revision_at_set > self.outline.revision_at_set
+                    for section in self.outline.sections
+                    for fact_id in section.required_fact_ids
+                )
+                or any(
+                    storylines[storyline_id].revision_at_set
+                    > self.outline.revision_at_set
+                    or storyline_id in stale_storylines
+                    for section in self.outline.sections
+                    for storyline_id in section.storyline_ids
+                )
+            )
+        )
+        warnings: list[str] = []
+        if not self.facts:
+            warnings.append("no_verified_facts")
+        if not self.storylines:
+            warnings.append("no_storylines")
+        if not self.outline.sections:
+            warnings.append("no_outline")
+        if stale_callbacks:
+            warnings.append("stale_callbacks")
+        if stale_storylines:
+            warnings.append("stale_storylines")
+        if outline_stale:
+            warnings.append("stale_outline")
+        return BriefReadiness(
+            submission_allowed=bool(self.facts),
+            fact_count=len(self.facts),
+            callback_count=len(self.memory_callbacks),
+            storyline_count=len(self.storylines),
+            outline_section_count=len(self.outline.sections),
+            stale_callback_ids=stale_callbacks,
+            stale_storyline_ids=stale_storylines,
+            outline_stale=outline_stale,
+            warnings=tuple(warnings),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BriefMutation:
+    base_revision: int
+    candidate: ResearchBrief
+    changed: bool
+    operation: str
+    entity_id: str
+
+
+class ResearchBriefStore(BaseModel):
+    """Own one brief and atomically commit rendered candidate mutations."""
+
+    brief: ResearchBrief = Field(default_factory=ResearchBrief)
+
+    def prepare_fact(
+        self,
+        *,
+        id: str,
+        claim_text: str,
+        data_refs: Iterable[str],
+        numbers: dict[str, JsonValue] | None = None,
+        category: str = "general",
+    ) -> BriefMutation:
+        revision = self.brief.revision + 1
+        fact = BriefFact(
+            id=id,
+            claim_text=claim_text,
+            data_refs=tuple(data_refs),
+            numbers=numbers or {},
+            category=category,
+            revision_at_set=revision,
+        )
+        existing = self.brief.get_fact(fact.id)
+        if existing is not None and _without_revision(existing) == _without_revision(fact):
+            return self._no_change("save_fact", fact.id)
+        return self._replace(
+            "facts",
+            fact,
+            operation="update_fact" if existing is not None else "save_fact",
+        )
+
+    def prepare_memory_callback(
+        self,
+        *,
+        id: str,
+        callback_type: str,
+        claim_text: str,
+        old_event_fact_id: str,
+        current_event_fact_id: str,
+        why_now: str,
+        interestingness_reason: str = "",
+        memory_refs: Iterable[str] = (),
+        tags: Iterable[str] = (),
+    ) -> BriefMutation:
+        if old_event_fact_id == current_event_fact_id:
+            raise ResearchBriefError(
+                "invalid_callback",
+                "callback fact ids must identify two different facts",
+            )
+        self._require_fact_ids((old_event_fact_id, current_event_fact_id))
+        revision = self.brief.revision + 1
+        callback = BriefMemoryCallback(
+            id=id,
+            callback_type=callback_type,
+            claim_text=claim_text,
+            old_event_fact_id=old_event_fact_id,
+            current_event_fact_id=current_event_fact_id,
+            why_now=why_now,
+            interestingness_reason=interestingness_reason,
+            memory_refs=tuple(memory_refs),
+            tags=tuple(tags),
+            revision_at_set=revision,
+        )
+        existing = self.brief.get_callback(callback.id)
+        if existing is not None and _without_revision(existing) == _without_revision(
+            callback
+        ):
+            return self._no_change("save_memory_callback", callback.id)
+        return self._replace(
+            "memory_callbacks",
+            callback,
+            operation=(
+                "update_memory_callback"
+                if existing is not None
+                else "save_memory_callback"
+            ),
+        )
+
+    def prepare_storyline(
+        self,
+        *,
+        id: str,
+        headline: str,
+        summary: str,
+        supporting_fact_ids: Iterable[str],
+        priority: int = 2,
+        tags: Iterable[str] = (),
+    ) -> BriefMutation:
+        fact_ids = tuple(supporting_fact_ids)
+        self._require_fact_ids(fact_ids)
+        revision = self.brief.revision + 1
+        storyline = BriefStoryline(
+            id=id,
+            headline=headline,
+            summary=summary,
+            supporting_fact_ids=fact_ids,
+            priority=priority,
+            tags=tuple(tags),
+            revision_at_set=revision,
+        )
+        existing = self.brief.get_storyline(storyline.id)
+        if existing is not None and _without_revision(existing) == _without_revision(
+            storyline
+        ):
+            return self._no_change("save_storyline", storyline.id)
+        return self._replace(
+            "storylines",
+            storyline,
+            operation=(
+                "update_storyline" if existing is not None else "save_storyline"
+            ),
+        )
+
+    def prepare_outline(
+        self,
+        *,
+        sections: Iterable[BriefOutlineSection | dict[str, Any]],
+    ) -> BriefMutation:
+        parsed = tuple(
+            item
+            if isinstance(item, BriefOutlineSection)
+            else BriefOutlineSection.model_validate(item)
+            for item in sections
+        )
+        self._require_fact_ids(
+            fact_id for section in parsed for fact_id in section.required_fact_ids
+        )
+        self._require_storyline_ids(
+            storyline_id
+            for section in parsed
+            for storyline_id in section.storyline_ids
+        )
+        existing_sections = self.brief.outline.sections
+        if existing_sections == parsed:
+            return self._no_change("set_outline", "outline")
+        revision = self.brief.revision + 1
+        candidate = self.brief.model_copy(
+            update={
+                "revision": revision,
+                "outline": BriefOutline(
+                    sections=parsed,
+                    revision_at_set=revision,
+                ),
+            },
+            deep=True,
+        )
+        return BriefMutation(
+            base_revision=self.brief.revision,
+            candidate=candidate,
+            changed=True,
+            operation="set_outline",
+            entity_id="outline",
+        )
+
+    def commit(
+        self,
+        mutation: BriefMutation,
+        persist_projection: Callable[[str], object],
+    ) -> ResearchBrief:
+        if mutation.base_revision != self.brief.revision:
+            raise ResearchBriefError(
+                "revision_conflict",
+                "brief changed after the mutation was prepared",
+                expected_revision=mutation.base_revision,
+                current_revision=self.brief.revision,
+            )
+        if not mutation.changed:
+            return self.brief
+        content = render_research_brief(mutation.candidate)
+        persist_projection(content)
+        self.brief = mutation.candidate
+        return self.brief
+
+    def _replace(
+        self,
+        field: str,
+        item: BaseModel,
+        *,
+        operation: str,
+    ) -> BriefMutation:
+        current = getattr(self.brief, field)
+        replaced = _upsert_tuple(current, item)
+        candidate = self.brief.model_copy(
+            update={
+                "revision": self.brief.revision + 1,
+                field: replaced,
+            },
+            deep=True,
+        )
+        return BriefMutation(
+            base_revision=self.brief.revision,
+            candidate=candidate,
+            changed=True,
+            operation=operation,
+            entity_id=str(getattr(item, "id")),
+        )
+
+    def _no_change(self, operation: str, entity_id: str) -> BriefMutation:
+        return BriefMutation(
+            base_revision=self.brief.revision,
+            candidate=self.brief,
+            changed=False,
+            operation=operation,
+            entity_id=entity_id,
+        )
+
+    def _require_fact_ids(self, fact_ids: Iterable[str]) -> None:
+        known = {item.id for item in self.brief.facts}
+        missing = tuple(dict.fromkeys(item for item in fact_ids if item not in known))
+        if missing:
+            raise ResearchBriefError(
+                "unknown_fact_ids",
+                "brief references unknown fact ids",
+                missing_fact_ids=list(missing),
+            )
+
+    def _require_storyline_ids(self, storyline_ids: Iterable[str]) -> None:
+        known = {item.id for item in self.brief.storylines}
+        missing = tuple(
+            dict.fromkeys(item for item in storyline_ids if item not in known)
+        )
+        if missing:
+            raise ResearchBriefError(
+                "unknown_storyline_ids",
+                "outline references unknown storyline ids",
+                missing_storyline_ids=list(missing),
+            )
+
+
+def render_research_brief(brief: ResearchBrief) -> str:
+    """Render one brief deterministically without creating authoritative prose."""
+    readiness = brief.readiness()
+    context = brief.context
+    style = brief.style
+    bias = brief.bias
+    lines = [
+        "# Research Brief",
+        "",
+        f"Revision: {brief.revision}",
+        "",
+        "## Context",
+        "",
+        f"- League: {context.league_name or '(unknown)'}",
+        f"- League ID: {context.league_id or '(unknown)'}",
+        f"- Coverage weeks: {context.week_start}-{context.week_end}",
+        f"- Target length: about {context.length_target} words",
+        f"- Evidence policy: {context.evidence_policy}",
+        f"- Focus hints: {_list_value(context.focus_hints)}",
+        f"- Focus teams: {_list_value(context.focus_teams)}",
+        f"- Avoid topics: {_list_value(context.avoid_topics)}",
+        f"- Custom instructions: {context.custom_instructions or '(none)'}",
+        "",
+        "## Style and Bias",
+        "",
+        f"- Voice: {style.voice}",
+        f"- Snark level: {style.snark_level}",
+        f"- Hype level: {style.hype_level}",
+        f"- Seriousness: {style.seriousness}",
+        f"- Profanity policy: {style.profanity_policy}",
+        f"- Favored teams: {_list_value(bias.favored_teams)}",
+        f"- Disfavored teams: {_list_value(bias.disfavored_teams)}",
+        f"- Bias intensity: {bias.intensity}",
+        "- Bias rule: framing only; never change facts.",
+        "",
+        "## Verified Facts",
+        "",
+    ]
+    if brief.facts:
+        for fact in brief.facts:
+            lines.extend(
+                [
+                    f"### {fact.id}",
+                    "",
+                    f"- Claim: {fact.claim_text}",
+                    f"- Category: {fact.category}",
+                    f"- Data refs: {_list_value(fact.data_refs)}",
+                    f"- Numbers: {json.dumps(fact.numbers, sort_keys=True)}",
+                    f"- Set at revision: {fact.revision_at_set}",
+                    "",
+                ]
+            )
+    else:
+        lines.extend(["(none)", ""])
+
+    lines.extend(["## Verified Callbacks", ""])
+    if brief.memory_callbacks:
+        for callback in brief.memory_callbacks:
+            lines.extend(
+                [
+                    f"### {callback.id}",
+                    "",
+                    f"- Type: {callback.callback_type}",
+                    f"- Claim: {callback.claim_text}",
+                    f"- Old fact: {callback.old_event_fact_id}",
+                    f"- Current fact: {callback.current_event_fact_id}",
+                    f"- Why now: {callback.why_now}",
+                    f"- Interestingness: {callback.interestingness_reason or '(none)'}",
+                    f"- Memory refs: {_list_value(callback.memory_refs)}",
+                    f"- Tags: {_list_value(callback.tags)}",
+                    f"- Set at revision: {callback.revision_at_set}",
+                    "",
+                ]
+            )
+    else:
+        lines.extend(["(none)", ""])
+
+    lines.extend(["## Storylines", ""])
+    if brief.storylines:
+        for storyline in brief.storylines:
+            lines.extend(
+                [
+                    f"### {storyline.id}: {storyline.headline}",
+                    "",
+                    storyline.summary,
+                    "",
+                    f"- Supporting facts: {_list_value(storyline.supporting_fact_ids)}",
+                    f"- Priority: {storyline.priority}",
+                    f"- Tags: {_list_value(storyline.tags)}",
+                    f"- Set at revision: {storyline.revision_at_set}",
+                    "",
+                ]
+            )
+    else:
+        lines.extend(["(none)", ""])
+
+    lines.extend(["## Outline", ""])
+    if brief.outline.sections:
+        for section in brief.outline.sections:
+            lines.extend([f"### {section.title}", ""])
+            lines.extend(f"- {bullet}" for bullet in section.bullet_points)
+            lines.extend(
+                [
+                    f"- Required facts: {_list_value(section.required_fact_ids)}",
+                    f"- Storylines: {_list_value(section.storyline_ids)}",
+                    "",
+                ]
+            )
+        lines.append(f"Outline set at revision: {brief.outline.revision_at_set}")
+        lines.append("")
+    else:
+        lines.extend(["(none)", ""])
+
+    lines.extend(
+        [
+            "## Readiness",
+            "",
+            f"- Submission allowed: {'yes' if readiness.submission_allowed else 'no'}",
+            f"- Stale callbacks: {_list_value(readiness.stale_callback_ids)}",
+            f"- Stale storylines: {_list_value(readiness.stale_storyline_ids)}",
+            f"- Outline stale: {'yes' if readiness.outline_stale else 'no'}",
+            f"- Warnings: {_list_value(readiness.warnings)}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _upsert_tuple(items: tuple[Any, ...], item: Any) -> tuple[Any, ...]:
+    for index, existing in enumerate(items):
+        if existing.id == item.id:
+            return (*items[:index], item, *items[index + 1 :])
+    return (*items, item)
+
+
+def _without_revision(item: BaseModel) -> dict[str, Any]:
+    return item.model_dump(exclude={"revision_at_set"})
+
+
+def _trimmed_nonblank(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("value must be a non-empty string")
+    if value != value.strip():
+        raise ValueError("value cannot have surrounding whitespace")
+    return value
+
+
+def _unique_nonblank(values: Iterable[str]) -> tuple[str, ...]:
+    normalized = tuple(_trimmed_nonblank(value) for value in values)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _unique_ids(values: Iterable[str]) -> tuple[str, ...]:
+    ids = _unique_nonblank(values)
+    invalid = [value for value in ids if _BRIEF_ID_RE.fullmatch(value) is None]
+    if invalid:
+        raise ValueError(f"invalid brief ids: {', '.join(invalid)}")
+    return ids
+
+
+def _list_value(values: Iterable[str]) -> str:
+    items = tuple(values)
+    return ", ".join(items) if items else "(none)"
+
+
+__all__ = [
+    "BRIEF_ID_PATTERN",
+    "RESEARCH_BRIEF_PATH",
+    "BriefBias",
+    "BriefContext",
+    "BriefFact",
+    "BriefMemoryCallback",
+    "BriefMutation",
+    "BriefOutline",
+    "BriefOutlineSection",
+    "BriefReadiness",
+    "BriefStoryline",
+    "BriefStyle",
+    "ResearchBrief",
+    "ResearchBriefError",
+    "ResearchBriefStore",
+    "render_research_brief",
+]

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -37,11 +37,19 @@ class ArtifactStore(BaseModel):
     """In-memory Markdown workspace keyed by safe artifact path."""
 
     artifacts: dict[str, WorkingArtifact] = Field(default_factory=dict)
+    managed_paths: frozenset[str] = Field(default_factory=frozenset)
     submitted_path: str | None = None
 
     @model_validator(mode="after")
     def _validate_workspace(self) -> ArtifactStore:
         folded_paths: set[str] = set()
+        folded_managed_paths: set[str] = set()
+        for path in self.managed_paths:
+            validate_artifact_path(path)
+            folded = path.casefold()
+            if folded in folded_managed_paths:
+                raise ValueError("managed artifact paths must be unique ignoring case")
+            folded_managed_paths.add(folded)
         for key, artifact in self.artifacts.items():
             validate_artifact_path(key)
             if key != artifact.path:
@@ -75,6 +83,7 @@ class ArtifactStore(BaseModel):
         on_change: Callable[[ArtifactSnapshot], None] | None = None,
     ) -> ArtifactSnapshot:
         normalized = self._normalize_path(path)
+        self._require_generic_path(normalized)
         collision = self._casefold_collision(normalized)
         if collision is not None:
             raise ArtifactStoreError(
@@ -104,6 +113,7 @@ class ArtifactStore(BaseModel):
         on_change: Callable[[ArtifactSnapshot], None] | None = None,
     ) -> tuple[ArtifactSnapshot, bool]:
         normalized = self._normalize_path(path)
+        self._require_generic_path(normalized)
         artifact = self._get(normalized)
         self._check_revision(artifact, expected_revision)
         if artifact.finalized_revision is not None:
@@ -153,6 +163,7 @@ class ArtifactStore(BaseModel):
 
     def submit(self, path: str, *, expected_revision: int) -> ArtifactSnapshot:
         normalized = self._normalize_path(path)
+        self._require_generic_path(normalized)
         artifact = self._get(normalized)
         self._check_revision(artifact, expected_revision)
         if artifact.finalized_revision is not None:
@@ -181,6 +192,62 @@ class ArtifactStore(BaseModel):
         artifact.finalized_revision = artifact.current.revision
         self.submitted_path = normalized
         return artifact.final
+
+    def sync_managed(
+        self,
+        path: str,
+        content: str,
+        *,
+        on_change: Callable[[ArtifactSnapshot], None] | None = None,
+    ) -> tuple[ArtifactSnapshot, bool]:
+        """Create or replace a runtime-owned artifact as one atomic mutation."""
+        normalized = self._normalize_path(path)
+        managed_path = self._managed_collision(normalized)
+        if managed_path is None:
+            raise ArtifactStoreError(
+                "artifact_not_managed",
+                f"Artifact is not runtime-managed: {normalized}",
+                path=normalized,
+            )
+        if managed_path != normalized:
+            raise ArtifactStoreError(
+                "invalid_path",
+                f"Managed artifact path casing must match: {managed_path}",
+                path=normalized,
+                managed_path=managed_path,
+            )
+
+        artifact = self.artifacts.get(normalized)
+        if artifact is None:
+            created = WorkingArtifact.create(path=normalized, content=content)
+            self.artifacts[normalized] = created
+            try:
+                if on_change is not None:
+                    on_change(created.current)
+            except Exception:
+                del self.artifacts[normalized]
+                raise
+            return created.current, True
+
+        if artifact.finalized_revision is not None:
+            raise ArtifactStoreError(
+                "artifact_finalized",
+                f"Managed artifact cannot change after finalization: {normalized}",
+                path=normalized,
+                current_revision=artifact.current.revision,
+            )
+        if artifact.current.content == content:
+            return artifact.current, False
+
+        previous_snapshots = artifact.snapshots
+        snapshot = artifact.append(content)
+        try:
+            if on_change is not None:
+                on_change(snapshot)
+        except Exception:
+            artifact.snapshots = previous_snapshots
+            raise
+        return snapshot, True
 
     @property
     def submitted_artifact(self) -> ArtifactSnapshot | None:
@@ -211,6 +278,23 @@ class ArtifactStore(BaseModel):
             (existing for existing in self.artifacts if existing.casefold() == folded),
             None,
         )
+
+    def _managed_collision(self, path: str) -> str | None:
+        folded = path.casefold()
+        return next(
+            (managed for managed in self.managed_paths if managed.casefold() == folded),
+            None,
+        )
+
+    def _require_generic_path(self, path: str) -> None:
+        managed = self._managed_collision(path)
+        if managed is not None:
+            raise ArtifactStoreError(
+                "managed_artifact",
+                f"Artifact is runtime-managed and cannot be changed directly: {managed}",
+                path=path,
+                managed_path=managed,
+            )
 
     @staticmethod
     def _check_revision(

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 
-ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "2"
+ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "3"
 
 
 ARTIFACT_TOOL_SPECS: list[ToolDef] = [
@@ -35,7 +35,7 @@ ARTIFACT_TOOL_SPECS: list[ToolDef] = [
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Relative POSIX .md path, such as research/brief.md.",
+                        "description": "Relative POSIX .md path, such as research_brief.md.",
                     }
                 },
                 "required": ["path"],

--- a/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
+++ b/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
@@ -116,7 +116,7 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     seed_content = "# Brief"
     seed_version_id = recorder.record_artifact_mutation(
         ArtifactMutation(
-            path="research/brief.md",
+            path="research_brief.md",
             media_type="text/markdown",
             content=seed_content,
             revision=1,
@@ -164,7 +164,7 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     edited_content = "# Brief\n\nVerified fact."
     edited_version_id = recorder.record_artifact_mutation(
         ArtifactMutation(
-            path="research/brief.md",
+            path="research_brief.md",
             media_type="text/markdown",
             content=edited_content,
             revision=2,

--- a/backend/tests/resources/reporting/artifacts/test_manager.py
+++ b/backend/tests/resources/reporting/artifacts/test_manager.py
@@ -106,7 +106,7 @@ def test_list_orders_paths_and_filters_finalized_artifacts(
     generation_domain: GenerationDomain,
 ) -> None:
     _, generation_id = _create_running(session_factory, generation_domain)
-    _create(artifact_manager, generation_id, path="research/brief.md")
+    _create(artifact_manager, generation_id, path="research_brief.md")
     article = _create(artifact_manager, generation_id)
     version_manager = ArtifactVersionManager(
         session_factory, generation_context(generation_domain)
@@ -131,7 +131,7 @@ def test_list_orders_paths_and_filters_finalized_artifacts(
     page = artifact_manager.list(ArtifactQuery(generation_id=generation_id))
     assert [item.path for item in page.items] == [
         "article.md",
-        "research/brief.md",
+        "research_brief.md",
     ]
     assert page.items[0].revision_count == 2
     assert page.items[0].latest_version_at == version.created_at

--- a/backend/tests/resources/reporting/artifacts/test_objects.py
+++ b/backend/tests/resources/reporting/artifacts/test_objects.py
@@ -9,10 +9,10 @@ from backend.resources.reporting.artifacts import ArtifactQuery, CreateArtifact
 def test_artifact_identity_normalizes_media_type() -> None:
     command = CreateArtifact(
         generation_id=uuid4(),
-        path="research/brief.md",
+        path="research_brief.md",
         media_type=" Text/Markdown ",
     )
-    assert command.path == "research/brief.md"
+    assert command.path == "research_brief.md"
     assert command.media_type == "text/markdown"
 
 

--- a/backend/tests/services/generations/test_recorder.py
+++ b/backend/tests/services/generations/test_recorder.py
@@ -308,7 +308,7 @@ def test_recorder_persists_seed_and_tool_mutations_with_exact_provenance() -> No
     generation_id = uuid4()
     recorder, _, _, _, artifacts, versions = make_recorder(generation_id)
     seed = ArtifactMutation(
-        path="research/brief.md",
+        path="research_brief.md",
         media_type="text/markdown",
         content="# Brief",
         revision=1,
@@ -345,7 +345,7 @@ def test_recorder_persists_seed_and_tool_mutations_with_exact_provenance() -> No
         )
     )
     edited = ArtifactMutation(
-        path="research/brief.md",
+        path="research_brief.md",
         media_type="text/markdown",
         content="# Brief\n\nFact",
         revision=2,

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -222,7 +222,7 @@ class FakeReporter:
         if self.exercise_recorder:
             kwargs["recorder"].record_artifact_mutation(
                 ArtifactMutation(
-                    path="research/brief.md",
+                    path="research_brief.md",
                     media_type="text/markdown",
                     content="brief",
                     revision=1,

--- a/backend/tests/services/reporter/test_artifact_tools.py
+++ b/backend/tests/services/reporter/test_artifact_tools.py
@@ -72,10 +72,10 @@ def test_create_list_and_read_artifacts() -> None:
     ctx = make_ctx()
 
     created = decode(
-        create_artifact(ctx, path="research/brief.md", content="# Brief")
+        create_artifact(ctx, path="research_brief.md", content="# Brief")
     )
     listed = decode(list_artifacts(ctx))
-    read = decode(read_artifact(ctx, path="research/brief.md"))
+    read = decode(read_artifact(ctx, path="research_brief.md"))
 
     assert created["ok"] is True
     assert created["artifact"]["revision"] == 1
@@ -86,7 +86,7 @@ def test_create_list_and_read_artifacts() -> None:
         "artifact_count": 1,
         "artifacts": [
             {
-                "path": "research/brief.md",
+                "path": "research_brief.md",
                 "media_type": "text/markdown",
                 "revision": 1,
                 "content_hash": created["artifact"]["content_hash"],

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -195,7 +195,7 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
     assert "interleavable activities" in copied_message
     assert "fixed sequence" in copied_message
     assert copied_system_prompt() != legacy_system_prompt()
-    assert "research/brief.md" in copied_system_prompt()
+    assert "research_brief.md" in copied_system_prompt()
     assert "submit_artifact" in copied_system_prompt()
 
     copied_artifact_names = [
@@ -279,7 +279,7 @@ def test_generator_preserves_article_result_across_artifact_contract_divergence(
     assert copied.submitted_path == "article.md"
     assert [artifact.path for artifact in copied.artifacts] == [
         "article.md",
-        "research/brief.md",
+        "research_brief.md",
     ]
     assert copied.artifacts[0].revision == 1
     assert "# Research Brief" in copied.artifacts[1].content

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -188,7 +188,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                 tool_calls=[
                     tool_call(
                         "read_artifact",
-                        {"path": "research/brief.md"},
+                        {"path": "research_brief.md"},
                         "call_3",
                     )
                 ]
@@ -198,7 +198,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                     tool_call(
                         "edit_artifact",
                         {
-                            "path": "research/brief.md",
+                            "path": "research_brief.md",
                             "old_text": "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->",
                             "new_text": (
                                 "- Team Taco beat Waiver Wire 142.3-98.7.\n"
@@ -217,7 +217,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
                     tool_call(
                         "edit_artifact",
                         {
-                            "path": "research/brief.md",
+                            "path": "research_brief.md",
                             "old_text": "<!-- INSERT STORYLINES ABOVE THIS LINE -->",
                             "new_text": (
                                 "- Taco Takes Control: Team Taco paired a blowout "
@@ -298,18 +298,18 @@ def test_generate_article_end_to_end_tool_loop() -> None:
     assert output.submitted_path == "article.md"
     assert tuple(artifact.path for artifact in output.artifacts) == (
         "article.md",
-        "research/brief.md",
+        "research_brief.md",
     )
     assert artifacts["article.md"].revision == 2
     assert "improved to 7-1" in artifacts["article.md"].content
     assert "moved to 7-1" not in artifacts["article.md"].content
     assert len(artifacts["article.md"].content_hash) == 64
-    assert artifacts["research/brief.md"].revision == 3
-    assert "League ID: league_123" in artifacts["research/brief.md"].content
+    assert artifacts["research_brief.md"].revision == 3
+    assert "League ID: league_123" in artifacts["research_brief.md"].content
     assert "Team Taco beat Waiver Wire 142.3-98.7" in artifacts[
-        "research/brief.md"
+        "research_brief.md"
     ].content
-    assert "Taco Takes Control" in artifacts["research/brief.md"].content
+    assert "Taco Takes Control" in artifacts["research_brief.md"].content
     assert output.run_log_summary["submitted"] is True
     assert output.run_log_summary["total_turns"] == 9
     assert output.run_log_summary["procedures_loaded"] == [
@@ -342,13 +342,13 @@ def test_generate_article_end_to_end_tool_loop() -> None:
             for mutation in recorder.artifact_mutations
             if mutation.path == path
         ]
-        for path in ("research/brief.md", "article.md")
+        for path in ("research_brief.md", "article.md")
     }
-    assert [item.revision for item in histories["research/brief.md"]] == [1, 2, 3]
-    assert histories["research/brief.md"][0].source_tool_call_id is None
+    assert [item.revision for item in histories["research_brief.md"]] == [1, 2, 3]
+    assert histories["research_brief.md"][0].source_tool_call_id is None
     assert [item.revision for item in histories["article.md"]] == [1, 2]
     tool_mutations = (
-        histories["research/brief.md"][1:] + histories["article.md"]
+        histories["research_brief.md"][1:] + histories["article.md"]
     )
     assert all(item.source_tool_call_id is not None for item in tool_mutations)
 
@@ -440,7 +440,7 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
                 tool_calls=[
                     tool_call(
                         "read_artifact",
-                        {"path": "research/brief.md"},
+                        {"path": "research_brief.md"},
                         "call_2",
                     )
                 ]
@@ -460,7 +460,7 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
                     tool_call(
                         "edit_artifact",
                         {
-                            "path": "research/brief.md",
+                            "path": "research_brief.md",
                             "old_text": "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->",
                             "new_text": (
                                 "- Team Taco was 7-1 after week 8.\n\n"
@@ -517,7 +517,7 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
     ]
     artifacts = {artifact.path: artifact for artifact in output.artifacts}
     assert output.submitted_path == "article.md"
-    assert artifacts["research/brief.md"].revision == 2
-    assert "Team Taco was 7-1" in artifacts["research/brief.md"].content
+    assert artifacts["research_brief.md"].revision == 2
+    assert "Team Taco was 7-1" in artifacts["research_brief.md"].content
     assert artifacts["article.md"].revision == 1
     assert "Team Taco was 7-1" in artifacts["article.md"].content

--- a/backend/tests/services/reporter/test_research_brief.py
+++ b/backend/tests/services/reporter/test_research_brief.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    BriefContext,
+    BriefOutlineSection,
+    ResearchBrief,
+    ResearchBriefError,
+    ResearchBriefStore,
+    render_research_brief,
+)
+from backend.services.reporter.runner.state import ArtifactStore, ArtifactStoreError
+
+
+def _commit(store: ResearchBriefStore, mutation: object) -> None:
+    store.commit(mutation, lambda _: None)  # type: ignore[arg-type]
+
+
+def _fact(store: ResearchBriefStore, fact_id: str, claim: str = "Taco won.") -> None:
+    _commit(
+        store,
+        store.prepare_fact(
+            id=fact_id,
+            claim_text=claim,
+            data_refs=["league_snapshot:week=8", "league_snapshot:week=8"],
+            numbers={"wins": 1},
+            category="score",
+        ),
+    )
+
+
+def test_fact_upsert_is_idempotent_and_preserves_insertion_order() -> None:
+    store = ResearchBriefStore()
+
+    first = store.prepare_fact(
+        id="fact_taco_win",
+        claim_text="Taco won 142.3-98.7.",
+        data_refs=["league_snapshot:week=8", "league_snapshot:week=8"],
+        numbers={"winner_score": 142.3, "loser_score": 98.7},
+        category="score",
+    )
+    _commit(store, first)
+    duplicate = store.prepare_fact(
+        id="fact_taco_win",
+        claim_text="Taco won 142.3-98.7.",
+        data_refs=["league_snapshot:week=8"],
+        numbers={"winner_score": 142.3, "loser_score": 98.7},
+        category="score",
+    )
+    _commit(store, duplicate)
+    _fact(store, "fact_other")
+
+    assert first.changed is True
+    assert duplicate.changed is False
+    assert store.brief.revision == 2
+    assert [fact.id for fact in store.brief.facts] == [
+        "fact_taco_win",
+        "fact_other",
+    ]
+    assert store.brief.facts[0].data_refs == ("league_snapshot:week=8",)
+
+
+def test_invalid_brief_id_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResearchBriefStore().prepare_fact(
+            id="Fact 1",
+            claim_text="A claim.",
+            data_refs=["source"],
+        )
+
+
+def test_references_validate_and_fact_update_marks_dependents_stale() -> None:
+    store = ResearchBriefStore()
+    _fact(store, "fact_old", "A trade happened in week 3.")
+    _fact(store, "fact_current", "The traded player scored 30 in week 8.")
+    _commit(
+        store,
+        store.prepare_memory_callback(
+            id="callback_trade_regret",
+            callback_type="trade_regret",
+            claim_text="The week 3 trade backfired in week 8.",
+            old_event_fact_id="fact_old",
+            current_event_fact_id="fact_current",
+            why_now="The traded player decided the rematch.",
+        ),
+    )
+    _commit(
+        store,
+        store.prepare_storyline(
+            id="story_trade_regret",
+            headline="Trade regret arrives",
+            summary="The old deal changed the current matchup.",
+            supporting_fact_ids=["fact_old", "fact_current"],
+            priority=1,
+        ),
+    )
+    _commit(
+        store,
+        store.prepare_outline(
+            sections=[
+                BriefOutlineSection(
+                    title="Lead",
+                    required_fact_ids=("fact_current",),
+                    storyline_ids=("story_trade_regret",),
+                )
+            ]
+        ),
+    )
+
+    ready = store.brief.readiness()
+    assert ready.stale_callback_ids == ()
+    assert ready.stale_storyline_ids == ()
+    assert ready.outline_stale is False
+
+    _fact(store, "fact_current", "The traded player scored 31 in week 8.")
+    stale = store.brief.readiness()
+    assert stale.stale_callback_ids == ("callback_trade_regret",)
+    assert stale.stale_storyline_ids == ("story_trade_regret",)
+    assert stale.outline_stale is True
+
+
+def test_unknown_references_leave_state_unchanged() -> None:
+    store = ResearchBriefStore()
+
+    with pytest.raises(ResearchBriefError) as exc_info:
+        store.prepare_storyline(
+            id="story_missing",
+            headline="Missing",
+            summary="No evidence.",
+            supporting_fact_ids=["fact_missing"],
+        )
+
+    assert exc_info.value.code == "unknown_fact_ids"
+    assert store.brief.revision == 0
+
+
+def test_projection_is_deterministic_and_contains_readiness() -> None:
+    brief = ResearchBrief(
+        context=BriefContext(
+            league_name="Chaos League",
+            league_id="league_123",
+            week_start=8,
+            week_end=8,
+        )
+    )
+    store = ResearchBriefStore(brief=brief)
+    _fact(store, "fact_taco_win")
+
+    first = render_research_brief(store.brief)
+    second = render_research_brief(store.brief.model_copy(deep=True))
+
+    assert first == second
+    assert "League ID: league_123" in first
+    assert "### fact_taco_win" in first
+    assert "Submission allowed: yes" in first
+
+
+def test_brief_commit_is_atomic_when_projection_fails() -> None:
+    store = ResearchBriefStore()
+    mutation = store.prepare_fact(
+        id="fact_001",
+        claim_text="A verified claim.",
+        data_refs=["league_snapshot:week=8"],
+    )
+
+    with pytest.raises(RuntimeError, match="recorder failed"):
+        store.commit(
+            mutation,
+            lambda _: (_ for _ in ()).throw(RuntimeError("recorder failed")),
+        )
+
+    assert store.brief.revision == 0
+    assert store.brief.facts == ()
+
+
+def test_managed_artifact_syncs_and_blocks_generic_mutations() -> None:
+    artifacts = ArtifactStore(managed_paths=frozenset({RESEARCH_BRIEF_PATH}))
+
+    first, created = artifacts.sync_managed(RESEARCH_BRIEF_PATH, "# Brief\n\nOne")
+    second, changed = artifacts.sync_managed(RESEARCH_BRIEF_PATH, "# Brief\n\nTwo")
+    same, unchanged = artifacts.sync_managed(RESEARCH_BRIEF_PATH, "# Brief\n\nTwo")
+
+    assert created is True
+    assert changed is True
+    assert unchanged is False
+    assert [first.revision, second.revision, same.revision] == [1, 2, 2]
+
+    with pytest.raises(ArtifactStoreError) as exc_info:
+        artifacts.edit(
+            RESEARCH_BRIEF_PATH,
+            old_text="Two",
+            new_text="Three",
+            expected_revision=2,
+        )
+    assert exc_info.value.code == "managed_artifact"
+
+    with pytest.raises(ArtifactStoreError) as exc_info:
+        artifacts.submit(RESEARCH_BRIEF_PATH, expected_revision=2)
+    assert exc_info.value.code == "managed_artifact"
+
+
+def test_managed_artifact_recording_failure_rolls_back_history() -> None:
+    artifacts = ArtifactStore(managed_paths=frozenset({RESEARCH_BRIEF_PATH}))
+
+    with pytest.raises(RuntimeError, match="recording failed"):
+        artifacts.sync_managed(
+            RESEARCH_BRIEF_PATH,
+            "# Brief",
+            on_change=lambda _: (_ for _ in ()).throw(
+                RuntimeError("recording failed")
+            ),
+        )
+    assert artifacts.artifacts == {}
+
+    artifacts.sync_managed(RESEARCH_BRIEF_PATH, "# Brief\n\nOne")
+    with pytest.raises(RuntimeError, match="recording failed"):
+        artifacts.sync_managed(
+            RESEARCH_BRIEF_PATH,
+            "# Brief\n\nTwo",
+            on_change=lambda _: (_ for _ in ()).throw(
+                RuntimeError("recording failed")
+            ),
+        )
+    assert artifacts.read(RESEARCH_BRIEF_PATH).revision == 1
+    assert artifacts.read(RESEARCH_BRIEF_PATH).content.endswith("One")

--- a/backend/tests/services/reporter/test_schemas.py
+++ b/backend/tests/services/reporter/test_schemas.py
@@ -22,7 +22,7 @@ from backend.services.reporter.runner.state import (
 
 
 def test_working_artifact_keeps_immutable_snapshot_history() -> None:
-    artifact = WorkingArtifact.create(path="research/brief.md", content="# Brief")
+    artifact = WorkingArtifact.create(path="research_brief.md", content="# Brief")
     first = artifact.current
 
     second = artifact.append("# Brief\n\nMore evidence.")
@@ -80,7 +80,7 @@ def test_artifact_store_create_read_list_and_casefold_collision() -> None:
     store = ArtifactStore()
 
     article = store.create("article.md", "# Article")
-    brief = store.create("research/brief.md", "# Brief")
+    brief = store.create("research_brief.md", "# Brief")
 
     assert store.read("article.md") is article
     assert store.list() == (article, brief)
@@ -159,7 +159,7 @@ def test_submit_pins_existing_current_snapshot_without_new_revision() -> None:
 
 def test_reporter_output_exposes_submitted_content_and_all_artifacts() -> None:
     store = ArtifactStore()
-    store.create("research/brief.md", "# Brief")
+    store.create("research_brief.md", "# Brief")
     store.create("article.md", "# Article")
     store.submit("article.md", expected_revision=1)
 
@@ -172,7 +172,7 @@ def test_reporter_output_exposes_submitted_content_and_all_artifacts() -> None:
     assert output.submitted_artifact == store.submitted_artifact
     assert [artifact.path for artifact in output.artifacts] == [
         "article.md",
-        "research/brief.md",
+        "research_brief.md",
     ]
 
 

--- a/docs/database/reporting.md
+++ b/docs/database/reporting.md
@@ -234,7 +234,7 @@ describes representation and is immutable after creation; semantic categories
 do not belong in a closed artifact-kind enum.
 
 The reporter initially uses Markdown artifacts with `media_type =
-'text/markdown'`. Names such as `research/brief.md` and `article.md` are
+'text/markdown'`. Names such as `research_brief.md` and `article.md` are
 reporter-owned conventions. Outlines, diagnostics, or future editorial products
 use additional paths without requiring schema or enum changes. A separate
 article table is unnecessary while one successful generation represents one

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -95,7 +95,7 @@ flowchart LR
   revision-checked `submit_artifact`.
 - Use raw UTF-8 Markdown artifacts; mirror each successful mutation to an
   immutable version and finalize by selecting existing versions rather than
-  writing final copies. Paths such as `research/brief.md` and `article.md` are
+  writing final copies. Paths such as `research_brief.md` and `article.md` are
   reporter-owned conventions, never application query keys.
 - Store the exact submitted finalized artifact version on the generation. The
   application discovers generated articles through this pointer, independently

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -182,7 +182,7 @@ Changes from Reporter V2 are intentionally limited:
   generation workflow.
 
 The reporter continues to own registry construction, prompt building,
-`research/brief.md` seeding, runner construction, and `ReporterOutput` assembly.
+`research_brief.md` seeding, runner construction, and `ReporterOutput` assembly.
 
 The output selects the submitted artifact and returns one complete current
 snapshot for every artifact in deterministic path order:
@@ -234,7 +234,7 @@ connection, a source client, or the snapshot artifact path separately.
 Reporter V2 currently seeds structured brief league metadata and resolves
 roster keys via private SQLite access. That cannot continue. The new runtime
 already supplies league display data through curated snapshot results, but the
-exact non-tool metadata contract used to seed `research/brief.md` must be made
+exact non-tool metadata contract used to seed `research_brief.md` must be made
 public or supplied by `GenerationService`.
 
 Typed memory proposals involving a team require durable `franchise_id` or
@@ -385,7 +385,7 @@ submit_artifact(path, expected_revision)
 
 Artifacts use `text/markdown`. Paths are normalized relative logical names, not
 host filesystem paths. The reporter may use defaults such as
-`research/brief.md` and `article.md`, but owns those names and may select another
+`research_brief.md` and `article.md`, but owns those names and may select another
 publishable path. `create_artifact` rejects an existing path.
 `edit_artifact` succeeds only when `expected_revision` is current and
 `old_text` occurs exactly once; zero or multiple matches are typed tool errors.
@@ -395,7 +395,7 @@ as a new immutable version. There is deliberately no `replace_all` mode.
 `list_artifacts` and `read_artifact` never append versions. Failed mutations and
 content-identical edits do not append versions. Each successful create/edit
 passes its complete snapshot to the recorder with source AI/tool provenance.
-The generator records its seeded `research/brief.md` snapshot as revision 1
+The generator records its seeded `research_brief.md` snapshot as revision 1
 before the first model call, with no source AI call or tool call.
 
 `submit_artifact` accepts any non-empty artifact, requires its expected current

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -266,7 +266,7 @@ separate live identity source.
 The reporter:
 
 - registers generic artifact, procedure, frozen-data, and typed-memory tools;
-- seeds `research/brief.md` with equivalent league/config metadata;
+- seeds `research_brief.md` with equivalent league/config metadata;
 - runs the same turn loop and procedure replacement behavior;
 - records every provider attempt before/after network I/O;
 - records tool calls before/after handler execution;
@@ -349,7 +349,7 @@ one generic model-facing contract:
   any non-empty artifact and ends the reporter loop.
 
 All reporter artifacts are raw UTF-8 Markdown in the initial platform slice.
-Their paths are reporter-owned logical names. `research/brief.md` and
+Their paths are reporter-owned logical names. `research_brief.md` and
 `article.md` remain useful defaults, but persistence and application queries do
 not infer semantic roles from either name. Durable reporting artifacts mirror
 complete snapshots at successful mutation boundaries:
@@ -360,7 +360,7 @@ complete snapshots at successful mutation boundaries:
 | publishable draft artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision regardless of path |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
-The reporter-owned `research/brief.md` seed is persisted as revision 1 before
+The reporter-owned `research_brief.md` seed is persisted as revision 1 before
 the first provider call, without AI-call or tool-call provenance. Subsequent
 reporter edits therefore retain the same revision numbers in memory and in
 durable storage.

--- a/docs/generation/implementation-plan.md
+++ b/docs/generation/implementation-plan.md
@@ -86,7 +86,7 @@ within their artifact/generation and finalized artifacts cannot change.
 ### `generation-3` — generic Markdown reporter artifacts
 
 - Refactor only the copied reporter from structured brief/section state to raw
-  UTF-8 Markdown at `research/brief.md` and `article.md`.
+  UTF-8 Markdown at `research_brief.md` and `article.md`.
 - Replace specialized brief/article tools with `list_artifacts`,
   `read_artifact(path)`, `create_artifact(path, content)`,
   `edit_artifact(path, old_text, new_text, expected_revision)`, and

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -124,7 +124,7 @@ brief tools (`save_fact`, `save_memory_callback`, `save_storyline`,
 - `submit_artifact(path, expected_revision)`.
 
 Run-local artifacts are raw UTF-8 Markdown at reporter-owned logical paths.
-`research/brief.md` and `article.md` remain useful prompt defaults, not durable
+`research_brief.md` and `article.md` remain useful prompt defaults, not durable
 application roles. `edit_artifact` is a revision-checked literal
 find-and-replace: `old_text` must occur exactly once, and there is no
 `replace_all` mode. Successful creates and edits record complete immutable
@@ -183,7 +183,7 @@ state or weakened validation.
 | `save_storyline_trigger` | `propose_trigger` / `replace_trigger` | Replaced by discriminated rematch/trade-evaluation operations |
 | `mark_memory_used` | No canonical capability | Removed; no access-history state is synthesized |
 | `plan_memory_verification` | Reporter procedure guidance | Removed; the reporter plans frozen-data verification directly |
-| `record_memory_verification` | Run-local Markdown brief | Removed; verified callbacks remain in `research/brief.md` |
+| `record_memory_verification` | Run-local Markdown brief | Removed; verified callbacks remain in `research_brief.md` |
 
 ### Legacy persistent tools
 

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -50,7 +50,7 @@ It does not change the datalayer, generation job lifecycle, or the legacy
   what to investigate next; typed tools preserve what has been verified.
 - The structured brief is the source of truth for research state. Generic artifact
   text must never be parsed back into authoritative facts.
-- `research/brief.md` is a runtime-rendered projection. Generic artifact tools
+- `research_brief.md` is a runtime-rendered projection. Generic artifact tools
   cannot create, edit, delete, submit, or replace it.
 - The article remains a generic Markdown artifact so the writer retains freedom
   over form, tone, and revision strategy.
@@ -61,6 +61,10 @@ It does not change the datalayer, generation job lifecycle, or the legacy
   existing deterministic validator/finalizer and never writes memory directly.
 - Reporter memory search remains available during research; curation is not a
   substitute for loading relevant historical context.
+- Style and bias are initialized from `ReportConfig` and remain immutable within
+  the brief; the agent does not spend turns restating them.
+- Submission requires at least one verified fact. Storyline, callback, and outline
+  readiness remain visible diagnostics rather than rigid workflow gates.
 
 ## Non-Goals
 

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -5,7 +5,7 @@
 - **Research brief:** runtime-owned typed state for verified research. Owned by the
   reporter runner for one run.
 - **Brief projection:** deterministic Markdown rendering of the research brief at
-  `research/brief.md`. Owned by the brief renderer.
+  `research_brief.md`. Owned by the brief renderer.
 - **Article artifact:** model-authored Markdown eligible for submission. Owned by
   the existing artifact store.
 - **Source reference:** traceable description of the data or memory read that
@@ -22,16 +22,11 @@ The exact Python representation may use frozen dataclasses, Pydantic models, or 
 repository's established schema mechanism, but it must preserve these semantics.
 
 ```text
-BriefSourceRef
-  tool_name: non-empty string
-  arguments: normalized mapping
-  result_ref: optional receipt/result identifier
-
 BriefFact
   id: stable run-local identifier
   claim: non-empty factual statement
   category: non-empty string
-  sources: one or more BriefSourceRef
+  data_refs: one or more unique non-empty trace strings
   numbers: optional normalized mapping
 
 BriefCallback
@@ -61,27 +56,26 @@ Model-facing tool capabilities are:
 - `save_memory_callback`
 - `save_storyline`
 - `set_outline`
-- `set_style`
-- `set_bias`
 - `read_brief`
 
 Names may be adjusted to local conventions, but handlers must remain specialized
 typed operations. A generic `write_brief_markdown` capability is not equivalent.
 
 The existing generic artifact capabilities remain available for article creation
-and revision. They must reject the reserved `research/brief.md` path.
+and revision. They must reject the reserved `research_brief.md` path.
 
 ## M1 Lifecycle and State Transitions
 
-1. A run starts with a new empty `ResearchBrief` revision and no model-authored
-   brief artifact.
+1. A run starts with a new empty `ResearchBrief` revision and no brief artifact.
 2. Successful brief mutations increment the revision, recompute readiness and
    dependent staleness, render the projection, and emit research-log metadata.
 3. Failed mutations leave the revision and projection unchanged.
-4. Article artifacts may be created or revised at any brief revision.
-5. Submission selects a non-empty article artifact and captures the final brief
-   revision/readiness in reporter output.
-6. A run-scoped brief is immutable after reporter completion.
+4. The first successful mutation creates revision 1 of `research_brief.md`;
+   `read_brief` at revision 0 does not materialize it.
+5. Article artifacts may be created or revised at any brief revision.
+6. Submission requires at least one verified fact, selects a non-empty article
+   artifact, and captures the final brief revision/readiness in reporter output.
+7. A run-scoped brief is immutable after reporter completion.
 
 Idempotent replay of the same normalized mutation returns the existing logical
 item or a no-op result instead of adding a duplicate.
@@ -96,8 +90,9 @@ item or a no-op result instead of adding a duplicate.
   requires it to be updated; stale dependencies cannot silently appear ready.
 - The rendered projection is a deterministic function of the structured brief and
   revision.
-- Generic artifact operations cannot mutate, submit, or shadow the brief
+- Generic artifact operations cannot create, mutate, submit, or shadow the brief
   projection.
+- Style and bias are immutable values resolved from `ReportConfig`.
 - Procedures do not gate brief, data, memory, artifact, or submission tools.
 - Bias changes framing and emphasis only; it cannot alter factual brief state.
 - The selected article remains the publishable output. The brief remains research
@@ -120,9 +115,11 @@ exceptions.
 
 ## Compatibility and Transition
 
-- Reporter output continues to expose `research/brief.md` among observable
+- Reporter output exposes `research_brief.md` among observable
   artifacts, but its producer changes from the model-facing generic artifact store
   to the renderer.
+- Historical generations that stored `research/brief.md` remain unchanged and
+  readable through the generic artifact API; new runs use only the flat path.
 - Article artifact selection, run persistence, streaming events, and generation
   API shapes remain compatible.
 - Existing direct memory proposal/finalization behavior remains unchanged during
@@ -136,11 +133,12 @@ exceptions.
 Focused tests must cover:
 
 - schema validation and stable/idempotent identifiers;
-- fact, callback, storyline, outline, style, and bias mutations;
+- fact, callback, storyline, and outline mutations plus config-owned style/bias;
 - cross-reference rejection and dependent staleness;
 - deterministic projection at every successful revision;
 - atomic behavior when projection fails;
-- rejection of generic artifact operations on `research/brief.md`;
+- rejection of generic artifact operations on `research_brief.md`;
+- rejection of article submission before at least one verified fact exists;
 - compatible reporter output and article selection;
 - adaptive interleaving and backtracking without procedure gating;
 - no empty seed-artifact create/read turns; and

--- a/docs/reporter-research-pipeline/architecture.md
+++ b/docs/reporter-research-pipeline/architecture.md
@@ -62,14 +62,14 @@ brief state. Tool handlers are the only model-facing mutation boundary.
 
 ### `ResearchBriefRenderer` (M1)
 
-Deterministically renders current structured state to `research/brief.md`. The
+Deterministically renders current structured state to `research_brief.md`. The
 projection is included in reporter output and logs for observability, but is not an
 independent writable artifact.
 
 ### `ArtifactStore` (existing)
 
 Continues to own generic Markdown artifacts, especially candidate and selected
-articles. It reserves `research/brief.md` for the renderer.
+articles. It reserves `research_brief.md` for the renderer.
 
 ### `MemoryCurator` (M2)
 
@@ -92,7 +92,8 @@ workflow state machine.
    context as it does today.
 2. The runner creates an empty in-memory `ResearchBriefStore` and reserves the
    rendered brief path. It does not create an empty generic artifact that the
-   model must load and read.
+   model must load and read. The projection is materialized only by the first
+   successful brief mutation.
 3. The agent explores data and memory adaptively. Verified findings are captured
    through brief tools at the point they become useful.
 4. Every successful brief mutation validates references, updates readiness or
@@ -128,8 +129,8 @@ choice must preserve a successful article when curation fails.
 - A projection/render failure makes the originating brief mutation fail
   atomically.
 - Generic artifact operations targeting the reserved brief path fail clearly.
-- Missing brief readiness is visible at submission. The exact hard/soft submission
-  policy is contract-tested rather than inferred from procedure order.
+- Submission fails when no verified fact exists. Other readiness warnings remain
+  diagnostic and never impose a fixed procedure sequence.
 - Reporter failure and retry continue to follow the generation service's existing
   lifecycle.
 


### PR DESCRIPTION
## Summary

- Rename new-run brief artifacts to `research_brief.md` while retaining historical paths.
- Add typed brief schemas, atomic mutation preparation/commit, dependency staleness, and deterministic Markdown rendering.
- Add runtime-managed artifact synchronization with generic mutation protection and recorder rollback.
- Keep model-facing brief tools inactive until the next stacked PR.

## Stack

- Base: #198
- Next: brief-tool activation and lazy projection

## Verification

- `python -m py_compile` passed for changed Python files.
- `git diff --check` passed.
- Targeted pytest could not run locally because this workspace lacks `uv`, `pytest`, and project dependencies; CI is the pytest verifier.