### PR TITLE
Clarify reporter memory retrieval contract

### DIFF
--- a/backend/services/generations/contracts.py
+++ b/backend/services/generations/contracts.py
@@ -72,7 +72,7 @@ class GenerationModelSettings(ContractModel):
 
 class GenerationRunnerSettings(ContractModel):
     max_turns: PositiveInt = 60
-    procedure_history_mode: Literal["replace", "append"] = "replace"
+    procedure_history_mode: Literal["replace", "append"] = "append"
 
 
 class GenerationSettings(ContractModel):

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -7,6 +7,7 @@ Use this guide when the article covers several teams or weeks, a featured interp
 - The article's central framing and planned major claims have precise, relevant evidence.
 - Featured interpretations have enough targeted context to distinguish a meaningful development from a routine result.
 - Historical leads used in the article have been reverified against the frozen snapshot.
+- Recap and storyline-oriented work has tested current developments against relevant pinned memory once current evidence supplied concrete query hooks.
 - Important scores, records, player totals, transactions, and comparisons are saved as facts with the exact values the article will use.
 - No unresolved anomaly or high-value lead is likely to reverse the article's central interpretation.
 
@@ -39,9 +40,17 @@ Run independent reads together when their results do not depend on one another. 
 
 ## Memory Judgment
 
-Search memory when prior context could materially improve the article: trades and waivers, rematches and rivalries, playoff reversals, repeated lineup mistakes, focused-team histories, retrospectives, rankings, or season-long awards. For an ordinary recap, a lightweight scan is useful only when current teams, players, transactions, or stakes provide a plausible retrieval hook. Stop after an empty or low-value result unless the current evidence suggests a more specific query.
+After the broad current-week inventory, a targeted `search_memory` continuity check is normally useful for recaps and requests asking for storylines, trends, rankings, retrospectives, or season context. Build searches from current evidence:
 
-After a successful live submission, saved brief storylines and their supporting facts are bridged into memory automatically. Use `save_memory_event`, `save_team_context`, or `save_league_note` when durable event or context state should also be maintained. Memory work remains separate from proving today's article.
+- Prefer `team_keys` for current team names or roster IDs, and use exact entity keys, tags, or references only when another tool has supplied them. These are alternative discovery signals, so any one may find a candidate.
+- Use `text` only for one short lexical concept, name, phrase, or explicit `OR` set. Unquoted words are jointly required; it is not semantic search. Never pack unrelated teams, players, and themes into one text query. If distinct hooks are independently valuable, test them with separate focused calls.
+- Use `kinds`, `statuses`, and `week` only as hard filters. The `week` filter selects one exact memory week, not an at-or-before cutoff; omit it for continuity spanning prior weeks.
+- Prefer 5-10 focused results. Do not perform an unfiltered browse merely because memory exists.
+- Discard any match dated after the article's configured coverage.
+
+This is a continuity check, not a fixed research phase. Skip it when the request is purely factual and narrow or current evidence provides no plausible historical hook. Stop after an empty or low-value result unless a more specific query is justified.
+
+After a successful live submission, the runtime automatically buffers only the supporting facts referenced by final brief storylines; it does not create or update durable storyline cards. Use `upsert_storyline_memory_card` for an arc that should remain recognizable, and use `save_memory_event`, `save_storyline_trigger`, `save_team_context`, or `save_league_note` when durable event, callback, team, or league state should also be maintained. Memory work remains separate from proving today's article.
 
 ## Stop Or Switch
 

--- a/backend/services/reporter/procedures/research.md
+++ b/backend/services/reporter/procedures/research.md
@@ -40,7 +40,7 @@ Run independent reads together when their results do not depend on one another. 
 
 ## Memory Judgment
 
-After the broad current-week inventory, a targeted `search_memory` continuity check is normally useful for recaps and requests asking for storylines, trends, rankings, retrospectives, or season context. Build searches from current evidence:
+After the broad current-week inventory, do not treat the evidence base as sufficient for a recap or request asking for storylines, trends, rankings, retrospectives, or season context until one targeted `search_memory` continuity check has been attempted. Standings movement, streaks, contender or pretender judgments, repeated outcomes, transactions, matchups, and changed stakes are already plausible hooks; the purpose of search is to discover whether matching memory exists. Build searches from current evidence:
 
 - Prefer `team_keys` for current team names or roster IDs, and use exact entity keys, tags, or references only when another tool has supplied them. These are alternative discovery signals, so any one may find a candidate.
 - Use `text` only for one short lexical concept, name, phrase, or explicit `OR` set. Unquoted words are jointly required; it is not semantic search. Never pack unrelated teams, players, and themes into one text query. If distinct hooks are independently valuable, test them with separate focused calls.

--- a/backend/services/reporter/procedures/storyline.md
+++ b/backend/services/reporter/procedures/storyline.md
@@ -14,7 +14,7 @@ Use this guide when the evidence is real but the central thesis, hierarchy of an
 
 - Use `read_brief` when the current facts, callbacks, storylines, or outline are not already available in context.
 - Use a targeted datalayer call when a promising angle has one material evidence gap. Return to broader research only when the premise itself needs substantial investigation.
-- Use `search_memory` when a current team, player, transaction, matchup, or stake creates a specific historical question.
+- For recaps and requests about storylines, trends, rankings, or retrospectives, use `search_memory` after current evidence reveals a concrete team, player, transaction, matchup, or stakes hook. Prefer structured team keys; when lexical text is needed, test one focused concept or explicit alternative set rather than packing unrelated names into one query. Skip it for purely narrow factual work, and discard matches dated after the configured coverage.
 - Use `save_storyline` for developed narrative angles supported by saved fact IDs.
 - Use `save_memory_callback` only after the older event and current payoff both exist as reverified facts.
 - Use `set_outline` when explicit structure will improve emphasis, coverage, or drafting. An outline is optional and revisable.
@@ -34,7 +34,7 @@ Use this guide when the evidence is real but the central thesis, hierarchy of an
 
 ## Continuity Judgment
 
-After a successful live submission, the runtime automatically bridges saved brief storylines and their supporting facts into memory. Use `upsert_storyline_memory_card` to maintain the durable narrative state of an arc when a future generation could usefully recognize its next payoff or reversal. Relevant examples include trade evaluations, revenge or rematch conditions, playoff reversals, recurring lineup mistakes, waiver payoffs, and rivalry escalation. Add a trigger only when a specific future condition would make the arc useful again.
+After a successful live submission, the runtime automatically buffers the supporting facts referenced by final brief storylines, but it does not persist the storyline card itself. Use `upsert_storyline_memory_card` to maintain the durable narrative state of an arc when a future generation could usefully recognize its next payoff or reversal. Relevant examples include trade evaluations, revenge or rematch conditions, playoff reversals, recurring lineup mistakes, waiver payoffs, and rivalry escalation. Add a trigger only when a specific future condition would make the arc useful again.
 
 ## Stop Or Switch
 

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -27,7 +27,7 @@ Work on whichever unmet goal has the greatest effect on accuracy or reader value
 - **Find the meaning:** identify the strongest supported thesis, tensions, callbacks, consequences, and stakes.
 - **Shape the article:** produce a coherent opening, progression, emphasis, and conclusion in the requested voice.
 - **Earn publication confidence:** audit the actual draft, repair material gaps or errors, and submit only the current verified revision.
-- **Preserve useful continuity:** when an arc has plausible future value, buffer concise typed memory proposals without confusing persistence work with article readiness.
+- **Use and preserve useful continuity:** for recaps and requests about storylines, trends, rankings, or retrospectives, test current developments with a targeted `search_memory` call after current evidence supplies a concrete team, entity, transaction, matchup, or narrative hook. Skip this continuity check for purely narrow factual requests. Reverify useful leads, and when an arc has plausible future value, preserve its concise durable state without confusing persistence work with article readiness.
 
 After meaningful evidence or drafting work, reassess the most important remaining uncertainty. Drafting may expose research gaps; verification may expose weak framing; new evidence may change the outline. Follow the highest-value lead instead of preserving a stale plan.
 
@@ -44,12 +44,12 @@ Procedures are on-demand guides, not workflow stages or progress requirements. T
 ## Tool And State Map
 
 - Use datalayer tools for Sleeper league facts. Prefer the smallest result that can resolve the current material uncertainty, and avoid overlapping broad calls that mostly repeat evidence already in context.
-- Use `search_memory` for relevant historical narrative leads at the pinned revision. Verify useful matches with datalayer tools.
+- Use `search_memory` for relevant historical narrative leads at the pinned revision. Prefer structured team keys or exact entities when available. Its `text` field is lexical web search, not semantic search: use one short concept, name, phrase, or explicit `OR` set per call, never a bag of unrelated keywords. `kinds`, `statuses`, and exact `week` narrow every result; omit `week` when searching continuity across weeks. For recap and storyline-oriented work, make a targeted search part of establishing context after current evidence reveals a useful hook. Do not perform an unfiltered browse merely because memory exists, and do not use matches dated after the configured coverage. Verify useful matches with datalayer tools.
 - Use `save_fact`, `save_memory_callback`, `save_storyline`, `set_outline`, and `read_brief` for structured working state.
 - `research_brief.md` is a runtime-managed projection. Never create, edit, or submit it with generic artifact tools.
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` for publishable Markdown. Reuse content and revisions returned by successful operations; reread only when state is unknown or a full-document review is useful.
 - Every edit is an exact single-match replacement. Do not make a no-op edit when the draft already says what it should say.
-- After a successful live submission, the runtime automatically bridges saved brief storylines and their supporting facts into memory. Use semantic memory tools to maintain the durable narrative state around that evidence: `save_memory_event` for an event, `upsert_storyline_memory_card` for an arc's ongoing state, `save_storyline_trigger` for a future callback condition, `save_team_context` for team-specific context, and `save_league_note` for league-wide context. Buffered writes are not visible to `search_memory` during the same run.
+- After a successful live submission, the runtime automatically buffers only the supporting facts referenced by final brief storylines. It does not create or update durable storyline cards. Use semantic memory tools to maintain narrative state around that evidence: `save_memory_event` for an event, `upsert_storyline_memory_card` for an arc's ongoing state, `save_storyline_trigger` for a future callback condition, `save_team_context` for team-specific context, and `save_league_note` for league-wide context. Buffered writes are not visible to `search_memory` during the same run.
 - `article.md` is the default publishable path, not a required application identity.
 
 ## Article Quality

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -27,7 +27,7 @@ Work on whichever unmet goal has the greatest effect on accuracy or reader value
 - **Find the meaning:** identify the strongest supported thesis, tensions, callbacks, consequences, and stakes.
 - **Shape the article:** produce a coherent opening, progression, emphasis, and conclusion in the requested voice.
 - **Earn publication confidence:** audit the actual draft, repair material gaps or errors, and submit only the current verified revision.
-- **Use and preserve useful continuity:** for recaps and requests about storylines, trends, rankings, or retrospectives, test current developments with a targeted `search_memory` call after current evidence supplies a concrete team, entity, transaction, matchup, or narrative hook. Skip this continuity check for purely narrow factual requests. Reverify useful leads, and when an arc has plausible future value, preserve its concise durable state without confusing persistence work with article readiness.
+- **Use and preserve useful continuity:** for recaps and requests about storylines, trends, rankings, or retrospectives, the evidence base is incomplete until you attempt one targeted `search_memory` call after the current inventory. Standings movement, streaks, contender or pretender judgments, repeated outcomes, transactions, matchups, and changed stakes are already valid hooks; do not require advance knowledge that matching memory exists. Skip only when the request is purely factual and narrow or current evidence offers no plausible continuity question. Reverify useful leads, and when an arc has plausible future value, preserve its concise durable state without confusing persistence work with article readiness.
 
 After meaningful evidence or drafting work, reassess the most important remaining uncertainty. Drafting may expose research gaps; verification may expose weak framing; new evidence may change the outline. Follow the highest-value lead instead of preserving a stale plan.
 
@@ -39,7 +39,7 @@ Load a procedure when its detailed editorial guidance would materially help an u
 - `drafting` supports sustained composition, revision, voice, and proportional coverage.
 - `verification` supports claim-level audit, correction, and publication readiness.
 
-Procedures are on-demand guides, not workflow stages or progress requirements. They may be loaded in any order, revisited, or skipped when their outcome is already clear. Do not load a guide merely to announce a phase, and do not avoid a useful guide merely to save a turn.
+Procedures are on-demand guides, not workflow stages or progress requirements. They may be loaded in any order, combined, revisited, or skipped when their outcome is already clear. Do not load a guide merely to announce a phase, and do not avoid a useful guide merely to save a turn.
 
 ## Tool And State Map
 

--- a/backend/services/reporter/runner/state.py
+++ b/backend/services/reporter/runner/state.py
@@ -330,7 +330,7 @@ class ProcedureState(BaseModel):
 
 class RunnerConfig(BaseModel):
     max_turns: int = 60
-    procedure_history_mode: ProcedureHistoryMode = ProcedureHistoryMode.REPLACE
+    procedure_history_mode: ProcedureHistoryMode = ProcedureHistoryMode.APPEND
 
 
 __all__ = [

--- a/backend/services/reporter/runner/tools/memory_tools.py
+++ b/backend/services/reporter/runner/tools/memory_tools.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from backend.services.datalayer import FrozenLeagueData
 
 
-MEMORY_TOOL_IMPLEMENTATION_VERSION = "2"
+MEMORY_TOOL_IMPLEMENTATION_VERSION = "3"
 _READ_TOOL = "search_memory"
 _WRITE_TOOLS = (
     "save_memory_event",
@@ -131,18 +131,91 @@ class ReporterTriggerContent(_StrictModel):
 
 
 class SearchMemoryArgs(_StrictModel):
-    text: str | None = None
-    team_keys: list[str] = Field(default_factory=list)
-    entity_keys: list[str] = Field(default_factory=list)
-    evidence_version_ids: list[UUID] = Field(default_factory=list)
-    related_item_ids: list[UUID] = Field(default_factory=list)
-    tags: list[str] = Field(default_factory=list)
-    kinds: list[MemoryKind] = Field(default_factory=list)
-    statuses: list[str] = Field(default_factory=list)
-    week: int | None = Field(default=None, ge=0)
-    limit: int = Field(default=20, ge=1, le=100)
-    expand_exact_references: bool = False
-    expand_stable_references: bool = False
+    text: str | None = Field(
+        default=None,
+        description=(
+            "Optional PostgreSQL web-style lexical search, not semantic search. "
+            "Unquoted terms are jointly required. Keep one short concept, name, "
+            "or phrase per call; use quotes for a phrase, OR for explicit "
+            "alternatives, and -term to exclude a term. Do not concatenate "
+            "unrelated teams, players, and themes."
+        ),
+    )
+    team_keys: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Current team names or roster IDs. Each is resolved internally to "
+            "canonical franchise and season-roster keys; matching any key can "
+            "discover a memory."
+        ),
+    )
+    entity_keys: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Exact canonical entity keys already returned by another tool or memory "
+            "result. Matching any key can discover a memory. Prefer team_keys for "
+            "ordinary team names or roster IDs."
+        ),
+    )
+    evidence_version_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "Exact memory evidence-version IDs from an earlier result. Matching any "
+            "ID can discover a memory."
+        ),
+    )
+    related_item_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "Exact stable memory-item IDs from an earlier result. Matching any ID "
+            "can discover a related memory."
+        ),
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Exact memory tags; matching any tag can discover a memory.",
+    )
+    kinds: list[MemoryKind] = Field(
+        default_factory=list,
+        description=(
+            "Optional hard filter. Returned memories must have one of these kinds."
+        ),
+    )
+    statuses: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional hard filter. Returned memories must have one of these exact "
+            "statuses. Status vocabulary depends on memory kind."
+        ),
+    )
+    week: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Optional hard filter for one exact memory week. This is not an "
+            "at-or-before cutoff. Omit it when searching continuity across weeks."
+        ),
+    )
+    limit: int = Field(
+        default=10,
+        ge=1,
+        le=25,
+        description="Maximum hydrated matches to return; prefer 5-10 focused results.",
+    )
+    expand_exact_references: bool = Field(
+        default=False,
+        description=(
+            "Also hydrate exact evidence linked from matching storylines and "
+            "originating events linked from matching facts."
+        ),
+    )
+    expand_stable_references: bool = Field(
+        default=False,
+        description=(
+            "Also hydrate visible storyline or event items referenced by matching "
+            "storylines and triggers."
+        ),
+    )
 
 
 class SaveMemoryEventArgs(_StrictModel):
@@ -221,9 +294,13 @@ def _tool(name: str, description: str, arguments: type[BaseModel]) -> ToolDef:
 MEMORY_TOOL_SPECS: list[ToolDef] = [
     _tool(
         _READ_TOOL,
-        "Search fully hydrated canonical memory at this generation's pinned revision. "
-        "Returned memories are research leads and must be verified against frozen "
-        "data.",
+        "Search fully hydrated canonical memory at this generation's pinned "
+        "revision. Text, entity/team keys, references, and tags are alternative "
+        "discovery signals: matching any one can discover a memory. Kinds, statuses, "
+        "and exact week are hard filters applied to every result. With no discovery "
+        "signal, the tool browses memories allowed by those filters. Text is lexical "
+        "web search, not semantic search; see the text field for syntax. Returned "
+        "memories are research leads and must be verified against frozen data.",
         SearchMemoryArgs,
     ),
     _tool(

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -386,6 +386,10 @@ def _request(kind: GenerationKind = GenerationKind.LIVE) -> GenerationRequest:
     )
 
 
+def test_generation_settings_default_to_append_procedure_history() -> None:
+    assert GenerationSettings().runner.procedure_history_mode == "append"
+
+
 def _service(
     tmp_path: Path,
     *,

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -284,12 +284,17 @@ def test_prompt_and_procedure_assets_document_intentional_artifact_divergence() 
     assert "## Article Quality" in system_prompt
     assert "materially improve factual confidence" in system_prompt
     assert "make a targeted search part of establishing context" in system_prompt
+    assert "the evidence base is incomplete until you attempt" in system_prompt
+    assert "do not require advance knowledge" in system_prompt
+    assert "They may be loaded in any order, combined, revisited" in system_prompt
     assert "lexical web search, not semantic search" in system_prompt
     assert "never a bag of unrelated keywords" in system_prompt
     assert "It does not create or update durable storyline cards" in system_prompt
 
     research = (copied / "procedures/research.md").read_text(encoding="utf-8")
     assert "After the broad current-week inventory" in research
+    assert "do not treat the evidence base as sufficient" in research
+    assert "the purpose of search is to discover" in research
     assert "skip it when the request is purely factual and narrow" in research.lower()
     assert "prefer 5-10 focused results" in research.lower()
     assert "Unquoted words are jointly required" in research

--- a/backend/tests/services/reporter/test_characterization.py
+++ b/backend/tests/services/reporter/test_characterization.py
@@ -283,6 +283,22 @@ def test_prompt_and_procedure_assets_document_intentional_artifact_divergence() 
     )
     assert "## Article Quality" in system_prompt
     assert "materially improve factual confidence" in system_prompt
+    assert "make a targeted search part of establishing context" in system_prompt
+    assert "lexical web search, not semantic search" in system_prompt
+    assert "never a bag of unrelated keywords" in system_prompt
+    assert "It does not create or update durable storyline cards" in system_prompt
+
+    research = (copied / "procedures/research.md").read_text(encoding="utf-8")
+    assert "After the broad current-week inventory" in research
+    assert "skip it when the request is purely factual and narrow" in research.lower()
+    assert "prefer 5-10 focused results" in research.lower()
+    assert "Unquoted words are jointly required" in research
+    assert "Never pack unrelated teams" in research
+    assert "not an at-or-before cutoff" in research
+    assert "it does not create or update durable storyline cards" in research
+
+    storyline = (copied / "procedures/storyline.md").read_text(encoding="utf-8")
+    assert "it does not persist the storyline card itself" in storyline
 
 
 def test_generator_preserves_article_result_across_artifact_contract_divergence() -> None:

--- a/backend/tests/services/reporter/test_memory_tools.py
+++ b/backend/tests/services/reporter/test_memory_tools.py
@@ -250,6 +250,26 @@ def test_registers_legacy_semantic_surface() -> None:
     ]
 
 
+def test_search_schema_explains_discovery_filters_and_lexical_syntax() -> None:
+    search = next(
+        spec["function"]
+        for spec in MEMORY_TOOL_SPECS
+        if spec["function"]["name"] == "search_memory"
+    )
+    description = search["description"]
+    properties = search["parameters"]["properties"]
+
+    assert MEMORY_TOOL_IMPLEMENTATION_VERSION == "3"
+    assert "alternative discovery signals" in description
+    assert "hard filters" in description
+    assert "not semantic search" in properties["text"]["description"]
+    assert "OR for explicit alternatives" in properties["text"]["description"]
+    assert "team names or roster IDs" in properties["team_keys"]["description"]
+    assert "one exact memory week" in properties["week"]["description"]
+    assert properties["limit"]["default"] == 10
+    assert properties["limit"]["maximum"] == 25
+
+
 def test_search_remains_pinned_and_resolves_team_keys() -> None:
     registry, _, memory, retrieval, _ = _registered()
     result = _call(registry, "search_memory", text="push", team_keys=["Team Taco"])
@@ -258,6 +278,7 @@ def test_search_remains_pinned_and_resolves_team_keys() -> None:
         f"franchise:{TACO_FRANCHISE_ID}",
         f"season_roster:{TACO_ROSTER_ID}",
     )
+    assert retrieval.calls[0].query.limit == 10
 
 
 def test_legacy_writes_buffer_typed_proposals() -> None:

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -22,7 +22,6 @@ from backend.services.reporter.runner.recording import (
 from backend.services.reporter.runner.runner import Runner, RunnerRecordingError
 from backend.services.reporter.runner.state import (
     ArtifactStore,
-    ProcedureHistoryMode,
     RunnerConfig,
 )
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
@@ -891,7 +890,7 @@ def test_runner_procedure_replacement() -> None:
     )
 
 
-def test_runner_procedure_append_mode() -> None:
+def test_runner_appends_procedure_history_by_default() -> None:
     complete = FakeCompletion(
         [
             make_response(
@@ -910,7 +909,7 @@ def test_runner_procedure_append_mode() -> None:
     runner = Runner(
         registry_with("load_procedure", lambda *, name: f"# {name.title()}"),
         complete=complete,
-        config=RunnerConfig(procedure_history_mode=ProcedureHistoryMode.APPEND),
+        config=RunnerConfig(),
     )
 
     run(runner.run("system", "user"))

--- a/backend/tests/services/reporter/test_schemas.py
+++ b/backend/tests/services/reporter/test_schemas.py
@@ -180,4 +180,4 @@ def test_state_defaults() -> None:
     assert ArtifactStore().artifacts == {}
     assert ProcedureState().active is None
     assert RunnerConfig().max_turns == 60
-    assert RunnerConfig().procedure_history_mode == ProcedureHistoryMode.REPLACE
+    assert RunnerConfig().procedure_history_mode == ProcedureHistoryMode.APPEND

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -65,6 +65,14 @@ This is not the separate M2 curation pass.
   existing deterministic validator/finalizer and never writes memory directly.
 - Reporter memory search remains available during research; curation is not a
   substitute for loading relevant historical context.
+- Recaps and other storyline-oriented requests test current developments against
+  pinned memory with a targeted search once current evidence supplies concrete
+  team, player, transaction, matchup, or stakes hooks. Purely narrow factual
+  requests may skip that continuity check.
+- Memory retrieval exposes structured discovery keys and a lexical web-search
+  field. The lexical field is not semantic search: one focused concept or explicit
+  alternative set belongs in each query, while kind, status, and exact week are
+  narrowing filters.
 - Style and bias are initialized from `ReportConfig` and remain immutable within
   the brief; the agent does not spend turns restating them.
 - Submission requires at least one verified fact. Storyline, callback, and outline
@@ -73,6 +81,7 @@ This is not the separate M2 curation pass.
   operations and optimistic revision checks remain internal to the adapter.
 - After a successful live submission, supporting facts for every final brief
   storyline are buffered automatically; unreferenced brief facts stay run-local.
+  The bridge does not create or update durable storyline cards.
 - Backtests preserve the legacy read-only behavior: memory reads remain available,
   while write tools and the successful-submit bridge do not buffer mutations.
 

--- a/docs/reporter-research-pipeline/README.md
+++ b/docs/reporter-research-pipeline/README.md
@@ -66,9 +66,15 @@ This is not the separate M2 curation pass.
 - Reporter memory search remains available during research; curation is not a
   substitute for loading relevant historical context.
 - Recaps and other storyline-oriented requests test current developments against
-  pinned memory with a targeted search once current evidence supplies concrete
-  team, player, transaction, matchup, or stakes hooks. Purely narrow factual
-  requests may skip that continuity check.
+  pinned memory with a targeted search before their evidence base is considered
+  sufficient. Standings movement, streaks, contender or pretender judgments,
+  repeated outcomes, transactions, matchups, and changed stakes are concrete
+  hooks; the reporter need not know in advance that matching memory exists.
+  Purely narrow factual requests or current evidence with no plausible continuity
+  question may skip that check.
+- Procedure history defaults to append so every useful guide loaded during a
+  response remains available on later turns. Replace history remains an explicit
+  opt-in for runs that need aggressive procedure-context compaction.
 - Memory retrieval exposes structured discovery keys and a lexical web-search
   field. The lexical field is not semantic search: one focused concept or explicit
   alternative set belongs in each query, while kind, status, and exact week are

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -128,6 +128,27 @@ item or a no-op result instead of adding a duplicate.
   the model to supply an optimistic revision number.
 - Successful live submission bridges supporting facts for every final brief
   storyline and no unreferenced fact.
+- A recap, storyline, trend, ranking, or retrospective request performs a
+  targeted continuity search after current evidence supplies concrete query
+  hooks, unless the request is purely factual and narrow. This is prompt-owned
+  behavior, not a runner gate or fixed workflow phase.
+- `search_memory` discovery signals are alternatives: lexical text, entity/team
+  keys, exact references, and tags can each discover a candidate. Kind, status,
+  and week are hard filters applied to every candidate. A query without discovery
+  signals browses only the rows allowed by those filters.
+- The text field is PostgreSQL web-style lexical search, not semantic retrieval.
+  Unquoted terms are jointly required; quoted phrases, explicit `OR`, and negation
+  follow web-search syntax. A call should test one short concept, name, phrase, or
+  explicit alternative set rather than concatenate unrelated hooks. Because some
+  automatically bridged facts are text-only, a focused lexical query remains a
+  valid fallback when no structured key is available.
+- Team keys accept a current team name or roster ID and are resolved internally.
+  The optional week filter means one exact week and must not be treated as an
+  at-or-before cutoff. Continuity searches spanning prior weeks omit it and reject
+  returned memories beyond configured article coverage.
+- Retrieved matches dated after the configured coverage remain unusable, and the
+  supporting-fact bridge never substitutes for explicitly maintaining a durable
+  storyline card.
 
 ## M1 Error Semantics
 
@@ -176,6 +197,10 @@ Focused tests must cover:
 - current memory finalization compatibility;
 - semantic memory create and stable-ID update behavior;
 - deterministic successful-submit fact bridging and stable-ID idempotency; and
+- prompt characterization for targeted continuity search and explicit bridge
+  boundaries; and
+- model-facing search schema coverage for lexical syntax, structured discovery,
+  hard filters, exact-week behavior, and result bounds; and
 - failed-run rollback and read-only backtests that leave canonical revision state
   unchanged.
 

--- a/docs/reporter-research-pipeline/application-contracts.md
+++ b/docs/reporter-research-pipeline/application-contracts.md
@@ -129,9 +129,16 @@ item or a no-op result instead of adding a duplicate.
 - Successful live submission bridges supporting facts for every final brief
   storyline and no unreferenced fact.
 - A recap, storyline, trend, ranking, or retrospective request performs a
-  targeted continuity search after current evidence supplies concrete query
-  hooks, unless the request is purely factual and narrow. This is prompt-owned
-  behavior, not a runner gate or fixed workflow phase.
+  targeted continuity search before its evidence base is considered sufficient,
+  unless the request is purely factual and narrow or current evidence offers no
+  plausible continuity question. Current standings movement, streaks, contender
+  or pretender judgments, repeated outcomes, transactions, matchups, and changed
+  stakes are sufficient hooks; advance knowledge of a stored callback is not
+  required. This is prompt-owned behavior, not a runner gate or fixed workflow
+  phase.
+- Procedure history defaults to append, preserving all useful guide results across
+  turns even when several procedures are loaded together. Replace history remains
+  an explicit opt-in for runs that prefer aggressive procedure-context compaction.
 - `search_memory` discovery signals are alternatives: lexical text, entity/team
   keys, exact references, and tags can each discover a candidate. Kind, status,
   and week are hard filters applied to every candidate. A query without discovery

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -2269,7 +2269,7 @@ export interface components {
             max_turns: number;
             /**
              * Procedure History Mode
-             * @default replace
+             * @default append
              * @enum {string}
              */
             procedure_history_mode: "replace" | "append";

--- a/frontend/src/features/generations/draft.ts
+++ b/frontend/src/features/generations/draft.ts
@@ -335,7 +335,7 @@ export function createGenerationFormDefaults(
       fallbackModels: [],
       retry: { maxRetries: 3, baseDelaySeconds: 1, maxDelaySeconds: 30 },
     },
-    runner: { maxTurns: 60, procedureHistoryMode: "replace" },
+    runner: { maxTurns: 60, procedureHistoryMode: "append" },
   };
 }
 


### PR DESCRIPTION
## Summary

- make targeted continuity checks the prompt-level default for recap and storyline-oriented requests
- define `search_memory` v3 lexical, structured-discovery, hard-filter, exact-week, expansion, and result-bound semantics in the model-facing schema
- steer the reporter toward team keys and focused lexical queries instead of unrelated keyword bags
- clarify that the automatic bridge persists supporting facts, not durable storyline cards
- default procedure history to append across generation settings, direct runner use, and the frontend while retaining replace as an explicit option

## Live diagnosis

The initial prompt correction produced a `search_memory` call, but the model combined unrelated names into one PostgreSQL web-search query and applied an exact week filter, producing zero results. A later skipped search was traced to several procedures being loaded together under replace history, which discarded the research guide before the following turn.

This PR makes current retrieval behavior explicit and preserves every useful loaded guide by default. It does not add a runtime search gate or change canonical search internals. Replace history remains available for runs that intentionally prefer aggressive procedure-context compaction.

Concurrent live generations can still fail finalization when another run advances the pinned canonical revision. That behavior is deliberately deferred from this PR.

## Verification

- 106 focused reporter, memory-tool, generation, manifest, procedure, schema, integration, and runner tests passed
- frontend generated API schema check passed
- frontend TypeScript typecheck passed
- `git diff --check` passed; only expected Windows line-ending notices were emitted
- Supabase-backed API had previously been verified live with memory tool version 3 and healthy live/ready endpoints
