### PR TITLE
PR1: Separate tool results from execution metadata

### DIFF
--- a/backend/database/models/reporting/calls.py
+++ b/backend/database/models/reporting/calls.py
@@ -128,6 +128,11 @@ class ToolCall(Base):
     implementation_version: Mapped[str] = mapped_column(Text, nullable=False)
     arguments_jsonb: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False)
+    result_jsonb: Mapped[Any | None] = mapped_column(JSONB, nullable=True)
+    result_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_jsonb: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
     full_result_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     structured_result_jsonb: Mapped[dict[str, Any] | list[Any] | None] = mapped_column(
         JSONB, nullable=True

--- a/backend/migrations/versions/0010_tool_result_metadata.py
+++ b/backend/migrations/versions/0010_tool_result_metadata.py
@@ -1,0 +1,76 @@
+"""Separate logical tool results from exact text and private metadata.
+
+Revision ID: 0010
+Revises: 0009
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tool_calls",
+        sa.Column(
+            "result_jsonb",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema="reporting",
+    )
+    op.add_column(
+        "tool_calls",
+        sa.Column("result_text", sa.Text(), nullable=True),
+        schema="reporting",
+    )
+    op.add_column(
+        "tool_calls",
+        sa.Column(
+            "metadata_jsonb",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        schema="reporting",
+    )
+
+    # Existing terminal rows are protected from updates. Suspend the trigger only
+    # for the deterministic compatibility backfill, then restore it in the same
+    # transactional migration.
+    op.execute(
+        "ALTER TABLE reporting.tool_calls "
+        "DISABLE TRIGGER tool_calls_protect_terminal"
+    )
+    op.execute(
+        """
+        UPDATE reporting.tool_calls
+        SET result_jsonb = CASE
+                WHEN structured_result_jsonb IS NOT NULL
+                    THEN structured_result_jsonb
+                WHEN full_result_text IS NOT NULL
+                    THEN pg_catalog.to_jsonb(full_result_text)
+                ELSE NULL
+            END,
+            result_text = full_result_text,
+            metadata_jsonb = '{}'::jsonb
+        """
+    )
+    op.execute(
+        "ALTER TABLE reporting.tool_calls "
+        "ENABLE TRIGGER tool_calls_protect_terminal"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tool_calls", "metadata_jsonb", schema="reporting")
+    op.drop_column("tool_calls", "result_text", schema="reporting")
+    op.drop_column("tool_calls", "result_jsonb", schema="reporting")

--- a/backend/resources/reporting/tool_calls/manager.py
+++ b/backend/resources/reporting/tool_calls/manager.py
@@ -107,8 +107,9 @@ class ToolCallManager:
                 )
             now = datetime.now(UTC)
             stored.status = command.status.value
-            stored.full_result_text = command.full_result_text
-            stored.structured_result_jsonb = command.structured_result
+            stored.result_jsonb = command.result
+            stored.result_text = command.result_text
+            stored.metadata_jsonb = command.metadata
             stored.error_text = command.error_text
             stored.error_jsonb = command.error
             stored.completed_at = now
@@ -212,8 +213,9 @@ def _decode(stored: StoredToolCall) -> ToolCall:
         implementation_version=stored.implementation_version,
         arguments=stored.arguments_jsonb,
         status=stored.status,
-        full_result_text=stored.full_result_text,
-        structured_result=stored.structured_result_jsonb,
+        result=stored.result_jsonb,
+        result_text=stored.result_text,
+        metadata=stored.metadata_jsonb,
         error_text=stored.error_text,
         error=stored.error_jsonb,
         started_at=cast(datetime, stored.started_at),

--- a/backend/resources/reporting/tool_calls/objects.py
+++ b/backend/resources/reporting/tool_calls/objects.py
@@ -41,8 +41,9 @@ class BeginToolCall(ContractModel):
 class FinishToolCall(ContractModel):
     tool_call_id: UUID
     status: ToolCallTerminalStatus
-    full_result_text: str | None = None
-    structured_result: dict[str, JsonValue] | list[JsonValue] | None = None
+    result: JsonValue | None = None
+    result_text: str | None = None
+    metadata: dict[str, JsonValue] = Field(default_factory=dict)
     error_text: NonBlankStr | None = None
     error: dict[str, JsonValue] | None = None
 
@@ -51,8 +52,8 @@ class FinishToolCall(ContractModel):
         if self.status in {
             ToolCallTerminalStatus.SUCCEEDED,
             ToolCallTerminalStatus.FAILED,
-        } and self.full_result_text is None:
-            raise ValueError("completed tool calls require the full result text")
+        } and self.result_text is None:
+            raise ValueError("completed tool calls require the exact result text")
         if self.status is ToolCallTerminalStatus.SUCCEEDED and (
             self.error_text is not None or self.error is not None
         ):
@@ -78,8 +79,9 @@ class ToolCall(ContractModel):
     implementation_version: str
     arguments: dict[str, JsonValue]
     status: ToolCallStatus
-    full_result_text: str | None
-    structured_result: dict[str, JsonValue] | list[JsonValue] | None
+    result: JsonValue | None
+    result_text: str | None
+    metadata: dict[str, JsonValue]
     error_text: str | None
     error: dict[str, JsonValue] | None
     started_at: AwareDatetime

--- a/backend/services/generations/recorder.py
+++ b/backend/services/generations/recorder.py
@@ -136,8 +136,9 @@ class GenerationExecutionRecorder:
             FinishToolCall(
                 tool_call_id=execution_id,
                 status=result.status,
-                full_result_text=result.full_result_text,
-                structured_result=result.structured_result,
+                result=result.result,
+                result_text=result.result_text,
+                metadata=result.metadata,
                 error_text=result.error_text,
                 error=result.error,
             )

--- a/backend/services/reporter/runner/__init__.py
+++ b/backend/services/reporter/runner/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from backend.services.reporter.runner.runner import Runner
+from backend.services.reporter.runner.models import ToolExecutionResult
 from backend.services.reporter.runner.research_brief import (
     RESEARCH_BRIEF_PATH,
     BriefBias,
@@ -16,6 +16,7 @@ from backend.services.reporter.runner.research_brief import (
     ResearchBrief,
     ResearchBriefStore,
 )
+from backend.services.reporter.runner.runner import Runner
 from backend.services.reporter.runner.schemas import ReporterOutput
 from backend.services.reporter.runner.state import ProcedureHistoryMode, RunnerConfig
 from backend.services.reporter.runner.tools.registry import ToolRegistry
@@ -37,4 +38,5 @@ __all__ = [
     "Runner",
     "RunnerConfig",
     "ToolRegistry",
+    "ToolExecutionResult",
 ]

--- a/backend/services/reporter/runner/models.py
+++ b/backend/services/reporter/runner/models.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
+
+from pydantic import JsonValue
 
 
 ToolDef = dict[str, Any]
@@ -18,6 +20,14 @@ class ToolCall:
     id: str
     name: str
     arguments: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolExecutionResult:
+    """Logical tool result plus application-only execution metadata."""
+
+    result: JsonValue | str
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
 
 
 def tool_result_message(call: ToolCall, result: Any) -> ChatMessage:

--- a/backend/services/reporter/runner/recording.py
+++ b/backend/services/reporter/runner/recording.py
@@ -69,8 +69,9 @@ class ToolExecutionStart:
 @dataclass(frozen=True, slots=True)
 class ToolExecutionFinish:
     status: ToolExecutionStatus
-    full_result_text: str | None = None
-    structured_result: dict[str, JsonValue] | list[JsonValue] | None = None
+    result: JsonValue | None = None
+    result_text: str | None = None
+    metadata: dict[str, JsonValue] = field(default_factory=dict)
     error_text: str | None = None
     error: dict[str, JsonValue] | None = None
 

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -26,6 +26,7 @@ from backend.services.reporter.runner.completion import (
 from backend.services.reporter.runner.models import (
     ChatMessage,
     ToolCall,
+    ToolExecutionResult,
     assistant_tool_call_message,
     extract_text,
     extract_tool_calls,
@@ -284,8 +285,8 @@ class Runner:
                 "type": "UnknownToolError",
                 "message": message,
             }
-            result: Any = {"error": message}
-            result_content = self._as_tool_result_content(result)
+            execution_result = ToolExecutionResult(result={"error": message})
+            result_content = self._as_tool_result_content(execution_result.result)
             duration_ms = self._duration_ms(start)
             self.log.add_tool_call(
                 call.name,
@@ -298,8 +299,9 @@ class Runner:
                 execution_id,
                 ToolExecutionFinish(
                     status="failed",
-                    full_result_text=result_content,
-                    structured_result=cast(dict[str, JsonValue], result),
+                    result=execution_result.result,
+                    result_text=result_content,
+                    metadata=execution_result.metadata,
                     error_text=message,
                     error=error,
                 ),
@@ -309,9 +311,9 @@ class Runner:
         artifact_recording_error: ArtifactRecordingError | None = None
         try:
             with self.tool_context.bind_tool_execution(execution_id):
-                result = handler(**call.arguments)
-                if asyncio.iscoroutine(result):
-                    result = await result
+                handler_result = handler(**call.arguments)
+                if asyncio.iscoroutine(handler_result):
+                    handler_result = await handler_result
         except asyncio.CancelledError:
             self._finish_tool_execution(
                 execution_id,
@@ -322,12 +324,12 @@ class Runner:
             artifact_recording_error = exc
             error = sanitize_provider_error(exc)
             error_text = str(error.get("message") or type(exc).__name__)
-            result = {"error": error_text}
+            handler_result = {"error": error_text}
             status = "failed"
         except Exception as exc:
             error = sanitize_provider_error(exc)
             error_text = str(error.get("message") or type(exc).__name__)
-            result = {"error": error_text}
+            handler_result = {"error": error_text}
             status = "failed"
         else:
             error = None
@@ -335,7 +337,8 @@ class Runner:
             status = "succeeded"
 
         duration_ms = self._duration_ms(start)
-        result_content = self._as_tool_result_content(result)
+        execution_result = self._normalize_tool_result(handler_result)
+        result_content = self._as_tool_result_content(execution_result.result)
         self.log.add_tool_call(
             call.name,
             call.arguments,
@@ -347,8 +350,9 @@ class Runner:
             execution_id,
             ToolExecutionFinish(
                 status=status,
-                full_result_text=result_content,
-                structured_result=self._structured_result(result_content),
+                result=execution_result.result,
+                result_text=result_content,
+                metadata=execution_result.metadata,
                 error_text=error_text,
                 error=error,
             ),
@@ -453,18 +457,10 @@ class Runner:
         return isinstance(data, dict) and data.get("ok") is True
 
     @staticmethod
-    def _structured_result(
-        result: str,
-    ) -> dict[str, JsonValue] | list[JsonValue] | None:
-        try:
-            parsed = json.loads(result)
-        except (json.JSONDecodeError, TypeError):
-            return None
-        if isinstance(parsed, dict):
-            return cast(dict[str, JsonValue], parsed)
-        if isinstance(parsed, list):
-            return cast(list[JsonValue], parsed)
-        return None
+    def _normalize_tool_result(result: Any) -> ToolExecutionResult:
+        if isinstance(result, ToolExecutionResult):
+            return result
+        return ToolExecutionResult(result=cast(JsonValue, result))
 
     @staticmethod
     def _duration_ms(start: float) -> int:

--- a/backend/tests/api/test_generation_routes.py
+++ b/backend/tests/api/test_generation_routes.py
@@ -252,8 +252,9 @@ def _dependencies(competition_id: UUID, season_id: UUID) -> SimpleNamespace:
         implementation_version="1",
         arguments={"week": 8},
         status=ToolCallStatus.SUCCEEDED,
-        full_result_text='{"found":true}',
-        structured_result={"found": True},
+        result={"found": True},
+        result_text='{"found":true}',
+        metadata={"candidate_count": 3},
         error_text=None,
         error=None,
         started_at=NOW,
@@ -508,7 +509,11 @@ async def test_polling_and_resource_routes_preserve_durable_payloads() -> None:
     assert ai_call.json()["ai_call"]["usage"]["raw_provider_usage"] == {
         "provider_total": 140
     }
-    assert tool_call.json()["tool_call"]["full_result_text"] == '{"found":true}'
+    assert tool_call.json()["tool_call"]["result"] == {"found": True}
+    assert tool_call.json()["tool_call"]["result_text"] == '{"found":true}'
+    assert tool_call.json()["tool_call"]["metadata"] == {"candidate_count": 3}
+    assert "full_result_text" not in tool_call.json()["tool_call"]
+    assert "structured_result" not in tool_call.json()["tool_call"]
     assert artifacts.json()["page"]["items"][0]["path"] == "article.md"
     assert artifacts.json()["page"]["items"][0]["revision_count"] == 2
     assert (

--- a/backend/tests/database/migrations/test_tool_result_metadata.py
+++ b/backend/tests/database/migrations/test_tool_result_metadata.py
@@ -1,0 +1,203 @@
+from io import StringIO
+from pathlib import Path
+from uuid import uuid4
+
+from alembic import command
+from alembic.config import Config
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import DBAPIError
+
+from backend.database.models.core import Competition, CompetitionSeason
+from backend.database.models.reporting import Generation
+
+
+def _config(database_url: str, *, output_buffer: StringIO | None = None) -> Config:
+    root = Path(__file__).resolve().parents[4]
+    config = Config(
+        str(root / "backend" / "migrations" / "alembic.ini"),
+        output_buffer=output_buffer,
+    )
+    config.set_main_option("sqlalchemy.url", database_url.replace("%", "%%"))
+    return config
+
+
+def test_tool_result_metadata_upgrade_and_downgrade_compile_offline() -> None:
+    upgrade_sql = StringIO()
+    command.upgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=upgrade_sql,
+        ),
+        "0010",
+        sql=True,
+    )
+    upgrade = upgrade_sql.getvalue()
+    assert "ADD COLUMN result_jsonb JSONB" in upgrade
+    assert "ADD COLUMN result_text TEXT" in upgrade
+    assert "ADD COLUMN metadata_jsonb JSONB" in upgrade
+    assert "DISABLE TRIGGER tool_calls_protect_terminal" in upgrade
+    assert "ENABLE TRIGGER tool_calls_protect_terminal" in upgrade
+
+    downgrade_sql = StringIO()
+    command.downgrade(
+        _config(
+            "postgresql+psycopg://unused:unused@localhost/unused",
+            output_buffer=downgrade_sql,
+        ),
+        "0010:0009",
+        sql=True,
+    )
+    downgrade = downgrade_sql.getvalue()
+    assert "DROP COLUMN metadata_jsonb" in downgrade
+    assert "DROP COLUMN result_text" in downgrade
+    assert "DROP COLUMN result_jsonb" in downgrade
+
+
+def test_tool_result_metadata_migrates_legacy_rows_and_restores_protection(
+    database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIDAM_MIGRATION_REQUIRE_TLS", "false")
+    monkeypatch.setenv("AIDAM_MIGRATION_ROLE", "aidam_owner")
+    config = _config(database_url)
+    command.upgrade(config, "0009")
+
+    competition_id = uuid4()
+    season_id = uuid4()
+    generation_id = uuid4()
+    ai_call_id = uuid4()
+    structured_call_id = uuid4()
+    text_call_id = uuid4()
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(Competition),
+            {"id": competition_id, "display_name": "Tool Result Migration League"},
+        )
+        connection.execute(
+            sa.insert(CompetitionSeason),
+            {
+                "id": season_id,
+                "competition_id": competition_id,
+                "season_year": 2026,
+                "sequence_number": 1,
+                "sleeper_league_id": f"league-{uuid4()}",
+            },
+        )
+        connection.execute(
+            sa.insert(Generation),
+            {
+                "id": generation_id,
+                "competition_id": competition_id,
+                "competition_season_id": season_id,
+                "kind": "live",
+                "status": "running",
+                "request_text": "write the recap",
+                "requested_primary_model": "test-model",
+                "settings_jsonb": {},
+                "current_turn": 1,
+            },
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO reporting.ai_calls (
+                    id, generation_id, turn_number, attempt_number,
+                    requested_model, input_messages, tool_definitions,
+                    request_parameters, status, completed_at
+                ) VALUES (
+                    :id, :generation_id, 1, 0,
+                    'test-model', '[]'::jsonb, '[]'::jsonb,
+                    '{}'::jsonb, 'succeeded', pg_catalog.now()
+                )
+                """
+            ),
+            {"id": ai_call_id, "generation_id": generation_id},
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO reporting.tool_calls (
+                    id, generation_id, ai_call_id, tool_ordinal, tool_name,
+                    implementation_version, arguments_jsonb, status,
+                    full_result_text, structured_result_jsonb,
+                    completed_at, duration_ms
+                ) VALUES
+                    (
+                        :structured_id, :generation_id, :ai_call_id, 0,
+                        'lookup', 'v1', '{}'::jsonb, 'succeeded',
+                        :structured_text, CAST(:structured_result AS jsonb),
+                        pg_catalog.now(), 1
+                    ),
+                    (
+                        :text_id, :generation_id, :ai_call_id, 1,
+                        'procedure', 'v1', '{}'::jsonb, 'succeeded',
+                        '# Procedure', NULL, pg_catalog.now(), 1
+                    )
+                """
+            ),
+            {
+                "structured_id": structured_call_id,
+                "text_id": text_call_id,
+                "generation_id": generation_id,
+                "ai_call_id": ai_call_id,
+                "structured_text": '{"found":true}',
+                "structured_result": '{"found": true}',
+            },
+        )
+
+    command.upgrade(config, "0010")
+    with engine.connect() as connection:
+        columns = {
+            column["name"]
+            for column in inspect(connection).get_columns(
+                "tool_calls", schema="reporting"
+            )
+        }
+        rows = connection.execute(
+            text(
+                """
+                SELECT id, result_jsonb, result_text, metadata_jsonb
+                FROM reporting.tool_calls
+                WHERE generation_id = :generation_id
+                ORDER BY tool_ordinal
+                """
+            ),
+            {"generation_id": generation_id},
+        ).mappings().all()
+
+    assert {"result_jsonb", "result_text", "metadata_jsonb"} <= columns
+    assert rows[0]["result_jsonb"] == {"found": True}
+    assert rows[0]["result_text"] == '{"found":true}'
+    assert rows[0]["metadata_jsonb"] == {}
+    assert rows[1]["result_jsonb"] == "# Procedure"
+    assert rows[1]["result_text"] == "# Procedure"
+    assert rows[1]["metadata_jsonb"] == {}
+
+    with pytest.raises(DBAPIError, match="terminal tool call records are immutable"):
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    UPDATE reporting.tool_calls
+                    SET result_text = 'changed'
+                    WHERE id = :tool_call_id
+                    """
+                ),
+                {"tool_call_id": structured_call_id},
+            )
+
+    command.downgrade(config, "0009")
+    downgraded_columns = {
+        column["name"]
+        for column in inspect(engine).get_columns("tool_calls", schema="reporting")
+    }
+    assert {"result_jsonb", "result_text", "metadata_jsonb"}.isdisjoint(
+        downgraded_columns
+    )
+
+    command.upgrade(config, "0010")
+    command.downgrade(config, "base")
+    engine.dispose()

--- a/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
+++ b/backend/tests/resources/reporting/ai_calls/test_completion_recorder.py
@@ -178,8 +178,9 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
         execution_id,
         ToolExecutionFinish(
             status="succeeded",
-            full_result_text='{"ok": false}',
-            structured_result={"ok": False},
+            result={"ok": False},
+            result_text='{"ok": false}',
+            metadata={"source": "test"},
         ),
     )
 
@@ -191,8 +192,9 @@ def test_retry_and_fallback_round_trip_as_sequential_durable_attempts(
     assert stored_tool.ai_call_id == page.items[1].id
     assert stored_tool.tool_ordinal == 0
     assert stored_tool.status.value == "succeeded"
-    assert stored_tool.full_result_text == '{"ok": false}'
-    assert stored_tool.structured_result == {"ok": False}
+    assert stored_tool.result == {"ok": False}
+    assert stored_tool.result_text == '{"ok": false}'
+    assert stored_tool.metadata == {"source": "test"}
 
     artifacts = artifact_manager.list(ArtifactQuery(generation_id=generation_id))
     assert artifacts.total == 1

--- a/backend/tests/resources/reporting/tool_calls/test_manager.py
+++ b/backend/tests/resources/reporting/tool_calls/test_manager.py
@@ -104,7 +104,7 @@ def _begin(
     )
 
 
-def test_tool_call_lifecycle_preserves_full_and_structured_results(
+def test_tool_call_lifecycle_preserves_result_text_and_metadata(
     ai_call_manager: AICallManager,
     tool_call_manager: ToolCallManager,
     session_factory: SessionFactory,
@@ -118,12 +118,14 @@ def test_tool_call_lifecycle_preserves_full_and_structured_results(
         FinishToolCall(
             tool_call_id=started.id,
             status="succeeded",
-            full_result_text='{"found": true, "rows": [1, 2]}',
-            structured_result={"found": True, "rows": [1, 2]},
+            result={"found": True, "rows": [1, 2]},
+            result_text='{"found": true, "rows": [1, 2]}',
+            metadata={"query_id": "private-query"},
         )
     )
-    assert finished.full_result_text == '{"found": true, "rows": [1, 2]}'
-    assert finished.structured_result == {"found": True, "rows": [1, 2]}
+    assert finished.result == {"found": True, "rows": [1, 2]}
+    assert finished.result_text == '{"found": true, "rows": [1, 2]}'
+    assert finished.metadata == {"query_id": "private-query"}
     assert finished.duration_ms is not None
     assert tool_call_manager.get(started.id) == finished
     page = tool_call_manager.list(ToolCallQuery(generation_id=generation_id))

--- a/backend/tests/resources/reporting/tool_calls/test_objects.py
+++ b/backend/tests/resources/reporting/tool_calls/test_objects.py
@@ -29,17 +29,21 @@ def test_finish_contract_requires_full_results_for_completed_calls() -> None:
     completed = FinishToolCall(
         tool_call_id=uuid4(),
         status="failed",
-        full_result_text='{"ok": false}',
+        result={"ok": False},
+        result_text='{"ok": false}',
+        metadata={"diagnostic": "bounded"},
         error_text="unknown tool",
         error={"type": "unknown_tool"},
     )
     assert completed.error_text == "unknown tool"
-    with pytest.raises(ValidationError, match="full result"):
+    assert completed.metadata == {"diagnostic": "bounded"}
+    with pytest.raises(ValidationError, match="exact result"):
         FinishToolCall(tool_call_id=uuid4(), status="failed")
     with pytest.raises(ValidationError, match="cannot include an error"):
         FinishToolCall(
             tool_call_id=uuid4(),
             status="succeeded",
-            full_result_text="ok",
+            result="ok",
+            result_text="ok",
             error_text="unexpected",
         )

--- a/backend/tests/services/generations/test_recorder.py
+++ b/backend/tests/services/generations/test_recorder.py
@@ -243,8 +243,9 @@ def test_recorder_maps_tool_execution_to_successful_turn_provenance() -> None:
         execution_id,
         ToolExecutionFinish(
             status="succeeded",
-            full_result_text='{"found": true}',
-            structured_result={"found": True},
+            result={"found": True},
+            result_text='{"found": true}',
+            metadata={"candidate_count": 3},
         ),
     )
 
@@ -259,8 +260,9 @@ def test_recorder_maps_tool_execution_to_successful_turn_provenance() -> None:
     finished = tool_calls.finished[0]
     assert finished.tool_call_id == execution_id
     assert finished.status.value == "succeeded"
-    assert finished.full_result_text == '{"found": true}'
-    assert finished.structured_result == {"found": True}
+    assert finished.result == {"found": True}
+    assert finished.result_text == '{"found": true}'
+    assert finished.metadata == {"candidate_count": 3}
 
 
 def test_recorder_rejects_tools_without_a_successful_turn() -> None:

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
-from backend.services.reporter.runner.models import ToolCall
+from backend.services.reporter.runner.models import ToolCall, ToolExecutionResult
 from backend.services.reporter.runner.recording import (
     ArtifactMutation,
     GenerationProgress,
@@ -359,6 +359,73 @@ def test_runner_tool_call_dispatch() -> None:
     assert result_message["content"] == '{"ok": true, "value": 7}'
 
 
+@pytest.mark.parametrize(
+    ("raw_result", "expected_text"),
+    [
+        ("plain text", "plain text"),
+        (7, "7"),
+        (["one", 2], '["one", 2]'),
+        (None, "null"),
+    ],
+)
+def test_runner_keeps_raw_tool_results_compatible(
+    raw_result: Any,
+    expected_text: str,
+) -> None:
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup")]),
+            make_response(text="Done."),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner = Runner(
+        registry_with("lookup", lambda: raw_result),
+        complete=complete,
+        recorder=recorder,
+    )
+
+    run(runner.run("system", "user"))
+
+    recorded = recorder.finished[0][1]
+    assert recorded.result == raw_result
+    assert recorded.result_text == expected_text
+    assert recorded.metadata == {}
+    assert complete.requests[1]["messages"][-1]["content"] == expected_text
+
+
+def test_runner_hides_tool_execution_metadata_from_model_messages() -> None:
+    logical_result = {"memories": [{"headline": "A callback"}]}
+    metadata = {
+        "bindings": [{"item_id": "private-id", "result_ordinal": 0}],
+        "candidate_count": 4,
+    }
+    complete = FakeCompletion(
+        [
+            make_response(tool_calls=[tool_call("lookup")]),
+            make_response(text="Done."),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner = Runner(
+        registry_with(
+            "lookup",
+            lambda: ToolExecutionResult(result=logical_result, metadata=metadata),
+        ),
+        complete=complete,
+        recorder=recorder,
+    )
+
+    run(runner.run("system", "user"))
+
+    recorded = recorder.finished[0][1]
+    sent_text = complete.requests[1]["messages"][-1]["content"]
+    assert recorded.result == logical_result
+    assert recorded.result_text == sent_text
+    assert recorded.metadata == metadata
+    assert "private-id" not in sent_text
+
+
 def test_runner_records_parallel_tools_in_provider_order_with_exact_results() -> None:
     async def handler(*, value: int, delay: float) -> dict[str, Any]:
         await asyncio.sleep(delay)
@@ -390,7 +457,7 @@ def test_runner_records_parallel_tools_in_provider_order_with_exact_results() ->
         "succeeded",
     ]
     persisted_by_id = {
-        execution_id: result.full_result_text
+        execution_id: result.result_text
         for execution_id, result in recorder.finished
     }
     persisted_in_provider_order = [
@@ -441,7 +508,7 @@ def test_runner_records_unknown_tools_and_sanitized_handler_exceptions() -> None
         for message in complete.requests[1]["messages"]
         if message["role"] == "tool"
     ]
-    assert sent == [result.full_result_text for result in results]
+    assert sent == [result.result_text for result in results]
 
 
 def test_runner_records_tool_cancellation_and_reraises() -> None:

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3472,8 +3472,6 @@ export interface components {
             } | null;
             /** Error Text */
             error_text: string | null;
-            /** Full Result Text */
-            full_result_text: string | null;
             /**
              * Generation Id
              * Format: uuid
@@ -3486,18 +3484,21 @@ export interface components {
             id: string;
             /** Implementation Version */
             implementation_version: string;
+            /** Metadata */
+            metadata: {
+                [key: string]: components["schemas"]["pydantic__types__JsonValue"];
+            };
             /** Provider Tool Call Id */
             provider_tool_call_id: string | null;
+            result: components["schemas"]["pydantic__types__JsonValue"] | null;
+            /** Result Text */
+            result_text: string | null;
             /**
              * Started At
              * Format: date-time
              */
             started_at: string;
             status: components["schemas"]["ToolCallStatus"];
-            /** Structured Result */
-            structured_result: {
-                [key: string]: components["schemas"]["pydantic__types__JsonValue"];
-            } | components["schemas"]["pydantic__types__JsonValue"][] | null;
             /** Tool Name */
             tool_name: string;
             /** Tool Ordinal */

--- a/frontend/src/features/execution/execution-timeline.tsx
+++ b/frontend/src/features/execution/execution-timeline.tsx
@@ -275,13 +275,18 @@ function ToolCallDetail({
             defaultOpen
           />
           <StructuredContentViewer
-            title="Structured result"
-            content={query.data.tool_call.structured_result ?? undefined}
+            title="Result"
+            content={query.data.tool_call.result ?? undefined}
             defaultOpen
           />
           <StructuredContentViewer
-            title="Full result text"
-            content={query.data.tool_call.full_result_text ?? undefined}
+            title="Exact result text"
+            content={query.data.tool_call.result_text ?? undefined}
+            defaultOpen
+          />
+          <StructuredContentViewer
+            title="Metadata"
+            content={query.data.tool_call.metadata}
             defaultOpen
           />
           <StructuredContentViewer


### PR DESCRIPTION
## Summary

- add the generic ToolExecutionResult boundary and keep application metadata out of model tool messages
- persist logical result, exact result text, and metadata separately with additive migration 0010 and legacy-row backfill
- expose the new reporting contract through the API, generated frontend types, and execution inspector

## Stack

- PR0: #220 design baseline
- PR1: this pull request, targeting the PR0 branch
- Scope: rmr-1 only; semantic memory presentation and closeout remain later layers

## Verification

- 44 reporter runner, recorder, resource-contract, and API tests passed
- 7 PostgreSQL migration, tool-call manager, and durable-recorder tests passed
- Alembic upgrade/head/schema-drift/downgrade checks passed
- frontend API generation check and TypeScript typecheck passed
- targeted Prettier check and git diff check passed