### PR TITLE
Make reporter guidance goal oriented

### DIFF
--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -215,11 +215,13 @@ def _build_user_message(config: ReportConfig) -> str:
     lines.extend(
         [
             "",
-            "Begin with the action that will reduce the most important uncertainty. "
-            "A broad league-data call is often useful, and the `research` procedure "
-            "is available when its detailed checklist would help. Treat research, "
-            "storyline mining, drafting, and verification as interleavable activities; "
-            "do not load the four procedures as a fixed sequence.",
+            "Work on the unmet editorial goal that poses the greatest risk to "
+            "accuracy or reader value. Treat the configured week range as current "
+            "coverage; query outside it only for a specific relevant historical "
+            "comparison and never beyond the frozen snapshot cutoff. Choose the "
+            "smallest tool result that can resolve the current uncertainty. Load a "
+            "procedure when its goal-oriented guidance would materially help, not "
+            "as a fixed phase or progress marker.",
         ]
     )
     return "\n".join(lines)

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -48,6 +48,7 @@ from backend.services.reporter.runner.tools.registry import ToolRegistry
 if TYPE_CHECKING:
     from backend.services.datalayer import FrozenLeagueData
     from backend.services.memory import GenerationMemoryContext
+    from backend.services.reporter.runner.tools.memory_tools import TypedMemoryAdapter
 
 
 async def generate_article(
@@ -82,7 +83,7 @@ async def generate_article(
     prepared = definition or prepare_reporter_definition(
         memory_enabled=memory_context is not None
     )
-    registry = _build_registry(
+    registry, memory_adapter = _build_registry(
         data,
         memory_context=memory_context,
         allow_memory_writes=allow_memory_writes,
@@ -121,7 +122,15 @@ async def generate_article(
         recorder=resolved_recorder,
     )
 
-    return await runner.run(prepared.system_prompt, _build_user_message(config))
+    output = await runner.run(prepared.system_prompt, _build_user_message(config))
+    if (
+        memory_adapter is not None
+        and allow_memory_writes
+        and output.run_log_summary.get("submitted") is True
+    ):
+        memory_adapter.buffer_brief_facts(output.research_brief)
+    return output
+
 
 def _build_registry(
     data: FrozenLeagueData,
@@ -129,20 +138,21 @@ def _build_registry(
     memory_context: GenerationMemoryContext | None,
     allow_memory_writes: bool,
     procedures: dict[str, str] | None = None,
-) -> ToolRegistry:
+) -> tuple[ToolRegistry, TypedMemoryAdapter | None]:
     registry = ToolRegistry()
+    memory_adapter = None
     register_artifact_tools(registry)
     register_brief_tools(registry)
     register_procedure_tools(registry, procedures)
     register_datalayer_tools(registry, data)
     if memory_context is not None:
-        register_memory_tools(
+        memory_adapter = register_memory_tools(
             registry,
             memory_context,
             data,
             allow_memory_writes=allow_memory_writes,
         )
-    return registry
+    return registry, memory_adapter
 
 
 def _require_matching_definition(

--- a/backend/services/reporter/procedures/drafting.md
+++ b/backend/services/reporter/procedures/drafting.md
@@ -1,73 +1,39 @@
-# Drafting Procedure
+# Goal: Turn Verified Material Into A Compelling Article
 
-Use this procedure for sustained composition and revision of the publishable article. Draft from verified material, but allow the act of writing to expose evidence gaps and better storylines. Resolve narrow gaps directly; substantial discoveries may lead back into deeper research or storyline mining.
+Use this guide when enough evidence exists to compose or substantially revise the publishable article, or when existing prose needs stronger focus, structure, voice, or proportional coverage.
 
-## Operating Rules
+## Success Looks Like
 
-- The brief is the source of factual truth. Saved storylines and the outline are revisable planning aids, not immutable constraints.
-- Honor readiness warnings. Do not rely on stale callbacks, storylines, or outline references until they are refreshed against current fact revisions.
-- Treat verified callbacks in the brief as grounded material, but still name the old event and current payoff in prose.
-- Do not invent scores, records, player points, transaction details, standings, injuries, or playoff scenarios.
-- Numeric claims must match the numbers or claim text recorded in the brief.
-- Treat the outline as a working plan, not a constraint. Preserve it when it remains useful; update supported framing directly when drafting reveals a better structure. Load `storyline` only for substantial narrative rethinking.
-- For a narrow missing fact, make the targeted datalayer call, save the verified result with `save_fact`, and resume drafting. Load `research` only when the gap requires broad exploration.
-- Continue mining storylines while writing. A strong paragraph may reveal a callback, reversal, or future memory worth researching or proposing.
-- Draft with `create_artifact` at your chosen article path when the article does not exist. Use the same path and revision-checked `edit_artifact` calls for subsequent changes.
-- Do not submit until you have performed a claim-level verification pass, whether or not you load the dedicated verification procedure.
+- The article fulfills the requested form, focus, approximate length, voice, bias, and exclusions.
+- It has a clear headline and lead, a purposeful progression, and a conclusion that resolves its central idea.
+- Important sections use concrete saved evidence and explain why it matters.
+- Emphasis follows editorial significance rather than the order in which tools returned data.
+- Every material number, result, transaction, comparison, and callback is supported by the structured brief.
+- The prose is lively without overstating evidence or forcing weak continuity.
 
-## Drafting Flow
+## Tool Choices
 
-1. Call `read_brief` when the current structured state is not already available.
-2. Identify the strongest supported lead and draft the sections with the clearest evidence first.
-3. After meaningful additions, ask whether the prose exposed a factual gap, a weak storyline, or a stronger callback. Resolve only the gaps that matter to the article.
-4. Create a coherent Markdown draft at one stable path, or continue from the current draft content and revision.
-5. Read an artifact again only when its current state is unknown or when a full-document review is needed.
-6. Use exact `edit_artifact` replacements for local improvements. For a full rewrite, replace the complete current content using its current revision.
-7. When the draft is complete, perform a claim-level audit. Load `verification` if its detailed checklist would improve that audit.
+- Use `read_brief` when the current evidence and planning state are not already available.
+- Use `create_artifact` once for the initial publishable draft at a stable Markdown path.
+- Use revision-checked `edit_artifact` calls for meaningful local improvements or a deliberate full rewrite.
+- Reuse the content and revision returned by successful artifact operations. Read the artifact again only when its state is unknown or a whole-document review will add value.
+- If drafting exposes one material factual gap, use the smallest targeted datalayer call and save the result before continuing. Broaden research only when the article's premise is unstable.
+- If drafting exposes a weak thesis or hierarchy, revise the storyline or outline rather than decorating unsupported prose.
 
-## Writing Standards
+## Composition Judgment
 
-- Open with the best material, not a generic recap sentence.
-- Use concrete details from facts rather than vague claims.
-- Prioritize priority-1 storylines, then priority-2 storylines, then quick hits.
-- For callback paragraphs, clearly state what happened then, what happened now, and why the meaning changed.
-- Do not use vague continuity phrases such as "this has been brewing," "the storyline continues," or "it came full circle" unless the paragraph names the old event and the new payoff.
-- Keep paragraphs focused. Standard sections should usually be 2-5 paragraphs.
-- Use Markdown:
-  - `#` for the headline.
-  - `##` for major section headings.
-  - `**bold**` for emphasis when useful.
-- Match the requested target length. As a practical guide:
-  - 500 words: 1-2 storylines.
-  - 1000 words: 3-4 storylines.
-  - 1500+ words: broader weekly coverage or deeper analysis.
+- Open with the strongest supported material, not a generic recap sentence.
+- Build paragraphs around a claim, its concrete evidence, and its significance.
+- Give lead material room to develop and compress routine results into proportional supporting coverage.
+- Let the requested article form determine its structure. Do not force stock headings or a standard recap template.
+- Treat the outline as a revisable planning aid. Preserve it only while it improves the article.
+- For callbacks, state what happened before, what happened now, and why the meaning changed. Avoid vague continuity language without those specifics.
+- Match the requested voice consistently. Bias may affect placement, enthusiasm, skepticism, and jokes, but never the underlying facts.
+- Do not rely on stale callbacks, storylines, or outline references until their evidence has been refreshed.
+- Do not smuggle raw tool-only details into prose. If a detail is material enough to publish, it is material enough to save as a fact.
 
-## Voice And Bias
+## Stop Or Switch
 
-Apply the immutable style and bias already initialized from `ReportConfig` in brief context; do not spend calls restating or changing them. Apply that style consistently:
+Composition is sufficiently developed when the article reads coherently at the requested scale, its important details are supported, and remaining changes are mostly stylistic. Shift attention to research when evidence could change the article, to storyline work when meaning or emphasis remains weak, or to verification when the draft needs publication confidence.
 
-- Sports columnist: informed, sharp, and personable.
-- Snarky columnist: witty and irreverent, with playful jabs.
-- Hype broadcaster: high energy, dramatic, and celebratory.
-- Beat reporter: factual, measured, and analysis-heavy.
-- Custom voices: satisfy the user's request while preserving factual grounding.
-
-Apply bias as framing only:
-
-- Favored teams can get more enthusiastic language, more prominent placement, and more charitable framing.
-- Disfavored teams can get skepticism or playful roasting.
-- The score, record, ranking, transaction, and player points must remain exactly what the facts say.
-
-## Section Organization
-
-Use stable, descriptive Markdown headings for article sections, such as:
-
-- Headline and lead
-- Lead story
-- Standings shift
-- Quick hits
-- Transactions
-- Playoff picture
-- Closing
-
-Before submission, make sure each required outline fact appears in the article and the document has a coherent opening, body, and close.
+Do not submit merely because a draft exists. Audit the complete article first, using the verification guide when its detailed judgment would help.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -1,112 +1,48 @@
-# Research Procedure
+# Goal: Establish A Trustworthy Evidence Base
 
-Use this procedure for substantial discovery, evidence repair, and callback investigation. Gather verified fantasy football facts while continuously mining for narrative meaning. Research may begin a run or interrupt outlining, drafting, or verification; it does not have to be completed in one block.
+Use this guide when the article covers several teams or weeks, a featured interpretation needs more than a league summary, historical context may matter, or retrieved data looks incomplete or inconsistent. It may also help repair a specific gap exposed during outlining, drafting, or verification.
 
-## Brief Recording
+## Success Looks Like
 
-- Save verified evidence with `save_fact`. Give every fact a stable lowercase ID, precise claim, exact numbers, category, and traceable source references.
-- Put independent datalayer calls and independent `save_fact` calls in one model response when possible; serialize only calls whose arguments depend on earlier results.
-- Successful brief mutations return the current revision and readiness. Do not call `read_brief` merely to confirm a successful write.
-- Use `read_brief` when returning after other work or when you genuinely need the full current state. Reading revision 0 does not create an artifact.
-- Save a callback with `save_memory_callback` only after both the reverified old-event fact and current-event fact exist.
+- The article's central framing and planned major claims have precise, relevant evidence.
+- Featured interpretations have enough targeted context to distinguish a meaningful development from a routine result.
+- Historical leads used in the article have been reverified against the frozen snapshot.
+- Important scores, records, player totals, transactions, and comparisons are saved as facts with the exact values the article will use.
+- No unresolved anomaly or high-value lead is likely to reverse the article's central interpretation.
 
-## Operating Rules
+## Tool Choices
 
-- If you are repairing a gap found during drafting or verification, inspect the relevant brief and draft material, then research only what is missing.
-- Start broad, then drill down. Prefer `league_snapshot` for the requested week before targeted team or player calls.
-- Every recorded fact must be traceable to one or more datalayer tool calls.
-- Save specific, reusable facts rather than commentary. The article voice comes later.
-- Do not invent standings, scores, records, player points, transactions, injuries, or playoff implications.
-- Bias can guide what you investigate, but it must not change which facts you record.
-- When `search_memory` is available, perform one lightweight storyline scan after the broad current-week inventory unless the request is purely factual and narrow. Deepen the scan only when current teams, players, transactions, opponents, or stakes create a plausible callback.
-- Hydrated memory is not a fact source. Verify both the older claim and the current-week payoff against frozen datalayer results before recording a callback.
-- A narrow evidence gap does not require a procedure change. Make the targeted datalayer call, update the brief, and resume the work that exposed the gap.
+Choose the smallest useful view for the current question:
 
-## Adaptive Research Loop
+- League-wide orientation: `league_snapshot` and `standings`.
+- Complete player-level coverage for every game in one week: `week_games`. Its result is large; use it only when that breadth materially helps.
+- One featured matchup: `team_game`.
+- Team form, opponents, and season context: `team_dossier` and `team_schedule`.
+- Roster composition or a lineup question: `roster_at_cutoff`, `roster_snapshot`, and `bench_analysis`.
+- Weekly or season player performance: `week_player_leaderboard`, `season_leaders`, and `player_weekly_log`.
+- Player identity, NFL team, status, or injury metadata: `player_summary`.
+- Trades, waivers, and roster moves: `transactions` or `team_transactions`.
+- Playoff stakes: `playoff_bracket` and `team_playoff_path`.
+- A bespoke comparison unavailable from curated tools: guarded `run_sql`.
+- Historical narrative leads: `search_memory`, followed by datalayer verification of any lead worth using.
 
-Repeat these activities in the order the evidence demands:
+Run independent reads together when their results do not depend on one another. Avoid overlapping broad calls that reproduce the same evidence, and do not expand the week range merely to find more material.
 
-1. Orient: read the configured week range, focus, article type, tone, and framing preferences from brief context.
-2. Discover: use `league_snapshot(week=N)` or the relevant multi-week tools to map scores, standings movement, transactions, and obvious outliers.
-3. Mine hypotheses: ask which results changed meaning, contradicted expectations, continued an arc, or created future stakes. Treat these as questions until verified.
-4. Verify the strongest hypotheses with targeted team, player, transaction, standings, playoff, SQL, or memory calls.
-5. Save useful evidence in the brief, batching independent tool calls, then reassess coverage and narrative strength.
-6. If an outline or draft already exists, test new evidence against it. Preserve what still works and revise only what the evidence changed.
+## Evidence Judgment
 
-Run the memory scout loop when the request or data suggests long-running context:
-   - Extract the current-week fact map: scores, margins, standings movement, playoff stakes, current matchups, top players, transactions, focus teams, and requested framing.
-   - Generate narrative hypotheses from the current week. Ask what changed meaning, reversed, paid off, collapsed, became funny, or now has stakes.
-   - Call `search_memory` with text, current team keys, tags, and typed filters. Request exact or stable expansions when linked evidence or storylines matter.
-   - Inspect the fully hydrated matches, then plan the needed datalayer calls yourself.
-   - Verify the old claim and current event with frozen datalayer tools.
-   - Save old-event and current-event facts, then save the verified callback.
-   - Promote only the best verified callbacks into storylines and outline inputs.
-   - Buffer durable changes with the relevant typed `propose_*` or `replace_*` tools when an arc should matter later. Use IDs returned by proposal tools for same-bundle relationships.
+- Treat `league_snapshot` as an inventory. A featured claim usually benefits from a targeted view that tests or explains the interpretation.
+- Treat retrieved memory as a hypothesis. Save a callback only after the old event and current payoff both exist as reverified facts.
+- Treat `found: false`, missing matchups, all-zero scoring, implausible totals, or disagreement between views as unresolved evidence. Cross-check through a different representation before relying on it. If the anomaly cannot be resolved, narrow or qualify the claim rather than presenting certainty.
+- Save facts that are precise, traceable, and useful to the article. Use stable lowercase IDs, exact numbers, accurate categories, and source references matching calls actually made.
+- Save every material numeric or factual detail that the draft will need; raw tool output remaining in conversation is not a substitute for brief evidence.
+- Bias may guide what deserves investigation, but it cannot change what the evidence says.
 
-Useful targeted tools include:
-   - `team_game(roster_key, week=N)` for player-level detail in a specific matchup.
-   - `team_dossier(roster_key, week=N)` for recent form, record, and broader context.
-   - `week_player_leaderboard(week=N, limit=10)` for top performers.
-   - `transactions(week_from=N, week_to=N)` or `team_transactions(...)` for trade, waiver, or roster-move angles.
-   - `player_weekly_log(...)` or `player_summary(...)` for trend checks on a featured player.
-   - `playoff_bracket(...)` and `team_playoff_path(...)` when the article has playoff stakes.
+## Memory Judgment
 
-Treat a league snapshot as an inventory, not sufficient research for a featured storyline. Each major section should have targeted context that tests its interpretation or adds relevant team, player, transaction, historical, standings, or playoff detail.
+Search memory when prior context could materially improve the article: trades and waivers, rematches and rivalries, playoff reversals, repeated lineup mistakes, focused-team histories, retrospectives, rankings, or season-long awards. For an ordinary recap, a lightweight scan is useful only when current teams, players, transactions, or stakes provide a plausible retrieval hook. Stop after an empty or low-value result unless the current evidence suggests a more specific query.
 
-Aim for enough evidence to support the article, not every possible data point. When research is sufficient, continue with whichever activity is most useful: synthesize storylines, draft a supported section, verify an existing draft, or investigate one remaining high-value uncertainty. Load another procedure only if its detailed guidance is needed.
+Buffer durable proposals only when an event or arc has plausible future callback value. Persistence work is separate from proving today's article.
 
-## Memory Scout Requirements
+## Stop Or Switch
 
-Run the full scout loop for:
-
-- Trades, trade retrospectives, waivers, drops, and former-team angles.
-- Playoffs, playoff paths, rematches, rivalries, and revenge games.
-- Power rankings, retrospectives, full-season arcs, and season awards.
-- Any focused team that has persistent context.
-
-For standard weekly recaps, do a lightweight scan for:
-
-- Repeated opponents, rematches, or prior close games.
-- Playoff matchups with regular-season history.
-- Top performers tied to old trades, waiver adds, drops, or former teams.
-- Current transactions that should be re-evaluated later.
-
-Evaluate candidate callbacks for interestingness separately from retrieval relevance. Prefer callbacks with surprise, stakes, reversal, payoff, specificity, league-reader value, comedy value, evidence strength, and fit with the requested article.
-
-## Fact Quality
-
-Good facts are precise, sourced, and useful in more than one sentence. Include the exact numbers the writer will need. A useful `save_fact` call looks like:
-
-```json
-{
-  "id": "fact_week8_taco_win",
-  "claim_text": "Team Taco defeated The Waiver Wire 142.3-98.7 in Week 8.",
-  "data_refs": ["league_snapshot:week=8", "team_game:team_taco:week=8"],
-  "numbers": {"week": 8, "team_score": 142.3, "opponent_score": 98.7, "margin": 43.6},
-  "category": "score"
-}
-```
-
-Use stable IDs that describe the fact. Prefer categories such as `score`, `standing`, `transaction`, `player`, `streak`, `playoff`, and `general`.
-
-## What To Look For
-
-- Upsets: lower-ranked or struggling teams beating favorites.
-- Blowouts: dominant wins, especially margins around 30 points or more.
-- Nail-biters: games decided by fewer than 5 points.
-- Streaks: winning or losing runs, especially 3 or more games.
-- Breakouts: player or team performances that stand out from recent history.
-- Collapses: favorites or strong teams missing expectations.
-- Transactions: trades, waivers, and roster moves that affected the week.
-- Continuing arcs: previous storylines that changed, intensified, or resolved.
-- Playoff pressure: seed movement, elimination risk, byes, and bracket paths.
-
-## Sufficiency Criteria
-
-Research is sufficient when you have enough verified facts to support the requested article and no unresolved high-value lead is likely to change its central framing:
-
-- Short focused article: 5-8 strong facts.
-- Standard weekly recap: 10-20 strong facts.
-- Deep dive or power rankings: enough facts to support each featured team or section.
-
-Fact counts are diagnostics, not stopping targets. Continue when another call could materially change the lead, correct an important claim, or unlock a strong callback. Stop when additional calls would mostly add interchangeable detail.
+This goal is sufficiently met when the important claims and sections are supported, suspicious evidence has been resolved or qualified, the central framing is stable, and another call would mostly add substitutable color. Shift attention to narrative selection, composition, or publication confidence when one of those is now the greater risk.

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -41,7 +41,7 @@ Run independent reads together when their results do not depend on one another. 
 
 Search memory when prior context could materially improve the article: trades and waivers, rematches and rivalries, playoff reversals, repeated lineup mistakes, focused-team histories, retrospectives, rankings, or season-long awards. For an ordinary recap, a lightweight scan is useful only when current teams, players, transactions, or stakes provide a plausible retrieval hook. Stop after an empty or low-value result unless the current evidence suggests a more specific query.
 
-Buffer durable proposals only when an event or arc has plausible future callback value. Persistence work is separate from proving today's article.
+After a successful live submission, saved brief storylines and their supporting facts are bridged into memory automatically. Use `save_memory_event`, `save_team_context`, or `save_league_note` when durable event or context state should also be maintained. Memory work remains separate from proving today's article.
 
 ## Stop Or Switch
 

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -1,110 +1,40 @@
-# Storyline Procedure
+# Goal: Find The Article's Meaning
 
-Use this procedure for deliberate storyline mining and narrative synthesis. Storyline work may happen after a broad scan, between targeted research calls, while reshaping a draft, or during verification. It is not a mandatory bridge between research and drafting.
+Use this guide when the evidence is real but the central thesis, hierarchy of angles, callbacks, stakes, or article shape is still unclear. It may help before drafting, while testing prose, or when verification exposes weak framing.
 
-## Operating Rules
+## Success Looks Like
 
-- Call `read_brief` when you do not already hold the current structured state.
-- Every storyline recorded as verified must be supported by existing fact IDs. A promising unsupported angle is a research hypothesis: make the narrow calls needed to prove or reject it before recording it.
-- Storyline summaries may interpret the data, but they must not add new factual claims.
-- Save developed angles with `save_storyline`, then use `set_outline` if a formal plan will help. Refresh stale dependent items when later research changes their evidence.
-- Bias is framing only. Preserve the user's framing preferences without altering scores, records, or outcomes.
-- A callback used in the article must point to two saved brief facts: one old-event fact reverified against frozen data and one current-event fact. Retrieved memory is only the lead that prompted the investigation.
-- Successful brief-tool results include revision and readiness; do not reread solely to confirm them.
-- A small evidence gap does not require loading the research procedure. Investigate it directly, update the brief, and continue mining the angle. Load `research` only when the gap opens a substantial new investigation.
-- Inspecting or drafting a paragraph can be a useful test of whether a storyline has enough specificity. If prose exposes a weak premise, strengthen or drop the angle rather than forcing it into the outline.
+- The article has a clear supported idea appropriate to the request, not merely a list of results.
+- Featured angles explain a meaningful change, tension, consequence, payoff, reversal, irony, or future stake.
+- The strongest material receives the most attention; routine facts remain supporting color or are omitted.
+- Every saved storyline is supported by facts, and every callback names reverified old and current evidence.
+- Any outline reflects the current evidence and remains useful rather than ceremonial.
 
-## Storyline Mining Loop
+## Tool Choices
 
-For a standard weekly recap, 3-6 developed angles is a useful range rather than a quota; use fewer for narrow requests. Prefer fewer well-supported storylines over filling slots. Save each developed narrative thread with `save_storyline`.
+- Use `read_brief` when the current facts, callbacks, storylines, or outline are not already available in context.
+- Use a targeted datalayer call when a promising angle has one material evidence gap. Return to broader research only when the premise itself needs substantial investigation.
+- Use `search_memory` when a current team, player, transaction, matchup, or stake creates a specific historical question.
+- Use `save_storyline` for developed narrative angles supported by saved fact IDs.
+- Use `save_memory_callback` only after the older event and current payoff both exist as reverified facts.
+- Use `set_outline` when explicit structure will improve emphasis, coverage, or drafting. An outline is optional and revisable.
+- Use typed proposal tools only when an arc has credible future callback value or clear season-long significance.
 
-For each candidate angle:
+## Narrative Judgment
 
-1. Name the change or tension, not merely the result.
-2. Identify the supporting facts already present and the exact evidence gaps.
-3. Check current-week data and memory for reversal, payoff, continuity, irony, or future stakes.
-4. Verify high-value gaps and reject angles that remain vague or incidental.
-5. Rank surviving storylines by reader value and article fit, then update the outline or draft as appropriate.
+- Name what changed or why the event matters, not only what happened.
+- Distinguish retrieval relevance from reader value. A memory match or statistical outlier is not automatically a good storyline.
+- Prefer angles with specific evidence, consequence, surprise, stakes, reversal, payoff, league-reader relevance, or comedy that the facts genuinely support.
+- Treat unsupported framing as a hypothesis. Verify it, soften it, or drop it.
+- Storyline summaries may interpret facts but may not introduce new factual claims.
+- Test whether each featured angle earns its space and whether the article would lose meaning without it.
+- Let the requested form determine structure. A recap, ranking, deep dive, retrospective, and playoff piece need not share the same outline.
+- Use priority as a relative editorial ranking within this article, not a universal taxonomy.
 
-Priority guidance:
+## Continuity Judgment
 
-- `1`: lead story. Major upset, playoff swing, dominant performance, season-defining trend, or request-specific focus.
-- `2`: secondary story. Close game, important streak, notable breakout, trade fallout, or standings movement.
-- `3`: useful color. Routine wins, smaller stat nuggets, or supporting angles.
-- `4-5`: minor mentions that should only appear if space allows.
+Preserve an arc only when a future generation could usefully recognize its next payoff or reversal. Relevant examples include trade evaluations, revenge or rematch conditions, playoff reversals, recurring lineup mistakes, waiver payoffs, and rivalry escalation. Keep article planning state (`save_storyline`) distinct from durable memory proposals (`propose_*` and `replace_*`).
 
-Good `save_storyline` input:
+## Stop Or Switch
 
-```json
-{
-  "id": "story_taco_statement_win",
-  "headline": "Team Taco Turns A Win Into A Warning Shot",
-  "summary": "The margin and player production make the Week 8 win a statement.",
-  "supporting_fact_ids": ["fact_week8_taco_win", "fact_week8_taco_top_players"],
-  "priority": 1,
-  "tags": ["blowout", "contender", "week_8"]
-}
-```
-
-## Style And Bias
-
-Style and bias are immutable request context already present in the brief. Apply
-them as framing constraints; do not spend tool calls restating or changing them.
-
-## Outline Creation
-
-Use `set_outline` when a formal writing plan will help. Each section should include:
-
-- `title`: concise section heading.
-- `bullet_points`: what the section must accomplish.
-- `required_fact_ids`: exact facts the writer must use.
-- `storyline_ids`: storylines that belong in the section.
-
-A possible weekly recap structure:
-
-1. Opening hook: lead with the priority-1 storyline and set the week's theme.
-2. Lead story: give the strongest matchup or narrative enough room.
-3. Supporting storylines: cover the next 2-3 important arcs.
-4. Quick hits: short notes for lower-priority items, top performers, or transactions.
-5. Standings or outlook: playoff implications, next-week stakes, or season trajectory.
-6. Closing: resolve the article with the strongest takeaway.
-
-For power rankings, one section per rank or tier may work. For team deep dives, useful sections often include record, recent games, roster strengths or weaknesses, transactions, and outlook. Build only as much outline as the article needs, and revise it when new evidence changes the article's shape.
-
-## Typed Memory Proposals
-
-If typed memory proposal tools are available, buffer durable narrative state when it becomes clear; do not wait for a separate pre-drafting checkpoint:
-
-- Use `propose_storyline` for new durable arcs and `replace_storyline` only for canonical items returned by `search_memory` with an exact expected revision.
-- Use `propose_event` for inferred matchup or trade evidence and `propose_trigger` for typed rematch or trade-evaluation callbacks.
-- Use `propose_context_note` for franchise, season, or competition context.
-- Use `propose_fact` for reusable claims. Fact and event proposals are `unverified` or `inferred`; source-backed receipts are not available in this tool version.
-- Save verified callbacks with `save_memory_callback` if they were not already saved during research.
-- Proposal results may be referenced by later proposals in the same bundle, but buffered proposals do not appear in `search_memory` and cannot be replaced during the same run.
-
-Persist an arc only if it has either a plausible future callback condition or clear season-long significance. Useful durable arc types include:
-
-- `trade_payoff`
-- `trade_regret`
-- `trade_flop`
-- `revenge_game`
-- `regular_season_sweep`
-- `playoff_reversal`
-- `close_game_callback`
-- `waiver_hero`
-- `rivalry_escalation`
-- `lineup_mistake_repeat`
-
-Keep complete typed arc metadata in the proposal content. Use a concise structured summary when narrative context needs more explanation:
-
-```text
-Arc type: trade_regret
-Origin week: 3
-Involved: Team A, Team B, Player X, Player Y
-Receipt: Team A traded Player X for Player Y before Week 3.
-Why it may matter later: Player X could swing a playoff matchup against Team A.
-Next callback trigger: Team A faces Team B, Player X faces Team A, or either side loses a playoff game because of the trade assets.
-Verification needed before use: confirm original trade receipt and current payoff with saved brief facts.
-```
-
-When the narrative plan is useful, continue with the action that most improves the article. That may be drafting, targeted research, verification, or further storyline mining. Do not load `drafting` solely to announce a phase transition.
+This goal is sufficiently met when the lead and supporting angles are evidence-backed, proportionate to their importance, and coherent enough to guide prose. Shift attention when the greater risk is missing evidence, weak composition, or publication confidence. If drafting exposes a better thesis, revise the narrative plan instead of protecting the original outline.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -18,7 +18,8 @@ Use this guide when the evidence is real but the central thesis, hierarchy of an
 - Use `save_storyline` for developed narrative angles supported by saved fact IDs.
 - Use `save_memory_callback` only after the older event and current payoff both exist as reverified facts.
 - Use `set_outline` when explicit structure will improve emphasis, coverage, or drafting. An outline is optional and revisable.
-- Use typed proposal tools only when an arc has credible future callback value or clear season-long significance.
+- Use `upsert_storyline_memory_card` when an ongoing arc's durable headline, summary, status, or callback condition should be created or updated.
+- Use `save_storyline_trigger` when that arc has a concrete future condition worth checking, such as a rematch or trade reevaluation.
 
 ## Narrative Judgment
 
@@ -33,7 +34,7 @@ Use this guide when the evidence is real but the central thesis, hierarchy of an
 
 ## Continuity Judgment
 
-Preserve an arc only when a future generation could usefully recognize its next payoff or reversal. Relevant examples include trade evaluations, revenge or rematch conditions, playoff reversals, recurring lineup mistakes, waiver payoffs, and rivalry escalation. Keep article planning state (`save_storyline`) distinct from durable memory proposals (`propose_*` and `replace_*`).
+After a successful live submission, the runtime automatically bridges saved brief storylines and their supporting facts into memory. Use `upsert_storyline_memory_card` to maintain the durable narrative state of an arc when a future generation could usefully recognize its next payoff or reversal. Relevant examples include trade evaluations, revenge or rematch conditions, playoff reversals, recurring lineup mistakes, waiver payoffs, and rivalry escalation. Add a trigger only when a specific future condition would make the arc useful again.
 
 ## Stop Or Switch
 

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -1,79 +1,39 @@
-# Verification Procedure
+# Goal: Earn Publication Confidence
 
-Use this procedure for a detailed claim-level audit of the chosen publishable draft against the structured brief. Verification is usually the last activity before submission, but it is not a one-way terminal phase: follow important gaps into targeted research, storyline repair, or redrafting, then resume the audit.
+Use this guide when a publishable draft exists and the remaining question is whether its facts, framing, coverage, and current revision are trustworthy enough to submit. Verification may uncover a reason to research, reshape, or redraft before returning to this goal.
 
-## Operating Rules
+## Success Looks Like
 
-- Use `list_artifacts` only when the draft path is unknown. Read the draft or call `read_brief` only when you do not already hold its current state.
-- Honor readiness warnings. Do not rely on stale callbacks, storylines, or outline references until they are refreshed against current fact revisions.
-- Verify every numeric or factual claim against saved facts.
-- Treat the brief as authoritative. If the article and brief conflict, fix the article unless the brief is missing required evidence.
-- If the brief is missing evidence for a necessary claim, investigate the narrow gap directly and save the result with `save_fact`. Load `research` only when the problem requires substantial exploration.
-- If verification exposes a weak or unsupported framing choice, revise it directly. Load `storyline` only when the article needs broader narrative restructuring.
-- Treat callback claims as factual claims. They need evidence for both the older event and the current event.
-- Before submission, perform a deliberate memory harvest when proposal tools are available. Review the final lead storylines, verified callbacks, meaningful transactions, reversals, playoff stakes, and future rematch or evaluation conditions. Buffer only items with plausible future callback value or season-long significance; routine results do not need to persist.
+- Every material factual claim in the article maps to an accurate saved fact.
+- Scores, winners, records, ranks, player totals, transactions, margins, streaks, week ranges, playoff claims, and superlatives are correct and sufficiently supported.
+- Callbacks contain reverified evidence for both the older event and current payoff.
+- Suspicious or conflicting evidence has been independently checked rather than copied from the brief by default.
+- The article's framing is proportional to its evidence, matches the request, and does not imply unsupported causality or certainty.
+- The selected artifact is readable, coherent, close to the requested length, and at the current known revision.
 
-## Claims To Check
+## Tool Choices
 
-Check all claims involving:
+- Use `list_artifacts` only when the publishable path is unknown.
+- Reuse the current draft and brief state when available. Use `read_artifact` or `read_brief` when state is unknown or a complete review will add value.
+- Use the smallest targeted datalayer view to resolve a missing, suspicious, or conflicting claim, then save the corrected evidence.
+- Use `edit_artifact` for a real correction or meaningful improvement, carrying forward the returned revision.
+- Use `submit_artifact` only after the actual draft meets the publication goal. Submission pins that revision and ends the loop.
 
-- Scores and matchup winners.
-- Team records, standings ranks, playoff seeds, and playoff paths.
-- Player fantasy points and leaderboard placement.
-- Transaction counts, trade participants, waiver adds, and dropped players.
-- Margins of victory or defeat.
-- Streak lengths and week ranges.
-- Any superlative such as "highest", "first", "best", "worst", or "season high".
-- Any callback, revenge, regret, reversal, payoff, rematch, rivalry, or "full circle" claim.
+## Audit Judgment
 
-Flavor claims can be looser, but they must not imply unsupported facts.
+- Check the article itself, not merely whether the workflow produced facts, storylines, or an outline.
+- Treat the brief as structured evidence, not infallible truth. Confirm that source references match calls actually made and that saved claims faithfully represent their results.
+- Pay special attention to high-impact numbers, names, winners, transactions, comparative claims, and words such as “highest,” “first,” “best,” “worst,” or “season high.”
+- A flavor claim may be interpretive, but it must not smuggle in an unsupported factual premise.
+- For callbacks, confirm what happened then, what happened now, and why the meaning changed. Reject or soften a connection whose current payoff is weak or incidental.
+- Honor stale-dependency warnings. Refresh or remove stale callbacks, storylines, and outline references before relying on them.
+- Correct the smallest passage that resolves an issue unless the surrounding section depends on the same bad premise.
+- Replace unsupported specificity with verified specificity or appropriately qualified language.
+- Preserve voice while correcting facts. Bias never excuses an inaccurate premise.
+- If the draft is already correct, do not perform a no-op edit merely to demonstrate verification.
 
-## Callback Checks
+## Stop Or Switch
 
-For every callback paragraph:
+Return to research when missing or questionable evidence could change a material claim. Return to storyline work when the facts are sound but the thesis or emphasis is misleading. Return to drafting when corrections require substantial prose changes.
 
-- Map the older event to a saved fact ID whose claim was re-verified against frozen data.
-- Map the current payoff to a current-run saved fact ID.
-- Confirm both sides of every verified callback exist in the brief.
-- Confirm the paragraph explains what happened then, what happened now, and why the meaning changed.
-- Treat unsourced narrative memory as research context only, not prose support.
-- Reject or soften callbacks where the older event is real but the current payoff is weak, incidental, or not proven.
-
-## Verification Flow
-
-1. Establish the current draft path, content, and revision, and the current structured brief state. Reuse state returned by recent operations when available.
-2. Extract each factual claim from the article section by section.
-3. Match each claim to a fact ID and use the exact saved numbers.
-4. Classify issues:
-   - `error`: wrong score, winner, record, player points, transaction, or other critical fact.
-   - `warning`: unsupported superlative, ambiguous rounding, or overstatement.
-   - `info`: stylistic claim that is not directly factual but may be too strong.
-5. Correct `error` issues with exact, single-match `edit_artifact` calls.
-6. Correct or soften `warning` issues when the fix improves accuracy without hurting readability.
-7. When a correction requires new evidence or reframing, resolve it and continue the audit from the affected section; do not restart the entire workflow.
-8. After each edit, use its returned content and revision for the next check. Perform one final whole-article review after substantive corrections.
-9. Call `submit_artifact(path=<draft_path>, expected_revision=<current>)` only after the draft passes verification.
-
-## Correction Policy
-
-When editing the article:
-
-- Preserve the passage's purpose and voice.
-- Change only the unsupported or incorrect parts unless the whole section depends on bad information.
-- Replace unsupported numbers with sourced numbers, or remove the claim.
-- Replace unsupported superlatives with grounded phrasing, such as "one of the week's strongest performances" if the brief supports it.
-- Keep bias within the allowed framing rules. Roasting is allowed only when the factual premise is true.
-- If a target occurs zero or multiple times, read the current article and choose a more precise exact replacement rather than guessing.
-
-## Final Checklist
-
-Before `submit_artifact`, confirm:
-
-- The article is non-empty and has a clear Markdown structure.
-- All required outline facts are represented or intentionally omitted for a defensible reason.
-- All scores, records, rankings, and player points match the brief.
-- No datalayer-only facts appear in the article unless they were saved in the brief.
-- Bias changes word choice and emphasis only, never facts.
-- The article is readable and close to the target length.
-
-Submission pins the current chosen draft snapshot and ends the reporter loop. A revision conflict requires another read and verification pass.
+This goal is complete when no known material issue remains and another review would mostly repeat the same checks. Submit the current verified revision directly; a revision conflict means the artifact must be reread and publication confidence re-established.

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -49,7 +49,7 @@ Procedures are on-demand guides, not workflow stages or progress requirements. T
 - `research_brief.md` is a runtime-managed projection. Never create, edit, or submit it with generic artifact tools.
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` for publishable Markdown. Reuse content and revisions returned by successful operations; reread only when state is unknown or a full-document review is useful.
 - Every edit is an exact single-match replacement. Do not make a no-op edit when the draft already says what it should say.
-- Use explicit `propose_*` and `replace_*` tools only for context worth carrying into future generations. Buffered proposals are not visible to searches during the same run.
+- After a successful live submission, the runtime automatically bridges saved brief storylines and their supporting facts into memory. Use semantic memory tools to maintain the durable narrative state around that evidence: `save_memory_event` for an event, `upsert_storyline_memory_card` for an arc's ongoing state, `save_storyline_trigger` for a future callback condition, `save_team_context` for team-specific context, and `save_league_note` for league-wide context. Buffered writes are not visible to `search_memory` during the same run.
 - `article.md` is the default publishable path, not a required application identity.
 
 ## Article Quality

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -1,43 +1,61 @@
 You are an AI fantasy football reporter for a Sleeper league.
 
-Your job is to produce a verified, compelling Markdown article by adaptively combining evidence gathering, structured-brief updates, storyline mining, drafting, and claim checking, then submit the article artifact.
+## Mission
 
-Core rules:
-- Ground factual claims in tool data. Save important claims with `save_fact` before relying on them in the article.
-- Bias is framing only. Never alter scores, records, statistics, transaction details, or player names.
+Produce and submit a compelling Markdown article grounded in the frozen league snapshot and, when relevant, verified historical context.
+
+Success means:
+- The article fulfills the requested coverage, focus, length, voice, bias, and exclusions.
+- Every material factual claim is supported by a saved fact whose evidence comes from tool data.
+- The article has a clear editorial idea and explains why its selected events matter.
+- The final draft has no known material contradiction, unsupported claim, unresolved data anomaly, or high-value research gap.
+
+## Durable Invariants
+
+- Bias changes framing and emphasis only. Never alter scores, records, statistics, transactions, rankings, or names.
 - Keep evidence traceable through source references that identify the source tool and arguments.
-- Use typed generation memory only as narrative research leads, never as article-ready truth.
-- Treat retrieved memories as candidate callbacks. Re-verify old-event receipts and current-week payoffs before drafting from them.
-- Dormant storylines are valuable when this week's events create a meaningful reversal, payoff, revenge angle, regret arc, or stakes change.
-- Research, storyline mining, drafting, and verification are activities you may interleave, not mandatory sequential phases. Choose the next action that resolves the most important uncertainty or improves the article most.
-- Mine storylines throughout the run. After meaningful research or drafting discoveries, ask what changed, reversed, paid off, collapsed, became funny, or gained stakes.
-- Drafting may expose research gaps, and verification may expose better storylines. Follow those leads, update the brief, and then continue from the most useful point.
+- Treat memory as a source of narrative leads, not article-ready truth. Re-verify remembered events and current payoffs with frozen datalayer tools before using them.
+- Treat implausible or internally inconsistent data, such as all-zero scoring or disagreement between summary and player detail, as unresolved. Cross-check it through the smallest useful independent datalayer view before recording or publishing it.
+- Treat the configured week range as the article's current coverage. Query outside it only to verify a specific historical comparison or callback that materially serves the request, and never use data beyond the frozen snapshot cutoff.
+- Style and bias are already resolved from the request. Do not spend turns restating or changing them.
 
-Artifact rules:
-- Artifacts are raw Markdown addressed by logical path.
-- Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` to work with them.
-- `research_brief.md` is a runtime-managed projection of the structured brief. Never create, edit, or submit it with generic artifact tools.
-- Use `save_fact`, `save_memory_callback`, `save_storyline`, `set_outline`, and `read_brief` for brief state. Reading revision 0 does not create an artifact.
-- Style and bias are already resolved from the request. Do not spend turns restating them.
-- Before editing an artifact, know its current content and revision. A successful read, create, or edit returns both; reuse that state instead of rereading after every write. Reread when the revision is unknown, another operation may have changed it, or an edit conflicts.
-- Every edit is an exact, single-match replacement. Preserve a unique insertion marker when the document will need more additions.
-- Choose a stable normalized Markdown path for the publishable article.
-  `article.md` is the default convention, not a required application identity.
+## Editorial Goals
 
-Working method:
-- Procedures are optional operating guides, not workflow gates or a checklist. Load one when its detailed instructions will materially help the current work.
-- Do not load all four procedures just to move through named stages. You may skip a procedure, revisit one, or handle a narrow research, storyline, drafting, or verification task without changing the active procedure.
-- Continue directly with tools when the instructions already in context are sufficient. Loading a different procedure is not progress by itself.
-- Use `research` for substantial exploration or evidence repair, `storyline` for deliberate narrative synthesis, `drafting` for sustained composition, and `verification` for a detailed final audit.
-- Issue independent datalayer calls together in the same model turn. Serialize only calls whose arguments depend on earlier results.
-- Use datalayer tools for Sleeper league facts.
-- Use `search_memory`, when available, for revision-pinned hydrated memory leads.
-- Use explicit `propose_*` and `replace_*` tools to buffer typed memory changes for generation finalization. These proposals do not become visible to searches during the same run.
-- Verify remembered claims with frozen datalayer tools and save the verified evidence as facts; there are no memory access-history or verification-record tools.
-- Save verified callbacks only after both old and current fact IDs are present.
-- Consider durable memory whenever a meaningful arc emerges; do not postpone all memory work to a separate storyline phase.
-- Before submission, deliberately review the final storylines and callbacks for durable memory value. It is valid to propose nothing after a real review when the run contains only routine results.
-- Submission requires at least one saved verified fact. Storylines and an outline are valuable when the request needs them, but they are not universal submission gates.
+Work on whichever unmet goal has the greatest effect on accuracy or reader value. These goals are not phases and need not occur in order:
 
-Do not end with a normal assistant message. Finish by calling `submit_artifact`
-with the current revision of your chosen publishable artifact.
+- **Ground the article:** obtain a trustworthy evidence base for its important claims and central framing.
+- **Find the meaning:** identify the strongest supported thesis, tensions, callbacks, consequences, and stakes.
+- **Shape the article:** produce a coherent opening, progression, emphasis, and conclusion in the requested voice.
+- **Earn publication confidence:** audit the actual draft, repair material gaps or errors, and submit only the current verified revision.
+- **Preserve useful continuity:** when an arc has plausible future value, buffer concise typed memory proposals without confusing persistence work with article readiness.
+
+After meaningful evidence or drafting work, reassess the most important remaining uncertainty. Drafting may expose research gaps; verification may expose weak framing; new evidence may change the outline. Follow the highest-value lead instead of preserving a stale plan.
+
+## Guidance Library
+
+Load a procedure when its detailed editorial guidance would materially help an unmet goal:
+- `research` supports evidence coverage, targeted investigation, anomaly repair, and historical-lead verification.
+- `storyline` supports thesis selection, angle ranking, callbacks, stakes, and article structure.
+- `drafting` supports sustained composition, revision, voice, and proportional coverage.
+- `verification` supports claim-level audit, correction, and publication readiness.
+
+Procedures are on-demand guides, not workflow stages or progress requirements. They may be loaded in any order, revisited, or skipped when their outcome is already clear. Do not load a guide merely to announce a phase, and do not avoid a useful guide merely to save a turn.
+
+## Tool And State Map
+
+- Use datalayer tools for Sleeper league facts. Prefer the smallest result that can resolve the current material uncertainty, and avoid overlapping broad calls that mostly repeat evidence already in context.
+- Use `search_memory` for relevant historical narrative leads at the pinned revision. Verify useful matches with datalayer tools.
+- Use `save_fact`, `save_memory_callback`, `save_storyline`, `set_outline`, and `read_brief` for structured working state.
+- `research_brief.md` is a runtime-managed projection. Never create, edit, or submit it with generic artifact tools.
+- Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` for publishable Markdown. Reuse content and revisions returned by successful operations; reread only when state is unknown or a full-document review is useful.
+- Every edit is an exact single-match replacement. Do not make a no-op edit when the draft already says what it should say.
+- Use explicit `propose_*` and `replace_*` tools only for context worth carrying into future generations. Buffered proposals are not visible to searches during the same run.
+- `article.md` is the default publishable path, not a required application identity.
+
+## Article Quality
+
+A good article is accurate, specific, coherent, and selective. It has a supported central idea rather than reading like a dump of tool results. It distinguishes meaningful developments from routine results, gives important subjects enough context, and covers the league in proportion to the requested focus. It uses historical context when that context creates a relevant payoff, reversal, rivalry, regret, or change in stakes. Its voice is entertaining without outrunning its evidence.
+
+Continue while another action could materially improve factual confidence, central framing, request fulfillment, or narrative value. Submit when the article meets this quality bar and additional work would mostly add interchangeable detail.
+
+Do not end with a normal assistant message. Finish by calling `submit_artifact` with the current revision of the chosen publishable artifact.

--- a/backend/services/reporter/runner/tools/memory_tools.py
+++ b/backend/services/reporter/runner/tools/memory_tools.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, ValidationError
 
@@ -29,125 +30,19 @@ if TYPE_CHECKING:
     from backend.services.datalayer import FrozenLeagueData
 
 
-MEMORY_TOOL_IMPLEMENTATION_VERSION = "1"
+MEMORY_TOOL_IMPLEMENTATION_VERSION = "2"
 _READ_TOOL = "search_memory"
 _WRITE_TOOLS = (
-    "propose_fact",
-    "replace_fact",
-    "propose_event",
-    "replace_event",
-    "propose_storyline",
-    "replace_storyline",
-    "propose_trigger",
-    "replace_trigger",
-    "propose_context_note",
-    "replace_context_note",
+    "save_memory_event",
+    "upsert_storyline_memory_card",
+    "save_storyline_trigger",
+    "save_team_context",
+    "save_league_note",
 )
 
 
 class _StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
-
-class FactFranchiseSubject(_StrictModel):
-    kind: Literal["franchise"]
-    roster_key: str = Field(min_length=1)
-    role: Literal["subject"] = "subject"
-    display_name: str | None = None
-
-
-class FactSeasonRosterSubject(_StrictModel):
-    kind: Literal["season_roster"]
-    roster_key: str = Field(min_length=1)
-    role: Literal["subject"] = "subject"
-    display_name: str | None = None
-
-
-class FactPlayerSubject(_StrictModel):
-    kind: Literal["player"]
-    id: str = Field(min_length=1)
-    role: Literal["subject"] = "subject"
-    display_name: str | None = None
-
-
-class FactSeasonSubject(_StrictModel):
-    kind: Literal["season"]
-    id: UUID
-    role: Literal["subject"] = "subject"
-    display_name: str | None = None
-
-
-class FactSleeperUserSubject(_StrictModel):
-    kind: Literal["sleeper_user"]
-    id: str = Field(min_length=1)
-    role: Literal["subject"] = "subject"
-    display_name: str | None = None
-
-
-FactSubject = Annotated[
-    FactFranchiseSubject
-    | FactSeasonRosterSubject
-    | FactPlayerSubject
-    | FactSeasonSubject
-    | FactSleeperUserSubject,
-    Field(discriminator="kind"),
-]
-
-
-class StorylineFranchiseSubject(_StrictModel):
-    kind: Literal["franchise"]
-    roster_key: str = Field(min_length=1)
-    role: Literal["focus", "counterparty"]
-    display_name: str | None = None
-
-
-class StorylineSeasonRosterSubject(_StrictModel):
-    kind: Literal["season_roster"]
-    roster_key: str = Field(min_length=1)
-    role: Literal["focus", "counterparty"]
-    display_name: str | None = None
-
-
-class StorylinePlayerSubject(_StrictModel):
-    kind: Literal["player"]
-    id: str = Field(min_length=1)
-    role: Literal["focus", "counterparty"]
-    display_name: str | None = None
-
-
-class StorylineSeasonSubject(_StrictModel):
-    kind: Literal["season"]
-    id: UUID
-    role: Literal["focus", "counterparty"]
-    display_name: str | None = None
-
-
-class StorylineSleeperUserSubject(_StrictModel):
-    kind: Literal["sleeper_user"]
-    id: str = Field(min_length=1)
-    role: Literal["focus", "counterparty"]
-    display_name: str | None = None
-
-
-StorylineSubject = Annotated[
-    StorylineFranchiseSubject
-    | StorylineSeasonRosterSubject
-    | StorylinePlayerSubject
-    | StorylineSeasonSubject
-    | StorylineSleeperUserSubject,
-    Field(discriminator="kind"),
-]
-
-
-class ReporterFactContent(_StrictModel):
-    claim: str = Field(min_length=1)
-    category: str = Field(min_length=1)
-    numbers: dict[str, JsonValue] = Field(default_factory=dict)
-    confidence: Literal["unverified", "inferred"]
-    status: Literal["active", "superseded", "rejected", "archived"] = "active"
-    subjects: list[FactSubject] = Field(default_factory=list)
-    originating_event_version_ids: list[UUID] = Field(default_factory=list)
-    source_hints: dict[str, JsonValue] | None = None
 
 
 class PlayerTradeAsset(_StrictModel):
@@ -195,6 +90,8 @@ ReporterEventDetails = Annotated[
 
 
 class ReporterEventContent(_StrictModel):
+    """Reporter event payload adapted to canonical trade/matchup constraints."""
+
     event_type: Literal["trade", "matchup"]
     headline: str = Field(min_length=1)
     summary: str = Field(min_length=1)
@@ -203,31 +100,6 @@ class ReporterEventContent(_StrictModel):
     status: Literal["active", "superseded", "rejected", "archived"] = "active"
     details: ReporterEventDetails
     source_hints: dict[str, JsonValue] | None = None
-
-
-class StorylineEvidence(_StrictModel):
-    kind: Literal["fact", "event"]
-    version_id: UUID
-    role: Literal["origin", "support", "update", "payoff"]
-
-
-class RelatedStoryline(_StrictModel):
-    item_id: UUID
-    role: Literal["related_arc", "continuation", "counterpoint"]
-
-
-class ReporterStorylineContent(_StrictModel):
-    headline: str = Field(min_length=1)
-    summary: str = Field(min_length=1)
-    status: Literal["active", "dormant", "resolved", "archived"] = "active"
-    arc_type: str | None = None
-    salience: int = Field(ge=1, le=5)
-    tags: list[str] = Field(default_factory=list)
-    subjects: list[StorylineSubject] = Field(default_factory=list)
-    evidence: list[StorylineEvidence] = Field(default_factory=list)
-    related_storylines: list[RelatedStoryline] = Field(default_factory=list)
-    callback_condition: str | None = None
-    resolution_summary: str | None = None
 
 
 class ReporterRematchCondition(_StrictModel):
@@ -258,36 +130,6 @@ class ReporterTriggerContent(_StrictModel):
     resolution_reason: str | None = None
 
 
-class CompetitionNoteIdentity(_StrictModel):
-    scope: Literal["competition"]
-    note_key: str = Field(min_length=1)
-
-
-class CompetitionSeasonNoteIdentity(_StrictModel):
-    scope: Literal["competition_season"]
-    competition_season_id: UUID
-    note_key: str = Field(min_length=1)
-
-
-class FranchiseNoteIdentity(_StrictModel):
-    scope: Literal["franchise"]
-    roster_key: str = Field(min_length=1)
-    note_key: str = Field(min_length=1)
-
-
-ReporterContextNoteIdentity = Annotated[
-    CompetitionNoteIdentity | CompetitionSeasonNoteIdentity | FranchiseNoteIdentity,
-    Field(discriminator="scope"),
-]
-
-
-class ReporterContextNoteContent(_StrictModel):
-    narrative: str = Field(min_length=1)
-    outlook: str | None = None
-    status: Literal["active", "archived"] = "active"
-    tags: list[str] = Field(default_factory=list)
-
-
 class SearchMemoryArgs(_StrictModel):
     text: str | None = None
     team_keys: list[str] = Field(default_factory=list)
@@ -303,51 +145,64 @@ class SearchMemoryArgs(_StrictModel):
     expand_stable_references: bool = False
 
 
-class ProposeFactArgs(_StrictModel):
-    content: ReporterFactContent
+class SaveMemoryEventArgs(_StrictModel):
+    id: str = Field(min_length=1)
+    event_type: Literal["trade", "matchup"]
+    week: int = Field(ge=0)
+    headline: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    importance: int = 1
+    confidence: Literal["verified", "inferred", "needs_verification"] = (
+        "needs_verification"
+    )
+    source_refs: list[JsonValue] = Field(default_factory=list)
+    numbers: dict[str, JsonValue] = Field(default_factory=dict)
+    entities: list[dict[str, JsonValue]] = Field(default_factory=list)
+    transaction_id: str | None = None
+    matchup_id: str | None = None
+    details: ReporterEventDetails | None = None
 
 
-class ReplaceFactArgs(ProposeFactArgs):
-    item_id: UUID
-    expected_item_revision: int = Field(gt=0)
+class UpsertStorylineMemoryCardArgs(_StrictModel):
+    id: str = Field(min_length=1)
+    headline: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    status: Literal["active", "stale", "resolved"]
+    priority: int = Field(default=2, ge=1, le=5)
+    importance: int | None = None
+    arc_type: str | None = None
+    origin_week: int | None = Field(default=None, ge=0)
+    future_callback_condition: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    team_keys: list[str] = Field(default_factory=list)
+    entities: list[dict[str, JsonValue]] = Field(default_factory=list)
+    evidence_event_ids: list[str] = Field(default_factory=list)
+    trigger_specs: list[dict[str, JsonValue]] = Field(default_factory=list)
 
 
-class ProposeEventArgs(_StrictModel):
-    content: ReporterEventContent
+class SaveStorylineTriggerArgs(_StrictModel):
+    trigger_type: Literal["rematch", "trade_evaluation"]
+    id: str | None = None
+    storyline_id: str | None = None
+    event_id: str | None = None
+    target_week: int | None = Field(default=None, ge=0)
+    condition: dict[str, JsonValue] = Field(default_factory=dict)
+    fire_policy: Literal["one_shot", "recurring", "until_resolved"] = "one_shot"
+    status: Literal["open", "fired", "expired", "resolved"] = "open"
 
 
-class ReplaceEventArgs(ProposeEventArgs):
-    item_id: UUID
-    expected_item_revision: int = Field(gt=0)
+class SaveTeamContextArgs(_StrictModel):
+    roster_key: str = Field(min_length=1)
+    narrative: str = Field(min_length=1)
+    outlook: (
+        Literal["rebuilding", "contending", "middling", "surging", "fading"]
+        | None
+    ) = None
 
 
-class ProposeStorylineArgs(_StrictModel):
-    content: ReporterStorylineContent
-
-
-class ReplaceStorylineArgs(ProposeStorylineArgs):
-    item_id: UUID
-    expected_item_revision: int = Field(gt=0)
-
-
-class ProposeTriggerArgs(_StrictModel):
-    content: ReporterTriggerContent
-
-
-class ReplaceTriggerArgs(ProposeTriggerArgs):
-    item_id: UUID
-    expected_item_revision: int = Field(gt=0)
-
-
-class ProposeContextNoteArgs(_StrictModel):
-    identity: ReporterContextNoteIdentity
-    content: ReporterContextNoteContent
-
-
-class ReplaceContextNoteArgs(_StrictModel):
-    item_id: UUID
-    expected_item_revision: int = Field(gt=0)
-    content: ReporterContextNoteContent
+class SaveLeagueNoteArgs(_StrictModel):
+    key: str = Field(min_length=1)
+    value: str = Field(min_length=1)
 
 
 def _tool(name: str, description: str, arguments: type[BaseModel]) -> ToolDef:
@@ -367,34 +222,38 @@ MEMORY_TOOL_SPECS: list[ToolDef] = [
     _tool(
         _READ_TOOL,
         "Search fully hydrated canonical memory at this generation's pinned revision. "
-        "Returned memories are research leads and must be verified against frozen data.",
+        "Returned memories are research leads and must be verified against frozen "
+        "data.",
         SearchMemoryArgs,
     ),
-    _tool("propose_fact", "Buffer a new typed fact.", ProposeFactArgs),
-    _tool("replace_fact", "Buffer a complete replacement for a canonical fact.", ReplaceFactArgs),
-    _tool("propose_event", "Buffer a new typed matchup or trade event.", ProposeEventArgs),
     _tool(
-        "replace_event",
-        "Buffer a complete replacement for a canonical event.",
-        ReplaceEventArgs,
+        "save_memory_event",
+        "Save event evidence for later callbacks. A stable id creates or updates "
+        "the event. Include typed details for the trade participants and assets, "
+        "or the matchup winner, loser, and Sleeper matchup id.",
+        SaveMemoryEventArgs,
     ),
-    _tool("propose_storyline", "Buffer a new typed storyline.", ProposeStorylineArgs),
     _tool(
-        "replace_storyline",
-        "Buffer a complete replacement for a canonical storyline.",
-        ReplaceStorylineArgs,
+        "upsert_storyline_memory_card",
+        "Create or update a storyline memory card by stable id.",
+        UpsertStorylineMemoryCardArgs,
     ),
-    _tool("propose_trigger", "Buffer a new typed callback trigger.", ProposeTriggerArgs),
     _tool(
-        "replace_trigger",
-        "Buffer a complete replacement for a canonical trigger.",
-        ReplaceTriggerArgs,
+        "save_storyline_trigger",
+        "Save or update a dormant callback trigger by stable id. A rematch needs "
+        "target_week and two condition.roster_keys; a trade evaluation needs its "
+        "event_id and a target week.",
+        SaveStorylineTriggerArgs,
     ),
-    _tool("propose_context_note", "Buffer a new typed context note.", ProposeContextNoteArgs),
     _tool(
-        "replace_context_note",
-        "Buffer a complete replacement for a canonical context note.",
-        ReplaceContextNoteArgs,
+        "save_team_context",
+        "Save or update persistent narrative context for one team.",
+        SaveTeamContextArgs,
+    ),
+    _tool(
+        "save_league_note",
+        "Save or update a league-wide persistent note by key.",
+        SaveLeagueNoteArgs,
     ),
 ]
 
@@ -403,6 +262,12 @@ class MemoryToolInputError(ValueError):
     def __init__(self, code: str, message: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class _CanonicalReference:
+    item_id: UUID
+    version_id: UUID
 
 
 class TypedMemoryAdapter:
@@ -416,6 +281,11 @@ class TypedMemoryAdapter:
         self._memory_context = memory_context
         self._data = data
         self._proposed_item_ids: set[UUID] = set()
+        self._pinned_agent_candidates: dict[tuple[MemoryKind, str], Any] = {}
+        self._local_agent_refs: dict[tuple[MemoryKind, str], Any] = {}
+        self._completed_semantic_saves: dict[
+            tuple[str, str], tuple[str, dict[str, Any]]
+        ] = {}
 
     def search(self, arguments: SearchMemoryArgs) -> dict[str, Any]:
         entity_keys = list(arguments.entity_keys)
@@ -445,166 +315,392 @@ class TypedMemoryAdapter:
                 expand_stable_references=arguments.expand_stable_references,
             )
         )
+        self._pinned_agent_candidates.update(
+            ((match.memory.item.kind, match.memory.item.agent_key), match.memory)
+            for match in result.matches
+            if match.memory.item.agent_key is not None
+        )
         return {"ok": True, **result.model_dump(mode="json")}
 
-    def propose_fact(
+    def save_memory_event(
         self,
         context: ToolContext,
-        content: ReporterFactContent,
+        arguments: SaveMemoryEventArgs,
     ) -> dict[str, Any]:
-        canonical = FactContent.model_validate(
+        if arguments.confidence == "verified" and not arguments.source_refs:
+            raise MemoryToolInputError(
+                "missing_source_refs",
+                "verified memory events require at least one source ref",
+            )
+        canonical = self._legacy_event(arguments)
+        result = self._upsert(
+            MemoryKind.EVENT,
+            arguments.id,
+            canonical,
+            context=context,
+            week=arguments.week,
+            create=self._memory_context.propose_event,
+            replace=self._memory_context.replace_event,
+        )
+        return {
+            **result,
+            "id": arguments.id,
+            "confidence": arguments.confidence,
+        }
+
+    def upsert_storyline_memory_card(
+        self,
+        context: ToolContext,
+        arguments: UpsertStorylineMemoryCardArgs,
+    ) -> dict[str, Any]:
+        subjects: list[dict[str, Any]] = []
+        sleeper_team_ids: list[int | str] = []
+        unresolved: list[str] = []
+        team_keys = list(arguments.team_keys)
+        for entity in arguments.entities:
+            if entity.get("entity_type", entity.get("type")) == "team":
+                team_keys.append(str(entity.get("roster_key", entity.get("id", ""))))
+        for roster_key in dict.fromkeys(team_keys):
+            try:
+                roster = self._resolve_roster(roster_key)
+            except MemoryToolInputError:
+                unresolved.append(roster_key)
+                continue
+            subjects.append(
+                {"kind": "franchise", "id": roster.franchise_id, "role": "focus"}
+            )
+            sleeper_team_ids.append(_numeric_when_possible(roster.sleeper_roster_id))
+        evidence = []
+        missing_events: list[str] = []
+        for event_id in arguments.evidence_event_ids:
+            reference = self._agent_reference(MemoryKind.EVENT, event_id)
+            if reference is None:
+                missing_events.append(event_id)
+            else:
+                evidence.append(
+                    {
+                        "kind": "event",
+                        "version_id": reference.version_id,
+                        "role": "support",
+                    }
+                )
+        if missing_events:
+            raise MemoryToolInputError(
+                "unknown_evidence_events",
+                f"Could not resolve evidence events: {', '.join(missing_events)}",
+            )
+        status = {"active": "active", "stale": "dormant", "resolved": "resolved"}[
+            arguments.status
+        ]
+        canonical = StorylineContent.model_validate(
             {
-                **content.model_dump(mode="python", exclude={"subjects"}),
-                "subjects": [self._fact_subject(item) for item in content.subjects],
+                "headline": arguments.headline,
+                "summary": arguments.summary,
+                "status": status,
+                "arc_type": arguments.arc_type,
+                "salience": max(
+                    1,
+                    min(
+                        5,
+                        arguments.importance
+                        if arguments.importance is not None
+                        else 6 - arguments.priority,
+                    ),
+                ),
+                "tags": arguments.tags,
+                "subjects": subjects,
+                "evidence": evidence,
+                "related_storylines": [],
+                "callback_condition": arguments.future_callback_condition,
+                "resolution_summary": None,
             }
         )
-        return self._proposed(
-            self._memory_context.propose_fact(
-                canonical,
-                metadata=self._metadata(context),
-            )
+        result = self._upsert(
+            MemoryKind.STORYLINE,
+            arguments.id,
+            canonical,
+            context=context,
+            week=arguments.origin_week,
+            create=self._memory_context.propose_storyline,
+            replace=self._memory_context.replace_storyline,
         )
+        saved_triggers: list[str] = []
+        for raw_spec in arguments.trigger_specs:
+            spec = SaveStorylineTriggerArgs.model_validate(
+                {**raw_spec, "storyline_id": raw_spec.get("storyline_id", arguments.id)}
+            )
+            trigger_result = self.save_storyline_trigger(context, spec)
+            saved_triggers.append(str(trigger_result["id"]))
+        payload = {
+            **result,
+            "id": arguments.id,
+            "status": arguments.status,
+            "team_ids": sleeper_team_ids,
+            "linked_events": arguments.evidence_event_ids,
+            "triggers": saved_triggers,
+        }
+        if unresolved:
+            payload["unresolved_team_keys"] = unresolved
+        return payload
 
-    def replace_fact(
+    def save_storyline_trigger(
         self,
         context: ToolContext,
-        arguments: ReplaceFactArgs,
+        arguments: SaveStorylineTriggerArgs,
     ) -> dict[str, Any]:
-        self._require_canonical_target(arguments.item_id)
-        canonical = FactContent.model_validate(
+        trigger_id = arguments.id or f"trigger_{uuid4().hex[:12]}"
+        storyline = (
+            self._agent_reference(MemoryKind.STORYLINE, arguments.storyline_id)
+            if arguments.storyline_id
+            else None
+        )
+        event = (
+            self._agent_reference(MemoryKind.EVENT, arguments.event_id)
+            if arguments.event_id
+            else None
+        )
+        if arguments.storyline_id and storyline is None:
+            raise MemoryToolInputError(
+                "unknown_storyline", "Could not resolve storyline"
+            )
+        if arguments.event_id and event is None:
+            raise MemoryToolInputError("unknown_event", "Could not resolve event")
+        condition: dict[str, Any]
+        if arguments.trigger_type == "rematch":
+            roster_keys = arguments.condition.get("roster_keys")
+            if not isinstance(roster_keys, list) or len(roster_keys) != 2:
+                raise MemoryToolInputError(
+                    "invalid_trigger_condition",
+                    "rematch condition requires two roster_keys",
+                )
+            condition = {"kind": "rematch", "roster_keys": roster_keys}
+        else:
+            condition = {"kind": "trade_evaluation"}
+        canonical = self._trigger(
+            ReporterTriggerContent.model_validate(
+                {
+                    "trigger_type": arguments.trigger_type,
+                    "status": (
+                        "satisfied"
+                        if arguments.status == "resolved"
+                        else arguments.status
+                    ),
+                    "fire_policy": arguments.fire_policy,
+                    "target_storyline_item_id": (
+                        storyline.item_id if storyline else None
+                    ),
+                    "origin_event_item_id": event.item_id if event else None,
+                    "target_week": arguments.target_week,
+                    "condition": condition,
+                }
+            )
+        )
+        result = self._upsert(
+            MemoryKind.TRIGGER,
+            trigger_id,
+            canonical,
+            context=context,
+            create=self._memory_context.propose_trigger,
+            replace=self._memory_context.replace_trigger,
+        )
+        return {
+            **result,
+            "id": trigger_id,
+            "trigger_type": arguments.trigger_type,
+            "status": arguments.status,
+        }
+
+    def save_team_context(
+        self,
+        context: ToolContext,
+        arguments: SaveTeamContextArgs,
+    ) -> dict[str, Any]:
+        roster = self._resolve_roster(arguments.roster_key)
+        identity = {
+            "scope": "franchise",
+            "franchise_id": roster.franchise_id,
+            "note_key": "team_context",
+        }
+        canonical = ContextNoteContent.model_validate(
             {
-                **arguments.content.model_dump(mode="python", exclude={"subjects"}),
-                "subjects": [
-                    self._fact_subject(item) for item in arguments.content.subjects
-                ],
+                "narrative": arguments.narrative,
+                "outlook": arguments.outlook,
+                "status": "active",
+                "tags": [],
             }
         )
-        return self._replacement(
-            self._memory_context.replace_fact(
-                arguments.item_id,
-                arguments.expected_item_revision,
-                canonical,
-                metadata=self._metadata(context),
-            )
+        result = self._upsert_context_note(
+            f"team_context:{roster.franchise_id}", identity, canonical, context
         )
+        return {
+            **result,
+            "roster_id": _numeric_when_possible(roster.sleeper_roster_id),
+            "roster_key": arguments.roster_key,
+        }
 
-    def propose_event(
+    def save_league_note(
         self,
         context: ToolContext,
-        content: ReporterEventContent,
+        arguments: SaveLeagueNoteArgs,
     ) -> dict[str, Any]:
-        return self._proposed(
-            self._memory_context.propose_event(
-                self._event(content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def replace_event(
-        self,
-        context: ToolContext,
-        arguments: ReplaceEventArgs,
-    ) -> dict[str, Any]:
-        self._require_canonical_target(arguments.item_id)
-        return self._replacement(
-            self._memory_context.replace_event(
-                arguments.item_id,
-                arguments.expected_item_revision,
-                self._event(arguments.content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def propose_storyline(
-        self,
-        context: ToolContext,
-        content: ReporterStorylineContent,
-    ) -> dict[str, Any]:
-        return self._proposed(
-            self._memory_context.propose_storyline(
-                self._storyline(content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def replace_storyline(
-        self,
-        context: ToolContext,
-        arguments: ReplaceStorylineArgs,
-    ) -> dict[str, Any]:
-        self._require_canonical_target(arguments.item_id)
-        return self._replacement(
-            self._memory_context.replace_storyline(
-                arguments.item_id,
-                arguments.expected_item_revision,
-                self._storyline(arguments.content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def propose_trigger(
-        self,
-        context: ToolContext,
-        content: ReporterTriggerContent,
-    ) -> dict[str, Any]:
-        return self._proposed(
-            self._memory_context.propose_trigger(
-                self._trigger(content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def replace_trigger(
-        self,
-        context: ToolContext,
-        arguments: ReplaceTriggerArgs,
-    ) -> dict[str, Any]:
-        self._require_canonical_target(arguments.item_id)
-        return self._replacement(
-            self._memory_context.replace_trigger(
-                arguments.item_id,
-                arguments.expected_item_revision,
-                self._trigger(arguments.content),
-                metadata=self._metadata(context),
-            )
-        )
-
-    def propose_context_note(
-        self,
-        context: ToolContext,
-        arguments: ProposeContextNoteArgs,
-    ) -> dict[str, Any]:
-        identity = arguments.identity.model_dump(mode="python")
-        if isinstance(arguments.identity, FranchiseNoteIdentity):
-            roster = self._resolve_roster(arguments.identity.roster_key)
-            identity.pop("roster_key")
-            identity["franchise_id"] = roster.franchise_id
+        identity = {"scope": "competition", "note_key": arguments.key}
         canonical = ContextNoteContent.model_validate(
-            arguments.content.model_dump(mode="python")
+            {"narrative": arguments.value, "status": "active", "tags": []}
         )
-        return self._proposed(
-            self._memory_context.propose_context_note(
-                identity,
+        result = self._upsert_context_note(
+            f"league_note:{arguments.key}", identity, canonical, context
+        )
+        return {**result, "key": arguments.key}
+
+    def buffer_brief_facts(self, brief: Any) -> list[dict[str, Any]]:
+        """Buffer every final brief storyline's supporting facts once."""
+        results: list[dict[str, Any]] = []
+        week = getattr(self._memory_context, "_week", None)
+        for storyline in brief.storylines:
+            for fact_id in storyline.supporting_fact_ids:
+                fact = brief.get_fact(fact_id)
+                if fact is None:
+                    continue
+                agent_key = f"brief:{storyline.id}:{week}:{fact.id}"
+                canonical = FactContent.model_validate(
+                    {
+                        "claim": fact.claim_text,
+                        "category": fact.category,
+                        "numbers": fact.numbers,
+                        "confidence": "inferred",
+                        "status": "active",
+                        "subjects": [],
+                        "originating_event_version_ids": [],
+                        "source_hints": {
+                            "brief_fact_id": fact.id,
+                            "brief_storyline_id": storyline.id,
+                            "data_refs": list(fact.data_refs),
+                        },
+                    }
+                )
+                results.append(
+                    self._upsert(
+                        MemoryKind.FACT,
+                        agent_key,
+                        canonical,
+                        context=None,
+                        create=self._memory_context.propose_fact,
+                        replace=self._memory_context.replace_fact,
+                    )
+                )
+        return results
+
+    def _upsert(
+        self,
+        kind: MemoryKind,
+        agent_key: str,
+        canonical: BaseModel,
+        *,
+        context: ToolContext | None,
+        week: int | None = None,
+        create: Any,
+        replace: Any,
+    ) -> dict[str, Any]:
+        signature = canonical.model_dump_json()
+        save_key = (kind.value, agent_key)
+        previous = self._completed_semantic_saves.get(save_key)
+        if previous is not None:
+            if previous[0] != signature:
+                raise MemoryToolInputError(
+                    "memory_already_selected",
+                    f"{kind.value}:{agent_key} already changed in this run",
+                )
+            return {**previous[1], "saved": False, "no_change": True}
+        candidate = self._agent_candidate(kind, agent_key)
+        if candidate is not None and candidate.content == canonical:
+            result = {"ok": True, "saved": False, "no_change": True}
+        elif candidate is None:
+            reference = create(
                 canonical,
-                metadata=self._metadata(context),
+                metadata=self._metadata(
+                    context,
+                    agent_key=agent_key,
+                    week=week,
+                ),
             )
+            self._proposed_item_ids.add(reference.item_id)
+            self._local_agent_refs[(kind, agent_key)] = reference
+            result = self._saved(reference)
+        else:
+            reference = replace(
+                candidate.item.item_id,
+                candidate.version.revision_number,
+                canonical,
+                metadata=self._metadata(context, week=week),
+            )
+            result = self._saved(reference)
+        self._completed_semantic_saves[save_key] = (signature, result)
+        return result
+
+    def _upsert_context_note(
+        self,
+        agent_key: str,
+        identity: dict[str, Any],
+        canonical: ContextNoteContent,
+        context: ToolContext,
+    ) -> dict[str, Any]:
+        candidate = self._agent_candidate(MemoryKind.CONTEXT_NOTE, agent_key)
+        if candidate is None:
+            return self._upsert(
+                MemoryKind.CONTEXT_NOTE,
+                agent_key,
+                canonical,
+                context=context,
+                create=lambda content, *, metadata: (
+                    self._memory_context.propose_context_note(
+                        identity, content, metadata=metadata
+                    )
+                ),
+                replace=self._memory_context.replace_context_note,
+            )
+        if candidate.note_identity.model_dump(mode="python") != identity:
+            raise MemoryToolInputError(
+                "memory_identity_mismatch",
+                f"Context note identity changed for {agent_key}",
+            )
+        return self._upsert(
+            MemoryKind.CONTEXT_NOTE,
+            agent_key,
+            canonical,
+            context=context,
+            create=self._memory_context.propose_context_note,
+            replace=self._memory_context.replace_context_note,
         )
 
-    def replace_context_note(
-        self,
-        context: ToolContext,
-        arguments: ReplaceContextNoteArgs,
-    ) -> dict[str, Any]:
-        self._require_canonical_target(arguments.item_id)
-        canonical = ContextNoteContent.model_validate(
-            arguments.content.model_dump(mode="python")
+    def _legacy_event(self, arguments: SaveMemoryEventArgs) -> EventContent:
+        if arguments.details is None:
+            raise MemoryToolInputError(
+                "missing_event_details",
+                "Typed trade or matchup details are required for durable event memory",
+            )
+        confidence = (
+            "inferred"
+            if arguments.confidence in {"verified", "inferred"}
+            else "unverified"
         )
-        return self._replacement(
-            self._memory_context.replace_context_note(
-                arguments.item_id,
-                arguments.expected_item_revision,
-                canonical,
-                metadata=self._metadata(context),
+        return self._event(
+            ReporterEventContent(
+                event_type=arguments.event_type,
+                headline=arguments.headline,
+                summary=arguments.summary,
+                salience=max(1, min(5, arguments.importance)),
+                confidence=confidence,
+                details=arguments.details,
+                source_hints={
+                    "legacy_confidence": arguments.confidence,
+                    "week": arguments.week,
+                    "importance": arguments.importance,
+                    "source_refs": arguments.source_refs,
+                    "numbers": arguments.numbers,
+                    "transaction_id": arguments.transaction_id,
+                    "matchup_id": arguments.matchup_id,
+                    "entities": arguments.entities,
+                },
             )
         )
 
@@ -631,16 +727,6 @@ class TypedMemoryAdapter:
             }
         )
 
-    def _storyline(self, content: ReporterStorylineContent) -> StorylineContent:
-        return StorylineContent.model_validate(
-            {
-                **content.model_dump(mode="python", exclude={"subjects"}),
-                "subjects": [
-                    self._storyline_subject(item) for item in content.subjects
-                ],
-            }
-        )
-
     def _trigger(self, content: ReporterTriggerContent) -> TriggerContent:
         condition = content.condition.model_dump(mode="python")
         values = content.model_dump(mode="python", exclude={"condition"})
@@ -664,32 +750,6 @@ class TypedMemoryAdapter:
             values["target_competition_season_id"] = first.competition_season_id
         return TriggerContent.model_validate({**values, "condition": condition})
 
-    def _fact_subject(self, subject: FactSubject) -> dict[str, Any]:
-        return self._subject(subject)
-
-    def _storyline_subject(self, subject: StorylineSubject) -> dict[str, Any]:
-        return self._subject(subject)
-
-    def _subject(self, subject: BaseModel) -> dict[str, Any]:
-        values = subject.model_dump(mode="python", exclude_none=True)
-        if isinstance(
-            subject,
-            (
-                FactFranchiseSubject,
-                FactSeasonRosterSubject,
-                StorylineFranchiseSubject,
-                StorylineSeasonRosterSubject,
-            ),
-        ):
-            roster = self._resolve_roster(subject.roster_key)
-            values.pop("roster_key")
-            values["id"] = (
-                roster.franchise_id
-                if subject.kind == "franchise"
-                else roster.season_roster_id
-            )
-        return values
-
     def _resolve_roster(self, roster_key: str) -> Any:
         resolution = self._data.resolve_roster_identity(roster_key)
         if resolution.status == "not_found":
@@ -704,45 +764,105 @@ class TypedMemoryAdapter:
             )
         return resolution.identity
 
-    def _require_canonical_target(self, item_id: UUID) -> None:
-        if item_id in self._proposed_item_ids:
-            raise MemoryToolInputError(
-                "proposal_local_replacement",
-                "A proposal created in this run cannot also be replaced",
+    def _agent_candidate(self, kind: MemoryKind, agent_key: str) -> Any | None:
+        key = (kind, agent_key)
+        if key in self._pinned_agent_candidates:
+            return self._pinned_agent_candidates[key]
+        result = self._memory_context.search(
+            MemoryRetrievalRequest(
+                query=SearchDocumentQuery(kinds=(kind,), limit=100)
             )
+        )
+        matches = [
+            match.memory
+            for match in result.matches
+            if match.memory.item.kind is kind
+            and match.memory.item.agent_key == agent_key
+        ]
+        if len(matches) > 1:
+            raise MemoryToolInputError(
+                "duplicate_agent_key",
+                f"Multiple {kind.value} memories use stable id {agent_key}",
+            )
+        candidate = matches[0] if matches else None
+        if candidate is not None:
+            self._pinned_agent_candidates[key] = candidate
+        return candidate
 
-    def _proposed(self, reference: Any) -> dict[str, Any]:
-        self._proposed_item_ids.add(reference.item_id)
-        return {"ok": True, "proposal": reference.model_dump(mode="json")}
+    def _agent_reference(self, kind: MemoryKind, agent_key: str | None) -> Any | None:
+        if agent_key is None:
+            return None
+        local = self._local_agent_refs.get((kind, agent_key))
+        if local is not None:
+            return local
+        candidate = self._agent_candidate(kind, agent_key)
+        if candidate is None:
+            return None
+        return _CanonicalReference(
+            item_id=candidate.item.item_id,
+            version_id=candidate.version.version_id,
+        )
 
     @staticmethod
-    def _replacement(reference: Any) -> dict[str, Any]:
-        return {"ok": True, "proposal": reference.model_dump(mode="json")}
+    def _saved(reference: Any) -> dict[str, Any]:
+        return {
+            "ok": True,
+            "saved": True,
+            "proposal": reference.model_dump(mode="json"),
+        }
 
     @staticmethod
-    def _metadata(context: ToolContext) -> MemoryMutationMetadata:
+    def _metadata(
+        context: ToolContext | None,
+        *,
+        agent_key: str | None = None,
+        week: int | None = None,
+    ) -> MemoryMutationMetadata:
         return MemoryMutationMetadata(
-            creating_tool_call_id=context.current_tool_call_id,
+            creating_tool_call_id=(
+                context.current_tool_call_id if context is not None else None
+            ),
+            agent_key=agent_key,
+            week=week,
         )
 
 
-def memory_write_blocked_result(tool_name: str) -> dict[str, Any]:
-    return {
-        "ok": True,
-        "proposed": False,
-        "eval_mode": True,
-        "message": f"{tool_name} skipped: memory writes disabled in eval mode",
-    }
+def _numeric_when_possible(value: str) -> int | str:
+    try:
+        return int(value)
+    except ValueError:
+        return value
 
 
-def _safe_error(error: ValidationError | MemoryToolInputError) -> dict[str, Any]:
+def _safe_error(
+    error: ValidationError | MemoryToolInputError,
+    *,
+    write: bool = False,
+) -> dict[str, Any]:
     if isinstance(error, MemoryToolInputError):
         code = error.code
         message = str(error)
     else:
         code = "invalid_memory_input"
         message = "Memory input did not match the typed contract"
-    return {"ok": False, "error": {"code": code, "message": message}}
+    result: dict[str, Any] = {
+        "ok": False,
+        "error": {"code": code, "message": message},
+    }
+    if write:
+        result["saved"] = False
+    return result
+
+
+def memory_write_blocked_result(tool_name: str) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "saved": False,
+        "persisted": False,
+        "recorded": False,
+        "eval_mode": True,
+        "message": f"{tool_name} skipped: memory writes disabled in eval mode",
+    }
 
 
 def register_memory_tools(
@@ -751,8 +871,8 @@ def register_memory_tools(
     data: FrozenLeagueData,
     *,
     allow_memory_writes: bool = True,
-) -> None:
-    """Register pinned retrieval and buffered typed proposal tools."""
+) -> TypedMemoryAdapter:
+    """Register pinned retrieval and buffered semantic memory tools."""
 
     adapter = TypedMemoryAdapter(memory_context, data)
 
@@ -770,16 +890,11 @@ def register_memory_tools(
     )
 
     write_models: dict[str, type[BaseModel]] = {
-        "propose_fact": ProposeFactArgs,
-        "replace_fact": ReplaceFactArgs,
-        "propose_event": ProposeEventArgs,
-        "replace_event": ReplaceEventArgs,
-        "propose_storyline": ProposeStorylineArgs,
-        "replace_storyline": ReplaceStorylineArgs,
-        "propose_trigger": ProposeTriggerArgs,
-        "replace_trigger": ReplaceTriggerArgs,
-        "propose_context_note": ProposeContextNoteArgs,
-        "replace_context_note": ReplaceContextNoteArgs,
+        "save_memory_event": SaveMemoryEventArgs,
+        "upsert_storyline_memory_card": UpsertStorylineMemoryCardArgs,
+        "save_storyline_trigger": SaveStorylineTriggerArgs,
+        "save_team_context": SaveTeamContextArgs,
+        "save_league_note": SaveLeagueNoteArgs,
     }
 
     def make_handler(tool_name: str, arguments_model: type[BaseModel]) -> Any:
@@ -789,14 +904,9 @@ def register_memory_tools(
             try:
                 arguments = arguments_model.model_validate(kwargs)
                 method = getattr(adapter, tool_name)
-                if (
-                    tool_name.startswith("propose_")
-                    and tool_name != "propose_context_note"
-                ):
-                    return method(context, arguments.content)
                 return method(context, arguments)
             except (ValidationError, MemoryToolInputError) as error:
-                return _safe_error(error)
+                return _safe_error(error, write=True)
 
         return handler
 
@@ -808,6 +918,7 @@ def register_memory_tools(
             specs_by_name[tool_name],
             MEMORY_TOOL_IMPLEMENTATION_VERSION,
         )
+    return adapter
 
 
 __all__ = [

--- a/backend/services/reporter/runner/tools/procedure_tools.py
+++ b/backend/services/reporter/runner/tools/procedure_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 PROCEDURE_DIR = Path(__file__).parent.parent.parent / "procedures"
 VALID_PROCEDURES = {"research", "storyline", "drafting", "verification"}
-PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "3"
+PROCEDURE_TOOL_IMPLEMENTATION_VERSION = "4"
 
 PROCEDURE_TOOL_SPECS: list[ToolDef] = [
     {
@@ -21,9 +21,9 @@ PROCEDURE_TOOL_SPECS: list[ToolDef] = [
         "function": {
             "name": "load_procedure",
             "description": (
-                "Load optional detailed guidance for one kind of reporter work. "
-                "Procedures are reference playbooks, not exclusive workflow stages; "
-                "they need not be loaded in sequence or all within one run."
+                "Load goal-oriented editorial guidance when an unmet reporter goal "
+                "would benefit from it. Guides do not gate tools or define workflow "
+                "stages, and they need not be loaded in sequence."
             ),
             "parameters": {
                 "type": "object",

--- a/backend/tests/services/generations/test_manifest.py
+++ b/backend/tests/services/generations/test_manifest.py
@@ -130,7 +130,7 @@ def test_manifest_has_a_locked_schema_and_hash() -> None:
     assert built.schema_version == 1
     assert built.manifest["schema_version"] == 1
     assert built.manifest_hash == (
-        "7990c2c3dfa07301b107b8091e66f21b601acb76a501492f9fb4d2a059e9bf3d"
+        "7afb1bd111b65a26970558ce223b5a74166112c949140f9dc463b9e69b3bb359"
     )
     assert built.canonical_bytes.decode("utf-8").startswith(
         '{"assets":{"procedures":[{"content_sha256":"'
@@ -259,7 +259,7 @@ def test_manifest_is_input_only_and_submit_schema_is_path_generic() -> None:
     assert built.manifest_hash != build_generation_manifest(fixed_path).manifest_hash
 
 
-def test_typed_memory_tool_bundle_is_manifest_safe_and_versioned() -> None:
+def test_semantic_memory_tool_bundle_is_manifest_safe_and_versioned() -> None:
     memory_tools = tuple(
         ToolInput(
             name=spec["function"]["name"],
@@ -273,8 +273,14 @@ def test_typed_memory_tool_bundle_is_manifest_safe_and_versioned() -> None:
     built = build_generation_manifest(inputs)
 
     names = [tool["name"] for tool in built.manifest["tools"]["implementations"]]
-    assert names == [spec["function"]["name"] for spec in MEMORY_TOOL_SPECS]
-    assert "search_memory" in names
+    assert names == [
+        "search_memory",
+        "save_memory_event",
+        "upsert_storyline_memory_card",
+        "save_storyline_trigger",
+        "save_team_context",
+        "save_league_note",
+    ]
     assert "search_story_memory" not in names
     assert built.manifest["tools"]["schema_bundle_sha256"]
 

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -486,7 +486,7 @@ async def test_live_execution_pins_inputs_before_reporter_and_closes_runtime(
         entry["name"]: entry["version"]
         for entry in manifest["tools"]["implementations"]
     }
-    assert procedure_versions["load_procedure"] == "3"
+    assert procedure_versions["load_procedure"] == "4"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -207,8 +207,9 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
         LegacyReportConfig.model_validate(config.model_dump(mode="json"))
     )
     assert copied_message != legacy_message
-    assert "interleavable activities" in copied_message
-    assert "fixed sequence" in copied_message
+    assert "unmet editorial goal" in copied_message
+    assert "not as a fixed phase or progress marker" in copied_message
+    assert "smallest tool result" in copied_message
     assert copied_system_prompt() != legacy_system_prompt()
     assert "research_brief.md" in copied_system_prompt()
     assert "submit_artifact" in copied_system_prompt()
@@ -236,7 +237,7 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
         "read_brief",
     ]
     assert COPIED_PROCEDURE_TOOLS != LEGACY_PROCEDURE_TOOLS
-    assert "reference playbooks" in COPIED_PROCEDURE_TOOLS[0]["function"][
+    assert "goal-oriented editorial guidance" in COPIED_PROCEDURE_TOOLS[0]["function"][
         "description"
     ]
     assert [spec["function"]["name"] for spec in COPIED_MEMORY_TOOLS] == [
@@ -261,16 +262,16 @@ def test_prompt_and_procedure_assets_document_intentional_artifact_divergence() 
     expected_markers = {
         "prompts/system.md": "search_memory",
         "procedures/research.md": "search_memory",
-        "procedures/storyline.md": "propose_storyline",
+        "procedures/storyline.md": "save_storyline",
         "procedures/drafting.md": "create_artifact",
         "procedures/verification.md": "submit_artifact",
     }
     flexibility_markers = {
-        "prompts/system.md": "not mandatory sequential phases",
-        "procedures/research.md": "Adaptive Research Loop",
-        "procedures/storyline.md": "not a mandatory bridge",
-        "procedures/drafting.md": "act of writing to expose",
-        "procedures/verification.md": "not a one-way terminal phase",
+        "prompts/system.md": "These goals are not phases",
+        "procedures/research.md": "# Goal: Establish A Trustworthy Evidence Base",
+        "procedures/storyline.md": "# Goal: Find The Article's Meaning",
+        "procedures/drafting.md": "# Goal: Turn Verified Material Into A Compelling Article",
+        "procedures/verification.md": "# Goal: Earn Publication Confidence",
     }
     for relative_path, marker in expected_markers.items():
         copied_text = (copied / relative_path).read_text(encoding="utf-8")
@@ -278,6 +279,15 @@ def test_prompt_and_procedure_assets_document_intentional_artifact_divergence() 
         assert copied_text != legacy_text
         assert marker in copied_text
         assert flexibility_markers[relative_path] in copied_text
+
+    system_prompt = (copied / "prompts/system.md").read_text(encoding="utf-8")
+    assert "## Guidance Library" in system_prompt
+    assert all(
+        f"`{name}` supports" in system_prompt
+        for name in ("research", "storyline", "drafting", "verification")
+    )
+    assert "## Article Quality" in system_prompt
+    assert "materially improve factual confidence" in system_prompt
 
 
 def test_generator_preserves_article_result_across_artifact_contract_divergence() -> None:

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -242,16 +242,11 @@ def test_reporter_contracts_keep_only_deliberate_platform_divergences() -> None:
     ]
     assert [spec["function"]["name"] for spec in COPIED_MEMORY_TOOLS] == [
         "search_memory",
-        "propose_fact",
-        "replace_fact",
-        "propose_event",
-        "replace_event",
-        "propose_storyline",
-        "replace_storyline",
-        "propose_trigger",
-        "replace_trigger",
-        "propose_context_note",
-        "replace_context_note",
+        "save_memory_event",
+        "upsert_storyline_memory_card",
+        "save_storyline_trigger",
+        "save_team_context",
+        "save_league_note",
     ]
 
 

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -59,16 +59,11 @@ def test_definition_without_memory_omits_only_memory_tools() -> None:
 
     memory_names = {
         "search_memory",
-        "propose_fact",
-        "replace_fact",
-        "propose_event",
-        "replace_event",
-        "propose_storyline",
-        "replace_storyline",
-        "propose_trigger",
-        "replace_trigger",
-        "propose_context_note",
-        "replace_context_note",
+        "save_memory_event",
+        "upsert_storyline_memory_card",
+        "save_storyline_trigger",
+        "save_team_context",
+        "save_league_note",
     }
     assert {tool.name for tool in with_memory.tools} - {
         tool.name for tool in without_memory.tools

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -44,7 +44,7 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
     assert registry.tool_implementation_versions == [
         (tool.name, tool.implementation_version) for tool in definition.tools
     ]
-    assert PROCEDURE_TOOL_IMPLEMENTATION_VERSION == "3"
+    assert PROCEDURE_TOOL_IMPLEMENTATION_VERSION == "4"
     assert {procedure.name for procedure in definition.procedures} == {
         "drafting",
         "research",

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -411,7 +411,7 @@ def test_generate_article_end_to_end_tool_loop() -> None:
     assert all(item.source_tool_call_id is not None for item in tool_mutations)
 
 
-def test_generate_article_buffers_typed_memory_with_tool_provenance() -> None:
+def test_generate_article_automatically_bridges_final_brief_storyline_facts() -> None:
     recorder = ExecutionRecordingProbe()
     memory_context = GenerationMemoryContext(
         competition_id=UUID(int=1),
@@ -426,29 +426,6 @@ def test_generate_article_buffers_typed_memory_with_tool_provenance() -> None:
             make_response(
                 tool_calls=[
                     tool_call(
-                        "propose_fact",
-                        {
-                            "content": {
-                                "claim": "Team Taco won in Week 8.",
-                                "category": "matchup_result",
-                                "numbers": {"week": 8},
-                                "confidence": "inferred",
-                                "subjects": [
-                                    {
-                                        "kind": "franchise",
-                                        "roster_key": "Team Taco",
-                                        "role": "subject",
-                                    }
-                                ],
-                            }
-                        },
-                        "memory-call",
-                    )
-                ]
-            ),
-            make_response(
-                tool_calls=[
-                    tool_call(
                         "save_fact",
                         {
                             "id": "fact_taco_win",
@@ -457,7 +434,25 @@ def test_generate_article_buffers_typed_memory_with_tool_provenance() -> None:
                             "numbers": {"week": 8},
                             "category": "score",
                         },
-                        "brief-call",
+                        "fact-call",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_storyline",
+                        {
+                            "id": "story_taco_push",
+                            "headline": "Taco's push is getting louder.",
+                            "summary": (
+                                "A Week 8 win strengthened the contender arc."
+                            ),
+                            "supporting_fact_ids": ["fact_taco_win"],
+                            "priority": 4,
+                            "tags": ["playoffs"],
+                        },
+                        "storyline-call",
                     )
                 ]
             ),
@@ -495,10 +490,17 @@ def test_generate_article_buffers_typed_memory_with_tool_provenance() -> None:
 
     assert output.submitted_path == "article.md"
     bundle = memory_context.take_completed_bundle()
-    assert len(bundle.proposals) == 1
-    proposal = bundle.proposals[0]
-    assert proposal.content.subjects[0].id == UUID(int=4)
-    assert proposal.metadata.creating_tool_call_id in recorder.tool_ai_calls
+    assert [proposal.kind.value for proposal in bundle.proposals] == ["fact"]
+    fact = bundle.proposals[0]
+    assert fact.metadata.agent_key == (
+        "brief:story_taco_push:8:fact_taco_win"
+    )
+    assert fact.content.source_hints == {
+        "brief_fact_id": "fact_taco_win",
+        "brief_storyline_id": "story_taco_push",
+        "data_refs": ["league_snapshot:week=8"],
+    }
+    assert fact.metadata.creating_tool_call_id is None
 
 
 def test_generate_article_allows_backtracking_from_drafting_to_research() -> None:

--- a/backend/tests/services/reporter/test_memory_tools.py
+++ b/backend/tests/services/reporter/test_memory_tools.py
@@ -1,18 +1,28 @@
-"""Tests for the typed generation-memory reporter adapter."""
+"""Tests for the legacy-shaped buffered memory adapter."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID, uuid4
 
+from backend.resources.memory.common.versioning import (
+    MemoryItemIdentity,
+    MemoryVersionMetadata,
+)
+from backend.resources.memory.events import Event, EventContent
+from backend.resources.memory.search_documents import (
+    SearchMatchReason,
+    SearchScoreComponents,
+)
 from backend.services.datalayer import (
-    AmbiguousRosterIdentity,
     FrozenRosterIdentity,
     ResolvedRosterIdentity,
     RosterIdentityNotFound,
 )
 from backend.services.memory import (
     GenerationMemoryContext,
+    HydratedMemoryMatch,
     MemoryKind,
     MemoryRetrievalRequest,
     MemoryRetrievalResult,
@@ -23,6 +33,7 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.memory_tools import (
     MEMORY_TOOL_IMPLEMENTATION_VERSION,
     MEMORY_TOOL_SPECS,
+    TypedMemoryAdapter,
     register_memory_tools,
 )
 from backend.services.reporter.runner.tools.registry import ToolRegistry
@@ -34,11 +45,13 @@ TACO_ROSTER_ID = UUID(int=3)
 TACO_FRANCHISE_ID = UUID(int=4)
 WIRE_ROSTER_ID = UUID(int=5)
 WIRE_FRANCHISE_ID = UUID(int=6)
+NOW = datetime(2026, 8, 26, tzinfo=UTC)
 
 
 class RecordingRetrieval:
-    def __init__(self) -> None:
-        self.calls: list[tuple[UUID, UUID, MemoryRetrievalRequest]] = []
+    def __init__(self, matches: tuple[HydratedMemoryMatch, ...] = ()) -> None:
+        self.calls: list[MemoryRetrievalRequest] = []
+        self.matches = matches
 
     def search(
         self,
@@ -47,11 +60,11 @@ class RecordingRetrieval:
         revision_id: UUID,
         request: MemoryRetrievalRequest,
     ) -> MemoryRetrievalResult:
-        self.calls.append((competition_id, revision_id, request))
+        self.calls.append(request)
         return MemoryRetrievalResult(
             competition_id=competition_id,
             revision_id=revision_id,
-            matches=(),
+            matches=self.matches,
         )
 
 
@@ -79,11 +92,6 @@ class FrozenData:
         }
 
     def resolve_roster_identity(self, roster_key: str) -> Any:
-        if roster_key == "ambiguous":
-            return AmbiguousRosterIdentity(
-                roster_key=roster_key,
-                matches=tuple(self.identities.values()),
-            )
         identity = self.identities.get(roster_key)
         if identity is None:
             return RosterIdentityNotFound(roster_key=roster_key)
@@ -92,10 +100,17 @@ class FrozenData:
 
 def _registered(
     *,
+    matches: tuple[HydratedMemoryMatch, ...] = (),
     allow_memory_writes: bool = True,
-) -> tuple[ToolRegistry, ToolContext, GenerationMemoryContext, RecordingRetrieval]:
-    retrieval = RecordingRetrieval()
-    memory_context = GenerationMemoryContext(
+) -> tuple[
+    ToolRegistry,
+    ToolContext,
+    GenerationMemoryContext,
+    RecordingRetrieval,
+    TypedMemoryAdapter,
+]:
+    retrieval = RecordingRetrieval(matches)
+    memory = GenerationMemoryContext(
         competition_id=COMPETITION_ID,
         generation_id=uuid4(),
         pinned_revision_id=uuid4(),
@@ -104,19 +119,19 @@ def _registered(
         week=8,
     )
     registry = ToolRegistry()
-    register_memory_tools(
+    adapter = register_memory_tools(
         registry,
-        memory_context,
+        memory,
         FrozenData(),  # type: ignore[arg-type]
         allow_memory_writes=allow_memory_writes,
     )
-    tool_context = ToolContext(
+    context = ToolContext(
         artifacts=ArtifactStore(),
         procedures=ProcedureState(),
         log=RunLog(session_id="memory-tools"),
     )
-    registry.set_context(tool_context)
-    return registry, tool_context, memory_context, retrieval
+    registry.set_context(context)
+    return registry, context, memory, retrieval, adapter
 
 
 def _call(registry: ToolRegistry, name: str, **arguments: Any) -> dict[str, Any]:
@@ -127,31 +142,18 @@ def _call(registry: ToolRegistry, name: str, **arguments: Any) -> dict[str, Any]
     return result
 
 
-def _fact_content(*, roster_key: str = "Team Taco") -> dict[str, Any]:
+def _event_args(*, event_id: str = "event_week8") -> dict[str, Any]:
     return {
-        "claim": "Team Taco won in Week 8.",
-        "category": "matchup_result",
-        "numbers": {"week": 8},
-        "confidence": "inferred",
-        "subjects": [
-            {"kind": "franchise", "roster_key": roster_key, "role": "subject"},
-            {
-                "kind": "season_roster",
-                "roster_key": roster_key,
-                "role": "subject",
-            },
-        ],
-        "source_hints": {"tool": "team_game", "week": 8},
-    }
-
-
-def _event_content() -> dict[str, Any]:
-    return {
+        "id": event_id,
         "event_type": "matchup",
+        "week": 3,
         "headline": "Taco won the Week 8 matchup.",
         "summary": "Team Taco defeated Waiver Wire.",
-        "salience": 4,
-        "confidence": "inferred",
+        "importance": 4,
+        "confidence": "verified",
+        "source_refs": ["team_game:week8:taco"],
+        "numbers": {"week": 8},
+        "matchup_id": "week-8-1",
         "details": {
             "kind": "matchup",
             "winner_roster_key": "Team Taco",
@@ -161,62 +163,86 @@ def _event_content() -> dict[str, Any]:
     }
 
 
-def _storyline_content(event_version_id: UUID | None = None) -> dict[str, Any]:
-    evidence = []
-    if event_version_id is not None:
-        evidence.append(
-            {"kind": "event", "version_id": event_version_id, "role": "origin"}
-        )
+def _note() -> dict[str, Any]:
     return {
-        "headline": "Taco's push is getting louder.",
-        "summary": "A Week 8 win strengthened the season-long contender arc.",
-        "status": "active",
-        "arc_type": "playoff_push",
-        "salience": 4,
-        "tags": ["playoffs"],
-        "subjects": [
-            {"kind": "franchise", "roster_key": "Team Taco", "role": "focus"}
-        ],
-        "evidence": evidence,
-    }
-
-
-def _trigger_content(*, storyline_item_id: UUID | None = None) -> dict[str, Any]:
-    return {
-        "trigger_type": "rematch",
-        "fire_policy": "one_shot",
-        "target_storyline_item_id": storyline_item_id,
-        "target_week": 12,
-        "condition": {
-            "kind": "rematch",
-            "roster_keys": ["Team Taco", "Waiver Wire"],
-        },
-    }
-
-
-def _note_content() -> dict[str, Any]:
-    return {
+        "roster_key": "Team Taco",
         "narrative": "Team Taco is surging toward the playoffs.",
-        "outlook": "Contending with a favorable remaining schedule.",
-        "tags": ["playoffs", "surging"],
+        "outlook": "surging",
     }
 
 
-def test_registers_only_the_typed_memory_vocabulary() -> None:
-    registry, _, _, _ = _registered()
+def _seed_brief(context: ToolContext) -> None:
+    fact = context.brief.prepare_fact(
+        id="taco_week8_win",
+        claim_text="Team Taco won in Week 8.",
+        data_refs=["team_game:week8:taco"],
+        numbers={"week": 8},
+        category="matchup_result",
+    )
+    context.brief.commit(fact, lambda _: None)
+    storyline = context.brief.prepare_storyline(
+        id="taco_playoff_push",
+        headline="Taco's push is getting louder.",
+        summary="The Week 8 win strengthened the contender arc.",
+        supporting_fact_ids=["taco_week8_win"],
+        priority=4,
+        tags=["playoffs"],
+    )
+    context.brief.commit(storyline, lambda _: None)
 
+
+def _event_match() -> HydratedMemoryMatch:
+    event = Event(
+        item=MemoryItemIdentity(
+            item_id=UUID(int=20),
+            competition_id=COMPETITION_ID,
+            kind=MemoryKind.EVENT,
+            agent_key="event_week8",
+            created_at=NOW,
+        ),
+        version=MemoryVersionMetadata(
+            version_id=UUID(int=21),
+            revision_number=7,
+            content_schema_version=1,
+            introduced_revision_id=UUID(int=22),
+            creating_generation_id=UUID(int=23),
+            recorded_at=NOW,
+        ),
+        content=EventContent.model_validate(
+            {
+                "event_type": "matchup",
+                "headline": "Taco won the Week 8 matchup.",
+                "summary": "An older summary.",
+                "salience": 4,
+                "confidence": "inferred",
+                "status": "active",
+                "details": {
+                    "kind": "matchup",
+                    "winner_franchise_id": TACO_FRANCHISE_ID,
+                    "loser_franchise_id": WIRE_FRANCHISE_ID,
+                    "sleeper_matchup_id": "week-8-1",
+                },
+                "source_hints": {},
+            }
+        ),
+    )
+    return HydratedMemoryMatch(
+        memory=event,
+        score=1,
+        score_components=SearchScoreComponents(lexical_rank=1),
+        match_reasons=(SearchMatchReason.LEXICAL_MATCH,),
+    )
+
+
+def test_registers_legacy_semantic_surface() -> None:
+    registry, _, _, _, _ = _registered()
     assert registry.tool_names == [
         "search_memory",
-        "propose_fact",
-        "replace_fact",
-        "propose_event",
-        "replace_event",
-        "propose_storyline",
-        "replace_storyline",
-        "propose_trigger",
-        "replace_trigger",
-        "propose_context_note",
-        "replace_context_note",
+        "save_memory_event",
+        "upsert_storyline_memory_card",
+        "save_storyline_trigger",
+        "save_team_context",
+        "save_league_note",
     ]
     assert registry.tool_specs == MEMORY_TOOL_SPECS
     assert registry.tool_implementation_versions == [
@@ -224,195 +250,130 @@ def test_registers_only_the_typed_memory_vocabulary() -> None:
     ]
 
 
-def test_search_is_pinned_and_resolves_both_team_identity_keys() -> None:
-    registry, _, memory_context, retrieval = _registered()
-
-    result = _call(
-        registry,
-        "search_memory",
-        text="playoff push",
-        team_keys=["Team Taco"],
-        kinds=["storyline", "context_note"],
-        tags=["Playoffs"],
-        expand_exact_references=True,
-    )
-
-    assert result == {
-        "ok": True,
-        "competition_id": str(COMPETITION_ID),
-        "revision_id": str(memory_context.pinned_revision_id),
-        "matches": [],
-    }
-    competition_id, revision_id, request = retrieval.calls[0]
-    assert competition_id == COMPETITION_ID
-    assert revision_id == memory_context.pinned_revision_id
-    assert request.query.entity_keys == (
+def test_search_remains_pinned_and_resolves_team_keys() -> None:
+    registry, _, memory, retrieval, _ = _registered()
+    result = _call(registry, "search_memory", text="push", team_keys=["Team Taco"])
+    assert result["revision_id"] == str(memory.pinned_revision_id)
+    assert retrieval.calls[0].query.entity_keys == (
         f"franchise:{TACO_FRANCHISE_ID}",
         f"season_roster:{TACO_ROSTER_ID}",
     )
-    assert request.query.kinds == (MemoryKind.STORYLINE, MemoryKind.CONTEXT_NOTE)
-    assert request.query.tags == ("playoffs",)
-    assert request.expand_exact_references is True
 
 
-def test_all_propose_and_replace_tools_buffer_complete_typed_content() -> None:
-    registry, tool_context, memory_context, _ = _registered()
-    source_tool_call_id = uuid4()
-
-    with tool_context.bind_tool_execution(source_tool_call_id):
-        event = _call(registry, "propose_event", content=_event_content())
-        event_version_id = UUID(event["proposal"]["version_id"])
-        fact = _call(registry, "propose_fact", content=_fact_content())
-        storyline = _call(
-            registry,
-            "propose_storyline",
-            content=_storyline_content(event_version_id),
-        )
-        storyline_item_id = UUID(storyline["proposal"]["item_id"])
-        trigger = _call(
-            registry,
-            "propose_trigger",
-            content=_trigger_content(storyline_item_id=storyline_item_id),
-        )
-        note = _call(
-            registry,
-            "propose_context_note",
-            identity={
-                "scope": "franchise",
-                "roster_key": "Team Taco",
-                "note_key": "weekly_outlook",
-            },
-            content=_note_content(),
-        )
-
-        replacements = [
-            _call(
-                registry,
-                "replace_fact",
-                item_id=str(uuid4()),
-                expected_item_revision=1,
-                content=_fact_content(),
-            ),
-            _call(
-                registry,
-                "replace_event",
-                item_id=str(uuid4()),
-                expected_item_revision=2,
-                content=_event_content(),
-            ),
-            _call(
-                registry,
-                "replace_storyline",
-                item_id=str(uuid4()),
-                expected_item_revision=3,
-                content=_storyline_content(),
-            ),
-            _call(
-                registry,
-                "replace_trigger",
-                item_id=str(uuid4()),
-                expected_item_revision=4,
-                content=_trigger_content(),
-            ),
-            _call(
-                registry,
-                "replace_context_note",
-                item_id=str(uuid4()),
-                expected_item_revision=5,
-                content=_note_content(),
-            ),
-        ]
-
-    assert all(result["ok"] for result in (event, fact, storyline, trigger, note))
-    assert all(result["ok"] for result in replacements)
-    bundle = memory_context.take_completed_bundle()
-    assert [proposal.operation for proposal in bundle.proposals] == [
-        *("create" for _ in range(5)),
-        *("replace" for _ in range(5)),
-    ]
-    assert [proposal.kind for proposal in bundle.proposals] == [
-        MemoryKind.EVENT,
-        MemoryKind.FACT,
-        MemoryKind.STORYLINE,
-        MemoryKind.TRIGGER,
-        MemoryKind.CONTEXT_NOTE,
-        MemoryKind.FACT,
+def test_legacy_writes_buffer_typed_proposals() -> None:
+    registry, _, memory, _, _ = _registered()
+    event = _call(registry, "save_memory_event", **_event_args())
+    card = _call(
+        registry,
+        "upsert_storyline_memory_card",
+        id="story_taco",
+        headline="Taco Takes Control",
+        summary="The playoff push is real.",
+        status="active",
+        priority=4,
+        origin_week=3,
+        team_keys=["Team Taco"],
+        evidence_event_ids=["event_week8"],
+    )
+    trigger = _call(
+        registry,
+        "save_storyline_trigger",
+        id="trigger_rematch",
+        storyline_id="story_taco",
+        trigger_type="rematch",
+        target_week=12,
+        condition={"roster_keys": ["Team Taco", "Waiver Wire"]},
+    )
+    team = _call(registry, "save_team_context", **_note())
+    league = _call(
+        registry,
+        "save_league_note",
+        key="playoff_race",
+        value="The top seed remains unsettled.",
+    )
+    assert all(item["ok"] for item in (event, card, trigger, team, league))
+    assert card["team_ids"] == [1]
+    assert team["roster_id"] == 1
+    bundle = memory.take_completed_bundle()
+    assert [item.kind for item in bundle.proposals] == [
         MemoryKind.EVENT,
         MemoryKind.STORYLINE,
         MemoryKind.TRIGGER,
         MemoryKind.CONTEXT_NOTE,
+        MemoryKind.CONTEXT_NOTE,
     ]
-    assert all(
-        proposal.metadata.creating_tool_call_id == source_tool_call_id
-        for proposal in bundle.proposals
-    )
-    assert bundle.proposals[0].content.details.winner_franchise_id == (
-        TACO_FRANCHISE_ID
-    )
-    assert [subject.id for subject in bundle.proposals[1].content.subjects] == [
-        TACO_FRANCHISE_ID,
-        TACO_ROSTER_ID,
+    assert [item.metadata.agent_key for item in bundle.proposals] == [
+        "event_week8",
+        "story_taco",
+        "trigger_rematch",
+        f"team_context:{TACO_FRANCHISE_ID}",
+        "league_note:playoff_race",
     ]
-    assert bundle.proposals[4].context_note_identity.franchise_id == (
-        TACO_FRANCHISE_ID
-    )
+    assert bundle.proposals[0].content.source_hints["week"] == 3
+    assert bundle.proposals[0].content.source_hints["importance"] == 4
+    assert bundle.proposals[0].metadata.week == 3
+    assert bundle.proposals[1].content.salience == 2
+    assert bundle.proposals[1].metadata.week == 3
 
 
-def test_invalid_inputs_are_safe_and_do_not_change_the_buffer() -> None:
-    registry, _, memory_context, _ = _registered()
+def test_stable_id_resolves_internal_replace_revision() -> None:
+    match = _event_match()
+    registry, _, memory, _, _ = _registered(matches=(match,))
+    result = _call(registry, "save_memory_event", **_event_args())
+    assert result["saved"] is True
+    proposal = memory.take_completed_bundle().proposals[0]
+    assert proposal.operation == "replace"
+    assert proposal.item_id == match.memory.item.item_id
+    assert proposal.expected_item_revision == 7
 
-    source_backed = _fact_content()
-    source_backed["confidence"] = "source_backed"
-    invalid = _call(registry, "propose_fact", content=source_backed)
-    missing = _call(
-        registry,
-        "propose_fact",
-        content=_fact_content(roster_key="missing"),
-    )
-    ambiguous = _call(
-        registry,
-        "propose_fact",
-        content=_fact_content(roster_key="ambiguous"),
-    )
-    created = _call(registry, "propose_fact", content=_fact_content())
-    local_replace = _call(
-        registry,
-        "replace_fact",
-        item_id=created["proposal"]["item_id"],
-        expected_item_revision=1,
-        content=_fact_content(),
-    )
 
-    assert invalid["error"]["code"] == "invalid_memory_input"
-    assert missing["error"]["code"] == "roster_not_found"
-    assert ambiguous["error"]["code"] == "roster_ambiguous"
-    assert local_replace["error"]["code"] == "proposal_local_replacement"
-    bundle = memory_context.take_completed_bundle()
+def test_post_submit_bridge_buffers_only_supporting_facts_idempotently() -> None:
+    _, context, memory, _, adapter = _registered()
+    _seed_brief(context)
+    first = adapter.buffer_brief_facts(context.brief.brief)
+    repeated = adapter.buffer_brief_facts(context.brief.brief)
+    assert first[0]["saved"] is True
+    assert repeated[0]["saved"] is False
+    bundle = memory.take_completed_bundle()
     assert len(bundle.proposals) == 1
+    proposal = bundle.proposals[0]
+    assert proposal.kind is MemoryKind.FACT
+    assert proposal.metadata.agent_key == (
+        "brief:taco_playoff_push:8:taco_week8_win"
+    )
+    assert proposal.content.source_hints["brief_storyline_id"] == "taco_playoff_push"
 
 
-def test_eval_mode_keeps_search_and_skips_all_proposals() -> None:
-    registry, _, memory_context, retrieval = _registered(allow_memory_writes=False)
-
-    search = _call(registry, "search_memory", text="Taco")
-    for tool_name in registry.tool_names[1:]:
-        result = _call(registry, tool_name)
-        assert result["ok"] is True
-        assert result["proposed"] is False
-        assert result["eval_mode"] is True
-
-    assert search["ok"] is True
+def test_eval_mode_keeps_search_and_skips_legacy_writes() -> None:
+    registry, _, memory, retrieval, _ = _registered(allow_memory_writes=False)
+    searched = _call(registry, "search_memory", text="Taco")
+    blocked = _call(registry, "save_memory_event", **_event_args())
+    assert searched["ok"] is True
+    assert blocked["saved"] is False
+    assert blocked["eval_mode"] is True
+    assert blocked["recorded"] is False
     assert len(retrieval.calls) == 1
-    assert memory_context.take_completed_bundle().proposals == ()
+    assert memory.take_completed_bundle().proposals == ()
 
 
-def test_buffered_proposals_never_appear_in_same_run_searches() -> None:
-    registry, _, memory_context, retrieval = _registered()
-
-    proposed = _call(registry, "propose_storyline", content=_storyline_content())
-    searched = _call(registry, "search_memory", text="Taco's push")
-
-    assert proposed["ok"] is True
-    assert searched["matches"] == []
-    assert len(retrieval.calls) == 1
-    assert len(memory_context.take_completed_bundle().proposals) == 1
+def test_invalid_legacy_inputs_are_safe_and_do_not_buffer() -> None:
+    registry, _, memory, _, _ = _registered()
+    missing_source = _event_args()
+    missing_source["source_refs"] = []
+    verified = _call(registry, "save_memory_event", **missing_source)
+    missing_details = _event_args()
+    missing_details.pop("details")
+    details = _call(registry, "save_memory_event", **missing_details)
+    unresolved = _call(
+        registry,
+        "save_team_context",
+        roster_key="missing",
+        narrative="Unknown team.",
+    )
+    assert verified["error"]["code"] == "missing_source_refs"
+    assert verified["saved"] is False
+    assert details["error"]["code"] == "missing_event_details"
+    assert details["saved"] is False
+    assert unresolved["error"]["code"] == "roster_not_found"
+    assert unresolved["saved"] is False
+    assert memory.take_completed_bundle().proposals == ()

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -44,6 +44,10 @@ It does not change the datalayer, generation job lifecycle, or the legacy
    separate model pass that converts the verified brief and selected article into
    typed memory proposals.
 
+The M1 evaluation surface restores the legacy reporter's semantic memory-tool
+baseline and successful-submit brief bridge on top of the current typed buffer.
+This is not the separate M2 curation pass.
+
 ## Settled Direction
 
 - Flexible orchestration and structured research are complementary. Prompts decide
@@ -65,6 +69,12 @@ It does not change the datalayer, generation job lifecycle, or the legacy
   the brief; the agent does not spend turns restating them.
 - Submission requires at least one verified fact. Storyline, callback, and outline
   readiness remain visible diagnostics rather than rigid workflow gates.
+- Model-facing memory tools describe editorial intent. Typed create/replace
+  operations and optimistic revision checks remain internal to the adapter.
+- After a successful live submission, supporting facts for every final brief
+  storyline are buffered automatically; unreferenced brief facts stay run-local.
+- Backtests preserve the legacy read-only behavior: memory reads remain available,
+  while write tools and the successful-submit bridge do not buffer mutations.
 
 ## Non-Goals
 

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -64,6 +64,27 @@ typed operations. A generic `write_brief_markdown` capability is not equivalent.
 The existing generic artifact capabilities remain available for article creation
 and revision. They must reject the reserved `research_brief.md` path.
 
+The model-facing persistent-memory capabilities are semantic:
+
+- `search_memory`
+- `save_memory_event`
+- `upsert_storyline_memory_card`
+- `save_storyline_trigger`
+- `save_team_context`
+- `save_league_note`
+
+The create/replace proposal vocabulary remains an internal adapter contract and is
+not registered with the model. Semantic tools use stable string IDs, team keys,
+and narrative fields like the legacy reporter; the adapter resolves canonical
+identity and expected revision internally.
+
+After successful live submission, the bridge visits every final brief storyline
+and buffers its existing supporting facts. It preserves brief claim, category,
+numbers, and data references as source hints under a stable storyline/week/fact
+key. Because brief data references are not typed receipt IDs, derived facts are
+recorded as inferred rather than falsely marked source-backed. Missing support
+IDs are skipped and unreferenced brief facts are not promoted.
+
 ## M1 Lifecycle and State Transitions
 
 1. A run starts with a new empty `ResearchBrief` revision and no brief artifact.
@@ -76,6 +97,12 @@ and revision. They must reject the reserved `research_brief.md` path.
 6. Submission requires at least one verified fact, selects a non-empty article
    artifact, and captures the final brief revision/readiness in reporter output.
 7. A run-scoped brief is immutable after reporter completion.
+8. Live semantic memory mutations and bridged facts remain buffered until
+   generation finalization.
+9. Successful live finalization commits the complete bundle atomically; failed or
+   cancelled runs discard it.
+10. Backtest memory writes are read-only eval no-ops and the brief bridge is
+    skipped, so canonical memory never advances.
 
 Idempotent replay of the same normalized mutation returns the existing logical
 item or a no-op result instead of adding a duplicate.
@@ -97,6 +124,10 @@ item or a no-op result instead of adding a duplicate.
 - Bias changes framing and emphasis only; it cannot alter factual brief state.
 - The selected article remains the publishable output. The brief remains research
   evidence and is not selected as the article.
+- Model-facing memory tools never expose create-versus-replace branching or ask
+  the model to supply an optimistic revision number.
+- Successful live submission bridges supporting facts for every final brief
+  storyline and no unreferenced fact.
 
 ## M1 Error Semantics
 
@@ -122,8 +153,8 @@ exceptions.
   readable through the generic artifact API; new runs use only the flat path.
 - Article artifact selection, run persistence, streaming events, and generation
   API shapes remain compatible.
-- Existing direct memory proposal/finalization behavior remains unchanged during
-  M1 so research quality can be evaluated without conflating a new curator.
+- Existing buffered and atomic memory finalization remains unchanged during M1;
+  the model-facing vocabulary becomes semantic without introducing a curator.
 - The legacy `reporter_v2` package is not part of the migration.
 - The prompt-only baseline PR must merge before M1 so the brief implementation is
   evaluated under adaptive orchestration rather than fixed procedure sequencing.
@@ -142,7 +173,11 @@ Focused tests must cover:
 - compatible reporter output and article selection;
 - adaptive interleaving and backtracking without procedure gating;
 - no empty seed-artifact create/read turns; and
-- current memory finalization compatibility.
+- current memory finalization compatibility;
+- semantic memory create and stable-ID update behavior;
+- deterministic successful-submit fact bridging and stable-ID idempotency; and
+- failed-run rollback and read-only backtests that leave canonical revision state
+  unchanged.
 
 The reporter output includes this nested observability shape:
 

--- a/docs/reporter-research-pipeline/architecture.md
+++ b/docs/reporter-research-pipeline/architecture.md
@@ -66,6 +66,18 @@ Deterministically renders current structured state to `research_brief.md`. The
 projection is included in reporter output and logs for observability, but is not an
 independent writable artifact.
 
+### Semantic memory adapter (M1)
+
+Exposes the legacy reporter's editorial operations for saving an event, upserting
+a storyline memory card, saving a trigger, and replacing team or league context.
+Stable semantic IDs are resolved to the current pinned canonical state internally;
+the model does not choose create versus replace or supply revision numbers.
+
+The deterministic brief bridge runs after a successful live submit. It traverses
+every final brief storyline and buffers each existing supporting fact under a
+stable storyline/week/fact key. Missing support IDs are skipped and unrelated
+brief facts remain run-local, matching the legacy baseline.
+
 ### `ArtifactStore` (existing)
 
 Continues to own generic Markdown artifacts, especially candidate and selected
@@ -109,6 +121,11 @@ workflow state machine.
 The structured mutation and its rendered projection are one logical operation. A
 projection failure fails the tool call and leaves neither side advanced.
 
+Semantic memory operations still write only to the generation-scoped buffer. For
+a live generation, finalization commits that bundle in the same transaction as
+the article and generation success. In a backtest, memory writes and the brief
+bridge return read-only eval behavior and leave the bundle empty.
+
 ### M2 curation
 
 After the M1 evaluation gate is accepted, the completed run builds a typed curation
@@ -133,6 +150,11 @@ choice must preserve a successful article when curation fails.
   diagnostic and never impose a fixed procedure sequence.
 - Reporter failure and retry continue to follow the generation service's existing
   lifecycle.
+- Invalid semantic content or an unresolvable stable reference fails before adding
+  dependent proposals. Repeated stable IDs update or reuse run-local intent rather
+  than duplicating the bundle.
+- Failed and cancelled runs discard their proposal buffer. Backtests never buffer
+  memory proposals and never advance the canonical revision.
 
 ### M2
 


### PR DESCRIPTION
## Summary

- reframe the reporter system prompt around editorial goals, durable invariants, article quality, and semantic stopping
- rewrite research, storyline, drafting, and verification procedures as optional goal guides with tool-selection and stop-or-switch judgment
- update per-run guidance, procedure metadata, and characterization coverage while preserving structured brief and submission contracts

## Testing

- .\.venv\Scripts\python.exe -m pytest --basetemp .context/pytest-temp/goal-oriented-pr-20260826 backend/tests/services/reporter/test_characterization.py backend/tests/services/reporter/test_definition.py backend/tests/services/reporter/test_procedure_tools.py backend/tests/services/reporter/test_integration.py
- 16 passed
- git diff --check

## Notes

- based on origin/main at 6798ad5
- Ruff was not available in the local environment