### PR TITLE
PR0: Design reporter memory recall and closeout

### DIFF
--- a/docs/reporter-memory-refactor/README.md
+++ b/docs/reporter-memory-refactor/README.md
@@ -1,0 +1,65 @@
+
+# Reporter Memory Recall and Closeout Refactor
+
+**Status:** Proposed
+**Feature key:** `reporter-memory-refactor`
+
+## Purpose
+
+Make reporter memory useful throughout article generation. The reporter receives concise semantic memory, automatically sees due callbacks and applicable context notes, and completes a mandatory memory-closeout procedure after submitting the article. Tool-call records preserve the exact result returned to the reporter while storing application-only metadata separately.
+
+## Scope
+
+- Redesign model-facing memory search inputs and results around editorial relevance.
+- Introduce a generic tool execution result that separates `result` from `metadata`.
+- Persist the logical result, its exact serialized model message, and application-only metadata as separate tool-call fields.
+- Add an automatic recall prelude for due triggers and scoped context notes.
+- Force the same reporter agent into a memory-closeout procedure after article submission.
+- Retire automatic structured-brief fact persistence once closeout owns durable memory selection.
+- Add harness measurements for recall, use, saving, and later reuse.
+
+The canonical memory store remains responsible for identity, revisions, evidence receipts, and conflict detection. This feature changes how that state is presented and maintained, not the fundamental storage model.
+
+## Documents
+
+| Document | Owns |
+| --- | --- |
+| [`architecture.md`](architecture.md) | Component boundaries, generation and closeout flow, failures, and observability |
+| [`application-contracts.md`](application-contracts.md) | Tool results, model-visible memory schemas, lifecycle, and acceptance coverage |
+
+Related upstream contracts:
+
+- [`../memory/application-contracts.md`](../memory/application-contracts.md)
+- [`../memory/retrieval.md`](../memory/retrieval.md)
+- [`../memory/lifecycle.md`](../memory/lifecycle.md)
+- [`../reporter-research-pipeline/README.md`](../reporter-research-pipeline/README.md)
+- [`../reporter-research-pipeline/application-contracts.md`](../reporter-research-pipeline/application-contracts.md)
+
+## Settled Direction
+
+- Model-facing memory payloads contain semantic editorial context only. They omit canonical IDs, version IDs, revision numbers, creation or recording timestamps, competition IDs, hashes, ranking scores, matched keys, and projection diagnostics.
+- Handlers may return an internal `ToolExecutionResult(result, metadata)`. Only `result` is serialized into the model conversation. Plain handler return values remain supported and imply empty metadata.
+- The saved `ToolCall` uses the first-class fields `arguments`, `result`, `result_text`, `metadata`, `status`, `duration_ms`, and `error`, alongside call identity and implementation fields. Tool-specific private details remain nested under `metadata`.
+- Memory search accepts editorial filters such as text, teams, kinds, status, tags, temporal bounds, and limit. Canonical identifier filters are internal concerns and are removed from model-facing schemas.
+- A deterministic application-owned recall prelude automatically supplies due triggers and scoped context notes before research begins. The model does not need to remember to discover them.
+- The same reporter agent owns research, article writing, and memory closeout. Submission freezes the selected article revision and supplies the mandatory closeout procedure instead of terminating the runner.
+- The tool list remains unchanged for the entire conversation. Procedures guide behavior; they do not grant or revoke tools.
+- `complete_memory_review` terminates the run after the agent has saved useful memory or deliberately chosen a no-op.
+- Live generation commits the closeout's buffered memory proposals through the existing generation finalization path. Backtests keep memory writes disabled.
+- The automatic structured-brief fact bridge is retired once memory closeout is proven.
+
+## Non-Goals
+
+- Replacing the canonical memory database schema or revision model.
+- Exposing raw search documents, vectors, or retrieval diagnostics to the writer.
+- Asking models to manage database IDs, revisions, receipts, or transaction boundaries.
+- Parsing Markdown articles to infer memory when a structured brief and generation artifacts already exist.
+- Restoring legacy dual-write behavior.
+- Dynamically changing the available tool list or adding a runner-level tool-permission system.
+- Creating a separate curator model, curation packet, curation-attempt resource, or second generation service workflow.
+- Allowing the closeout procedure to modify the finalized article.
+
+## Deferred Decisions
+
+- Whether evidence later justifies a separate curator rather than same-agent closeout.
+- Whether embeddings materially improve retrieval after semantic presentation and recall coverage are fixed.

--- a/docs/reporter-memory-refactor/application-contracts.md
+++ b/docs/reporter-memory-refactor/application-contracts.md
@@ -1,0 +1,228 @@
+
+# Reporter Memory Recall and Closeout Refactor Application Contracts
+
+## Vocabulary and Ownership
+
+- **Result:** the logical tool value returned to the reporter. The tool owns its shape.
+- **Result text:** the exact serialized string placed in the model conversation for a tool result.
+- **Metadata:** application-only identity, provenance, ranking, binding, and diagnostic data for a tool execution. It is never returned to the reporter.
+- **Presentation:** a bounded transformation from canonical memory records into a semantic result plus metadata.
+- **Recall prelude:** application-selected semantic memory supplied when a memory-enabled generation starts.
+- **Memory closeout:** the mandatory post-submit procedure performed by the same reporter agent before the runner terminates.
+
+## Public Contracts
+
+### Internal tool execution result
+
+Handlers that need application-only metadata return:
+
+```python
+@dataclass(frozen=True)
+class ToolExecutionResult:
+    result: JsonValue | str
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
+```
+
+The wrapper is runner infrastructure and is never serialized wholesale. The runner performs the equivalent of:
+
+```python
+execution_result = handler(**arguments)
+model_message = serialize(execution_result.result)
+
+saved_tool_call.result = execution_result.result
+saved_tool_call.result_text = model_message
+saved_tool_call.metadata = execution_result.metadata
+```
+
+Existing tools may continue returning a plain JSON-compatible value or string. The runner normalizes that value to `ToolExecutionResult(result=value, metadata={})`.
+
+### Saved `ToolCall`
+
+The saved resource and reporting API expose these stable fields:
+
+```json
+{
+  "id": "7b36911d-8bd4-4a99-b18a-a25a1808096a",
+  "generation_id": "284a799a-d313-442f-b961-017508ac162e",
+  "turn_number": 6,
+  "tool_ordinal": 0,
+  "tool_name": "search_memory",
+  "implementation_version": "semantic-memory-v1",
+  "arguments": {
+    "text": "Waffle House scoring decline",
+    "kinds": ["storyline", "trigger"],
+    "limit": 5
+  },
+  "result": {
+    "memories": [
+      {
+        "kind": "storyline",
+        "headline": "Waffle House keeps escaping disaster",
+        "summary": "Three narrow wins have hidden a declining scoring trend.",
+        "status": "active",
+        "subjects": ["Waffle House"],
+        "callback_condition": "Revisit after their next loss."
+      }
+    ],
+    "truncated": false
+  },
+  "result_text": "{\"memories\":[...],\"truncated\":false}",
+  "metadata": {
+    "pinned_memory_revision": 18,
+    "candidate_count": 14,
+    "bindings": [
+      {
+        "result_ordinal": 0,
+        "item_id": "f93e441b-4ea4-4c14-a26f-c8c676af3c47",
+        "version_id": "dca2901d-7990-4dad-b173-d75605ba382a",
+        "item_revision": 6,
+        "retrieval_score": 0.84721
+      }
+    ]
+  },
+  "status": "succeeded",
+  "duration_ms": 42,
+  "error": null
+}
+```
+
+The contract is:
+
+- `result` is exactly the logical value returned to the reporter.
+- `result_text` is exactly the serialized string placed in the model conversation. It also supports Markdown and plain-string tool results.
+- `metadata` is never returned to the reporter.
+- `tool_name`, `implementation_version`, `arguments`, `result`, `result_text`, `status`, `duration_ms`, and `error` remain first-class fields shared by all tools.
+- Tool-specific private values belong under `metadata`; no separate per-key metadata fields are introduced.
+
+Repository implementations may map structured fields to JSONB columns, but domain and API names remain `arguments`, `result`, and `metadata`.
+
+### Model-facing memory search
+
+The writer-facing search accepts only editorial selectors:
+
+```python
+class MemorySearchArgs(BaseModel):
+    text: str | None = None
+    team_keys: list[str] = []
+    tags: list[str] = []
+    kinds: list[MemoryKind] = []
+    statuses: list[str] = []
+    week_from: int | None = None
+    week_to: int | None = None
+    limit: int = 8
+    include_evidence: bool = True
+    include_related: bool = True
+```
+
+Canonical item IDs, version IDs, entity IDs, related-item IDs, evidence-version IDs, and expected revisions are not model-facing search inputs. Temporal bounds are inclusive. Server-side league and season scope is mandatory and implicit.
+
+The logical tool `result` has the semantic shape:
+
+```python
+class MemorySearchContext(BaseModel):
+    memories: list[MemoryContext]
+    notice: str | None = None
+    truncated: bool = False
+```
+
+Each memory kind exposes only fields useful to writing:
+
+- **Storyline:** headline, summary, status, salience, arc type, human-readable subjects, tags, callback condition, bounded semantic evidence, related-memory summaries, and relevant week.
+- **Fact:** claim, category, important numbers, confidence, status, human-readable subjects, and relevant week.
+- **Event:** event type, headline, summary, salience, confidence, status, human-readable participants/assets, and relevant week.
+- **Trigger:** trigger type, status, fire policy, condition summary, due week or due time, and linked-memory summaries.
+- **Context note:** scope label, narrative, outlook, status, and tags.
+
+No model-facing result contains canonical IDs, version IDs, revisions, creation/recording timestamps, competition IDs, content hashes, rank scores, matched keys, raw rank components, or projection details.
+
+The paired `metadata` may contain:
+
+- presentation schema and builder versions
+- pinned memory revision and resolved scope/query
+- candidate, returned, omitted, and truncation counts
+- canonical bindings by stable result ordinal
+- item/version IDs, agent keys, expected revisions, matched keys and reasons, rank components, and omitted-field diagnostics
+
+### Recall prelude
+
+Generation-start recall consumes generation scope, request intent, snapshot week, and pinned memory revision. The reporter receives only semantic context grouped into due callbacks, standing context, and likely relevant memories. Canonical bindings and selection diagnostics remain metadata.
+
+Trigger evaluation is deterministic. A trigger is due according to its stored fire policy and current generation scope, not because the writer happened to search for or interpret it.
+
+### Memory closeout procedure
+
+After successful `submit_artifact`, its result includes the `memory_closeout` procedure as the mandatory next action. The same tool-result message remains valid conversation history; the runner does not synthesize a tool call or change the available tool definitions.
+
+The procedure requires the reporter to:
+
+- review the finalized article and verified research brief;
+- identify only information likely to improve future reporting;
+- search existing memory when useful to avoid duplicate or contradictory entries;
+- create or update appropriate facts, events, storylines, triggers, and context notes using existing semantic memory tools;
+- avoid saving article prose, style instructions, unsupported inference, or routine transient details without future narrative value;
+- save nothing when no durable memory is warranted;
+- finish by calling `complete_memory_review`.
+
+`complete_memory_review` has no required model-supplied bookkeeping fields. The application derives proposal counts and outcomes from recorded calls and the generation memory context.
+
+## Lifecycle and State Transitions
+
+The runner tracks two lifecycle facts:
+
+- `article_submitted`
+- `memory_review_completed`
+
+A memory-enabled run begins with both false. A successful `submit_artifact` sets `article_submitted`, freezes the selected artifact revision, activates the closeout procedure in the returned result, and keeps the loop running. A successful `complete_memory_review` requires `article_submitted`, sets `memory_review_completed`, and terminates the loop.
+
+The runner terminates normally only when both facts are true. The tool definitions and their ordering remain constant on every completion request. A bounded closeout allowance guarantees the reporter receives an opportunity to act even when submission occurs at the normal writing-turn limit.
+
+Live finalization consumes the existing generation memory proposal bundle. Backtest mode continues returning blocked results for memory writes and completes closeout as a no-op.
+
+## Invariants
+
+- `result` is the logical value returned to the reporter, and `result_text` is the exact serialized tool message placed in its conversation.
+- `metadata` never enters the model conversation unless a tool deliberately promotes a value into its public `result` contract.
+- Every presented canonical memory that may later be updated has a hidden, unambiguous binding in metadata.
+- All memory reads and writes remain league-and-season scoped.
+- A model cannot select a canonical record by supplying an identifier hidden from its context.
+- Due triggers and applicable context notes do not depend on an optional writer search.
+- Submission makes the selected artifact immutable before closeout begins.
+- Tool availability does not change during a run.
+- Memory closeout permits zero writes and still requires explicit completion.
+- Live generation produces zero or one canonical memory revision through the existing finalization path.
+- Backtest and simulation runs do not produce canonical memory proposals.
+
+## Error Semantics
+
+- Invalid model-facing search arguments return a bounded tool error without storage details.
+- Presentation or serialization failure fails the tool call and records diagnostics in metadata and error fields.
+- `complete_memory_review` before successful submission returns a bounded lifecycle error and does not terminate the runner.
+- Attempts to edit the submitted article retain the existing `artifact_finalized` error.
+- Reaching the closeout turn allowance without completion is recorded distinctly from successful or no-op closeout.
+- Invalid memory proposals retain existing tool and generation-finalization error behavior.
+
+## Compatibility and Transition
+
+1. Add `ToolExecutionResult` support while treating existing raw handler returns as `result` with empty metadata.
+2. Add the `result`, `result_text`, and `metadata` reporting fields. Map existing structured results to `result`, exact result strings to `result_text`, and initialize missing metadata to an empty object.
+3. Migrate memory search to semantic presentation and hidden bindings; preserve canonical store search APIs for trusted callers.
+4. Add the automatic recall prelude and deterministic trigger evaluation.
+5. Add the forced same-agent memory-closeout procedure and `complete_memory_review` terminal tool while keeping the tool schema stable.
+6. Exercise closeout with the structured-brief fact bridge disabled in controlled generations, then remove the bridge after acceptance checks pass.
+
+No compatibility layer should duplicate canonical writes. Reporting rows without metadata remain readable with an empty object.
+
+## Acceptance Coverage
+
+- Runner tests prove metadata never appears in the model tool message and raw handler returns remain compatible.
+- Recording migration/API tests prove existing rows read correctly and new rows preserve logical result, exact result text, and separate metadata.
+- Memory presentation tests assert forbidden fields are absent for every memory kind.
+- Binding tests prove every returned memory can be reconciled without exposing identity to the model.
+- Recall tests prove due triggers and scoped context notes appear without an explicit search call and respect league/season/time scope.
+- Stable-schema tests assert the same ordered tool definitions are sent before and after submission.
+- Submission tests prove the article becomes immutable, the closeout procedure appears in the actual submission result, and the runner continues.
+- Completion tests prove `complete_memory_review` cannot finish early, supports a no-op, and terminates after submission.
+- Turn-budget tests prove closeout gets its bounded opportunity after a last-turn submission.
+- Live/backtest tests prove closeout proposals use existing finalization and backtests do not mutate memory.
+- Cutover tests prove removal of structured-brief fact buffering does not duplicate closeout writes.
+- A sequential multi-week harness demonstrates at least one complete callback path: trigger saved during closeout, automatically recalled when due, used in an article, updated during closeout, and recalled later.

--- a/docs/reporter-memory-refactor/architecture.md
+++ b/docs/reporter-memory-refactor/architecture.md
@@ -1,0 +1,84 @@
+
+# Reporter Memory Recall and Closeout Refactor Architecture
+
+## Context and Goals
+
+One reporter run owns research, drafting, verification, submission, and memory closeout. Memory retrieval returns concise semantic material to the reporter while canonical identity, revisions, ranking, and diagnostics remain application-only metadata. Due triggers and applicable context notes are placed in the reporter's starting context so their use does not depend on a voluntary search.
+
+Article submission is a phase transition inside the same runner conversation. It freezes the selected artifact revision and gives the reporter a mandatory memory-closeout procedure. The reporter then uses the existing memory tools and completes the run with `complete_memory_review`.
+
+## System Boundary
+
+The refactor spans reporter tool execution and recording, memory presentation, generation-start recall, the post-submit closeout lifecycle, and the generation harness. It uses the existing canonical memory context and generation finalization path.
+
+The tool registry is built once and remains stable for every model turn. Procedures guide the reporter but do not change tool availability. The canonical memory service remains responsible for scope, identity, revisions, evidence receipts, validation, and final mutation. The reporting subsystem records what the reporter received and what only the application knew, but does not become another memory store.
+
+## Component Model
+
+- **Generation-start recall** deterministically selects due triggers, scoped context notes, and a bounded set of likely relevant memories from generation scope and current canonical state.
+- **`MemoryPresentationAdapter`** converts hydrated memory records into concise, kind-specific editorial context and produces a hidden binding map for the records it presented.
+- **`ToolExecutionResult`** is the internal runner boundary containing the logical `result` returned to the reporter and application-only `metadata`.
+- **Runner and generation recorder** serialize only `result` into the model conversation and persist `result`, `result_text`, and `metadata` as distinct tool-call fields.
+- **Reporter agent** researches current league facts, uses recalled memory for continuity, owns the structured brief and final article, and selects durable memory during closeout.
+- **`memory_closeout` procedure** tells the reporter how to review verified artifacts and save useful facts, events, storylines, triggers, and context notes without requiring any write.
+- **`complete_memory_review` tool** explicitly records completion or no-op and terminates the runner after an article has been submitted.
+- **Generation memory context** buffers semantic memory proposals throughout the run and supplies the existing finalization bundle.
+
+## Data and Control Flow
+
+1. Generation pins its Sleeper snapshot and current memory revision. Generation-start recall evaluates due triggers and selects scope-relevant context notes and bounded relevant memory.
+2. The reporter receives that semantic prelude and may call memory search during research. Each tool result contains only editorially useful content; the saved tool call separately records hidden bindings and retrieval diagnostics.
+3. The reporter builds the verified brief, drafts and verifies the article, then calls `submit_artifact`.
+4. Successful submission freezes the selected artifact revision. Its tool result also supplies the mandatory `memory_closeout` procedure, and the runner continues with the same messages, model, tool schemas, and memory context.
+5. The reporter reviews the finalized article and verified brief, searches memory when useful for reconciliation, and calls existing semantic memory tools for durable items. It may intentionally save nothing.
+6. The reporter calls `complete_memory_review`. The runner terminates only after both article submission and memory-review completion.
+7. Live generation finalization commits the submitted artifact and buffered memory proposals through the existing transaction. Backtest finalization receives no memory proposals because memory writes remain disabled.
+
+The runner always sends the same ordered tool definitions to the model. It does not remove research, artifact, or memory tools during closeout. ArtifactStore immutability prevents edits to the submitted artifact. The automatic structured-brief fact bridge is removed after the closeout path satisfies its acceptance gate.
+
+## Failure and Recovery Semantics
+
+- Generation-start recall failures degrade to an explicit empty or partial prelude and are recorded; they do not fabricate context.
+- Presentation failures fail that tool call because the exact model-visible result cannot be trusted.
+- `result`, `result_text`, and `metadata` for a tool execution are recorded coherently under the same call identity.
+- `complete_memory_review` returns an error before successful article submission and does not terminate the runner.
+- A successful `submit_artifact` does not terminate the runner. The runner guarantees a bounded closeout opportunity even when submission consumes the normal writing-turn budget.
+- If the reporter reaches the closeout limit without completing review, the run reports that explicit condition; it does not invent memory operations.
+- Trigger state changes only through a valid buffered memory proposal. Merely recalling or mentioning a trigger does not fire or resolve it.
+- Canonical revision conflicts continue to use the generation finalizer's existing failure behavior; this feature does not add a second retry or transaction layer.
+
+## Observability
+
+Every tool call records arguments, logical result, exact serialized result text, application-only metadata, status, timing, and any error. This makes it possible to reproduce what the reporter saw without leaking retrieval internals into its prompt.
+
+Generation telemetry records the submission turn, closeout start and completion turns, whether closeout completed or was a no-op, and proposed memory counts by kind and operation.
+
+The harness measures the complete memory funnel:
+
+`available -> recalled -> reverified -> used in article -> saved during closeout -> accepted -> recalled later`
+
+Coverage is segmented by memory kind, generation mode, league, season, and week. This distinguishes a retrieval failure from a presentation failure, reporter non-use, closeout omission, canonical rejection, or later recall failure.
+
+## Security and Privacy
+
+Model context is scoped to the active league and season and contains only semantic fields needed for the current editorial task. Tool metadata is trusted application data and never accepted back from the model as authority. Secrets and provider credentials are excluded from both the result and metadata.
+
+Hiding identifiers is a context-quality and trust-boundary improvement, not an authorization mechanism. League/season scoping, mutation validation, and revision checks remain mandatory server-side.
+
+## Architecture Decisions
+
+- **Semantic presentation model:** presentation DTOs are distinct from canonical records so storage evolution does not enlarge prompts.
+- **Generic result split:** `ToolExecutionResult(result, metadata)` belongs at the runner boundary because any tool may need private execution detail.
+- **Deterministic trigger evaluation:** due-ness is application behavior, not a prompt-following obligation.
+- **Ambient context notes:** applicable notes enter the recall prelude automatically because they describe standing editorial context rather than optional search hits.
+- **Same-agent closeout:** the reporter already owns the verified brief, article, and conversation context, so it performs memory selection without a second model workflow.
+- **Stable tool surface:** tools remain available and ordered identically on every completion request, preserving provider cache behavior and valid conversation history.
+- **Submission freezes content:** existing artifact immutability protects the article without a tool-permission layer.
+- **Explicit completion:** `complete_memory_review` gives the runner a reliable terminal signal and permits a deliberate no-op.
+- **One automatic write path:** after cutover, closeout replaces automatic brief-to-fact persistence.
+
+## Deferred Decisions
+
+- Initial recall budgets per memory kind.
+- Whether closeout needs more than the initial bounded turn allowance.
+- Whether measured closeout quality eventually warrants a separate curator workflow.


### PR DESCRIPTION
## Summary

- Establish PR0 design contracts for reporter memory recall and same-agent post-submit closeout.
- Define semantic memory tool results with application-only metadata.
- Define saved ToolCall fields: arguments, result, result_text, metadata, status, duration, and error.
- Keep one stable tool surface throughout the run and use complete_memory_review as the terminal signal.

## Stack

- PR0 (this PR): durable architecture and application contracts.
- PR1+: dependency-ordered implementation milestones tracked locally as rmr-1 through rmr-6.

## Verification

- Durable design whitespace and stale-terminology checks passed.
- All linked upstream design documents exist.
- No product tests were run because this PR changes documentation only.