### PR TITLE
Make article viewing reader-first

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -30,6 +30,7 @@ not part of this UI slice.
 | Document | Owns |
 | --- | --- |
 | [`user-journeys.md`](user-journeys.md) | Information architecture, page inventory, flows, and user-visible states |
+| [`article-viewing.md`](article-viewing.md) | Reader-first article library, exact article reader, and audit-detail hierarchy |
 | [`application-contracts.md`](application-contracts.md) | Required HTTP surface, implemented coverage, gaps, and transport semantics |
 | [`frontend-architecture.md`](frontend-architecture.md) | TypeScript application structure, libraries, data flow, quality gates, and delivery |
 | [`release-checklist.md`](release-checklist.md) | Final clean-start, real-data journey, cross-cutting review, and release signoff |
@@ -88,6 +89,10 @@ durable cross-season identity.
 - Article content is rendered from the exact submitted artifact version.
   Intermediate artifacts and later/earlier versions never replace it by path
   convention.
+- Submitted articles use a reader-first hierarchy: headline and exact body are
+  primary, league/week/date context is secondary, and generation machinery is
+  available through `Behind this article`. Non-submitted runs remain
+  operations-first.
 - Cost is labeled **estimated cost**. The backend calculates it from persisted
   actual provider/model usage and the current LiteLLM price map; missing usage
   or pricing remains visibly unknown rather than being treated as zero. The

--- a/docs/ui/article-viewing.md
+++ b/docs/ui/article-viewing.md
@@ -1,0 +1,231 @@
+# Article Viewing Experience
+
+## Purpose
+
+The Articles area is the reading surface for finished work. Its default state
+must help a league member find and read an article without confronting the
+machinery that produced it. Generation settings, artifacts, execution traces,
+and usage remain available to the operator, but they are supporting evidence,
+not peer content.
+
+This contract applies to two related surfaces:
+
+- the **article library**, where readers discover submitted articles; and
+- the **article reader**, where one exact submitted version is read.
+
+Pending, failed, and cancelled runs are not articles. They retain the existing
+operations-first generation page.
+
+## Information Priority
+
+The UI uses four priority levels. Higher levels must not be displaced by lower
+levels on initial load.
+
+| Priority | Information | Presentation rule |
+| --- | --- | --- |
+| 1. Reading | Article title, optional preview/dek, exact article body | Dominates the viewport and reading order |
+| 2. Context | League, season, week range, completion date, historical-backtest disclosure | Compact masthead and library-card metadata |
+| 3. Reader actions | Back to library, previous/next article, Copy Markdown, Generate another | Available near the article without interrupting it |
+| 4. Production evidence | Assignment, model chain, snapshot, memory input, hashes, artifacts, execution, token usage, estimated cost, rerun/edit controls | Hidden behind `Behind this article` / `Run details` by default |
+
+The live/backtest distinction is contextual truth, not general telemetry. A
+historical backtest must be visibly labeled in both the library and reader. A
+normal live article may use a quieter label.
+
+The assignment is not the article summary. Until the API exposes a preview
+derived from submitted content, request text may be used as a clearly
+identified fallback, but it must not visually compete with the headline.
+
+## Page Model
+
+### Article library
+
+Route: `/competitions/:competitionId/articles`
+
+The library is an editorial archive, not a generation-usage table.
+
+1. A compact page masthead contains `Articles`, the competition context, and
+   `Generate article`.
+2. Season and mode filters occupy one compact toolbar. Filters remain in the
+   URL and the latest applicable article is selected after filtering. Week
+   filtering may join the toolbar when the API supports it.
+3. The newest matching article is a featured story with headline, preview,
+   season/week, completion date, mode disclosure, and `Read article`.
+4. Remaining results appear in a headline-led vertical list. Each item shows
+   headline, preview, season/week, date, and historical disclosure.
+5. Model, token, cost, hash, rerun, and workspace fields do not appear in the
+   default library. They remain available from the article's run details.
+6. Pagination stays at the end of the archive. Empty and error states retain a
+   clear route to generate an article or clear filters.
+
+The wide-screen default is a featured article followed by a two-column archive
+only when cards remain comfortably readable. A single vertical list is the
+baseline and the mobile layout.
+
+### Article reader
+
+Canonical route:
+`/competitions/:competitionId/articles/:generationId`
+
+The existing generation route remains canonical for non-submitted runs and for
+operational inspection. Existing successful-generation article links may
+redirect to or render the canonical reader so bookmarks remain valid.
+
+The reader is ordered as follows:
+
+1. A quiet breadcrumb/back action returns to the filtered article library.
+2. The article masthead shows mode/category, headline, optional preview,
+   league/season/week, and completion date.
+3. A small action group offers `Copy Markdown` and `Behind this article`.
+4. The exact submitted Markdown renders immediately below the masthead in a
+   centered reading column of roughly 68–76 characters.
+5. Previous and next submitted articles provide chronological navigation at
+   the end of the body.
+6. A compact footer offers `Generate another article`.
+
+On large screens, the body remains the visual center. Reader context may occupy
+a narrow rail only when it does not reduce the prose below the target reading
+measure. On smaller screens, all content is one column and the production
+evidence opens as a full-height sheet or an in-flow disclosure.
+
+### Behind this article
+
+`Behind this article` is the bridge from reading to operations. It opens a
+secondary surface rather than inserting a full run dashboard before the body.
+It contains:
+
+- a concise Overview: assignment, mode, model chain, snapshot, memory input,
+  completion time, and rerun/edit actions;
+- Artifacts;
+- Execution; and
+- Usage.
+
+Hashes, opaque IDs, artifact paths, and manifests are shown only inside this
+surface and only where they support verification. The existing detail panels
+remain reusable; the redesign changes their hierarchy and entry point, not the
+truth they display.
+
+### Active and unsuccessful runs
+
+Pending and running generations keep the progress-first page with stage, turn,
+elapsed time, assignment, and execution. Failed or cancelled generations keep
+failure recovery and rerun/edit actions prominent. The UI must never present
+these states as empty or partially available articles.
+
+## Responsive and Accessibility Contract
+
+- Article content precedes secondary evidence in DOM and visual order.
+- Headline links have descriptive accessible names; entire cards are not
+  nested interactive click targets.
+- Filter state, library page, and selected article remain deep-linkable.
+- Returning from the reader restores the prior filters and page when browser
+  history is available.
+- The reading column has no horizontal overflow; Markdown tables keep their
+  existing independently scrollable region.
+- Opening and closing run details preserves focus. The sheet/disclosure is
+  keyboard reachable and labeled by its article title.
+- Historical-backtest meaning is communicated with text, not color alone.
+- Loading uses stable article-shaped skeletons. A reader error does not expose
+  an empty run-audit shell as if the article loaded successfully.
+
+## Data and Route Contract
+
+The first implementation can use the existing article list and exact submitted
+article endpoints. To support a true editorial library, `ArticleSummary` should
+later add:
+
+- `preview: str | None`, derived from the first useful prose paragraph in the
+  exact submitted Markdown after removing headings and formatting; and
+- optionally a stable article category if category becomes a reporter output
+  contract rather than an inference from assignment text.
+
+The frontend must not fetch every full artifact to construct previews. Until
+`preview` exists, it should label request text as `Assignment` or omit the
+preview rather than implying it was extracted from the article.
+
+Previous/next navigation may initially use the current filtered article page.
+If the library becomes large or direct-reader navigation must cross page
+boundaries, add a server-owned adjacent-article projection rather than loading
+unbounded history.
+
+## Layout Sketches
+
+Wide article library:
+
+```text
+Articles                                      [Generate article]
+[Season] [Live / Backtest]
+
+LATEST
+Large headline
+Article preview or labeled Assignment fallback
+2026 · Week 8 · Aug 26                         [Read article]
+
+MORE ARTICLES
+Headline + preview + season/week/date          [Read]
+Headline + preview + season/week/date          [Read]
+                                               [Previous] [Next]
+```
+
+Wide article reader:
+
+```text
+< Back to articles
+
+BACKTEST · 2026 · WEEK 8 · AUG 26
+Article headline
+Optional article-derived preview
+                              [Copy Markdown] [Behind this article]
+
+                 Exact submitted article body
+                 in a centered reading column
+
+< Previous article                         Next article >
+```
+
+`Behind this article` opens as a right-side sheet on wide screens and a
+full-height sheet or in-flow disclosure on narrow screens. It contains
+Overview, Artifacts, Execution, and Usage without moving the reader's scroll
+position.
+
+## Implementation Sequence
+
+1. **Reader first:** add the submitted-article route and layout, reuse the exact
+   article query/Markdown renderer, and move existing audit panels behind the
+   secondary disclosure. Preserve successful generation links through redirect
+   or compatibility rendering.
+2. **Library second:** replace the operational table with a featured latest
+   story and headline-led archive while retaining URL-backed filters, paging,
+   and current loading/error/empty behavior.
+3. **Preview quality:** optionally add `ArticleSummary.preview` on the backend
+   and generated client contract. The first two slices can ship with a labeled
+   Assignment fallback.
+4. **Acceptance:** run the existing frontend format, lint, typecheck, and build
+   gates once, then manually verify direct links, browser history, filters,
+   paging, keyboard/focus behavior, 375 px layout, and every generation state.
+
+## Acceptance Coverage
+
+- The first viewport of a successful reader contains the headline and the
+  beginning of the article body at ordinary desktop and mobile sizes.
+- No assignment card, run-metadata card, success banner, or audit-tab header
+  appears before the article body.
+- The library can be understood from headlines, article context, and previews
+  without model or cost knowledge.
+- Backtests are clearly distinguishable from live articles.
+- Copy Markdown uses the exact submitted version.
+- Run details remain reachable in one action and preserve all existing audit
+  capabilities.
+- Pending, failed, and cancelled generations keep truthful operations-first
+  behavior.
+- Direct links, browser back, filters, pagination, keyboard use, and 375 px
+  layouts are manually verified without console errors.
+
+## Non-goals
+
+- public publishing, sharing, comments, reactions, or readership analytics;
+- rich-text or Markdown editing;
+- generated hero images;
+- replacing durable generation, artifact, execution, or usage contracts; and
+- presenting generation cost or model telemetry as reader-facing article
+  quality signals.

--- a/docs/ui/user-journeys.md
+++ b/docs/ui/user-journeys.md
@@ -24,12 +24,14 @@ Competitions
 │   ├── Refresh actions and freshness
 │   └── Recent activity
 ├── Articles
-│   ├── Article history
-│   └── Generation detail
-│       ├── Article
-│       ├── Artifacts
-│       ├── Execution
-│       └── Usage
+│   ├── Article library
+│   ├── Article reader
+│   │   └── Behind this article
+│   │       ├── Overview
+│   │       ├── Artifacts
+│   │       ├── Execution
+│   │       └── Usage
+│   └── Generation detail for active/unsuccessful runs
 └── Generate
     ├── Live generation
     └── Historical backtest
@@ -50,14 +52,17 @@ requiring horizontal scrolling for core actions.
 | `/competitions`                                          | Competition list     | Browse, create, archive, and choose a competition            |
 | `/competitions/:competitionId`                           | Competition overview | Seasons, freshness, refresh history, and recent runs         |
 | `/competitions/:competitionId/articles`                  | Article history      | Filter and browse submitted articles for one competition     |
+| `/competitions/:competitionId/articles/:generationId`    | Article reader       | Read the exact submitted article with secondary run details  |
 | `/competitions/:competitionId/generate`                  | Generate article     | Configure, validate, and submit a generation                 |
-| `/competitions/:competitionId/generations/:generationId` | Generation detail    | Article/run status plus artifacts, execution, and usage tabs |
+| `/competitions/:competitionId/generations/:generationId` | Generation detail    | Active/failed run status and operational inspection          |
 
 Creation stays in a dialog or sheet on `/competitions`; it does not need a
 dedicated route in v1. Season creation is a dialog on the competition overview.
 The generation detail route represents pending, running, failed, cancelled, and
-successful runs. Successful article-history entries link to the same route,
-avoiding a second detail model for “article” versus “generation.”
+successful runs. A successful run with an exact submitted version also has a
+reader-first article route. Both routes use the same durable generation and
+submitted-version identity; they are two presentations for different tasks,
+not two article records. Existing generation-detail article links remain valid.
 
 ## Journey 1: View and Manage Leagues
 
@@ -196,28 +201,37 @@ visible and offers `Rerun` plus `Edit settings and try again`.
 
 ### Article history
 
-Article history is competition-scoped and newest-first. Filters include season,
-live/backtest kind, week or week range, model, and a free-text request search
-when the API supports it. Each row/card shows:
+Article history is competition-scoped and newest-first. It is an editorial
+library rather than a generation-usage table. Filters include season,
+live/backtest kind, week or week range, and free-text article search when the
+API supports it. The newest matching article is featured; remaining articles
+use a headline-led archive list. Each item shows:
 
-- completion time;
+- headline and an article-derived preview when available;
+- completion date;
 - season and week range;
-- live/backtest badge;
-- request excerpt;
-- requested primary model;
-- token total and estimated cost when available; and
-- rerun/workspace relationship.
+- live/backtest badge; and
+- a clearly labeled assignment fallback only when no article preview exists.
 
 Only generations with an explicit submitted artifact version appear here.
 Pending and failed work remains on recent activity/run history, not in the
-article library.
+article library. Model, token, cost, hash, rerun, and workspace details are
+available from `Behind this article`, not in the default library.
 
-### Generation detail tabs
+### Article reader and run details
 
-**Article** renders the exact submitted Markdown version with readable editorial
-typography. A metadata rail shows request, dates, mode, model chain, snapshot,
-memory input, and manifest hash. `Copy Markdown` is available; editing and
-publishing are deferred.
+The **article reader** renders the exact submitted Markdown immediately after a
+compact masthead with headline, league/season/week context, completion date,
+and a prominent historical-backtest disclosure when applicable. The article
+body is centered at a readable measure. `Copy Markdown`, back-to-library, and
+previous/next article navigation are available; editing and publishing are
+deferred.
+
+`Behind this article` opens the production evidence as a secondary surface. Its
+Overview contains request, dates, mode, model chain, snapshot, memory input,
+manifest identity, and rerun/edit actions. It also provides the existing
+Artifacts, Execution, and Usage views. Full assignment and run-metadata cards,
+success banners, and audit navigation never precede the submitted article body.
 
 **Artifacts** lists logical path, media type, finalization state, revision
 count, and modified time. Selecting an artifact shows its version history and
@@ -242,6 +256,9 @@ never loaded into the article reading surface by default.
 tokens; model/provider breakdown; attempt count; latency; and estimated cost.
 The quote time and “estimated” label are always visible. Unknown price or usage
 produces an incomplete-estimate warning and identifies the affected calls.
+
+The complete layout, priority, responsive, and acceptance contract lives in
+[`article-viewing.md`](article-viewing.md).
 
 ## Common States and Guardrails
 

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -24,6 +24,10 @@ export const router = createBrowserRouter([
         lazy: () => import("@/routes/articles"),
       },
       {
+        path: "competitions/:competitionId/articles/:generationId",
+        lazy: () => import("@/routes/article-reader"),
+      },
+      {
         path: "competitions/:competitionId/generate",
         lazy: () => import("@/routes/generate"),
       },

--- a/frontend/src/components/shared/breadcrumbs.tsx
+++ b/frontend/src/components/shared/breadcrumbs.tsx
@@ -8,6 +8,7 @@ interface BreadcrumbsProps {
 }
 
 function resourceLabel(pathname: string): string | undefined {
+  if (pathname.includes("/articles/")) return "Article";
   if (pathname.endsWith("/articles")) return "Articles";
   if (pathname.endsWith("/generate")) return "Generate";
   if (pathname.includes("/generations/")) return "Generation";

--- a/frontend/src/features/articles/navigation.ts
+++ b/frontend/src/features/articles/navigation.ts
@@ -1,0 +1,69 @@
+import type { GenerationKind } from "@/features/articles/api";
+
+export const ARTICLE_PAGE_SIZE = 25;
+
+export function positiveArticlePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+export function articleKind(
+  value: string | null,
+): GenerationKind | undefined {
+  return value === "live" || value === "backtest" ? value : undefined;
+}
+
+function querySuffix(parameters: URLSearchParams): string {
+  const query = parameters.toString();
+  return query ? `?${query}` : "";
+}
+
+export function articleReaderPath(
+  competitionId: string,
+  generationId: string,
+  librarySearch: URLSearchParams,
+): string {
+  const context = new URLSearchParams();
+  const season = librarySearch.get("season");
+  const kind = articleKind(librarySearch.get("kind"));
+  const page = positiveArticlePage(librarySearch.get("page"));
+
+  if (season) context.set("season", season);
+  if (kind) context.set("kind", kind);
+  if (page > 1) context.set("libraryPage", String(page));
+
+  return `/competitions/${competitionId}/articles/${generationId}${querySuffix(context)}`;
+}
+
+export function siblingArticlePath(
+  competitionId: string,
+  generationId: string,
+  readerSearch: URLSearchParams,
+): string {
+  const context = new URLSearchParams();
+  const season = readerSearch.get("season");
+  const kind = articleKind(readerSearch.get("kind"));
+  const page = positiveArticlePage(readerSearch.get("libraryPage"));
+
+  if (season) context.set("season", season);
+  if (kind) context.set("kind", kind);
+  if (page > 1) context.set("libraryPage", String(page));
+
+  return `/competitions/${competitionId}/articles/${generationId}${querySuffix(context)}`;
+}
+
+export function articleLibraryPath(
+  competitionId: string,
+  readerSearch: URLSearchParams,
+): string {
+  const context = new URLSearchParams();
+  const season = readerSearch.get("season");
+  const kind = articleKind(readerSearch.get("kind"));
+  const page = positiveArticlePage(readerSearch.get("libraryPage"));
+
+  if (season) context.set("season", season);
+  if (kind) context.set("kind", kind);
+  if (page > 1) context.set("page", String(page));
+
+  return `/competitions/${competitionId}/articles${querySuffix(context)}`;
+}

--- a/frontend/src/routes/article-reader.tsx
+++ b/frontend/src/routes/article-reader.tsx
@@ -1,0 +1,615 @@
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  CircleAlert,
+  Copy,
+  FileSearch,
+  LoaderCircle,
+  Pencil,
+  RotateCcw,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router";
+import { toast } from "sonner";
+
+import { ApiError } from "@/api/errors";
+import { DateTime } from "@/components/shared/date-time";
+import { MarkdownArticle } from "@/components/shared/markdown-article";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import type { SubmittedArticleResponse } from "@/features/articles/api";
+import {
+  ARTICLE_PAGE_SIZE,
+  articleKind,
+  articleLibraryPath,
+  positiveArticlePage,
+  siblingArticlePath,
+} from "@/features/articles/navigation";
+import {
+  useArticleList,
+  useSubmittedArticle,
+} from "@/features/articles/queries";
+import { ArtifactBrowser } from "@/features/artifacts/artifact-browser";
+import { ExecutionTimeline } from "@/features/execution/execution-timeline";
+import {
+  createGenerationFormValuesFromDetail,
+  saveGenerationDraft,
+} from "@/features/generations/draft";
+import { useRerunGeneration } from "@/features/generations/queries";
+import { useSeasonList } from "@/features/seasons/queries";
+import { UsagePanel } from "@/features/usage/usage-panel";
+import { cn } from "@/lib/utils";
+
+const seasonListParameters = { limit: 200, offset: 0 } as const;
+const detailTabs = ["overview", "artifacts", "execution", "usage"] as const;
+type DetailTab = (typeof detailTabs)[number];
+type SubmittedGeneration = SubmittedArticleResponse["generation"];
+type SubmittedArtifact = SubmittedArticleResponse["artifact"];
+type SubmittedVersion = SubmittedArticleResponse["version"];
+
+interface SplitArticle {
+  body: string;
+  title: string;
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[_\-.\s]+/u)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function weekLabel(start: number | null, end: number | null): string {
+  if (start === null || end === null) return "Weeks not recorded";
+  return start === end
+    ? `Week ${String(start)}`
+    : `Weeks ${String(start)}–${String(end)}`;
+}
+
+function plainHeading(markdown: string): string {
+  return markdown
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1")
+    .replace(/`([^`]+)`/gu, "$1")
+    .replace(/<[^>]*>/gu, "")
+    .replace(/(?<!\\)[*_~]/gu, "")
+    .replace(/\\([\\`*{}[\]()#+.!_>~-])/gu, "$1")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .trim();
+}
+
+function splitArticle(markdown: string): SplitArticle {
+  const lines = markdown.split(/\r?\n/u);
+  let fenceCharacter: string | undefined;
+  let fenceLength = 0;
+
+  for (const [index, line] of lines.entries()) {
+    const fence = /^\s*(`{3,}|~{3,})/u.exec(line);
+    if (fenceCharacter) {
+      const marker = fence?.[1];
+      const fenceText = fence?.[0];
+      if (
+        marker?.[0] === fenceCharacter &&
+        marker.length >= fenceLength &&
+        fenceText !== undefined &&
+        /^\s*$/.test(line.slice(fenceText.length))
+      ) {
+        fenceCharacter = undefined;
+        fenceLength = 0;
+      }
+      continue;
+    }
+    if (fence?.[1]) {
+      fenceCharacter = fence[1][0];
+      fenceLength = fence[1].length;
+      continue;
+    }
+
+    const heading = /^\s{0,3}#(?!#)\s+(.+?)\s*#*\s*$/u.exec(line);
+    if (!heading?.[1]) continue;
+    const title = plainHeading(heading[1]);
+    if (!title) continue;
+    lines.splice(index, 1);
+    return { title, body: lines.join("\n").trimStart() };
+  }
+
+  return { title: "Untitled article", body: markdown };
+}
+
+function ReaderSkeleton(): React.JSX.Element {
+  return (
+    <div className="mx-auto max-w-5xl px-5 py-10 sm:px-8 sm:py-14">
+      <Skeleton className="h-8 w-36" />
+      <div className="mx-auto mt-12 max-w-3xl space-y-5">
+        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-5 w-80" />
+        <Skeleton className="mt-12 h-[32rem] w-full" />
+      </div>
+    </div>
+  );
+}
+function RunOverview({
+  artifact,
+  competitionId,
+  generation,
+  seasonYear,
+  version,
+}: {
+  artifact: SubmittedArtifact;
+  competitionId: string;
+  generation: SubmittedGeneration;
+  seasonYear?: number;
+  version: SubmittedVersion;
+}): React.JSX.Element {
+  const navigate = useNavigate();
+  const editableValues = createGenerationFormValuesFromDetail(generation);
+  const fallbackModels = editableValues?.model.fallbackModels ?? [];
+  const rerun = useRerunGeneration(competitionId, generation.id);
+
+  async function rerunGeneration(): Promise<void> {
+    try {
+      const response = await rerun.mutateAsync();
+      toast.success("Rerun queued");
+      await navigate(
+        `/competitions/${competitionId}/generations/${response.generation.id}`,
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof ApiError
+          ? error.message
+          : "The rerun could not be queued.",
+      );
+    }
+  }
+
+  function editSettings(): void {
+    if (!editableValues) return;
+    saveGenerationDraft(competitionId, editableValues);
+    void navigate(
+      `/competitions/${competitionId}/generate?season=${generation.competition_season_id}`,
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-border bg-card p-5 sm:p-6">
+        <h3 className="font-editorial text-2xl font-semibold">Assignment</h3>
+        <p className="mt-4 whitespace-pre-wrap text-sm leading-7">
+          {generation.request_text}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-2 border-t border-border pt-5">
+          <Button
+            variant="outline"
+            disabled={rerun.isPending}
+            onClick={() => void rerunGeneration()}
+          >
+            {rerun.isPending ? (
+              <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <RotateCcw className="size-4" aria-hidden="true" />
+            )}
+            Rerun exact request
+          </Button>
+          <Button
+            variant="outline"
+            disabled={!editableValues}
+            onClick={editSettings}
+          >
+            <Pencil className="size-4" aria-hidden="true" />
+            Edit settings
+          </Button>
+          <Link
+            className={buttonVariants({ variant: "ghost" })}
+            to={`/competitions/${competitionId}/generations/${generation.id}?tab=execution`}
+          >
+            Open generation record
+          </Link>
+        </div>
+        {rerun.isError ? (
+          <div
+            className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive"
+            role="alert"
+          >
+            {rerun.error instanceof ApiError
+              ? rerun.error.message
+              : "The rerun could not be queued."}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-5 sm:p-6">
+        <h3 className="font-editorial text-2xl font-semibold">Run details</h3>
+        <dl className="mt-5 grid gap-5 text-sm sm:grid-cols-2">
+          <div>
+            <dt className="text-xs text-muted-foreground">Season and scope</dt>
+            <dd className="mt-1 font-medium">
+              {seasonYear ?? generation.competition_season_id} ·{" "}
+              {weekLabel(generation.week_start, generation.week_end)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Mode</dt>
+            <dd className="mt-1 font-medium">{titleCase(generation.kind)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Completed</dt>
+            <dd className="mt-1">
+              <DateTime value={generation.completed_at} showExact />
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Model chain</dt>
+            <dd className="mt-1 break-all font-medium">
+              {generation.requested_primary_model}
+              {fallbackModels.length > 0
+                ? ` → ${fallbackModels.join(" → ")}`
+                : ""}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Submitted version</dt>
+            <dd className="mt-1 break-all font-mono text-xs">
+              Revision {version.revision_number} · {artifact.path}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Snapshot</dt>
+            <dd className="mt-1 break-all font-mono text-xs">
+              {generation.data_snapshot_id ?? "Not recorded"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Memory input</dt>
+            <dd className="mt-1 break-all font-mono text-xs">
+              {generation.input_memory_revision_id ??
+                generation.input_memory_artifact_version_id ??
+                "No persisted memory input"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground">Manifest hash</dt>
+            <dd className="mt-1 break-all font-mono text-xs">
+              {generation.manifest_hash ?? "Not recorded"}
+            </dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="text-xs text-muted-foreground">Content hash</dt>
+            <dd className="mt-1 break-all font-mono text-xs">
+              {version.content_hash}
+            </dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+function RunDetailsSheet({
+  article,
+  competitionId,
+  seasonYear,
+}: {
+  article: SubmittedArticleResponse;
+  competitionId: string;
+  seasonYear?: number;
+}): React.JSX.Element {
+  const [activeTab, setActiveTab] = useState<DetailTab>("overview");
+  const split = useMemo(
+    () => splitArticle(article.version.content),
+    [article.version.content],
+  );
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">
+          <FileSearch className="size-4" aria-hidden="true" />
+          Behind this article
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-full max-w-5xl overflow-hidden p-0 sm:w-[min(64rem,94vw)]"
+      >
+        <SheetHeader className="mb-0 border-b border-border px-5 py-5 pr-12 sm:px-7">
+          <SheetTitle>Behind “{split.title}”</SheetTitle>
+          <SheetDescription>
+            Assignment, provenance, artifacts, execution, and usage for this
+            exact submitted version.
+          </SheetDescription>
+        </SheetHeader>
+        <Tabs
+          className="min-h-0 flex-1 gap-0"
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as DetailTab)}
+        >
+          <div className="shrink-0 overflow-x-auto border-b border-border px-5 sm:px-7">
+            <TabsList className="min-w-max border-b-0">
+              {detailTabs.map((tab) => (
+                <TabsTrigger key={tab} value={tab}>
+                  {titleCase(tab)}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6 sm:px-7">
+            <TabsContent value="overview">
+              <RunOverview
+                artifact={article.artifact}
+                competitionId={competitionId}
+                generation={article.generation}
+                seasonYear={seasonYear}
+                version={article.version}
+              />
+            </TabsContent>
+            <TabsContent value="artifacts">
+              <ArtifactBrowser
+                competitionId={competitionId}
+                generationId={article.generation.id}
+                submittedVersionId={article.version.id}
+                active={activeTab === "artifacts"}
+              />
+            </TabsContent>
+            <TabsContent value="execution">
+              <ExecutionTimeline
+                competitionId={competitionId}
+                generationId={article.generation.id}
+                active={activeTab === "execution"}
+                generationActive={false}
+              />
+            </TabsContent>
+            <TabsContent value="usage">
+              <UsagePanel
+                competitionId={competitionId}
+                generationId={article.generation.id}
+                active={activeTab === "usage"}
+                provisional={false}
+              />
+            </TabsContent>
+          </div>
+        </Tabs>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function Component(): React.JSX.Element {
+  const { competitionId, generationId } = useParams();
+  const [searchParameters] = useSearchParams();
+  const resolvedCompetitionId = competitionId ?? "";
+  const resolvedGenerationId = generationId ?? "";
+  const validScope =
+    resolvedCompetitionId.length > 0 && resolvedGenerationId.length > 0;
+  const articleQuery = useSubmittedArticle(
+    resolvedCompetitionId,
+    resolvedGenerationId,
+    validScope,
+  );
+  const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
+  const libraryPage = positiveArticlePage(searchParameters.get("libraryPage"));
+  const seasonId = searchParameters.get("season") ?? undefined;
+  const kind = articleKind(searchParameters.get("kind"));
+  const libraryQuery = useArticleList(competitionId, {
+    competitionSeasonId: seasonId,
+    kind,
+    limit: ARTICLE_PAGE_SIZE,
+    offset: (libraryPage - 1) * ARTICLE_PAGE_SIZE,
+  });
+  const [copyStatus, setCopyStatus] = useState<string>();
+
+  if (articleQuery.isPending) return <ReaderSkeleton />;
+
+  if (articleQuery.isError || !validScope) {
+    const missing =
+      articleQuery.error instanceof ApiError &&
+      articleQuery.error.status === 404;
+    return (
+      <div className="mx-auto max-w-3xl px-5 py-16 sm:px-8">
+        <CircleAlert className="size-8 text-destructive" aria-hidden="true" />
+        <h1 className="mt-4 font-editorial text-3xl font-semibold">
+          {missing ? "Submitted article not found" : "Article unavailable"}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+          {articleQuery.error instanceof ApiError
+            ? articleQuery.error.message
+            : "The exact submitted article could not be loaded."}
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          {!missing ? (
+            <Button
+              variant="outline"
+              onClick={() => void articleQuery.refetch()}
+            >
+              Try again
+            </Button>
+          ) : null}
+          <Link
+            className={buttonVariants({ variant: "ghost" })}
+            to={
+              competitionId
+                ? articleLibraryPath(competitionId, searchParameters)
+                : "/competitions"
+            }
+          >
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            Back to articles
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const article = articleQuery.data;
+  const split = splitArticle(article.version.content);
+  const season = seasonsQuery.data?.page.items.find(
+    (item) => item.season.id === article.generation.competition_season_id,
+  );
+  const libraryItems = libraryQuery.data?.page.items ?? [];
+  const currentIndex = libraryItems.findIndex(
+    (item) => item.generation_id === resolvedGenerationId,
+  );
+  const newerArticle =
+    currentIndex > 0 ? libraryItems[currentIndex - 1] : undefined;
+  const olderArticle =
+    currentIndex >= 0 && currentIndex < libraryItems.length - 1
+      ? libraryItems[currentIndex + 1]
+      : undefined;
+
+  async function copyMarkdown(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(article.version.content);
+      setCopyStatus("Markdown copied to the clipboard.");
+    } catch {
+      setCopyStatus(
+        "Markdown could not be copied. Select the article text instead.",
+      );
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-5 py-8 sm:px-8 sm:py-12">
+      <Link
+        className={cn(buttonVariants({ variant: "ghost" }), "-ml-3")}
+        to={articleLibraryPath(resolvedCompetitionId, searchParameters)}
+      >
+        <ArrowLeft className="size-4" aria-hidden="true" />
+        Back to articles
+      </Link>
+
+      <div className="mx-auto mt-9 max-w-3xl">
+        <header className="border-b border-border pb-8 sm:pb-10">
+          <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            <Badge
+              variant={article.generation.kind === "backtest" ? "secondary" : "outline"}
+            >
+              {article.generation.kind === "backtest"
+                ? "Historical backtest"
+                : "Live article"}
+            </Badge>
+            <span>{season?.season.season_year ?? "Season"}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              {weekLabel(
+                article.generation.week_start,
+                article.generation.week_end,
+              )}
+            </span>
+          </div>
+          <h1 className="mt-5 font-editorial text-4xl font-semibold leading-tight tracking-tight sm:text-6xl">
+            {split.title}
+          </h1>
+          <div className="mt-5 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Completed{" "}
+              <DateTime value={article.generation.completed_at} showExact />
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" onClick={() => void copyMarkdown()}>
+                {copyStatus?.startsWith("Markdown copied") ? (
+                  <Check className="size-4" aria-hidden="true" />
+                ) : (
+                  <Copy className="size-4" aria-hidden="true" />
+                )}
+                Copy Markdown
+              </Button>
+              <RunDetailsSheet
+                article={article}
+                competitionId={resolvedCompetitionId}
+                seasonYear={season?.season.season_year}
+              />
+            </div>
+          </div>
+          {copyStatus ? (
+            <p className="mt-3 text-xs text-muted-foreground" role="status">
+              {copyStatus}
+            </p>
+          ) : null}
+        </header>
+
+        <section className="py-9 sm:py-12" aria-label="Article content">
+          <MarkdownArticle content={split.body} />
+        </section>
+
+        <nav
+          aria-label="Adjacent articles"
+          className="grid gap-3 border-t border-border pt-6 sm:grid-cols-2"
+        >
+          {newerArticle ? (
+            <Link
+              className="group rounded-lg border border-border p-4 transition-colors hover:bg-accent"
+              to={siblingArticlePath(
+                resolvedCompetitionId,
+                newerArticle.generation_id,
+                searchParameters,
+              )}
+            >
+              <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                <ArrowLeft className="size-3" aria-hidden="true" />
+                Newer article
+              </span>
+              <span className="mt-2 block font-editorial text-lg font-semibold leading-snug group-hover:underline">
+                {newerArticle.title}
+              </span>
+            </Link>
+          ) : (
+            <span />
+          )}
+          {olderArticle ? (
+            <Link
+              className="group rounded-lg border border-border p-4 text-right transition-colors hover:bg-accent"
+              to={siblingArticlePath(
+                resolvedCompetitionId,
+                olderArticle.generation_id,
+                searchParameters,
+              )}
+            >
+              <span className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+                Older article
+                <ArrowRight className="size-3" aria-hidden="true" />
+              </span>
+              <span className="mt-2 block font-editorial text-lg font-semibold leading-snug group-hover:underline">
+                {olderArticle.title}
+              </span>
+            </Link>
+          ) : null}
+        </nav>
+
+        <footer className="mt-10 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-6">
+          <Link
+            className={buttonVariants({ variant: "ghost" })}
+            to={articleLibraryPath(resolvedCompetitionId, searchParameters)}
+          >
+            View all articles
+          </Link>
+          <Link
+            className={buttonVariants({ variant: "default" })}
+            to={`/competitions/${resolvedCompetitionId}/generate?season=${article.generation.competition_season_id}`}
+          >
+            Generate another article
+          </Link>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/articles.tsx
+++ b/frontend/src/routes/articles.tsx
@@ -13,269 +13,190 @@ import { DateTime } from "@/components/shared/date-time";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { ArticleSummary, GenerationKind } from "@/features/articles/api";
+import type { ArticleSummary } from "@/features/articles/api";
+import {
+  ARTICLE_PAGE_SIZE,
+  articleKind,
+  articleReaderPath,
+  positiveArticlePage,
+} from "@/features/articles/navigation";
 import { useArticleList } from "@/features/articles/queries";
 import { useSeasonList } from "@/features/seasons/queries";
 import { cn } from "@/lib/utils";
 
-const PAGE_SIZE = 25;
 const seasonListParameters = { limit: 200, offset: 0 } as const;
-
-function positivePage(value: string | null): number {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
-}
-
-function generationKind(value: string | null): GenerationKind | undefined {
-  return value === "live" || value === "backtest" ? value : undefined;
-}
-
-function titleCase(value: string): string {
-  return value
-    .split(/[_\-.\s]+/u)
-    .filter(Boolean)
-    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
-    .join(" ");
-}
 
 function weekLabel(article: ArticleSummary): string {
   if (article.week_start === null || article.week_end === null)
-    return "Weeks —";
+    return "Weeks not recorded";
   return article.week_start === article.week_end
     ? `Week ${String(article.week_start)}`
     : `Weeks ${String(article.week_start)}–${String(article.week_end)}`;
 }
 
-function formatCost(value: string | null, currency: string): string {
-  if (value === null) return "Unavailable";
-  const amount = Number(value);
-  if (!Number.isFinite(amount)) return `${currency} ${value}`;
-  if (amount > 0 && amount < 0.000001) return `${currency} ${value}`;
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency,
-      maximumFractionDigits: amount < 0.01 ? 6 : 2,
-    }).format(amount);
-  } catch {
-    return `${currency} ${value}`;
-  }
-}
-
-function actualModelLabel(article: ArticleSummary): string {
-  const models = article.usage.models;
-  if (models.length === 0) return "No recorded model";
-  const first = models[0];
-  const identity = [first?.provider, first?.model].filter(Boolean).join(" / ");
-  return models.length > 1
-    ? `${identity || "Unknown model"} +${String(models.length - 1)}`
-    : identity || "Unknown model";
-}
-
-function estimatedCostLabel(article: ArticleSummary): string {
-  if (article.usage.estimated_cost === null) return "Estimate unavailable";
-  return `${formatCost(
-    article.usage.estimated_cost,
-    article.usage.currency,
-  )} estimated`;
-}
-
-function tokenLabel(article: ArticleSummary): string {
-  if (article.usage.complete) {
-    return `${article.usage.total_tokens.toLocaleString()} tokens`;
-  }
-  if (article.usage.attempt_count === 0) return "Usage unavailable";
-  return `${article.usage.total_tokens.toLocaleString()} recorded tokens`;
-}
-
-function relationshipLabel(article: ArticleSummary): string | undefined {
-  if (article.rerun_of_generation_id) {
-    return `Exact rerun of ${article.rerun_of_generation_id.slice(0, 8)}`;
-  }
-  if (article.workspace_sequence_number !== null) {
-    return `Workspace run ${String(article.workspace_sequence_number)}`;
-  }
-  return undefined;
-}
-
-function ArticleTable({
-  competitionId,
-  items,
+function ArticleContext({
+  article,
 }: {
-  competitionId: string;
-  items: ArticleSummary[];
+  article: ArticleSummary;
 }): React.JSX.Element {
   return (
-    <div className="hidden overflow-hidden rounded-lg border border-border bg-card lg:block">
-      <table className="w-full border-collapse text-left text-sm">
-        <thead className="bg-muted/70 text-xs uppercase tracking-[0.1em] text-muted-foreground">
-          <tr>
-            <th className="px-5 py-3 font-semibold">Article</th>
-            <th className="px-4 py-3 font-semibold">Scope</th>
-            <th className="px-4 py-3 font-semibold">Models</th>
-            <th className="px-4 py-3 font-semibold">Usage</th>
-            <th className="px-4 py-3 font-semibold">Completed</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {items.map((article) => (
-            <tr
-              key={article.generation_id}
-              className="align-top hover:bg-muted/35"
-            >
-              <td className="max-w-md px-5 py-4">
-                <Link
-                  className="font-editorial text-lg font-semibold underline-offset-4 hover:underline"
-                  to={`/competitions/${competitionId}/generations/${article.generation_id}?tab=article`}
-                >
-                  {article.title}
-                </Link>
-                <p
-                  className="mt-1 max-w-md truncate text-xs text-muted-foreground"
-                  title={article.request_text}
-                >
-                  {article.request_text}
-                </p>
-                {article.rerun_of_generation_id ? (
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Exact rerun · source{" "}
-                    <Link
-                      className="font-mono text-primary underline-offset-4 hover:underline"
-                      to={`/competitions/${competitionId}/generations/${article.rerun_of_generation_id}`}
-                    >
-                      {article.rerun_of_generation_id.slice(0, 8)}
-                    </Link>
-                  </p>
-                ) : article.workspace_sequence_number !== null ? (
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Workspace run {article.workspace_sequence_number}
-                  </p>
-                ) : null}
-              </td>
-              <td className="px-4 py-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium">{article.season_year}</span>
-                  <Badge variant="outline">{titleCase(article.kind)}</Badge>
-                </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {weekLabel(article)}
-                </p>
-              </td>
-              <td className="max-w-56 px-4 py-4">
-                <p className="break-all font-medium">
-                  {article.requested_primary_model}
-                </p>
-                <p className="mt-1 break-all text-xs text-muted-foreground">
-                  Actual: {actualModelLabel(article)}
-                </p>
-              </td>
-              <td className="px-4 py-4">
-                <p className="font-medium">{tokenLabel(article)}</p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {estimatedCostLabel(article)}
-                </p>
-                {!article.usage.complete ? (
-                  <Badge className="mt-2" variant="secondary">
-                    Incomplete usage/cost
-                  </Badge>
-                ) : null}
-              </td>
-              <td className="px-4 py-4">
-                <DateTime value={article.completed_at} showExact />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+      <Badge variant={article.kind === "backtest" ? "secondary" : "outline"}>
+        {article.kind === "backtest" ? "Historical backtest" : "Live"}
+      </Badge>
+      <span>{article.season_year}</span>
+      <span aria-hidden="true">·</span>
+      <span>{weekLabel(article)}</span>
+      <span aria-hidden="true">·</span>
+      <DateTime value={article.completed_at} />
+    </div>
+  );
+}
+function AssignmentFallback({
+  article,
+  featured = false,
+}: {
+  article: ArticleSummary;
+  featured?: boolean;
+}): React.JSX.Element {
+  return (
+    <div className={featured ? "mt-6 max-w-2xl" : "mt-3 max-w-3xl"}>
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        Assignment
+      </p>
+      <p
+        className={cn(
+          "mt-1 text-muted-foreground",
+          featured ? "text-base leading-7" : "line-clamp-2 text-sm leading-6",
+        )}
+      >
+        {article.request_text}
+      </p>
     </div>
   );
 }
 
-function ArticleCards({
+function FeaturedArticle({
+  article,
+  competitionId,
+  searchParameters,
+}: {
+  article: ArticleSummary;
+  competitionId: string;
+  searchParameters: URLSearchParams;
+}): React.JSX.Element {
+  return (
+    <article className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="border-b border-border bg-muted/40 px-5 py-3 sm:px-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Latest article
+        </p>
+      </div>
+      <div className="px-5 py-7 sm:px-8 sm:py-10">
+        <ArticleContext article={article} />
+        <h2 className="mt-5 max-w-4xl font-editorial text-4xl font-semibold leading-tight tracking-tight sm:text-5xl">
+          <Link
+            className="underline-offset-4 hover:underline"
+            to={articleReaderPath(
+              competitionId,
+              article.generation_id,
+              searchParameters,
+            )}
+          >
+            {article.title}
+          </Link>
+        </h2>
+        <AssignmentFallback article={article} featured />
+        <div className="mt-7">
+          <Link
+            className={buttonVariants({ variant: "default" })}
+            to={articleReaderPath(
+              competitionId,
+              article.generation_id,
+              searchParameters,
+            )}
+          >
+            Read article
+            <ArrowRight className="size-4" aria-hidden="true" />
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ArticleArchive({
   competitionId,
   items,
+  searchParameters,
 }: {
   competitionId: string;
   items: ArticleSummary[];
-}): React.JSX.Element {
+  searchParameters: URLSearchParams;
+}): React.JSX.Element | null {
+  if (items.length === 0) return null;
+
   return (
-    <div className="space-y-3 lg:hidden">
-      {items.map((article) => (
-        <article
-          key={article.generation_id}
-          className="rounded-lg border border-border bg-card p-5"
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge variant="outline">{titleCase(article.kind)}</Badge>
-            <span className="text-xs text-muted-foreground">
-              {article.season_year} · {weekLabel(article)}
-            </span>
-          </div>
-          <h2 className="mt-3 font-editorial text-2xl font-semibold leading-tight">
-            <Link
-              className="underline-offset-4 hover:underline"
-              to={`/competitions/${competitionId}/generations/${article.generation_id}?tab=article`}
-            >
-              {article.title}
-            </Link>
-          </h2>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            {article.request_text}
+    <section className="mt-10" aria-labelledby="article-archive-heading">
+      <div className="mb-4 flex items-end justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Archive
           </p>
-          {relationshipLabel(article) ? (
-            <p className="mt-2 text-xs text-muted-foreground">
-              {relationshipLabel(article)}
-            </p>
-          ) : null}
-          <dl className="mt-5 grid gap-4 border-t border-border pt-4 text-sm sm:grid-cols-3">
-            <div>
-              <dt className="text-xs text-muted-foreground">Models</dt>
-              <dd className="mt-1 break-all font-medium">
-                {article.requested_primary_model}
-              </dd>
-              <dd className="mt-1 break-all text-xs text-muted-foreground">
-                Actual: {actualModelLabel(article)}
-              </dd>
+          <h2
+            id="article-archive-heading"
+            className="mt-2 font-editorial text-3xl font-semibold"
+          >
+            More articles
+          </h2>
+        </div>
+      </div>
+      <div className="divide-y divide-border border-y border-border">
+        {items.map((article) => (
+          <article
+            key={article.generation_id}
+            className="grid gap-5 py-6 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+          >
+            <div className="min-w-0">
+              <ArticleContext article={article} />
+              <h3 className="mt-3 max-w-4xl font-editorial text-2xl font-semibold leading-snug sm:text-3xl">
+                <Link
+                  className="underline-offset-4 hover:underline"
+                  to={articleReaderPath(
+                    competitionId,
+                    article.generation_id,
+                    searchParameters,
+                  )}
+                >
+                  {article.title}
+                </Link>
+              </h3>
+              <AssignmentFallback article={article} />
             </div>
-            <div>
-              <dt className="text-xs text-muted-foreground">Usage</dt>
-              <dd className="mt-1 font-medium">{tokenLabel(article)}</dd>
-              <dd className="mt-1 text-xs text-muted-foreground">
-                {estimatedCostLabel(article)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted-foreground">Completed</dt>
-              <dd className="mt-1">
-                <DateTime value={article.completed_at} showExact />
-              </dd>
-            </div>
-          </dl>
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-            {!article.usage.complete ? (
-              <Badge variant="secondary">Incomplete usage/cost</Badge>
-            ) : (
-              <span />
-            )}
             <Link
               className={buttonVariants({ variant: "outline", size: "sm" })}
-              to={`/competitions/${competitionId}/generations/${article.generation_id}?tab=article`}
+              to={articleReaderPath(
+                competitionId,
+                article.generation_id,
+                searchParameters,
+              )}
             >
-              Read article
+              Read
               <ArrowRight className="size-4" aria-hidden="true" />
             </Link>
-          </div>
-        </article>
-      ))}
-    </div>
+          </article>
+        ))}
+      </div>
+    </section>
   );
 }
 
 function ArticleListSkeleton(): React.JSX.Element {
   return (
-    <div className="space-y-3" aria-label="Loading submitted articles">
+    <div className="space-y-6" aria-label="Loading submitted articles">
+      <Skeleton className="h-80 w-full rounded-xl" />
       {[0, 1, 2].map((item) => (
-        <Skeleton key={item} className="h-32 w-full rounded-lg" />
+        <Skeleton key={item} className="h-36 w-full rounded-lg" />
       ))}
     </div>
   );
@@ -284,19 +205,19 @@ function ArticleListSkeleton(): React.JSX.Element {
 export function Component(): React.JSX.Element {
   const { competitionId } = useParams();
   const [searchParameters, setSearchParameters] = useSearchParams();
-  const page = positivePage(searchParameters.get("page"));
+  const page = positiveArticlePage(searchParameters.get("page"));
   const seasonId = searchParameters.get("season") ?? undefined;
-  const kind = generationKind(searchParameters.get("kind"));
+  const kind = articleKind(searchParameters.get("kind"));
   const seasonsQuery = useSeasonList(competitionId, seasonListParameters);
   const articlesQuery = useArticleList(competitionId, {
     competitionSeasonId: seasonId,
     kind,
-    limit: PAGE_SIZE,
-    offset: (page - 1) * PAGE_SIZE,
+    limit: ARTICLE_PAGE_SIZE,
+    offset: (page - 1) * ARTICLE_PAGE_SIZE,
   });
   const totalPages = Math.max(
     1,
-    Math.ceil((articlesQuery.data?.page.total ?? 0) / PAGE_SIZE),
+    Math.ceil((articlesQuery.data?.page.total ?? 0) / ARTICLE_PAGE_SIZE),
   );
 
   useEffect(() => {
@@ -344,6 +265,8 @@ export function Component(): React.JSX.Element {
   }
 
   const items = articlesQuery.data?.page.items ?? [];
+  const featuredArticle = page === 1 ? items[0] : undefined;
+  const archiveItems = featuredArticle ? items.slice(1) : items;
   const filtered = seasonId !== undefined || kind !== undefined;
   const error = articlesQuery.error;
 
@@ -352,14 +275,13 @@ export function Component(): React.JSX.Element {
       <header className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div className="max-w-3xl">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Submitted work
+            League desk
           </p>
           <h1 className="mt-3 font-editorial text-4xl font-semibold tracking-tight sm:text-5xl">
             Articles
           </h1>
           <p className="mt-4 text-base leading-7 text-muted-foreground">
-            Browse exact submitted article versions and open the durable run
-            record behind each one.
+            Read the latest submitted coverage or browse the league archive.
           </p>
         </div>
         <Link
@@ -371,16 +293,17 @@ export function Component(): React.JSX.Element {
         </Link>
       </header>
 
-      <section className="mt-9 rounded-lg border border-border bg-card p-4 sm:p-5">
+      <section
+        className="mt-8 rounded-lg border border-border bg-card p-4"
+        aria-label="Article filters"
+      >
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="space-y-1.5 text-xs font-medium text-muted-foreground">
             Season
             <select
               className="block h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
               value={seasonId ?? ""}
-              onChange={(event) => {
-                setFilter("season", event.target.value);
-              }}
+              onChange={(event) => setFilter("season", event.target.value)}
             >
               <option value="">All seasons</option>
               {(seasonsQuery.data?.page.items ?? []).map(
@@ -398,9 +321,7 @@ export function Component(): React.JSX.Element {
             <select
               className="block h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
               value={kind ?? ""}
-              onChange={(event) => {
-                setFilter("kind", event.target.value);
-              }}
+              onChange={(event) => setFilter("kind", event.target.value)}
             >
               <option value="">Live and backtests</option>
               <option value="live">Live</option>
@@ -410,30 +331,22 @@ export function Component(): React.JSX.Element {
         </div>
       </section>
 
-      <section className="mt-8" aria-labelledby="article-list-heading">
-        <div className="mb-4 flex min-h-6 items-center justify-between gap-3">
-          <h2
-            id="article-list-heading"
-            className="font-editorial text-2xl font-semibold"
+      <section className="mt-8" aria-label="Submitted articles">
+        {articlesQuery.isFetching && !articlesQuery.isPending ? (
+          <p
+            className="mb-3 text-right text-xs text-muted-foreground"
+            role="status"
           >
-            Submitted articles
-          </h2>
-          {articlesQuery.isFetching && !articlesQuery.isPending ? (
-            <span className="text-xs text-muted-foreground" role="status">
-              Updating…
-            </span>
-          ) : null}
-        </div>
+            Updating articles…
+          </p>
+        ) : null}
 
         {articlesQuery.isPending ? <ArticleListSkeleton /> : null}
 
         {error ? (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
-            <CircleAlert
-              className="size-6 text-destructive"
-              aria-hidden="true"
-            />
-            <h3 className="mt-3 font-semibold">Article library unavailable</h3>
+            <CircleAlert className="size-6 text-destructive" aria-hidden="true" />
+            <h2 className="mt-3 font-semibold">Article library unavailable</h2>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
               {error instanceof ApiError
                 ? error.message
@@ -442,9 +355,7 @@ export function Component(): React.JSX.Element {
             <Button
               className="mt-4"
               variant="outline"
-              onClick={() => {
-                void articlesQuery.refetch();
-              }}
+              onClick={() => void articlesQuery.refetch()}
             >
               Try again
             </Button>
@@ -457,14 +368,14 @@ export function Component(): React.JSX.Element {
               className="mx-auto size-8 text-muted-foreground"
               aria-hidden="true"
             />
-            <h3 className="mt-5 font-editorial text-2xl font-semibold">
+            <h2 className="mt-5 font-editorial text-2xl font-semibold">
               {filtered
                 ? "No articles match these filters"
                 : "No submitted articles yet"}
-            </h3>
+            </h2>
             <p className="mx-auto mt-2 max-w-lg text-sm leading-6 text-muted-foreground">
               {filtered
-                ? "Choose another season or mode to broaden the article history."
+                ? "Choose another season or mode to broaden the article archive."
                 : "Successful generations with an explicit submitted version will appear here."}
             </p>
             <div className="mt-6 flex flex-wrap justify-center gap-3">
@@ -483,43 +394,50 @@ export function Component(): React.JSX.Element {
           </div>
         ) : null}
 
-        {articlesQuery.isSuccess && items.length > 0 ? (
-          <>
-            <ArticleTable competitionId={competitionId} items={items} />
-            <ArticleCards competitionId={competitionId} items={items} />
-            {articlesQuery.data.page.total > PAGE_SIZE ? (
-              <div className="mt-5 flex flex-col gap-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-                <span className="text-muted-foreground">
-                  Page {page} of {totalPages} · {articlesQuery.data.page.total}{" "}
-                  articles
-                </span>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={page <= 1}
-                    onClick={() => {
-                      setPage(page - 1);
-                    }}
-                  >
-                    <ArrowLeft className="size-4" aria-hidden="true" />
-                    Previous
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={page >= totalPages}
-                    onClick={() => {
-                      setPage(page + 1);
-                    }}
-                  >
-                    Next
-                    <ArrowRight className="size-4" aria-hidden="true" />
-                  </Button>
-                </div>
-              </div>
-            ) : null}
-          </>
+        {articlesQuery.isSuccess && featuredArticle ? (
+          <FeaturedArticle
+            article={featuredArticle}
+            competitionId={competitionId}
+            searchParameters={searchParameters}
+          />
+        ) : null}
+
+        {articlesQuery.isSuccess ? (
+          <ArticleArchive
+            competitionId={competitionId}
+            items={archiveItems}
+            searchParameters={searchParameters}
+          />
+        ) : null}
+
+        {articlesQuery.isSuccess &&
+        articlesQuery.data.page.total > ARTICLE_PAGE_SIZE ? (
+          <div className="mt-7 flex flex-col gap-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-muted-foreground">
+              Page {page} of {totalPages} · {articlesQuery.data.page.total}{" "}
+              articles
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage(page - 1)}
+              >
+                <ArrowLeft className="size-4" aria-hidden="true" />
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage(page + 1)}
+              >
+                Next
+                <ArrowRight className="size-4" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
         ) : null}
       </section>
 

--- a/frontend/src/routes/generation-detail.tsx
+++ b/frontend/src/routes/generation-detail.tsx
@@ -10,7 +10,13 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { Link, useNavigate, useParams, useSearchParams } from "react-router";
+import {
+  Link,
+  Navigate,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router";
 import { toast } from "sonner";
 
 import { ApiError } from "@/api/errors";
@@ -156,6 +162,19 @@ export function Component(): React.JSX.Element {
   const progressStart = generation.started_at ?? generation.created_at;
   const submitted = generation.submitted_artifact_version_id !== null;
   const activeTab = detailTab(searchParameters.get("tab"), submitted);
+
+  if (
+    submitted &&
+    (searchParameters.get("tab") === null ||
+      searchParameters.get("tab") === "article")
+  ) {
+    return (
+      <Navigate
+        replace
+        to={`/competitions/${resolvedCompetitionId}/articles/${resolvedGenerationId}`}
+      />
+    );
+  }
 
   function selectTab(nextTab: string): void {
     const next = new URLSearchParams(searchParameters);
@@ -315,8 +334,18 @@ export function Component(): React.JSX.Element {
               </h2>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 The exact submitted artifact version is attached to this durable
-                run and available in the Article tab below.
+                run. Open the reader for the article-first view, or continue
+                below to inspect this run.
               </p>
+              <Link
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "sm" }),
+                  "mt-4",
+                )}
+                to={`/competitions/${resolvedCompetitionId}/articles/${resolvedGenerationId}`}
+              >
+                Read submitted article
+              </Link>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add a dedicated article reader route with compatibility redirects from generation detail
- make the latest article prominent and reorganize the archive around editorial metadata
- move provenance, artifacts, execution details, and usage into a Behind this article panel
- preserve article filters and paging across navigation and document the viewing contract

## Validation
- git diff --cached --check (passed before commit)
- targeted title-parsing regex smoke check (passed)
- frontend formatting, lint, typecheck, build, browser, and full-stack validation intentionally deferred per request; frontend dependencies are not installed in this worktree