### PR TITLE
Add reporter brief evaluation metrics

### DIFF
--- a/backend/services/reporter/runner/run_log.py
+++ b/backend/services/reporter/runner/run_log.py
@@ -145,6 +145,27 @@ class RunLog(BaseModel):
                 )
         return switches
 
+    def first_artifact_write_turn(
+        self,
+        *,
+        operations: frozenset[str],
+        artifact: str | None = None,
+        excluded_artifacts: frozenset[str] = frozenset(),
+    ) -> int | None:
+        """Return the first successful matching artifact-write turn."""
+        for entry in self.entries:
+            if entry.event_type != "artifact_write":
+                continue
+            entry_artifact = entry.data.get("artifact")
+            if entry.data.get("operation") not in operations:
+                continue
+            if artifact is not None and entry_artifact != artifact:
+                continue
+            if entry_artifact in excluded_artifacts:
+                continue
+            return entry.turn
+        return None
+
     def start_streaming(self, path: Path) -> None:
         self._stream_file = open(path, "w", encoding="utf-8")
         self._stream_file.write(f"# Run Log: {self.session_id}\n")

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -39,7 +39,10 @@ from backend.services.reporter.runner.recording import (
     ToolExecutionFinish,
     ToolExecutionStart,
 )
-from backend.services.reporter.runner.research_brief import ResearchBriefStore
+from backend.services.reporter.runner.research_brief import (
+    RESEARCH_BRIEF_PATH,
+    ResearchBriefStore,
+)
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import (
@@ -176,6 +179,7 @@ class Runner:
                         for procedure in self.log.procedure_history
                     ],
                     "submitted": self._submitted,
+                    "brief": self._build_brief_summary(),
                 },
                 run_log_entries=[
                     entry.model_dump(mode="json") for entry in self.log.entries
@@ -183,6 +187,48 @@ class Runner:
             )
         finally:
             self.log.stop_streaming()
+
+    def _build_brief_summary(self) -> dict[str, Any]:
+        brief = self.brief.brief
+        readiness = brief.readiness().model_dump(mode="json")
+        projection = self.artifacts.artifacts.get(RESEARCH_BRIEF_PATH)
+        draft_path = self.artifacts.submitted_path
+        first_draft_turn = self.log.first_artifact_write_turn(
+            operations=frozenset({"create_artifact", "edit_artifact"}),
+            artifact=draft_path,
+        )
+        if first_draft_turn is None and draft_path is None:
+            first_draft_turn = self.log.first_artifact_write_turn(
+                operations=frozenset({"create_artifact", "edit_artifact"}),
+                excluded_artifacts=frozenset({RESEARCH_BRIEF_PATH}),
+            )
+        return {
+            "revision": brief.revision,
+            "projection_revision": (
+                projection.current.revision if projection is not None else None
+            ),
+            "fact_count": readiness["fact_count"],
+            "callback_count": readiness["callback_count"],
+            "storyline_count": readiness["storyline_count"],
+            "outline_section_count": readiness["outline_section_count"],
+            "stale_callback_ids": readiness["stale_callback_ids"],
+            "stale_storyline_ids": readiness["stale_storyline_ids"],
+            "outline_stale": readiness["outline_stale"],
+            "readiness_warnings": readiness["warnings"],
+            "first_fact_turn": self.log.first_artifact_write_turn(
+                operations=frozenset({"save_fact"}),
+                artifact=RESEARCH_BRIEF_PATH,
+            ),
+            "first_storyline_turn": self.log.first_artifact_write_turn(
+                operations=frozenset({"save_storyline"}),
+                artifact=RESEARCH_BRIEF_PATH,
+            ),
+            "first_draft_turn": first_draft_turn,
+            "submission_turn": self.log.first_artifact_write_turn(
+                operations=frozenset({"submit_artifact"}),
+                artifact=draft_path,
+            ),
+        }
 
     async def _execute_tool_batch(
         self,

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -352,6 +352,22 @@ def test_generate_article_end_to_end_tool_loop() -> None:
         "research",
         "verification",
     ]
+    assert output.run_log_summary["brief"] == {
+        "revision": 5,
+        "projection_revision": 5,
+        "fact_count": 3,
+        "callback_count": 0,
+        "storyline_count": 1,
+        "outline_section_count": 1,
+        "stale_callback_ids": [],
+        "stale_storyline_ids": [],
+        "outline_stale": False,
+        "readiness_warnings": [],
+        "first_fact_turn": 3,
+        "first_storyline_turn": 4,
+        "first_draft_turn": 6,
+        "submission_turn": 9,
+    }
     assert any(
         entry["event_type"] == "tool_call"
         and entry["data"]["tool_name"] == "league_snapshot"

--- a/backend/tests/services/reporter/test_run_log.py
+++ b/backend/tests/services/reporter/test_run_log.py
@@ -120,3 +120,45 @@ def test_artifact_write_metadata_with_optional_revision() -> None:
         "key": "outline",
         "brief_revision": None,
     }
+
+
+def test_first_artifact_write_turn_uses_successful_mutation_events() -> None:
+    log = RunLog()
+    log.add_tool_call("save_fact", {}, "error", 1, turn=1)
+    log.add_artifact_write(
+        "research_brief.md",
+        "save_fact",
+        "fact_001",
+        revision=1,
+        turn=2,
+    )
+    log.add_artifact_write(
+        "notes.md",
+        "create_artifact",
+        "notes.md",
+        revision=1,
+        turn=3,
+    )
+    log.add_artifact_write(
+        "article.md",
+        "create_artifact",
+        "article.md",
+        revision=1,
+        turn=4,
+    )
+
+    assert log.first_artifact_write_turn(
+        operations=frozenset({"save_fact"}),
+        artifact="research_brief.md",
+    ) == 2
+    assert log.first_artifact_write_turn(
+        operations=frozenset({"create_artifact"}),
+        artifact="article.md",
+    ) == 4
+    assert log.first_artifact_write_turn(
+        operations=frozenset({"create_artifact"}),
+        excluded_artifacts=frozenset({"notes.md"}),
+    ) == 4
+    assert log.first_artifact_write_turn(
+        operations=frozenset({"submit_artifact"}),
+    ) is None

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -26,6 +26,12 @@ from backend.services.reporter.runner.state import (
     RunnerConfig,
 )
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
+from backend.services.reporter.runner.tools.brief_tools import (
+    save_fact,
+    save_memory_callback,
+    save_storyline,
+    set_outline,
+)
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.procedure_tools import (
     register_procedure_tools,
@@ -209,11 +215,105 @@ def test_runner_simple_text_response() -> None:
     assert output.artifacts == ()
     assert output.run_log_summary["total_turns"] == 1
     assert output.run_log_summary["total_tool_calls"] == 0
+    assert output.run_log_summary["brief"] == {
+        "revision": 0,
+        "projection_revision": None,
+        "fact_count": 0,
+        "callback_count": 0,
+        "storyline_count": 0,
+        "outline_section_count": 0,
+        "stale_callback_ids": [],
+        "stale_storyline_ids": [],
+        "outline_stale": False,
+        "readiness_warnings": [
+            "no_verified_facts",
+            "no_storylines",
+            "no_outline",
+        ],
+        "first_fact_turn": None,
+        "first_storyline_turn": None,
+        "first_draft_turn": None,
+        "submission_turn": None,
+    }
     assert runner.log.entries[0].event_type == "model_text"
     assert complete.requests[0]["messages"][0]["role"] == "system"
     assert complete.requests[0]["messages"][1]["role"] == "user"
     assert complete.requests[0]["model"] is None
     assert "turn_number" not in complete.requests[0]
+
+
+def test_runner_brief_summary_propagates_stale_dependency_warnings() -> None:
+    runner = Runner(
+        ToolRegistry(),
+        complete=FakeCompletion([make_response(text="Done.")]),
+    )
+    ctx = runner.tool_context
+    ctx.turn = 1
+    save_fact(
+        ctx,
+        id="fact_old",
+        claim_text="The Week 3 trade happened.",
+        data_refs=["transactions:week=3"],
+    )
+    ctx.turn = 2
+    save_fact(
+        ctx,
+        id="fact_current",
+        claim_text="The player decided the Week 8 rematch.",
+        data_refs=["team_game:week=8"],
+    )
+    ctx.turn = 3
+    save_memory_callback(
+        ctx,
+        id="callback_trade_regret",
+        callback_type="trade_regret",
+        claim_text="The trade backfired in the rematch.",
+        old_event_fact_id="fact_old",
+        current_event_fact_id="fact_current",
+        why_now="The former player decided the rematch.",
+    )
+    ctx.turn = 4
+    save_storyline(
+        ctx,
+        id="story_trade_regret",
+        headline="The trade comes due",
+        summary="The old move changed the current matchup.",
+        supporting_fact_ids=["fact_old", "fact_current"],
+    )
+    ctx.turn = 5
+    set_outline(
+        ctx,
+        sections=[
+            {
+                "title": "Lead",
+                "required_fact_ids": ["fact_current"],
+                "storyline_ids": ["story_trade_regret"],
+            }
+        ],
+    )
+    ctx.turn = 6
+    save_fact(
+        ctx,
+        id="fact_current",
+        claim_text="The player scored twice in the Week 8 rematch.",
+        data_refs=["team_game:week=8"],
+        numbers={"touchdowns": 2},
+    )
+
+    summary = run(runner.run("system", "user")).run_log_summary["brief"]
+
+    assert summary["revision"] == 6
+    assert summary["projection_revision"] == 6
+    assert summary["stale_callback_ids"] == ["callback_trade_regret"]
+    assert summary["stale_storyline_ids"] == ["story_trade_regret"]
+    assert summary["outline_stale"] is True
+    assert summary["readiness_warnings"] == [
+        "stale_callbacks",
+        "stale_storylines",
+        "stale_outline",
+    ]
+    assert summary["first_fact_turn"] == 1
+    assert summary["first_storyline_turn"] == 4
 
 
 def test_runner_passes_explicit_model_override() -> None:

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -144,6 +144,30 @@ Focused tests must cover:
 - no empty seed-artifact create/read turns; and
 - current memory finalization compatibility.
 
+The reporter output includes this nested observability shape:
+
+```text
+run_log_summary.brief
+  revision
+  projection_revision | null
+  fact_count
+  callback_count
+  storyline_count
+  outline_section_count
+  stale_callback_ids[]
+  stale_storyline_ids[]
+  outline_stale
+  readiness_warnings[]
+  first_fact_turn | null
+  first_storyline_turn | null
+  first_draft_turn | null
+  submission_turn | null
+```
+
+Revision-zero or aborted runs may have a null projection revision and null
+milestone turns. Successful runs have a projection because the submission gate
+requires a verified fact.
+
 The live M1 gate uses representative weeks, report types, and supported models. It
 records research depth, verified fact/storyline coverage, factual accuracy,
 research-to-drafting interleaving, total turns, latency, and token usage against

--- a/docs/reporter-research-pipeline/architecture.md
+++ b/docs/reporter-research-pipeline/architecture.md
@@ -153,6 +153,13 @@ evaluation should report at least:
 - factual-correction count during verification; and
 - total turns, latency, and token usage.
 
+`ReporterOutput.run_log_summary.brief` provides the run-local M1 summary without
+a database migration. It reports structured and projection revisions, fact,
+callback, storyline, and outline-section counts, stale dependency IDs, readiness
+warnings, and the first successful fact, storyline, draft, and submission turns.
+Those turn metrics come from successful existing artifact-write events, so failed
+tool attempts do not count as milestones.
+
 M2 adds curator outcome, duration, proposal counts, validation rejections, retries,
 and persisted mutation counts.
 


### PR DESCRIPTION
## Stack

- Base: PR #200 (brief tool activation and lazy projection)
- This PR: M1 observability and evaluation instrumentation

## What changed

- adds a nested brief summary to ReporterOutput.run_log_summary
- reports structured and projection revisions
- reports fact, callback, storyline, and outline-section counts
- propagates stale callback/storyline IDs, outline freshness, and readiness warnings
- records first successful fact, storyline, draft, and submission turns
- derives milestones from successful existing artifact-write events so failed tool attempts do not count
- adds no database migration or second model call

## Verification

- 39 focused run-log, runner, integration, and characterization tests passed
- git diff --check passed

## Live M1 gate

Go/no-go conclusion: NO-GO pending live evidence.

The required Luna, Terra, and Sol baseline-versus-M1 matrix could not run in this workspace because no .env, OPENAI_API_KEY, database URL, or live competition data is configured. The full pending matrix is recorded in the ignored feature workflow state. Do not begin the M2 memory-curation pass until the live matrix is run and the documented acceptance thresholds pass.
