### PR TITLE
Activate structured reporter brief tools

### DIFF
--- a/backend/services/reporter/definition.py
+++ b/backend/services/reporter/definition.py
@@ -12,6 +12,10 @@ from backend.services.reporter.runner.tools.artifact_tools import (
     ARTIFACT_TOOL_IMPLEMENTATION_VERSION,
     ARTIFACT_TOOL_SPECS,
 )
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_IMPLEMENTATION_VERSION,
+    BRIEF_TOOL_SPECS,
+)
 from backend.services.reporter.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_IMPLEMENTATION_VERSION,
     DATALAYER_TOOL_SPECS,
@@ -76,6 +80,7 @@ def prepare_reporter_definition(
     )
     groups = [
         (ARTIFACT_TOOL_SPECS, ARTIFACT_TOOL_IMPLEMENTATION_VERSION),
+        (BRIEF_TOOL_SPECS, BRIEF_TOOL_IMPLEMENTATION_VERSION),
         (PROCEDURE_TOOL_SPECS, PROCEDURE_TOOL_IMPLEMENTATION_VERSION),
         (DATALAYER_TOOL_SPECS, DATALAYER_TOOL_IMPLEMENTATION_VERSION),
     ]

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -3,17 +3,16 @@
 Owns product wiring that the Runner must not know about:
 - tool registration (artifacts, procedure, datalayer, memory)
 - CompletionClient construction from settings / injectable fakes
-- Markdown brief seeding from league data + ReportConfig
+- structured brief initialization from league data + ReportConfig
 - system/user prompt construction
 - typed memory capability wiring
 
-The Runner only receives a registry, client, RunnerConfig, and optional
-pre-seeded ArtifactStore.
+The Runner receives a registry, client, RunnerConfig, artifact store, and
+structured brief store.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -28,15 +27,19 @@ from backend.services.reporter.runner.completion import (
     CompletionSettings,
     make_completion_client,
 )
-from backend.services.reporter.runner.recording import (
-    ArtifactMutation,
-    ArtifactRecordingError,
-    ExecutionRecorder,
+from backend.services.reporter.runner.recording import ExecutionRecorder
+from backend.services.reporter.runner.research_brief import (
+    BriefBias,
+    BriefContext,
+    BriefStyle,
+    ResearchBrief,
+    ResearchBriefStore,
 )
 from backend.services.reporter.runner.runner import Runner
-from backend.services.reporter.runner.schemas import ArtifactSnapshot, ReporterOutput
+from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
+from backend.services.reporter.runner.tools.brief_tools import register_brief_tools
 from backend.services.reporter.runner.tools.datalayer_tools import register_datalayer_tools
 from backend.services.reporter.runner.tools.memory_tools import register_memory_tools
 from backend.services.reporter.runner.tools.procedure_tools import register_procedure_tools
@@ -100,19 +103,12 @@ async def generate_article(
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
     league_id, league_name = _get_league_metadata(data)
-    artifacts = ArtifactStore()
-    artifacts.create(
-        "research_brief.md",
-        _build_brief_seed(
+    brief = ResearchBriefStore(
+        brief=_build_research_brief(
             config,
             league_id=league_id,
             league_name=league_name,
-        ),
-        on_change=(
-            _seed_artifact_recorder(resolved_recorder)
-            if resolved_recorder is not None
-            else None
-        ),
+        )
     )
 
     runner = Runner(
@@ -120,34 +116,12 @@ async def generate_article(
         client=resolved_client,
         config=runner_config or RunnerConfig(),
         log_path=log_path,
-        artifacts=artifacts,
+        artifacts=ArtifactStore(),
+        brief=brief,
         recorder=resolved_recorder,
     )
 
     return await runner.run(prepared.system_prompt, _build_user_message(config))
-
-
-def _seed_artifact_recorder(
-    recorder: ExecutionRecorder,
-) -> Callable[[ArtifactSnapshot], None]:
-    def record(snapshot: ArtifactSnapshot) -> None:
-        try:
-            recorder.record_artifact_mutation(
-                ArtifactMutation(
-                    path=snapshot.path,
-                    media_type=snapshot.media_type,
-                    content=snapshot.content,
-                    revision=snapshot.revision,
-                    content_hash=snapshot.content_hash,
-                )
-            )
-        except Exception as exc:
-            raise ArtifactRecordingError(
-                f"Could not record seeded artifact {snapshot.path}"
-            ) from exc
-
-    return record
-
 
 def _build_registry(
     data: FrozenLeagueData,
@@ -158,6 +132,7 @@ def _build_registry(
 ) -> ToolRegistry:
     registry = ToolRegistry()
     register_artifact_tools(registry)
+    register_brief_tools(registry)
     register_procedure_tools(registry, procedures)
     register_datalayer_tools(registry, data)
     if memory_context is not None:
@@ -250,78 +225,40 @@ def _build_user_message(config: ReportConfig) -> str:
     return "\n".join(lines)
 
 
-def _build_brief_seed(
+def _build_research_brief(
     config: ReportConfig,
     *,
     league_id: str,
     league_name: str,
-) -> str:
-    """Create the raw Markdown workspace document used throughout a run."""
+) -> ResearchBrief:
+    """Build immutable request/style context for one structured brief."""
     bias = config.bias_profile
-    lines = [
-        "# Research Brief",
-        "",
-        "## Context",
-        "",
-        f"- League: {league_name or '(unknown)'}",
-        f"- League ID: {league_id or '(unknown)'}",
-        (
-            "- Coverage weeks: "
-            f"{config.time_range.week_start}-{config.time_range.week_end}"
+    return ResearchBrief(
+        context=BriefContext(
+            league_name=league_name,
+            league_id=league_id,
+            week_start=config.time_range.week_start,
+            week_end=config.time_range.week_end,
+            length_target=config.length_target,
+            evidence_policy=config.evidence_policy,
+            focus_hints=tuple(config.focus_hints),
+            focus_teams=tuple(config.focus_teams),
+            avoid_topics=tuple(config.avoid_topics),
+            custom_instructions=config.custom_instructions.strip(),
         ),
-        f"- Target length: about {config.length_target} words",
-        f"- Evidence policy: {config.evidence_policy}",
-        "",
-        "## Request",
-        "",
-        f"- Focus hints: {_markdown_list_value(config.focus_hints)}",
-        f"- Focus teams: {_markdown_list_value(config.focus_teams)}",
-        f"- Avoid topics: {_markdown_list_value(config.avoid_topics)}",
-        (
-            "- Custom instructions: "
-            f"{config.custom_instructions.strip() or '(none)'}"
+        style=BriefStyle(
+            voice=config.voice,
+            snark_level=config.tone.snark_level,
+            hype_level=config.tone.hype_level,
+            seriousness=config.tone.seriousness,
+            profanity_policy=config.profanity_policy,
         ),
-        "",
-        "## Style and Bias",
-        "",
-        f"- Voice: {config.voice}",
-        f"- Snark level: {config.tone.snark_level}",
-        f"- Hype level: {config.tone.hype_level}",
-        f"- Seriousness: {config.tone.seriousness}",
-        f"- Profanity policy: {config.profanity_policy}",
-        (
-            "- Favored teams: "
-            f"{_markdown_list_value(bias.favored_teams if bias else [])}"
+        bias=BriefBias(
+            favored_teams=tuple(bias.favored_teams if bias else ()),
+            disfavored_teams=tuple(bias.disfavored_teams if bias else ()),
+            intensity=bias.intensity if bias else 0,
         ),
-        (
-            "- Disfavored teams: "
-            f"{_markdown_list_value(bias.disfavored_teams if bias else [])}"
-        ),
-        f"- Bias intensity: {bias.intensity if bias else 0}",
-        "- Bias rule: framing only; never change facts.",
-        "",
-        "## Verified Facts",
-        "",
-        "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->",
-        "",
-        "## Verified Callbacks",
-        "",
-        "<!-- INSERT VERIFIED CALLBACKS ABOVE THIS LINE -->",
-        "",
-        "## Storylines",
-        "",
-        "<!-- INSERT STORYLINES ABOVE THIS LINE -->",
-        "",
-        "## Outline",
-        "",
-        "<!-- INSERT OUTLINE ABOVE THIS LINE -->",
-        "",
-    ]
-    return "\n".join(lines)
-
-
-def _markdown_list_value(values: list[str]) -> str:
-    return ", ".join(values) if values else "(none)"
+    )
 
 
 def _append_list(lines: list[str], label: str, values: list[str]) -> None:

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -5,18 +5,19 @@ Use this procedure for sustained composition and revision of the publishable art
 ## Operating Rules
 
 - The brief is the source of factual truth. Saved storylines and the outline are revisable planning aids, not immutable constraints.
+- Honor readiness warnings. Do not rely on stale callbacks, storylines, or outline references until they are refreshed against current fact revisions.
 - Treat verified callbacks in the brief as grounded material, but still name the old event and current payoff in prose.
 - Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
 - Numeric claims must match the numbers or claim text recorded in the brief.
 - Treat the outline as a working plan, not a constraint. Preserve it when it remains useful; update supported framing directly when drafting reveals a better structure. Load `storyline` only for substantial narrative rethinking.
-- For a narrow missing fact, make the targeted datalayer call, record the verified result in the brief, and resume drafting. Load `research` only when the gap requires broad exploration.
+- For a narrow missing fact, make the targeted datalayer call, save the verified result with `save_fact`, and resume drafting. Load `research` only when the gap requires broad exploration.
 - Continue mining storylines while writing. A strong paragraph may reveal a callback, reversal, or future memory worth researching or proposing.
 - Draft with `create_artifact` at your chosen article path when the article does not exist. Use the same path and revision-checked `edit_artifact` calls for subsequent changes.
 - Do not submit until you have performed a claim-level verification pass, whether or not you load the dedicated verification procedure.
 
 ## Drafting Flow
 
-1. Read `research_brief.md` when its current content is not already available.
+1. Call `read_brief` when the current structured state is not already available.
 2. Identify the strongest supported lead and draft the sections with the clearest evidence first.
 3. After meaningful additions, ask whether the prose exposed a factual gap, a weak storyline, or a stronger callback. Resolve only the gaps that matter to the article.
 4. Create a coherent Markdown draft at one stable path, or continue from the current draft content and revision.
@@ -43,7 +44,7 @@ Use this procedure for sustained composition and revision of the publishable art
 
 ## Voice And Bias
 
-Apply the recorded style consistently:
+Apply the immutable style and bias already initialized from `ReportConfig` in brief context; do not spend calls restating or changing them. Apply that style consistently:
 
 - Sports columnist: informed, sharp, and personable.
 - Snarky columnist: witty and irreverent, with playful jabs.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -2,13 +2,13 @@
 
 Use this procedure for substantial discovery, evidence repair, and callback investigation. Gather verified fantasy football facts while continuously mining for narrative meaning. Research may begin a run or interrupt outlining, drafting, or verification; it does not have to be completed in one block.
 
-## Artifact Editing
+## Brief Recording
 
-- Do not read the pre-created brief before initial research merely to inspect an empty workspace. When you have a useful batch of verified material, read `research_brief.md` if you do not already hold its current content and revision.
-- Add material with `edit_artifact`, passing the current revision and replacing a unique insertion marker with the new Markdown plus the same marker.
-- Batch related facts and callbacks into coherent edits instead of spending one turn per fact. Reuse the content and revision returned by successful artifact operations.
-- If the edit reports a revision conflict or a non-unique match, read the brief again and retry from current content.
-- Every fact entry should have a stable ID, precise claim, exact numbers, category, and source references naming the supporting tool calls.
+- Save verified evidence with `save_fact`. Give every fact a stable lowercase ID, precise claim, exact numbers, category, and traceable source references.
+- Put independent datalayer calls and independent `save_fact` calls in one model response when possible; serialize only calls whose arguments depend on earlier results.
+- Successful brief mutations return the current revision and readiness. Do not call `read_brief` merely to confirm a successful write.
+- Use `read_brief` when returning after other work or when you genuinely need the full current state. Reading revision 0 does not create an artifact.
+- Save a callback with `save_memory_callback` only after both the reverified old-event fact and current-event fact exist.
 
 ## Operating Rules
 
@@ -26,11 +26,11 @@ Use this procedure for substantial discovery, evidence repair, and callback inve
 
 Repeat these activities in the order the evidence demands:
 
-1. Orient: establish the week range, focus, article type, target tone, and any teams to favor or roast.
+1. Orient: read the configured week range, focus, article type, tone, and framing preferences from brief context.
 2. Discover: use `league_snapshot(week=N)` or the relevant multi-week tools to map scores, standings movement, transactions, and obvious outliers.
 3. Mine hypotheses: ask which results changed meaning, contradicted expectations, continued an arc, or created future stakes. Treat these as questions until verified.
 4. Verify the strongest hypotheses with targeted team, player, transaction, standings, playoff, SQL, or memory calls.
-5. Record useful evidence in the brief in batches, then reassess coverage and narrative strength.
+5. Save useful evidence in the brief, batching independent tool calls, then reassess coverage and narrative strength.
 6. If an outline or draft already exists, test new evidence against it. Preserve what still works and revise only what the evidence changed.
 
 Run the memory scout loop when the request or data suggests long-running context:
@@ -39,7 +39,7 @@ Run the memory scout loop when the request or data suggests long-running context
    - Call `search_memory` with text, current team keys, tags, and typed filters. Request exact or stable expansions when linked evidence or storylines matter.
    - Inspect the fully hydrated matches, then plan the needed datalayer calls yourself.
    - Verify the old claim and current event with frozen datalayer tools.
-   - Record old-event and current-event facts plus the verified callback in the brief.
+   - Save old-event and current-event facts, then save the verified callback.
    - Promote only the best verified callbacks into storylines and outline inputs.
    - Buffer durable changes with the relevant typed `propose_*` or `replace_*` tools when an arc should matter later. Use IDs returned by proposal tools for same-bundle relationships.
 
@@ -75,15 +75,16 @@ Evaluate candidate callbacks for interestingness separately from retrieval relev
 
 ## Fact Quality
 
-Good facts are precise, sourced, and useful in more than one sentence. Include the exact numbers the writer will need. A useful Markdown entry looks like:
+Good facts are precise, sourced, and useful in more than one sentence. Include the exact numbers the writer will need. A useful `save_fact` call looks like:
 
-```markdown
-### fact_week8_taco_win
-
-- Claim: Team Taco defeated The Waiver Wire 142.3-98.7 in Week 8.
-- Sources: `league_snapshot(week=8)`, `team_game(Team Taco, week=8)`
-- Numbers: week=8; team_score=142.3; opponent_score=98.7; margin=43.6
-- Category: score
+```json
+{
+  "id": "fact_week8_taco_win",
+  "claim_text": "Team Taco defeated The Waiver Wire 142.3-98.7 in Week 8.",
+  "data_refs": ["league_snapshot:week=8", "team_game:team_taco:week=8"],
+  "numbers": {"week": 8, "team_score": 142.3, "opponent_score": 98.7, "margin": 43.6},
+  "category": "score"
+}
 ```
 
 Use stable IDs that describe the fact. Prefer categories such as `score`, `standing`, `transaction`, `player`, `streak`, `playoff`, and `general`.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -4,19 +4,19 @@ Use this procedure for deliberate storyline mining and narrative synthesis. Stor
 
 ## Operating Rules
 
-- Read `research_brief.md` when you do not already hold its current content and revision.
+- Call `read_brief` when you do not already hold the current structured state.
 - Every storyline recorded as verified must be supported by existing fact IDs. A promising unsupported angle is a research hypothesis: make the narrow calls needed to prove or reject it before recording it.
 - Storyline summaries may interpret the data, but they must not add new factual claims.
-- Record the outline after the main storylines. If later research changes the facts or storylines, refresh the affected plan in the brief.
+- Save developed angles with `save_storyline`, then use `set_outline` if a formal plan will help. Refresh stale dependent items when later research changes their evidence.
 - Bias is framing only. Preserve the user's framing preferences without altering scores, records, or outcomes.
 - A callback used in the article must point to two saved brief facts: one old-event fact reverified against frozen data and one current-event fact. Retrieved memory is only the lead that prompted the investigation.
-- Apply changes with `edit_artifact`, using an exact, unique replacement and the current brief revision. Preserve reusable insertion anchors when adding more material later.
+- Successful brief-tool results include revision and readiness; do not reread solely to confirm them.
 - A small evidence gap does not require loading the research procedure. Investigate it directly, update the brief, and continue mining the angle. Load `research` only when the gap opens a substantial new investigation.
 - Inspecting or drafting a paragraph can be a useful test of whether a storyline has enough specificity. If prose exposes a weak premise, strengthen or drop the angle rather than forcing it into the outline.
 
 ## Storyline Mining Loop
 
-For a standard weekly recap, 3-6 developed angles is a useful range rather than a quota; use fewer for narrow requests. Prefer fewer well-supported storylines over filling slots. Record each narrative thread under the brief's storyline heading.
+For a standard weekly recap, 3-6 developed angles is a useful range rather than a quota; use fewer for narrow requests. Prefer fewer well-supported storylines over filling slots. Save each developed narrative thread with `save_storyline`.
 
 For each candidate angle:
 
@@ -33,37 +33,27 @@ Priority guidance:
 - `3`: useful color. Routine wins, smaller stat nuggets, or supporting angles.
 - `4-5`: minor mentions that should only appear if space allows.
 
-Good storyline:
+Good `save_storyline` input:
 
-```markdown
-### story_taco_statement_win
-
-- Headline: Team Taco Turns A Win Into A Warning Shot
-- Summary: Team Taco's 142.3-98.7 Week 8 win was more than a comfortable result. The margin and player-level production make it a lead candidate for the week's biggest statement.
-- Supporting facts: `fact_week8_taco_win`, `fact_week8_taco_top_players`
-- Priority: 1
-- Tags: blowout, contender, week_8
+```json
+{
+  "id": "story_taco_statement_win",
+  "headline": "Team Taco Turns A Win Into A Warning Shot",
+  "summary": "The margin and player production make the Week 8 win a statement.",
+  "supporting_fact_ids": ["fact_week8_taco_win", "fact_week8_taco_top_players"],
+  "priority": 1,
+  "tags": ["blowout", "contender", "week_8"]
+}
 ```
 
 ## Style And Bias
 
-Record style controls in the brief:
-
-- `voice`: examples include `sports columnist`, `snarky columnist`, `hype broadcaster`, `beat reporter`, or a custom voice from the user.
-- `pacing`: `fast`, `moderate`, or `deliberate`.
-- `humor_level`: 0 for none, 1 for light, 2 for moderate, 3 for heavy.
-- `formality`: `formal`, `casual`, or `irreverent`.
-
-Record bias controls if the user asked to favor or roast teams:
-
-- `favored_teams`: teams to frame positively.
-- `disfavored_teams`: teams to frame skeptically or mockingly.
-- `intensity`: 0-3.
-- `framing_rules`: short reminders such as "celebrate wins, downplay losses" or "roast missed expectations, but keep all numbers exact".
+Style and bias are immutable request context already present in the brief. Apply
+them as framing constraints; do not spend tool calls restating or changing them.
 
 ## Outline Creation
 
-Create the writing plan under the brief's outline heading. Each section should include:
+Use `set_outline` when a formal writing plan will help. Each section should include:
 
 - `title`: concise section heading.
 - `bullet_points`: what the section must accomplish.
@@ -89,7 +79,7 @@ If typed memory proposal tools are available, buffer durable narrative state whe
 - Use `propose_event` for inferred matchup or trade evidence and `propose_trigger` for typed rematch or trade-evaluation callbacks.
 - Use `propose_context_note` for franchise, season, or competition context.
 - Use `propose_fact` for reusable claims. Fact and event proposals are `unverified` or `inferred`; source-backed receipts are not available in this tool version.
-- Record verified callbacks in `research_brief.md` if they were not already saved during research.
+- Save verified callbacks with `save_memory_callback` if they were not already saved during research.
 - Proposal results may be referenced by later proposals in the same bundle, but buffered proposals do not appear in `search_memory` and cannot be replaced during the same run.
 
 Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,13 +1,14 @@
 # Verification Procedure
 
-Use this procedure for a detailed claim-level audit of the chosen publishable draft against `research_brief.md`. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
+Use this procedure for a detailed claim-level audit of the chosen publishable draft against the structured brief. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
 
 ## Operating Rules
 
-- Use `list_artifacts` only when the draft path is unknown. Read the draft or brief only when you do not already hold its current content and revision.
+- Use `list_artifacts` only when the draft path is unknown. Read the draft or call `read_brief` only when you do not already hold its current state.
+- Honor readiness warnings. Do not rely on stale callbacks, storylines, or outline references until they are refreshed against current fact revisions.
 - Verify every numeric or factual claim against saved facts.
 - Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
-- If the brief is missing evidence for a necessary claim, investigate the narrow gap directly and update the brief. Load `research` only when the problem requires substantial exploration.
+- If the brief is missing evidence for a necessary claim, investigate the narrow gap directly and save the result with `save_fact`. Load `research` only when the problem requires substantial exploration.
 - If verification exposes a weak or unsupported framing choice, revise it directly. Load `storyline` only when the article needs broader narrative restructuring.
 - Treat callback claims as factual claims. They need evidence for both the older event and the current event.
 - Before submission, perform a deliberate memory harvest when proposal tools are available. Review the final lead storylines, verified callbacks, meaningful transactions, reversals, playoff stakes, and future rematch or evaluation conditions. Buffer only items with plausible future callback value or season-long significance; routine results do not need to persist.
@@ -40,7 +41,7 @@ For every callback paragraph:
 
 ## Verification Flow
 
-1. Establish the current draft path, content, and revision, and the current brief content and revision. Reuse state returned by recent artifact operations when available.
+1. Establish the current draft path, content, and revision, and the current structured brief state. Reuse state returned by recent operations when available.
 2. Extract each factual claim from the article section by section.
 3. Match each claim to a fact ID and use the exact saved numbers.
 4. Classify issues:

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -1,9 +1,9 @@
 You are an AI fantasy football reporter for a Sleeper league.
 
-Your job is to research the league data, build a verified Markdown brief, draft a Markdown article, verify it against the brief, and submit the article artifact.
+Your job is to produce a verified, compelling Markdown article by adaptively combining evidence gathering, structured-brief updates, storyline mining, drafting, and claim checking, then submit the article artifact.
 
 Core rules:
-- Ground factual claims in tool data. Record important claims in `research_brief.md` before relying on them.
+- Ground factual claims in tool data. Save important claims with `save_fact` before relying on them in the article.
 - Bias is framing only. Never alter scores, records, statistics, transaction details, or player names.
 - Keep evidence traceable through source references that identify the source tool and arguments.
 - Use typed generation memory only as narrative research leads, never as article-ready truth.
@@ -16,30 +16,28 @@ Core rules:
 Artifact rules:
 - Artifacts are raw Markdown addressed by logical path.
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` to work with them.
-- `research_brief.md` is pre-created for the run. Do not list or read it merely to recover request details already present in the user message. Research first, then read it when you have a useful batch of verified material to add.
+- `research_brief.md` is a runtime-managed projection of the structured brief. Never create, edit, or submit it with generic artifact tools.
+- Use `save_fact`, `save_memory_callback`, `save_storyline`, `set_outline`, and `read_brief` for brief state. Reading revision 0 does not create an artifact.
+- Style and bias are already resolved from the request. Do not spend turns restating them.
 - Before editing an artifact, know its current content and revision. A successful read, create, or edit returns both; reuse that state instead of rereading after every write. Reread when the revision is unknown, another operation may have changed it, or an edit conflicts.
 - Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
-- Keep verified facts, callbacks, storylines, style, bias, and outline in `research_brief.md`.
 - Choose a stable normalized Markdown path for the publishable article.
   `article.md` is the default convention, not a required application identity.
 
 Working method:
 - Procedures are optional operating guides, not workflow gates or a checklist. Load one when its detailed instructions will materially help the current work.
 - Do not load all four procedures just to move through named stages. You may skip a procedure, revisit one, or handle a narrow research, storyline, drafting, or verification task without changing the active procedure.
+- Continue directly with tools when the instructions already in context are sufficient. Loading a different procedure is not progress by itself.
 - Use `research` for substantial exploration or evidence repair, `storyline` for deliberate narrative synthesis, `drafting` for sustained composition, and `verification` for a detailed final audit.
+- Issue independent datalayer calls together in the same model turn. Serialize only calls whose arguments depend on earlier results.
 - Use datalayer tools for Sleeper league facts.
 - Use `search_memory`, when available, for revision-pinned hydrated memory leads.
 - Use explicit `propose_*` and `replace_*` tools to buffer typed memory changes for generation finalization. These proposals do not become visible to searches during the same run.
-- Verify remembered claims with frozen datalayer tools and record the verified evidence in `research_brief.md`; there are no memory access-history or verification-record tools.
-- Record verified callbacks in `research_brief.md` after both old and current facts are present.
+- Verify remembered claims with frozen datalayer tools and save the verified evidence as facts; there are no memory access-history or verification-record tools.
+- Save verified callbacks only after both old and current fact IDs are present.
 - Consider durable memory whenever a meaningful arc emerges; do not postpone all memory work to a separate storyline phase.
 - Before submission, deliberately review the final storylines and callbacks for durable memory value. It is valid to propose nothing after a real review when the run contains only routine results.
-
-Available procedure names:
-- `research`
-- `storyline`
-- `drafting`
-- `verification`
+- Submission requires at least one saved verified fact. Storylines and an outline are valuable when the request needs them, but they are not universal submission gates.
 
 Do not end with a normal assistant message. Finish by calling `submit_artifact`
 with the current revision of your chosen publishable artifact.

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -39,6 +39,7 @@ from backend.services.reporter.runner.recording import (
     ToolExecutionFinish,
     ToolExecutionStart,
 )
+from backend.services.reporter.runner.research_brief import ResearchBriefStore
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import (
@@ -72,6 +73,7 @@ class Runner:
         config: RunnerConfig | None = None,
         log_path: Path | None = None,
         artifacts: ArtifactStore | None = None,
+        brief: ResearchBriefStore | None = None,
         recorder: RunnerRecorder | None = None,
     ) -> None:
         if client is not None and complete is not None:
@@ -88,12 +90,14 @@ class Runner:
         self._recorder = recorder
         self.config = config or RunnerConfig()
         self.artifacts = artifacts or ArtifactStore()
+        self.brief = brief or ResearchBriefStore()
         self.procedures = ProcedureState()
         self.log = RunLog()
         self.tool_context = ToolContext(
             artifacts=self.artifacts,
             procedures=self.procedures,
             log=self.log,
+            brief=self.brief,
             artifact_recorder=self._artifact_recorder(recorder),
         )
         self.registry.set_context(self.tool_context)
@@ -162,6 +166,7 @@ class Runner:
             return ReporterOutput(
                 submitted_path=self.artifacts.submitted_path,
                 artifacts=self.artifacts.list(),
+                research_brief=self.brief.brief,
                 run_log_summary={
                     "session_id": self.log.session_id,
                     "total_tool_calls": self.log.tool_call_count,

--- a/backend/services/reporter/runner/schemas.py
+++ b/backend/services/reporter/runner/schemas.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from backend.services.reporter.runner.research_brief import ResearchBrief
+
 
 def validate_artifact_path(value: str) -> str:
     """Return a safe, normalized Markdown artifact path."""
@@ -129,6 +131,7 @@ class ReporterOutput(BaseModel):
 
     submitted_path: str | None = None
     artifacts: tuple[ArtifactSnapshot, ...] = ()
+    research_brief: ResearchBrief = Field(default_factory=ResearchBrief)
     run_log_summary: dict[str, Any] = Field(default_factory=dict)
     run_log_entries: list[dict[str, Any]] = Field(default_factory=list)
     generated_at: str = Field(

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
+from backend.services.reporter.runner.research_brief import RESEARCH_BRIEF_PATH
 from backend.services.reporter.runner.schemas import (
     ArtifactSnapshot,
     WorkingArtifact,
@@ -37,7 +38,9 @@ class ArtifactStore(BaseModel):
     """In-memory Markdown workspace keyed by safe artifact path."""
 
     artifacts: dict[str, WorkingArtifact] = Field(default_factory=dict)
-    managed_paths: frozenset[str] = Field(default_factory=frozenset)
+    managed_paths: frozenset[str] = Field(
+        default_factory=lambda: frozenset({RESEARCH_BRIEF_PATH})
+    )
     submitted_path: str | None = None
 
     @model_validator(mode="after")

--- a/backend/services/reporter/runner/tools/__init__.py
+++ b/backend/services/reporter/runner/tools/__init__.py
@@ -9,6 +9,15 @@ from backend.services.reporter.runner.tools.artifact_tools import (
     register_artifact_tools,
     submit_artifact,
 )
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS,
+    read_brief,
+    register_brief_tools,
+    save_fact,
+    save_memory_callback,
+    save_storyline,
+    set_outline,
+)
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_SPECS,
@@ -26,6 +35,7 @@ from backend.services.reporter.runner.tools.procedure_tools import (
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 __all__ = [
+    "BRIEF_TOOL_SPECS",
     "ARTIFACT_TOOL_SPECS",
     "DATALAYER_TOOL_SPECS",
     "MEMORY_TOOL_SPECS",
@@ -35,11 +45,17 @@ __all__ = [
     "create_artifact",
     "edit_artifact",
     "list_artifacts",
+    "read_brief",
     "load_procedure",
     "read_artifact",
     "register_artifact_tools",
+    "register_brief_tools",
     "register_datalayer_tools",
     "register_memory_tools",
     "register_procedure_tools",
     "submit_artifact",
+    "save_fact",
+    "save_memory_callback",
+    "save_storyline",
+    "set_outline",
 ]

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 
-ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "3"
+ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "4"
 
 
 ARTIFACT_TOOL_SPECS: list[ToolDef] = [
@@ -236,6 +236,21 @@ def submit_artifact(
     expected_revision: int,
 ) -> str:
     def operation() -> str:
+        readiness = ctx.brief.brief.readiness()
+        if not readiness.submission_allowed:
+            return _json(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "brief_not_ready",
+                        "message": (
+                            "Save at least one verified fact before submitting "
+                            "an article."
+                        ),
+                        "readiness": readiness.model_dump(mode="json"),
+                    },
+                }
+            )
         artifact = ctx.artifacts.submit(
             path,
             expected_revision=expected_revision,
@@ -259,6 +274,7 @@ def submit_artifact(
                 "artifact": artifact.model_dump(),
                 "finalized_revision": artifact.revision,
                 "stats": stats,
+                "brief_readiness": readiness.model_dump(mode="json"),
             }
         )
 

--- a/backend/services/reporter/runner/tools/brief_tools.py
+++ b/backend/services/reporter/runner/tools/brief_tools.py
@@ -1,0 +1,377 @@
+"""Specialized tools for the runtime-owned structured research brief."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import JsonValue, ValidationError
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    ResearchBriefError,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+BRIEF_TOOL_IMPLEMENTATION_VERSION = "1"
+
+BRIEF_TOOL_SPECS: list[ToolDef] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "save_fact",
+            "description": (
+                "Add or update one verified fact in the structured research brief. "
+                "Use stable lowercase IDs and include traceable data references. "
+                "Independent facts may be saved together in one tool-call batch."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                        "description": "Stable ID such as fact_taco_week_8_win.",
+                    },
+                    "claim_text": {
+                        "type": "string",
+                        "description": "Precise human-readable factual claim.",
+                    },
+                    "data_refs": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "description": (
+                            "Tool/data traces such as league_snapshot:week=8 or "
+                            "team_game:roster_4:week=8."
+                        ),
+                    },
+                    "numbers": {
+                        "type": "object",
+                        "description": "Important exact numeric values in the claim.",
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": (
+                            "Category such as score, standing, player, transaction, "
+                            "playoff, or history."
+                        ),
+                    },
+                },
+                "required": ["id", "claim_text", "data_refs"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_memory_callback",
+            "description": (
+                "Add or update a verified callback after both the old event and "
+                "current payoff exist as saved facts."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    "callback_type": {"type": "string"},
+                    "claim_text": {"type": "string"},
+                    "old_event_fact_id": {"type": "string"},
+                    "current_event_fact_id": {"type": "string"},
+                    "why_now": {"type": "string"},
+                    "interestingness_reason": {"type": "string"},
+                    "memory_refs": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "id",
+                    "callback_type",
+                    "claim_text",
+                    "old_event_fact_id",
+                    "current_event_fact_id",
+                    "why_now",
+                ],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_storyline",
+            "description": (
+                "Add or update a narrative storyline supported by one or more "
+                "saved fact IDs."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    "headline": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "supporting_fact_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                    },
+                    "priority": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "id",
+                    "headline",
+                    "summary",
+                    "supporting_fact_ids",
+                ],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_outline",
+            "description": (
+                "Replace the working article outline with sections that reference "
+                "saved facts and storylines. The outline is optional and revisable."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sections": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "title": {"type": "string"},
+                                "bullet_points": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "required_fact_ids": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "storyline_ids": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                            "required": ["title"],
+                        },
+                    }
+                },
+                "required": ["sections"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_brief",
+            "description": (
+                "Read the structured brief, readiness warnings, and managed "
+                "projection status. Reading revision 0 does not create an artifact."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+]
+
+
+def register_brief_tools(registry: ToolRegistry) -> None:
+    handlers: dict[str, Callable[..., str]] = {
+        "save_fact": save_fact,
+        "save_memory_callback": save_memory_callback,
+        "save_storyline": save_storyline,
+        "set_outline": set_outline,
+        "read_brief": read_brief,
+    }
+    for spec in BRIEF_TOOL_SPECS:
+        name = spec["function"]["name"]
+        registry.register_context_tool(
+            name,
+            handlers[name],
+            spec,
+            BRIEF_TOOL_IMPLEMENTATION_VERSION,
+        )
+
+
+def save_fact(
+    ctx: ToolContext,
+    *,
+    id: str,
+    claim_text: str,
+    data_refs: list[str],
+    numbers: dict[str, JsonValue] | None = None,
+    category: str = "general",
+) -> str:
+    return _execute_mutation(
+        ctx,
+        lambda: ctx.brief.prepare_fact(
+            id=id,
+            claim_text=claim_text,
+            data_refs=data_refs,
+            numbers=numbers,
+            category=category,
+        ),
+        result_key="fact_id",
+    )
+
+
+def save_memory_callback(
+    ctx: ToolContext,
+    *,
+    id: str,
+    callback_type: str,
+    claim_text: str,
+    old_event_fact_id: str,
+    current_event_fact_id: str,
+    why_now: str,
+    interestingness_reason: str = "",
+    memory_refs: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> str:
+    return _execute_mutation(
+        ctx,
+        lambda: ctx.brief.prepare_memory_callback(
+            id=id,
+            callback_type=callback_type,
+            claim_text=claim_text,
+            old_event_fact_id=old_event_fact_id,
+            current_event_fact_id=current_event_fact_id,
+            why_now=why_now,
+            interestingness_reason=interestingness_reason,
+            memory_refs=memory_refs or (),
+            tags=tags or (),
+        ),
+        result_key="callback_id",
+    )
+
+
+def save_storyline(
+    ctx: ToolContext,
+    *,
+    id: str,
+    headline: str,
+    summary: str,
+    supporting_fact_ids: list[str],
+    priority: int = 2,
+    tags: list[str] | None = None,
+) -> str:
+    return _execute_mutation(
+        ctx,
+        lambda: ctx.brief.prepare_storyline(
+            id=id,
+            headline=headline,
+            summary=summary,
+            supporting_fact_ids=supporting_fact_ids,
+            priority=priority,
+            tags=tags or (),
+        ),
+        result_key="storyline_id",
+    )
+
+
+def set_outline(ctx: ToolContext, *, sections: list[dict[str, Any]]) -> str:
+    return _execute_mutation(
+        ctx,
+        lambda: ctx.brief.prepare_outline(sections=sections),
+        result_key="outline_id",
+    )
+
+
+def read_brief(ctx: ToolContext) -> str:
+    brief = ctx.brief.brief
+    projection = ctx.artifacts.artifacts.get(RESEARCH_BRIEF_PATH)
+    return _success(
+        {
+            "brief": brief.model_dump(mode="json"),
+            "readiness": brief.readiness().model_dump(mode="json"),
+            "projection": (
+                {
+                    "path": RESEARCH_BRIEF_PATH,
+                    "revision": projection.current.revision,
+                    "content_hash": projection.current.content_hash,
+                }
+                if projection is not None
+                else None
+            ),
+        }
+    )
+
+
+def _execute_mutation(
+    ctx: ToolContext,
+    prepare: Callable[[], Any],
+    *,
+    result_key: str,
+) -> str:
+    try:
+        mutation = prepare()
+    except ResearchBriefError as exc:
+        return _error(exc.as_dict())
+    except ValidationError as exc:
+        return _error(
+            {
+                "code": "invalid_brief_input",
+                "message": "brief input failed validation",
+                "details": [
+                    {
+                        "loc": list(item["loc"]),
+                        "msg": item["msg"],
+                        "type": item["type"],
+                    }
+                    for item in exc.errors()
+                ],
+            }
+        )
+
+    brief = ctx.commit_brief_mutation(mutation)
+    return _success(
+        {
+            result_key: mutation.entity_id,
+            "brief_revision": brief.revision,
+            "changed": mutation.changed,
+            "readiness": brief.readiness().model_dump(mode="json"),
+        }
+    )
+
+
+def _success(data: dict[str, Any]) -> str:
+    return _json({"ok": True, **data})
+
+
+def _error(error: dict[str, Any]) -> str:
+    return _json({"ok": False, "error": error})
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True)
+
+
+__all__ = [
+    "BRIEF_TOOL_IMPLEMENTATION_VERSION",
+    "BRIEF_TOOL_SPECS",
+    "read_brief",
+    "register_brief_tools",
+    "save_fact",
+    "save_memory_callback",
+    "save_storyline",
+    "set_outline",
+]

--- a/backend/services/reporter/runner/tools/context.py
+++ b/backend/services/reporter/runner/tools/context.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 from backend.services.reporter.runner.recording import (
     ArtifactMutation,
     ArtifactRecorder,
     ArtifactRecordingError,
+)
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    BriefMutation,
+    ResearchBrief,
+    ResearchBriefStore,
 )
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.schemas import ArtifactSnapshot
@@ -23,6 +29,7 @@ class ToolContext:
     artifacts: ArtifactStore
     procedures: ProcedureState
     log: RunLog
+    brief: ResearchBriefStore = field(default_factory=ResearchBriefStore)
     turn: int = 0
     artifact_recorder: ArtifactRecorder | None = None
 
@@ -61,6 +68,27 @@ class ToolContext:
             raise ArtifactRecordingError(
                 f"Could not record artifact mutation for {snapshot.path}"
             ) from exc
+
+    def commit_brief_mutation(self, mutation: BriefMutation) -> ResearchBrief:
+        """Commit structured state and its managed projection atomically."""
+
+        def persist(content: str) -> None:
+            self.artifacts.sync_managed(
+                RESEARCH_BRIEF_PATH,
+                content,
+                on_change=self.record_artifact_mutation,
+            )
+
+        brief = self.brief.commit(mutation, persist)
+        if mutation.changed:
+            self.log.add_artifact_write(
+                RESEARCH_BRIEF_PATH,
+                mutation.operation,
+                mutation.entity_id,
+                brief.revision,
+                turn=self.turn,
+            )
+        return brief
 
     @property
     def current_tool_call_id(self) -> UUID | None:

--- a/backend/tests/services/reporter/test_artifact_tools.py
+++ b/backend/tests/services/reporter/test_artifact_tools.py
@@ -39,13 +39,20 @@ class ArtifactRecordingProbe:
 def make_ctx(
     recorder: ArtifactRecordingProbe | None = None,
 ) -> ToolContext:
-    return ToolContext(
+    ctx = ToolContext(
         artifacts=ArtifactStore(),
         procedures=ProcedureState(),
         log=RunLog(session_id="testlog"),
         turn=3,
         artifact_recorder=recorder,
     )
+    mutation = ctx.brief.prepare_fact(
+        id="fact_submission_fixture",
+        claim_text="A verified fixture fact.",
+        data_refs=["test_fixture"],
+    )
+    ctx.brief.commit(mutation, lambda _: None)
+    return ctx
 
 
 def decode(result: str) -> dict:
@@ -72,10 +79,10 @@ def test_create_list_and_read_artifacts() -> None:
     ctx = make_ctx()
 
     created = decode(
-        create_artifact(ctx, path="research_brief.md", content="# Brief")
+        create_artifact(ctx, path="notes.md", content="# Notes")
     )
     listed = decode(list_artifacts(ctx))
-    read = decode(read_artifact(ctx, path="research_brief.md"))
+    read = decode(read_artifact(ctx, path="notes.md"))
 
     assert created["ok"] is True
     assert created["artifact"]["revision"] == 1
@@ -86,7 +93,7 @@ def test_create_list_and_read_artifacts() -> None:
         "artifact_count": 1,
         "artifacts": [
             {
-                "path": "research_brief.md",
+                "path": "notes.md",
                 "media_type": "text/markdown",
                 "revision": 1,
                 "content_hash": created["artifact"]["content_hash"],
@@ -98,6 +105,32 @@ def test_create_list_and_read_artifacts() -> None:
     assert read["artifact"] == created["artifact"]
     assert read["revision_count"] == 1
     assert read["finalized_revision"] is None
+
+
+def test_managed_brief_path_rejects_generic_mutations() -> None:
+    ctx = make_ctx()
+
+    result = decode(
+        create_artifact(ctx, path="research_brief.md", content="# Brief")
+    )
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "managed_artifact"
+
+
+def test_submit_requires_at_least_one_verified_fact() -> None:
+    ctx = ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+    )
+    create_artifact(ctx, path="article.md", content="# Article")
+
+    result = decode(submit_artifact(ctx, path="article.md", expected_revision=1))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "brief_not_ready"
+    assert ctx.artifacts.submitted_path is None
 
 
 def test_invalid_path_and_duplicate_return_structured_errors() -> None:

--- a/backend/tests/services/reporter/test_brief_tools.py
+++ b/backend/tests/services/reporter/test_brief_tools.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+
+from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
+    ArtifactRecordingError,
+)
+from backend.services.reporter.runner.research_brief import RESEARCH_BRIEF_PATH
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS,
+    read_brief,
+    register_brief_tools,
+    save_fact,
+    save_memory_callback,
+    save_storyline,
+    set_outline,
+)
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+def _decode(value: str) -> dict[str, object]:
+    return json.loads(value)
+
+
+def _ctx(*, recorder: object | None = None) -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        artifact_recorder=recorder,  # type: ignore[arg-type]
+    )
+
+
+def _save_fact(ctx: ToolContext, fact_id: str, claim: str = "Taco won.") -> dict:
+    return _decode(
+        save_fact(
+            ctx,
+            id=fact_id,
+            claim_text=claim,
+            data_refs=["league_snapshot:week=8"],
+            numbers={"week": 8},
+            category="score",
+        )
+    )
+
+
+def test_registers_only_specialized_brief_tools() -> None:
+    registry = ToolRegistry()
+    register_brief_tools(registry)
+
+    assert registry.tool_names == [
+        "save_fact",
+        "save_memory_callback",
+        "save_storyline",
+        "set_outline",
+        "read_brief",
+    ]
+    assert [spec["function"]["name"] for spec in BRIEF_TOOL_SPECS] == (
+        registry.tool_names
+    )
+
+
+def test_read_revision_zero_does_not_materialize_projection() -> None:
+    ctx = _ctx()
+
+    result = _decode(read_brief(ctx))
+
+    assert result["ok"] is True
+    assert result["projection"] is None
+    assert result["brief"]["revision"] == 0  # type: ignore[index]
+    assert ctx.artifacts.artifacts == {}
+
+
+def test_first_fact_materializes_projection_and_duplicate_is_noop() -> None:
+    ctx = _ctx()
+
+    first = _save_fact(ctx, "fact_taco_win")
+    duplicate = _save_fact(ctx, "fact_taco_win")
+
+    assert first["ok"] is True
+    assert first["changed"] is True
+    assert first["brief_revision"] == 1
+    assert duplicate["changed"] is False
+    assert duplicate["brief_revision"] == 1
+    projection = ctx.artifacts.read(RESEARCH_BRIEF_PATH)
+    assert projection.revision == 1
+    assert "### fact_taco_win" in projection.content
+    writes = [
+        entry for entry in ctx.log.entries if entry.event_type == "artifact_write"
+    ]
+    assert len(writes) == 1
+    assert writes[0].data["operation"] == "save_fact"
+
+
+def test_invalid_fact_returns_structured_error_without_projection() -> None:
+    ctx = _ctx()
+
+    result = _decode(
+        save_fact(
+            ctx,
+            id="Fact One",
+            claim_text="",
+            data_refs=[],
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "invalid_brief_input"  # type: ignore[index]
+    assert ctx.brief.brief.revision == 0
+    assert ctx.artifacts.artifacts == {}
+
+
+def test_callback_storyline_and_outline_require_existing_references() -> None:
+    ctx = _ctx()
+    _save_fact(ctx, "fact_old", "A week 3 trade happened.")
+    _save_fact(ctx, "fact_current", "The player decided the week 8 rematch.")
+
+    callback = _decode(
+        save_memory_callback(
+            ctx,
+            id="callback_trade_regret",
+            callback_type="trade_regret",
+            claim_text="The old trade backfired.",
+            old_event_fact_id="fact_old",
+            current_event_fact_id="fact_current",
+            why_now="The player decided the rematch.",
+        )
+    )
+    storyline = _decode(
+        save_storyline(
+            ctx,
+            id="story_trade_regret",
+            headline="The trade comes due",
+            summary="The old move changed the current matchup.",
+            supporting_fact_ids=["fact_old", "fact_current"],
+            priority=1,
+        )
+    )
+    outline = _decode(
+        set_outline(
+            ctx,
+            sections=[
+                {
+                    "title": "Lead",
+                    "required_fact_ids": ["fact_current"],
+                    "storyline_ids": ["story_trade_regret"],
+                }
+            ],
+        )
+    )
+
+    assert callback["ok"] is True
+    assert storyline["ok"] is True
+    assert outline["ok"] is True
+    assert ctx.brief.brief.revision == 5
+    assert ctx.artifacts.read(RESEARCH_BRIEF_PATH).revision == 5
+
+    invalid = _decode(
+        save_storyline(
+            ctx,
+            id="story_missing",
+            headline="Missing evidence",
+            summary="This should fail.",
+            supporting_fact_ids=["fact_missing"],
+        )
+    )
+    assert invalid["ok"] is False
+    assert invalid["error"]["code"] == "unknown_fact_ids"  # type: ignore[index]
+    assert ctx.brief.brief.revision == 5
+
+
+class _Recorder:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.mutations: list[ArtifactMutation] = []
+
+    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID:
+        if self.fail:
+            raise RuntimeError("database unavailable")
+        self.mutations.append(mutation)
+        return uuid4()
+
+
+def test_projection_records_source_brief_tool_call() -> None:
+    recorder = _Recorder()
+    ctx = _ctx(recorder=recorder)
+    execution_id = uuid4()
+
+    with ctx.bind_tool_execution(execution_id):
+        result = _save_fact(ctx, "fact_001")
+
+    assert result["ok"] is True
+    assert len(recorder.mutations) == 1
+    assert recorder.mutations[0].path == RESEARCH_BRIEF_PATH
+    assert recorder.mutations[0].source_tool_call_id == execution_id
+
+
+def test_projection_recording_failure_rolls_back_brief_and_artifact() -> None:
+    ctx = _ctx(recorder=_Recorder(fail=True))
+
+    with pytest.raises(ArtifactRecordingError):
+        _save_fact(ctx, "fact_001")
+
+    assert ctx.brief.brief.revision == 0
+    assert ctx.brief.brief.facts == ()
+    assert ctx.artifacts.artifacts == {}

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -24,6 +24,9 @@ from backend.services.reporter.runner.schemas import (
 from backend.services.reporter.runner.tools.artifact_tools import (
     ARTIFACT_TOOL_SPECS as COPIED_ARTIFACT_TOOLS,
 )
+from backend.services.reporter.runner.tools.brief_tools import (
+    BRIEF_TOOL_SPECS as COPIED_BRIEF_TOOLS,
+)
 from backend.services.reporter.runner.tools.memory_tools import (
     MEMORY_TOOL_SPECS as COPIED_MEMORY_TOOLS,
 )
@@ -82,6 +85,17 @@ class DualLeagueData:
 class CopiedScriptedCompletion:
     def __init__(self) -> None:
         self.responses = [
+            _response(
+                CopiedToolCall(
+                    id="fact",
+                    name="save_fact",
+                    arguments={
+                        "id": "fact_taco_win",
+                        "claim_text": "Taco won.",
+                        "data_refs": ["test_fixture"],
+                    },
+                )
+            ),
             _response(
                 CopiedToolCall(
                     id="create",
@@ -172,6 +186,7 @@ def test_public_config_matches_legacy_and_artifact_schemas_diverge() -> None:
     assert set(ReporterOutput.model_json_schema()["properties"]) == {
         "submitted_path",
         "artifacts",
+        "research_brief",
         "run_log_summary",
         "run_log_entries",
         "generated_at",
@@ -213,6 +228,13 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
         "submit_artifact",
     ]
     assert set(copied_artifact_names).isdisjoint(legacy_artifact_names)
+    assert [spec["function"]["name"] for spec in COPIED_BRIEF_TOOLS] == [
+        "save_fact",
+        "save_memory_callback",
+        "save_storyline",
+        "set_outline",
+        "read_brief",
+    ]
     assert COPIED_PROCEDURE_TOOLS != LEGACY_PROCEDURE_TOOLS
     assert "reference playbooks" in COPIED_PROCEDURE_TOOLS[0]["function"][
         "description"
@@ -285,5 +307,9 @@ def test_generator_preserves_article_result_across_artifact_contract_divergence(
     assert "# Research Brief" in copied.artifacts[1].content
     assert copied.run_log_summary["submitted"] is True
     assert legacy.run_log_summary["submitted"] is True
-    assert _tool_names(copied) == ["create_artifact", "submit_artifact"]
+    assert _tool_names(copied) == [
+        "save_fact",
+        "create_artifact",
+        "submit_artifact",
+    ]
     assert _tool_names(legacy) == ["write_section", "submit_article"]

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -21,6 +21,9 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
     from backend.services.reporter.runner.tools.datalayer_tools import (
         register_datalayer_tools,
     )
+    from backend.services.reporter.runner.tools.brief_tools import (
+        register_brief_tools,
+    )
     from backend.services.reporter.runner.tools.memory_tools import (
         register_memory_tools,
     )
@@ -28,6 +31,7 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
     data = object()
     memory = object()
     register_artifact_tools(registry)
+    register_brief_tools(registry)
     register_procedure_tools(registry, definition.procedure_contents)
     register_datalayer_tools(registry, data)  # type: ignore[arg-type]
     register_memory_tools(

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -187,26 +187,60 @@ def test_generate_article_end_to_end_tool_loop() -> None:
             make_response(
                 tool_calls=[
                     tool_call(
-                        "read_artifact",
-                        {"path": "research_brief.md"},
-                        "call_3",
-                    )
+                        "save_fact",
+                        {
+                            "id": "fact_taco_win",
+                            "claim_text": (
+                                "Team Taco beat Waiver Wire 142.3-98.7 in week 8."
+                            ),
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {
+                                "winner_points": 142.3,
+                                "loser_points": 98.7,
+                            },
+                            "category": "score",
+                        },
+                        "call_3a",
+                    ),
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_taco_record",
+                            "claim_text": "Team Taco improved to 7-1 after week 8.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 7, "losses": 1},
+                            "category": "standing",
+                        },
+                        "call_3b",
+                    ),
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_waiver_record",
+                            "claim_text": "Waiver Wire fell to 2-6 after week 8.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 2, "losses": 6},
+                            "category": "standing",
+                        },
+                        "call_3c",
+                    ),
                 ]
             ),
             make_response(
                 tool_calls=[
                     tool_call(
-                        "edit_artifact",
+                        "save_storyline",
                         {
-                            "path": "research_brief.md",
-                            "old_text": "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->",
-                            "new_text": (
-                                "- Team Taco beat Waiver Wire 142.3-98.7.\n"
-                                "- Team Taco improved to 7-1.\n"
-                                "- Waiver Wire fell to 2-6.\n\n"
-                                "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->"
+                            "id": "story_taco_control",
+                            "headline": "Taco Takes Control",
+                            "summary": (
+                                "Team Taco paired a blowout win with a 7-1 record."
                             ),
-                            "expected_revision": 1,
+                            "supporting_fact_ids": [
+                                "fact_taco_win",
+                                "fact_taco_record",
+                            ],
+                            "priority": 1,
                         },
                         "call_4",
                     )
@@ -215,18 +249,20 @@ def test_generate_article_end_to_end_tool_loop() -> None:
             make_response(
                 tool_calls=[
                     tool_call(
-                        "edit_artifact",
+                        "set_outline",
                         {
-                            "path": "research_brief.md",
-                            "old_text": "<!-- INSERT STORYLINES ABOVE THIS LINE -->",
-                            "new_text": (
-                                "- Taco Takes Control: Team Taco paired a blowout "
-                                "win with a 7-1 record.\n\n"
-                                "<!-- INSERT STORYLINES ABOVE THIS LINE -->"
-                            ),
-                            "expected_revision": 2,
+                            "sections": [
+                                {
+                                    "title": "Lead",
+                                    "required_fact_ids": [
+                                        "fact_taco_win",
+                                        "fact_taco_record",
+                                    ],
+                                    "storyline_ids": ["story_taco_control"],
+                                }
+                            ]
                         },
-                        "call_6",
+                        "call_5",
                     )
                 ]
             ),
@@ -304,7 +340,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
     assert "improved to 7-1" in artifacts["article.md"].content
     assert "moved to 7-1" not in artifacts["article.md"].content
     assert len(artifacts["article.md"].content_hash) == 64
-    assert artifacts["research_brief.md"].revision == 3
+    assert artifacts["research_brief.md"].revision == 5
     assert "League ID: league_123" in artifacts["research_brief.md"].content
     assert "Team Taco beat Waiver Wire 142.3-98.7" in artifacts[
         "research_brief.md"
@@ -332,9 +368,10 @@ def test_generate_article_end_to_end_tool_loop() -> None:
         "edit_artifact",
         "submit_artifact",
     }.issubset(tool_names)
-    assert {"save_fact", "read_brief", "write_section", "submit_article"}.isdisjoint(
+    assert {"save_fact", "read_brief", "save_storyline", "set_outline"}.issubset(
         tool_names
     )
+    assert {"write_section", "submit_article"}.isdisjoint(tool_names)
     assert "league_snapshot" in tool_names
     histories = {
         path: [
@@ -344,12 +381,9 @@ def test_generate_article_end_to_end_tool_loop() -> None:
         ]
         for path in ("research_brief.md", "article.md")
     }
-    assert [item.revision for item in histories["research_brief.md"]] == [1, 2, 3]
-    assert histories["research_brief.md"][0].source_tool_call_id is None
+    assert [item.revision for item in histories["research_brief.md"]] == [1, 2, 3, 4, 5]
     assert [item.revision for item in histories["article.md"]] == [1, 2]
-    tool_mutations = (
-        histories["research_brief.md"][1:] + histories["article.md"]
-    )
+    tool_mutations = histories["research_brief.md"] + histories["article.md"]
     assert all(item.source_tool_call_id is not None for item in tool_mutations)
 
 
@@ -385,6 +419,21 @@ def test_generate_article_buffers_typed_memory_with_tool_provenance() -> None:
                             }
                         },
                         "memory-call",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_taco_win",
+                            "claim_text": "Team Taco won in Week 8.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"week": 8},
+                            "category": "score",
+                        },
+                        "brief-call",
                     )
                 ]
             ),
@@ -439,8 +488,8 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
             make_response(
                 tool_calls=[
                     tool_call(
-                        "read_artifact",
-                        {"path": "research_brief.md"},
+                        "read_brief",
+                        {},
                         "call_2",
                     )
                 ]
@@ -458,15 +507,13 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
             make_response(
                 tool_calls=[
                     tool_call(
-                        "edit_artifact",
+                        "save_fact",
                         {
-                            "path": "research_brief.md",
-                            "old_text": "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->",
-                            "new_text": (
-                                "- Team Taco was 7-1 after week 8.\n\n"
-                                "<!-- INSERT VERIFIED FACTS ABOVE THIS LINE -->"
-                            ),
-                            "expected_revision": 1,
+                            "id": "fact_taco_record",
+                            "claim_text": "Team Taco was 7-1 after week 8.",
+                            "data_refs": ["league_snapshot:week=8"],
+                            "numbers": {"wins": 7, "losses": 1},
+                            "category": "standing",
                         },
                         "call_5",
                     )
@@ -517,7 +564,7 @@ def test_generate_article_allows_backtracking_from_drafting_to_research() -> Non
     ]
     artifacts = {artifact.path: artifact for artifact in output.artifacts}
     assert output.submitted_path == "article.md"
-    assert artifacts["research_brief.md"].revision == 2
+    assert artifacts["research_brief.md"].revision == 1
     assert "Team Taco was 7-1" in artifacts["research_brief.md"].content
     assert artifacts["article.md"].revision == 1
     assert "Team Taco was 7-1" in artifacts["article.md"].content

--- a/backend/tests/services/reporter/test_procedure_tools.py
+++ b/backend/tests/services/reporter/test_procedure_tools.py
@@ -89,7 +89,7 @@ def test_procedure_state_updated(tmp_path, monkeypatch) -> None:
     assert ctx.procedures.active == "verification"
 
 
-def test_prompts_reference_only_generic_artifact_tools() -> None:
+def test_prompts_reference_structured_brief_and_generic_article_tools() -> None:
     reporter_root = (
         Path(__file__).parents[4] / "backend" / "services" / "reporter"
     )
@@ -100,13 +100,8 @@ def test_prompts_reference_only_generic_artifact_tools() -> None:
     content = "\n".join(path.read_text(encoding="utf-8") for path in prompt_paths)
 
     removed_tools = {
-        "read_brief",
-        "save_fact",
-        "save_storyline",
         "set_style",
         "set_bias",
-        "set_outline",
-        "save_memory_callback",
         "read_article",
         "write_section",
         "rewrite_section",
@@ -115,6 +110,15 @@ def test_prompts_reference_only_generic_artifact_tools() -> None:
     }
     for tool_name in removed_tools:
         assert re.search(rf"`{re.escape(tool_name)}(?:`|\()", content) is None
+
+    for tool_name in {
+        "read_brief",
+        "save_fact",
+        "save_storyline",
+        "set_outline",
+        "save_memory_callback",
+    }:
+        assert f"`{tool_name}" in content
 
     for tool_name in {
         "list_artifacts",

--- a/backend/tests/services/reporter/test_schemas.py
+++ b/backend/tests/services/reporter/test_schemas.py
@@ -80,7 +80,7 @@ def test_artifact_store_create_read_list_and_casefold_collision() -> None:
     store = ArtifactStore()
 
     article = store.create("article.md", "# Article")
-    brief = store.create("research_brief.md", "# Brief")
+    brief, _ = store.sync_managed("research_brief.md", "# Brief")
 
     assert store.read("article.md") is article
     assert store.list() == (article, brief)
@@ -159,7 +159,7 @@ def test_submit_pins_existing_current_snapshot_without_new_revision() -> None:
 
 def test_reporter_output_exposes_submitted_content_and_all_artifacts() -> None:
     store = ArtifactStore()
-    store.create("research_brief.md", "# Brief")
+    store.sync_managed("research_brief.md", "# Brief")
     store.create("article.md", "# Article")
     store.submit("article.md", expected_revision=1)
 

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -182,7 +182,8 @@ Changes from Reporter V2 are intentionally limited:
   generation workflow.
 
 The reporter continues to own registry construction, prompt building,
-`research_brief.md` seeding, runner construction, and `ReporterOutput` assembly.
+structured brief initialization and projection, runner construction, and
+`ReporterOutput` assembly.
 
 The output selects the submitted artifact and returns one complete current
 snapshot for every artifact in deterministic path order:
@@ -199,6 +200,7 @@ class ArtifactSnapshot(BaseModel, frozen=True):
 class ReporterOutput(BaseModel, frozen=True):
     submitted_path: str | None
     artifacts: tuple[ArtifactSnapshot, ...]
+    research_brief: ResearchBrief
 ```
 
 `ReporterOutput` can represent an unsubmitted diagnostic result, but generation
@@ -231,11 +233,11 @@ connection, a source client, or the snapshot artifact path separately.
 
 ### Required metadata/identity seam
 
-Reporter V2 currently seeds structured brief league metadata and resolves
+Reporter V2 currently initializes structured brief league metadata and resolves
 roster keys via private SQLite access. That cannot continue. The new runtime
 already supplies league display data through curated snapshot results, but the
-exact non-tool metadata contract used to seed `research_brief.md` must be made
-public or supplied by `GenerationService`.
+exact non-tool metadata contract used to initialize `ResearchBrief` must be
+made public or supplied by `GenerationService`.
 
 Typed memory proposals involving a team require durable `franchise_id` or
 `season_roster_id`. Snapshot projection v2 stores one exact core identity for
@@ -384,9 +386,10 @@ submit_artifact(path, expected_revision)
 ```
 
 Artifacts use `text/markdown`. Paths are normalized relative logical names, not
-host filesystem paths. The reporter may use defaults such as
-`research_brief.md` and `article.md`, but owns those names and may select another
-publishable path. `create_artifact` rejects an existing path.
+host filesystem paths. The runtime reserves `research_brief.md` as a managed
+projection; generic create, edit, and submit operations reject that path. The
+reporter may use `article.md` or another non-managed path for the publishable
+artifact. `create_artifact` rejects an existing path.
 `edit_artifact` succeeds only when `expected_revision` is current and
 `old_text` occurs exactly once; zero or multiple matches are typed tool errors.
 It performs one literal replacement and appends the resulting complete content
@@ -395,13 +398,16 @@ as a new immutable version. There is deliberately no `replace_all` mode.
 `list_artifacts` and `read_artifact` never append versions. Failed mutations and
 content-identical edits do not append versions. Each successful create/edit
 passes its complete snapshot to the recorder with source AI/tool provenance.
-The generator records its seeded `research_brief.md` snapshot as revision 1
-before the first model call, with no source AI call or tool call.
+The structured brief starts at revision 0 without an artifact. Its first
+successful changed mutation creates `research_brief.md` revision 1 with that
+brief tool call's provenance; later changed mutations advance state and
+projection atomically.
 
 `submit_artifact` accepts any non-empty artifact, requires its expected current
-revision, records no content version, and ends the reporter loop. The resulting
-`ReporterOutput` contains `submitted_path` plus current snapshots of all
-artifacts. Generation finalization finalizes that artifact and sets
+revision, and additionally requires at least one verified brief fact. It records
+no content version and ends the reporter loop. The resulting `ReporterOutput`
+contains `submitted_path`, current snapshots of all artifacts, and the typed
+`research_brief`. Generation finalization finalizes that artifact and sets
 `generation.submitted_artifact_version_id` to the same existing version. It
 never appends a distinct final copy or mutates an artifact version in place.
 

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -265,8 +265,12 @@ separate live identity source.
 
 The reporter:
 
-- registers generic artifact, procedure, frozen-data, and typed-memory tools;
-- seeds `research_brief.md` with equivalent league/config metadata;
+- registers generic artifact, structured-brief, procedure, frozen-data, and
+  typed-memory tools;
+- initializes immutable structured request/style/bias context without creating
+  a Markdown artifact;
+- materializes the managed `research_brief.md` projection only after the first
+  successful brief mutation;
 - runs the same turn loop and procedure replacement behavior;
 - records every provider attempt before/after network I/O;
 - records tool calls before/after handler execution;
@@ -279,10 +283,12 @@ The reporter:
 
 `submit_artifact(path, expected_revision)` remains a reporter-level selection
 and stop signal, not the durable generation commit. It accepts any current,
-non-empty Markdown artifact. `ReporterOutput` returns the nullable submitted
-path plus complete snapshots of every in-memory artifact. Artifact paths remain
-inside the reporter contract and carry no application-level role. Only a
-submitted output is eligible for success. `GenerationService` then:
+non-empty Markdown artifact only after the structured brief contains at least
+one verified fact. `ReporterOutput` returns the nullable submitted path, the
+typed research brief, and complete snapshots of every in-memory artifact.
+Artifact paths remain inside the reporter contract and carry no
+application-level role. Only a submitted output is eligible for success.
+`GenerationService` then:
 
 - obtains the complete memory proposal bundle exactly once;
 - verifies that the submitted revision already exists durably and belongs to
@@ -338,7 +344,7 @@ Dollar pricing remains an application-time analytic over recorded usage.
 ## Artifact Model
 
 The in-memory `ArtifactStore` is the reporter's fast working state. It exposes
-one generic model-facing contract:
+one generic model-facing contract for reporter-authored artifacts:
 
 - `list_artifacts()` lists paths, media types, and current revisions;
 - `read_artifact(path)` returns one current snapshot;
@@ -349,21 +355,25 @@ one generic model-facing contract:
   any non-empty artifact and ends the reporter loop.
 
 All reporter artifacts are raw UTF-8 Markdown in the initial platform slice.
-Their paths are reporter-owned logical names. `research_brief.md` and
-`article.md` remain useful defaults, but persistence and application queries do
-not infer semantic roles from either name. Durable reporting artifacts mirror
+Their paths are reporter-owned logical names except for the reserved,
+runtime-managed `research_brief.md` projection. Generic create, edit, and submit
+operations cannot target managed paths; brief tools synchronize that projection
+atomically with structured state. Persistence and application queries do not
+infer semantic roles from artifact names. Durable reporting artifacts mirror
 complete snapshots at successful mutation boundaries:
 
 | Artifact | Durable behavior |
 | --- | --- |
-| research or planning artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
+| managed research brief projection (`text/markdown`) | append a complete immutable version after each changed structured brief mutation |
+| other research or planning artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
 | publishable draft artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision regardless of path |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
-The reporter-owned `research_brief.md` seed is persisted as revision 1 before
-the first provider call, without AI-call or tool-call provenance. Subsequent
-reporter edits therefore retain the same revision numbers in memory and in
-durable storage.
+The initial structured brief is revision 0 and does not create an artifact.
+The first successful brief mutation creates `research_brief.md` revision 1
+with the source AI/tool provenance of that mutation. Later changed mutations
+advance the structured revision and projection revision together; identical
+upserts are no-ops.
 
 Artifact versions use their source AI call/tool call when available. Reads do
 not append versions. Failed and content-identical mutations do not append

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -1,7 +1,7 @@
 
 # Reporter Research Pipeline Design
 
-**Status:** Proposed
+**Status:** M1 implementation in progress
 
 ## Purpose
 


### PR DESCRIPTION
## Stack

- Base: PR #199 (brief foundation and path rename)
- This PR: M1 brief activation
- Follow-up: observability and evaluation gate

## What changed

- registers save_fact, save_memory_callback, save_storyline, set_outline, and read_brief
- initializes style, bias, and request context from ReportConfig without model calls
- removes the eager Markdown seed and lazily creates research_brief.md after the first changed brief mutation
- records each projection revision with its originating brief tool call
- returns typed research_brief state on ReporterOutput while preserving article and artifact compatibility
- requires at least one verified fact before submit_artifact can succeed
- keeps storyline, callback, outline, and freshness conditions as readiness warnings
- revises prompts and procedures to encourage adaptive interleaving and batched independent data/fact calls
- preserves existing memory search, proposal, and generation-finalization behavior

## Verification

- 67 targeted reporter tests passed
- 31 generation recorder/service/artifact tests passed
- 10 PostgreSQL-only tests skipped because AIDAM_TEST_DATABASE_URL is not configured
- git diff --check passed

## M1 boundary

This PR does not add the separate memory-curation pass, database migrations, canonical evidence receipts, or stricter research-completeness gates. Those remain outside M1 activation.
