### PR TITLE
Batch artifact versions by turn

### DIFF
--- a/backend/services/reporter/runner/artifact_recording.py
+++ b/backend/services/reporter/runner/artifact_recording.py
@@ -1,0 +1,62 @@
+"""Turn-scoped coalescing for durable reporter artifact versions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from backend.services.reporter.runner.recording import (
+    ArtifactMutation,
+    ArtifactRecorder,
+)
+from backend.services.reporter.runner.schemas import ArtifactSnapshot
+
+
+class TurnArtifactRecorder:
+    """Buffer mutations and persist one final snapshot per artifact and turn."""
+
+    def __init__(self, recorder: ArtifactRecorder) -> None:
+        self._recorder = recorder
+        self._pending: dict[str, ArtifactMutation] = {}
+        self._durable_revisions: dict[str, int] = {}
+        self._durable_content: dict[str, tuple[str, str]] = {}
+
+    def record_artifact_mutation(
+        self,
+        mutation: ArtifactMutation,
+    ) -> None:
+        self._pending[mutation.path] = mutation
+
+    def flush_turn(self) -> None:
+        pending = tuple(self._pending.values())
+        self._pending.clear()
+
+        for mutation in pending:
+            durable_content = self._durable_content.get(mutation.path)
+            if durable_content == (mutation.content_hash, mutation.content):
+                continue
+
+            revision = self._durable_revisions.get(mutation.path, 0) + 1
+            self._recorder.record_artifact_mutation(
+                replace(mutation, revision=revision)
+            )
+            self._durable_revisions[mutation.path] = revision
+            self._durable_content[mutation.path] = (
+                mutation.content_hash,
+                mutation.content,
+            )
+
+    def durable_snapshots(
+        self,
+        snapshots: tuple[ArtifactSnapshot, ...],
+    ) -> tuple[ArtifactSnapshot, ...]:
+        if self._pending:
+            raise RuntimeError("artifact mutations must be flushed before output")
+        return tuple(
+            snapshot.model_copy(
+                update={"revision": self._durable_revisions[snapshot.path]}
+            )
+            for snapshot in snapshots
+        )
+
+
+__all__ = ["TurnArtifactRecorder"]

--- a/backend/services/reporter/runner/recording.py
+++ b/backend/services/reporter/runner/recording.py
@@ -122,7 +122,10 @@ class RunnerRecorder(Protocol):
 class ArtifactRecorder(Protocol):
     """Record complete immutable snapshots for one generation."""
 
-    def record_artifact_mutation(self, mutation: ArtifactMutation) -> UUID: ...
+    def record_artifact_mutation(
+        self,
+        mutation: ArtifactMutation,
+    ) -> UUID | None: ...
 
 
 class ExecutionRecorder(

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 from pydantic import JsonValue
 
+from backend.services.reporter.runner.artifact_recording import TurnArtifactRecorder
 from backend.services.reporter.runner.completion import (
     CompletionClient,
     CompletionFn,
@@ -96,12 +97,18 @@ class Runner:
         self.brief = brief or ResearchBriefStore()
         self.procedures = ProcedureState()
         self.log = RunLog()
+        artifact_recorder = self._artifact_recorder(recorder)
+        self._turn_artifacts = (
+            TurnArtifactRecorder(artifact_recorder)
+            if artifact_recorder is not None
+            else None
+        )
         self.tool_context = ToolContext(
             artifacts=self.artifacts,
             procedures=self.procedures,
             log=self.log,
             brief=self.brief,
-            artifact_recorder=self._artifact_recorder(recorder),
+            artifact_recorder=self._turn_artifacts,
         )
         self.registry.set_context(self.tool_context)
         self._procedure_message_idx: int | None = None
@@ -137,6 +144,7 @@ class Runner:
                     messages.append(assistant_tool_call_message(calls, response))
                     previous_stage = self.procedures.active
                     results = await self._execute_tool_batch(calls, turn)
+                    self._flush_artifact_turn(turn)
                     if (
                         self.procedures.active is not None
                         and self.procedures.active != previous_stage
@@ -166,9 +174,14 @@ class Runner:
                 },
                 turn=turn,
             )
+            artifact_snapshots = self.artifacts.list()
+            if self._turn_artifacts is not None:
+                artifact_snapshots = self._turn_artifacts.durable_snapshots(
+                    artifact_snapshots
+                )
             return ReporterOutput(
                 submitted_path=self.artifacts.submitted_path,
-                artifacts=self.artifacts.list(),
+                artifacts=artifact_snapshots,
                 research_brief=self.brief.brief,
                 run_log_summary={
                     "session_id": self.log.session_id,
@@ -387,6 +400,16 @@ class Runner:
         except Exception as exc:
             raise RunnerRecordingError(
                 f"Could not record generation progress for turn {turn}"
+            ) from exc
+
+    def _flush_artifact_turn(self, turn: int) -> None:
+        if self._turn_artifacts is None:
+            return
+        try:
+            self._turn_artifacts.flush_turn()
+        except Exception as exc:
+            raise RunnerRecordingError(
+                f"Could not record durable artifact versions for turn {turn}"
             ) from exc
 
     @staticmethod

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -340,7 +340,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
     assert "improved to 7-1" in artifacts["article.md"].content
     assert "moved to 7-1" not in artifacts["article.md"].content
     assert len(artifacts["article.md"].content_hash) == 64
-    assert artifacts["research_brief.md"].revision == 5
+    assert artifacts["research_brief.md"].revision == 3
     assert "League ID: league_123" in artifacts["research_brief.md"].content
     assert "Team Taco beat Waiver Wire 142.3-98.7" in artifacts[
         "research_brief.md"
@@ -397,8 +397,16 @@ def test_generate_article_end_to_end_tool_loop() -> None:
         ]
         for path in ("research_brief.md", "article.md")
     }
-    assert [item.revision for item in histories["research_brief.md"]] == [1, 2, 3, 4, 5]
+    assert [item.revision for item in histories["research_brief.md"]] == [1, 2, 3]
     assert [item.revision for item in histories["article.md"]] == [1, 2]
+    turn_three_tool_ids = [
+        execution_id
+        for execution_id, ai_call_id in recorder.tool_ai_calls.items()
+        if ai_call_id == recorder.successful_turns[3]
+    ]
+    assert histories["research_brief.md"][0].source_tool_call_id == (
+        turn_three_tool_ids[-1]
+    )
     tool_mutations = histories["research_brief.md"] + histories["article.md"]
     assert all(item.source_tool_call_id is not None for item in tool_mutations)
 

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -541,7 +541,7 @@ def test_runner_tool_recording_fails_closed_around_handler() -> None:
     assert len(finish_complete.requests) == 1
 
 
-def test_runner_artifact_recording_fails_closed_and_rolls_back() -> None:
+def test_runner_artifact_turn_flush_fails_closed() -> None:
     registry = ToolRegistry()
     register_artifact_tools(registry)
     recorder = RecordingProbe(fail_artifact=True)
@@ -562,8 +562,66 @@ def test_runner_artifact_recording_fails_closed_and_rolls_back() -> None:
     with pytest.raises(RunnerRecordingError, match="artifact"):
         run(runner.run("system", "user"))
 
-    assert runner.artifacts.list() == ()
-    assert recorder.finished[-1][1].status == "failed"
+    assert runner.artifacts.read("article.md").content == "Draft"
+    assert recorder.finished[-1][1].status == "succeeded"
+    assert recorder.artifact_mutations == []
+
+
+def test_runner_coalesces_artifact_mutations_by_turn() -> None:
+    registry = ToolRegistry()
+    register_artifact_tools(registry)
+
+    def compose_draft(ctx: ToolContext) -> str:
+        ctx.artifacts.create(
+            "article.md",
+            "Alpha beta",
+            on_change=ctx.record_artifact_mutation,
+        )
+        ctx.artifacts.edit(
+            "article.md",
+            old_text="beta",
+            new_text="gamma",
+            expected_revision=1,
+            on_change=ctx.record_artifact_mutation,
+        )
+        return '{"ok": true}'
+
+    registry.register_context_tool(
+        "compose_draft",
+        compose_draft,
+        tool_def("compose_draft"),
+        "test-v1",
+    )
+    recorder = RecordingProbe()
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("compose_draft")]),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "edit_artifact",
+                        {
+                            "path": "article.md",
+                            "old_text": "Alpha",
+                            "new_text": "Delta",
+                            "expected_revision": 2,
+                        },
+                    )
+                ]
+            ),
+            make_response(text="Done."),
+        ]
+    )
+    runner = Runner(registry, complete=complete, recorder=recorder)
+
+    output = run(runner.run("system", "user"))
+
+    assert [(item.revision, item.content) for item in recorder.artifact_mutations] == [
+        (1, "Alpha gamma"),
+        (2, "Delta gamma"),
+    ]
+    assert output.artifacts[0].revision == 2
+    assert output.artifacts[0].content == "Delta gamma"
 
 
 def test_runner_parallel_artifact_provenance_is_invocation_local() -> None:

--- a/docs/generation/README.md
+++ b/docs/generation/README.md
@@ -93,9 +93,10 @@ flowchart LR
   artifact store. The model-facing contract is `list_artifacts`,
   `read_artifact`, `create_artifact`, exact-match `edit_artifact`, and
   revision-checked `submit_artifact`.
-- Use raw UTF-8 Markdown artifacts; mirror each successful mutation to an
-  immutable version and finalize by selecting existing versions rather than
-  writing final copies. Paths such as `research_brief.md` and `article.md` are
+- Use raw UTF-8 Markdown artifacts; coalesce successful mutations by artifact
+  within each model turn and mirror the final turn snapshot to one immutable
+  version. Finalize by selecting an existing version rather than writing a
+  final copy. Paths such as `research_brief.md` and `article.md` are
   reporter-owned conventions, never application query keys.
 - Store the exact submitted finalized artifact version on the generation. The
   application discovers generated articles through this pointer, independently

--- a/docs/generation/application-contracts.md
+++ b/docs/generation/application-contracts.md
@@ -392,22 +392,30 @@ reporter may use `article.md` or another non-managed path for the publishable
 artifact. `create_artifact` rejects an existing path.
 `edit_artifact` succeeds only when `expected_revision` is current and
 `old_text` occurs exactly once; zero or multiple matches are typed tool errors.
-It performs one literal replacement and appends the resulting complete content
-as a new immutable version. There is deliberately no `replace_all` mode.
+It performs one literal replacement and queues the resulting complete content
+for the turn's coalesced durable version. There is deliberately no
+`replace_all` mode.
 
 `list_artifacts` and `read_artifact` never append versions. Failed mutations and
 content-identical edits do not append versions. Each successful create/edit
-passes its complete snapshot to the recorder with source AI/tool provenance.
-The structured brief starts at revision 0 without an artifact. Its first
-successful changed mutation creates `research_brief.md` revision 1 with that
-brief tool call's provenance; later changed mutations advance state and
-projection atomically.
+passes its complete snapshot to a turn-local recorder buffer with source
+AI/tool provenance. After the complete tool batch finishes, the runner appends
+only the last changed snapshot for each artifact, producing at most one durable
+version per artifact and model turn. The durable version uses that turn's AI
+call and the artifact's last successful mutation tool call as provenance. A
+flush failure aborts execution before the next model call. The structured brief
+starts at revision 0 without an artifact. Its changed run-local mutations can
+advance more than once inside a turn, while its durable Markdown projection
+advances once for the final turn snapshot.
 
 `submit_artifact` accepts any non-empty artifact, requires its expected current
 revision, and additionally requires at least one verified brief fact. It records
 no content version and ends the reporter loop. The resulting `ReporterOutput`
 contains `submitted_path`, current snapshots of all artifacts, and the typed
-`research_brief`. Generation finalization finalizes that artifact and sets
+`research_brief`. Output artifact revision numbers identify the coalesced
+durable versions, while tool-facing revision checks remain run-local so several
+edits can safely compose before a turn flush. Generation finalization finalizes
+that artifact and sets
 `generation.submitted_artifact_version_id` to the same existing version. It
 never appends a distinct final copy or mutates an artifact version in place.
 

--- a/docs/generation/architecture.md
+++ b/docs/generation/architecture.md
@@ -142,8 +142,10 @@ It is needed in three places:
    see retry and fallback attempts hidden from `Runner`.
 2. `Runner` records every tool request/result because it owns dispatch and
    parallel execution.
-3. Artifact tools record complete artifact content after each successful
-   mutation because they know when in-memory state changed.
+3. Artifact tools buffer complete artifact content after each successful
+   mutation because they know when in-memory state changed; the runner flushes
+   only the final snapshot for each changed artifact after the turn's complete
+   tool batch finishes.
 
 Tests and the temporary standalone CLI may use an in-memory/no-op recorder. The
 production generation path always uses the durable recorder.
@@ -274,7 +276,8 @@ The reporter:
 - runs the same turn loop and procedure replacement behavior;
 - records every provider attempt before/after network I/O;
 - records tool calls before/after handler execution;
-- appends complete artifact versions after successful mutations; and
+- appends at most one complete artifact version per changed artifact and model
+  turn after the turn's tool batch completes; and
 - returns `ReporterOutput` with all current snapshots. `submitted_path` names
   the reporter-selected artifact only after `submit_artifact` succeeds and is
   otherwise `null`; an unsubmitted output cannot succeed the generation.
@@ -364,20 +367,25 @@ complete snapshots at successful mutation boundaries:
 
 | Artifact | Durable behavior |
 | --- | --- |
-| managed research brief projection (`text/markdown`) | append a complete immutable version after each changed structured brief mutation |
-| other research or planning artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation |
-| publishable draft artifact (`text/markdown`) | append a complete immutable version after each successful create/edit mutation; `submit_artifact` selects one existing revision regardless of path |
+| managed research brief projection (`text/markdown`) | append the final complete projection once per model turn when one or more structured brief mutations changed it |
+| other research or planning artifact (`text/markdown`) | append the final complete snapshot once per model turn when one or more creates/edits changed it |
+| publishable draft artifact (`text/markdown`) | append the final complete snapshot once per model turn when one or more creates/edits changed it; `submit_artifact` selects one existing revision regardless of path |
 | run log | do not treat as canonical; AI/tool/artifact tables are the full audit trail |
 
 The initial structured brief is revision 0 and does not create an artifact.
-The first successful brief mutation creates `research_brief.md` revision 1
-with the source AI/tool provenance of that mutation. Later changed mutations
-advance the structured revision and projection revision together; identical
-upserts are no-ops.
+The first turn containing a successful brief mutation creates durable
+`research_brief.md` revision 1 with the turn's AI-call provenance and the last
+changed brief tool's provenance. Structured state still advances after each
+changed operation, while its durable Markdown projection advances at most once
+per turn; identical upserts are no-ops.
 
-Artifact versions use their source AI call/tool call when available. Reads do
-not append versions. Failed and content-identical mutations do not append
-versions. Durable finalization pins the selected version both on its artifact
+Artifact versions use their source AI call and the last successful mutation's
+tool call within the turn when available. Reads do not append versions. Failed
+and content-identical mutations do not append versions. If several successful
+mutations touch one artifact in a turn, intermediate snapshots remain
+run-local and only the final snapshot becomes durable. The turn flush is
+fail-closed: persistence failure aborts reporter execution before another model
+turn begins. Durable finalization pins the selected version both on its artifact
 and on the generation; it does not create another artifact version. The
 generation pointer is the application-level article output and supports article
 queries without inspecting reporter-controlled paths.

--- a/docs/generation/transition.md
+++ b/docs/generation/transition.md
@@ -127,9 +127,11 @@ Run-local artifacts are raw UTF-8 Markdown at reporter-owned logical paths.
 `research_brief.md` and `article.md` remain useful prompt defaults, not durable
 application roles. `edit_artifact` is a revision-checked literal
 find-and-replace: `old_text` must occur exactly once, and there is no
-`replace_all` mode. Successful creates and edits record complete immutable
-snapshots. Reads do not mutate state. `submit_artifact` accepts the current
-revision of any non-empty artifact, ends the reporter loop, and produces
+`replace_all` mode. Successful creates and edits update run-local state
+immediately, then the runner records only the final complete snapshot for each
+changed artifact once the model turn's tool batch finishes. Reads do not mutate
+state. `submit_artifact` accepts the current run-local revision of any non-empty
+artifact, ends the reporter loop, and produces
 `ReporterOutput(submitted_path, artifacts)`; it does not independently mark the
 generation succeeded or append a final copy.
 

--- a/frontend/src/features/artifacts/artifact-browser.tsx
+++ b/frontend/src/features/artifacts/artifact-browser.tsx
@@ -4,8 +4,9 @@ import {
   CircleAlert,
   FileArchive,
   FileText,
+  History,
 } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { ApiError } from "@/api/errors";
@@ -13,6 +14,14 @@ import { ArtifactContentViewer } from "@/components/shared/artifact-content-view
 import { DateTime } from "@/components/shared/date-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useSubmittedArticle } from "@/features/articles/queries";
 import type {
@@ -239,6 +248,7 @@ export function ArtifactBrowser({
   active,
 }: ArtifactBrowserProps): React.JSX.Element {
   const [searchParameters, setSearchParameters] = useSearchParams();
+  const [historyOpen, setHistoryOpen] = useState(false);
   const artifactPage = positivePage(searchParameters.get("artifactPage"));
   const requestedArtifactId = searchParameters.get("artifact") ?? undefined;
   const requestedVersionId = searchParameters.get("version") ?? undefined;
@@ -401,6 +411,7 @@ export function ArtifactBrowser({
   ]);
 
   function selectArtifact(artifactId: string): void {
+    setHistoryOpen(false);
     const next = new URLSearchParams(searchParameters);
     next.set("artifact", artifactId);
     next.delete("version");
@@ -412,6 +423,7 @@ export function ArtifactBrowser({
     const next = new URLSearchParams(searchParameters);
     next.set("version", versionId);
     setSearchParameters(next);
+    setHistoryOpen(false);
   }
 
   function setArtifactPage(nextPage: number): void {
@@ -497,7 +509,7 @@ export function ArtifactBrowser({
 
       <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-card">
         {selectedArtifact ? (
-          <>
+          <Sheet open={historyOpen} onOpenChange={setHistoryOpen}>
             <header className="border-b border-border px-5 py-5 sm:px-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
@@ -515,7 +527,7 @@ export function ArtifactBrowser({
                     )}
                   </p>
                 </div>
-                <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap items-center gap-2">
                   {selectedArtifact.id === submittedArtifactId ? (
                     <Badge>Submitted artifact</Badge>
                   ) : null}
@@ -524,69 +536,22 @@ export function ArtifactBrowser({
                   ) : (
                     <Badge variant="secondary">Draft</Badge>
                   )}
+                  <SheetTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      <History className="size-4" aria-hidden="true" />
+                      History
+                      {versionsQuery.data ? (
+                        <span className="text-muted-foreground">
+                          ({versionsQuery.data.page.total})
+                        </span>
+                      ) : null}
+                    </Button>
+                  </SheetTrigger>
                 </div>
               </div>
             </header>
 
-            <div className="grid min-w-0 gap-6 p-5 sm:p-6 xl:grid-cols-[15rem_minmax(0,1fr)]">
-              <div className="min-w-0">
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <h4 className="font-semibold">Versions</h4>
-                  {versionsQuery.isFetching && !versionsQuery.isPending ? (
-                    <span
-                      className="text-xs text-muted-foreground"
-                      role="status"
-                    >
-                      Updating…
-                    </span>
-                  ) : null}
-                </div>
-                {versionsQuery.isPending ? (
-                  <div className="space-y-2">
-                    <Skeleton className="h-20 w-full" />
-                    <Skeleton className="h-20 w-full" />
-                  </div>
-                ) : versionsQuery.isError ? (
-                  <InlineError
-                    title="Version history unavailable"
-                    error={versionsQuery.error}
-                    onRetry={() => void versionsQuery.refetch()}
-                  />
-                ) : versions.length === 0 ? (
-                  <p className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
-                    This artifact has no recorded versions.
-                  </p>
-                ) : (
-                  <>
-                    <div className="space-y-2">
-                      {versions.map((version) => (
-                        <VersionChoice
-                          key={version.id}
-                          version={version}
-                          selected={version.id === selectedVersionId}
-                          submitted={version.id === submittedVersionId}
-                          finalized={
-                            version.id === selectedArtifact.finalized_version_id
-                          }
-                          onSelect={() => {
-                            selectVersion(version.id);
-                          }}
-                        />
-                      ))}
-                    </div>
-                    <div className="mt-4">
-                      <Pager
-                        label="Versions"
-                        page={versionPage}
-                        totalPages={versionTotalPages}
-                        total={versionsQuery.data.page.total}
-                        onPageChange={setVersionPage}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
-
+            <div className="min-w-0 p-5 sm:p-6">
               <div className="min-w-0">
                 <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
                   <h4 className="font-semibold">
@@ -643,7 +608,77 @@ export function ArtifactBrowser({
                 )}
               </div>
             </div>
-          </>
+
+            <SheetContent side="right">
+              <SheetHeader>
+                <SheetTitle>Version history</SheetTitle>
+                <SheetDescription>
+                  Choose a stored revision of {selectedArtifact.path}.
+                </SheetDescription>
+              </SheetHeader>
+              <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <span className="text-xs text-muted-foreground">
+                    {versionsQuery.data
+                      ? `${String(versionsQuery.data.page.total)} total`
+                      : "Loading revisions…"}
+                  </span>
+                  {versionsQuery.isFetching && !versionsQuery.isPending ? (
+                    <span
+                      className="text-xs text-muted-foreground"
+                      role="status"
+                    >
+                      Updating…
+                    </span>
+                  ) : null}
+                </div>
+                {versionsQuery.isPending ? (
+                  <div className="space-y-2">
+                    <Skeleton className="h-20 w-full" />
+                    <Skeleton className="h-20 w-full" />
+                  </div>
+                ) : versionsQuery.isError ? (
+                  <InlineError
+                    title="Version history unavailable"
+                    error={versionsQuery.error}
+                    onRetry={() => void versionsQuery.refetch()}
+                  />
+                ) : versions.length === 0 ? (
+                  <p className="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground">
+                    This artifact has no recorded versions.
+                  </p>
+                ) : (
+                  <>
+                    <div className="space-y-2">
+                      {versions.map((version) => (
+                        <VersionChoice
+                          key={version.id}
+                          version={version}
+                          selected={version.id === selectedVersionId}
+                          submitted={version.id === submittedVersionId}
+                          finalized={
+                            version.id === selectedArtifact.finalized_version_id
+                          }
+                          onSelect={() => {
+                            selectVersion(version.id);
+                          }}
+                        />
+                      ))}
+                    </div>
+                    <div className="mt-4">
+                      <Pager
+                        label="Versions"
+                        page={versionPage}
+                        totalPages={versionTotalPages}
+                        total={versionsQuery.data.page.total}
+                        onPageChange={setVersionPage}
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            </SheetContent>
+          </Sheet>
         ) : (
           <div className="p-8 text-center text-sm text-muted-foreground">
             Select an artifact to inspect its versions.


### PR DESCRIPTION
## Summary

- move artifact version navigation behind an on-demand History side sheet
- coalesce artifact mutations into one durable version per artifact and model turn
- preserve exact submitted-version finalization and last-mutation provenance
- update generation contracts and targeted regression coverage

## Verification

- 73 targeted backend tests passed
- frontend typecheck, lint, Prettier check, and production build passed under Node 22
- Python compileall and git diff --check passed