### PR TITLE
PR4: Force same-agent memory closeout

### DIFF
--- a/backend/services/memory/generation_context.py
+++ b/backend/services/memory/generation_context.py
@@ -231,6 +231,12 @@ class GenerationMemoryContext:
         self._closed = True
         return bundle
 
+    def proposal_snapshot(self) -> tuple[MemoryProposal, ...]:
+        """Return the currently buffered proposals without closing the context."""
+
+        self._require_open()
+        return tuple(self._proposals)
+
     def discard(self) -> None:
         """Close and erase an abandoned proposal buffer without persistence."""
 

--- a/backend/services/reporter/definition.py
+++ b/backend/services/reporter/definition.py
@@ -20,6 +20,10 @@ from backend.services.reporter.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_IMPLEMENTATION_VERSION,
     DATALAYER_TOOL_SPECS,
 )
+from backend.services.reporter.runner.tools.memory_closeout_tools import (
+    MEMORY_CLOSEOUT_TOOL_IMPLEMENTATION_VERSION,
+    MEMORY_CLOSEOUT_TOOL_SPECS,
+)
 from backend.services.reporter.runner.tools.memory_tools import (
     MEMORY_TOOL_IMPLEMENTATION_VERSION,
     MEMORY_TOOL_SPECS,
@@ -71,12 +75,15 @@ def prepare_reporter_definition(
     system_prompt = (reporter_dir / "prompts" / "system.md").read_text(
         encoding="utf-8"
     ).strip()
+    procedure_names = set(VALID_PROCEDURES)
+    if memory_enabled:
+        procedure_names.add("memory_closeout")
     procedures = tuple(
         PreparedProcedure(
             name=name,
             content=(PROCEDURE_DIR / f"{name}.md").read_text(encoding="utf-8"),
         )
-        for name in sorted(VALID_PROCEDURES)
+        for name in sorted(procedure_names)
     )
     groups = [
         (ARTIFACT_TOOL_SPECS, ARTIFACT_TOOL_IMPLEMENTATION_VERSION),
@@ -86,6 +93,12 @@ def prepare_reporter_definition(
     ]
     if memory_enabled:
         groups.append((MEMORY_TOOL_SPECS, MEMORY_TOOL_IMPLEMENTATION_VERSION))
+        groups.append(
+            (
+                MEMORY_CLOSEOUT_TOOL_SPECS,
+                MEMORY_CLOSEOUT_TOOL_IMPLEMENTATION_VERSION,
+            )
+        )
 
     tools = tuple(
         PreparedTool(

--- a/backend/services/reporter/generator.py
+++ b/backend/services/reporter/generator.py
@@ -27,6 +27,7 @@ from backend.services.reporter.runner.completion import (
     CompletionSettings,
     make_completion_client,
 )
+from backend.services.reporter.runner.memory_closeout import MemoryCloseoutState
 from backend.services.reporter.runner.recording import (
     ExecutionRecorder,
     MemoryRecallRecord,
@@ -44,6 +45,9 @@ from backend.services.reporter.runner.state import ArtifactStore, RunnerConfig
 from backend.services.reporter.runner.tools.artifact_tools import register_artifact_tools
 from backend.services.reporter.runner.tools.brief_tools import register_brief_tools
 from backend.services.reporter.runner.tools.datalayer_tools import register_datalayer_tools
+from backend.services.reporter.runner.tools.memory_closeout_tools import (
+    register_memory_closeout_tools,
+)
 from backend.services.reporter.runner.tools.memory_tools import register_memory_tools
 from backend.services.reporter.runner.tools.procedure_tools import register_procedure_tools
 from backend.services.reporter.runner.tools.registry import ToolRegistry
@@ -123,6 +127,15 @@ async def generate_article(
         artifacts=ArtifactStore(),
         brief=brief,
         recorder=resolved_recorder,
+        memory_closeout=(
+            MemoryCloseoutState(
+                procedure=prepared.procedure_contents["memory_closeout"],
+                memory_writes_enabled=allow_memory_writes,
+                proposal_snapshot=memory_context.proposal_snapshot,
+            )
+            if memory_context is not None
+            else None
+        ),
     )
 
     initial_context: tuple[str, ...] = ()
@@ -175,6 +188,7 @@ def _build_registry(
             data,
             allow_memory_writes=allow_memory_writes,
         )
+        register_memory_closeout_tools(registry)
     return registry, memory_adapter
 
 

--- a/backend/services/reporter/procedures/memory_closeout.md
+++ b/backend/services/reporter/procedures/memory_closeout.md
@@ -1,0 +1,23 @@
+# Goal: Preserve Durable Memory After Publication
+
+The article is final and immutable. Review that exact submitted article together with the verified research brief, then preserve only context that is likely to improve future reporting. This is a required closeout step, but it may deliberately produce no memory writes.
+
+## What Is Worth Preserving
+
+- A verified event whose consequences, rivalry, reversal, or later evaluation may matter again.
+- An active or dormant storyline with a concise current state and a plausible future payoff.
+- A concrete callback condition that should bring an unresolved development back when due.
+- Stable team or league context that will remain useful beyond this article.
+- A durable fact only when it carries future explanatory value rather than merely repeating routine weekly detail.
+
+Do not save article prose, jokes, voice instructions, unsupported inference, generic summaries, or transient details with no likely future narrative value. Memory is continuity state, not an archive of the finished article.
+
+## Reconciliation
+
+Use the finalized article and verified brief as your evidence boundary. When an existing remembered arc may overlap, use `search_memory` to reconcile it before writing. Do not guess hidden identities or treat remembered material as proof. Use the existing semantic memory tools to create or update the appropriate event, storyline, trigger, team context, or league note.
+
+If memory writes are disabled, do not retry blocked writes or invent substitute bookkeeping. Complete the review as an intentional no-op.
+
+## Required Finish
+
+When useful durable items have been saved—or when you have determined that none are warranted—call `complete_memory_review`. Do not return a normal assistant message and do not attempt to revise the submitted article.

--- a/backend/services/reporter/procedures/verification.md
+++ b/backend/services/reporter/procedures/verification.md
@@ -17,7 +17,7 @@ Use this guide when a publishable draft exists and the remaining question is whe
 - Reuse the current draft and brief state when available. Use `read_artifact` or `read_brief` when state is unknown or a complete review will add value.
 - Use the smallest targeted datalayer view to resolve a missing, suspicious, or conflicting claim, then save the corrected evidence.
 - Use `edit_artifact` for a real correction or meaningful improvement, carrying forward the returned revision.
-- Use `submit_artifact` only after the actual draft meets the publication goal. Submission pins that revision and ends the loop.
+- Use `submit_artifact` only after the actual draft meets the publication goal. Submission pins that revision. When its result supplies the mandatory `memory_closeout` procedure, the same conversation continues for memory review and ends only through `complete_memory_review`.
 
 ## Audit Judgment
 
@@ -36,4 +36,4 @@ Use this guide when a publishable draft exists and the remaining question is whe
 
 Return to research when missing or questionable evidence could change a material claim. Return to storyline work when the facts are sound but the thesis or emphasis is misleading. Return to drafting when corrections require substantial prose changes.
 
-This goal is complete when no known material issue remains and another review would mostly repeat the same checks. Submit the current verified revision directly; a revision conflict means the artifact must be reread and publication confidence re-established.
+This goal is complete when no known material issue remains and another review would mostly repeat the same checks. Submit the current verified revision directly; a revision conflict means the artifact must be reread and publication confidence re-established. After a successful submission, do not revise the article. Follow any mandatory closeout procedure returned by the tool.

--- a/backend/services/reporter/prompts/system.md
+++ b/backend/services/reporter/prompts/system.md
@@ -27,7 +27,7 @@ Work on whichever unmet goal has the greatest effect on accuracy or reader value
 - **Find the meaning:** identify the strongest supported thesis, tensions, callbacks, consequences, and stakes.
 - **Shape the article:** produce a coherent opening, progression, emphasis, and conclusion in the requested voice.
 - **Earn publication confidence:** audit the actual draft, repair material gaps or errors, and submit only the current verified revision.
-- **Use and preserve useful continuity:** when an `automatic_reporter_memory` context message is present, treat its due callbacks, standing context, and likely relevant memories as initial narrative leads. Do not call `search_memory` merely to rediscover that material. Search only when current evidence exposes a distinct continuity question that the prelude does not answer. Reverify every material lead, and when an arc has plausible future value, preserve its concise durable state without confusing persistence work with article readiness.
+- **Use and preserve useful continuity:** when an `automatic_reporter_memory` context message is present, treat its due callbacks, standing context, and likely relevant memories as initial narrative leads. Do not call `search_memory` merely to rediscover that material. Search only when current evidence exposes a distinct continuity question that the prelude does not answer. Reverify every material lead. When submission returns a mandatory `memory_closeout` next action, review the immutable article and brief, preserve only useful durable state, and explicitly complete the review.
 
 After meaningful evidence or drafting work, reassess the most important remaining uncertainty. Drafting may expose research gaps; verification may expose weak framing; new evidence may change the outline. Follow the highest-value lead instead of preserving a stale plan.
 
@@ -50,6 +50,7 @@ Procedures are on-demand guides, not workflow stages or progress requirements. T
 - Use `list_artifacts`, `read_artifact`, `create_artifact`, and `edit_artifact` for publishable Markdown. Reuse content and revisions returned by successful operations; reread only when state is unknown or a full-document review is useful.
 - Every edit is an exact single-match replacement. Do not make a no-op edit when the draft already says what it should say.
 - After a successful live submission, the runtime automatically buffers only the supporting facts referenced by final brief storylines. It does not create or update durable storyline cards. Use semantic memory tools to maintain narrative state around that evidence: `save_memory_event` for an event, `upsert_storyline_memory_card` for an arc's ongoing state, `save_storyline_trigger` for a future callback condition, `save_team_context` for team-specific context, and `save_league_note` for league-wide context. Buffered writes are not visible to `search_memory` during the same run.
+- When `submit_artifact` returns `next_action.type="mandatory_procedure"`, follow that supplied procedure in the same conversation. The submitted revision is immutable, the tool list is unchanged, and `complete_memory_review`—not a normal assistant message—ends the closeout. A deliberate no-op is valid when nothing durable warrants saving.
 - `article.md` is the default publishable path, not a required application identity.
 
 ## Article Quality
@@ -58,4 +59,4 @@ A good article is accurate, specific, coherent, and selective. It has a supporte
 
 Continue while another action could materially improve factual confidence, central framing, request fulfillment, or narrative value. Submit when the article meets this quality bar and additional work would mostly add interchangeable detail.
 
-Do not end with a normal assistant message. Finish by calling `submit_artifact` with the current revision of the chosen publishable artifact.
+Do not end with a normal assistant message. Submit the current revision of the chosen publishable artifact. If submission supplies a mandatory closeout next action, follow it and finish with `complete_memory_review`; otherwise submission ends the run.

--- a/backend/services/reporter/runner/__init__.py
+++ b/backend/services/reporter/runner/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from backend.services.reporter.runner.memory_closeout import (
+    MEMORY_CLOSEOUT_TURN_ALLOWANCE,
+    MemoryCloseoutIncompleteError,
+    MemoryCloseoutState,
+)
 from backend.services.reporter.runner.models import ToolExecutionResult
 from backend.services.reporter.runner.research_brief import (
     RESEARCH_BRIEF_PATH,
@@ -31,6 +36,9 @@ __all__ = [
     "BriefReadiness",
     "BriefStoryline",
     "BriefStyle",
+    "MEMORY_CLOSEOUT_TURN_ALLOWANCE",
+    "MemoryCloseoutIncompleteError",
+    "MemoryCloseoutState",
     "ResearchBrief",
     "ResearchBriefStore",
     "ReporterOutput",

--- a/backend/services/reporter/runner/memory_closeout.py
+++ b/backend/services/reporter/runner/memory_closeout.py
@@ -1,0 +1,133 @@
+"""Same-agent memory-closeout lifecycle state."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from backend.services.memory.proposals import MemoryProposal
+
+
+MEMORY_CLOSEOUT_TURN_ALLOWANCE = 6
+
+
+class MemoryCloseoutIncompleteError(RuntimeError):
+    """The reporter submitted an article but did not complete memory review."""
+
+
+@dataclass(slots=True)
+class MemoryCloseoutState:
+    """Mutable lifecycle facts shared by the runner and closeout tools."""
+
+    procedure: str
+    memory_writes_enabled: bool
+    proposal_snapshot: Callable[[], tuple[MemoryProposal, ...]]
+    article_submitted: bool = False
+    memory_review_completed: bool = False
+    exhausted: bool = False
+    submission_turn: int | None = None
+    completion_turn: int | None = None
+    closeout_turns_used: int = 0
+    no_op: bool | None = None
+    proposal_counts: dict[str, Any] = field(default_factory=dict)
+    _baseline_proposal_ids: frozenset[UUID] = field(default_factory=frozenset)
+
+    @property
+    def active(self) -> bool:
+        return self.article_submitted and not self.memory_review_completed
+
+    @property
+    def status(self) -> str:
+        if self.exhausted:
+            return "exhausted"
+        if self.memory_review_completed:
+            return "completed"
+        if self.article_submitted:
+            return "active"
+        return "pending_submission"
+
+    def activate(self, *, turn: int) -> None:
+        if self.article_submitted:
+            return
+        self.article_submitted = True
+        self.submission_turn = turn
+        self._baseline_proposal_ids = frozenset(
+            proposal.proposal_id for proposal in self.proposal_snapshot()
+        )
+
+    def begin_turn(self) -> None:
+        if self.active:
+            self.closeout_turns_used += 1
+
+    def complete(self, *, turn: int) -> dict[str, Any]:
+        if not self.article_submitted:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "article_not_submitted",
+                    "message": (
+                        "Submit the final article before completing memory review."
+                    ),
+                },
+            }
+        if self.memory_review_completed:
+            return {
+                "ok": True,
+                "memory_review_completed": True,
+                "already_completed": True,
+                "outcome": "no_op" if self.no_op else "proposals_saved",
+                "proposal_counts": self.proposal_counts,
+            }
+
+        proposals = tuple(
+            proposal
+            for proposal in self.proposal_snapshot()
+            if proposal.proposal_id not in self._baseline_proposal_ids
+        )
+        self.proposal_counts = _proposal_counts(proposals)
+        self.no_op = not proposals
+        self.memory_review_completed = True
+        self.completion_turn = turn
+        return {
+            "ok": True,
+            "memory_review_completed": True,
+            "already_completed": False,
+            "outcome": "no_op" if self.no_op else "proposals_saved",
+            "proposal_counts": self.proposal_counts,
+        }
+
+    def mark_exhausted(self) -> None:
+        self.exhausted = True
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "status": self.status,
+            "memory_writes_enabled": self.memory_writes_enabled,
+            "turn_allowance": MEMORY_CLOSEOUT_TURN_ALLOWANCE,
+            "turns_used": self.closeout_turns_used,
+            "submission_turn": self.submission_turn,
+            "completion_turn": self.completion_turn,
+            "no_op": self.no_op,
+            "proposal_counts": self.proposal_counts,
+        }
+
+
+def _proposal_counts(proposals: tuple[MemoryProposal, ...]) -> dict[str, Any]:
+    by_kind = Counter(proposal.kind.value for proposal in proposals)
+    by_operation = Counter(proposal.operation for proposal in proposals)
+    return {
+        "total": len(proposals),
+        "by_kind": dict(sorted(by_kind.items())),
+        "by_operation": dict(sorted(by_operation.items())),
+    }
+
+
+__all__ = [
+    "MEMORY_CLOSEOUT_TURN_ALLOWANCE",
+    "MemoryCloseoutIncompleteError",
+    "MemoryCloseoutState",
+]

--- a/backend/services/reporter/runner/run_log.py
+++ b/backend/services/reporter/runner/run_log.py
@@ -127,6 +127,21 @@ class RunLog(BaseModel):
     def add_completion(self, stats: dict[str, Any], *, turn: int) -> None:
         self._add(RunLogEntry(turn=turn, event_type="completion", data=stats))
 
+    def add_memory_closeout(
+        self,
+        event: str,
+        *,
+        turn: int,
+        **details: Any,
+    ) -> None:
+        self._add(
+            RunLogEntry(
+                turn=turn,
+                event_type="memory_closeout",
+                data={"event": event, **details},
+            )
+        )
+
     @property
     def tool_call_count(self) -> int:
         return sum(1 for entry in self.entries if entry.event_type == "tool_call")
@@ -227,6 +242,8 @@ class RunLog(BaseModel):
             )
         if entry.event_type == "completion":
             return f"{elapsed} COMPLETE: {json.dumps(data)}"
+        if entry.event_type == "memory_closeout":
+            return f"{elapsed} MEMORY CLOSEOUT: {json.dumps(data)}"
         return f"{elapsed} {entry.event_type}: {data}"
 
     @staticmethod

--- a/backend/services/reporter/runner/runner.py
+++ b/backend/services/reporter/runner/runner.py
@@ -33,6 +33,11 @@ from backend.services.reporter.runner.models import (
     serialize_model_value,
     tool_result_message,
 )
+from backend.services.reporter.runner.memory_closeout import (
+    MEMORY_CLOSEOUT_TURN_ALLOWANCE,
+    MemoryCloseoutIncompleteError,
+    MemoryCloseoutState,
+)
 from backend.services.reporter.runner.provider_telemetry import sanitize_provider_error
 from backend.services.reporter.runner.recording import (
     ArtifactRecorder,
@@ -57,10 +62,16 @@ from backend.services.reporter.runner.state import (
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
-__all__ = ["CompletionFn", "Runner", "RunnerRecordingError"]
+__all__ = [
+    "CompletionFn",
+    "MemoryCloseoutIncompleteError",
+    "Runner",
+    "RunnerRecordingError",
+]
 
 
 _UNKNOWN_TOOL_IMPLEMENTATION_VERSION = "unregistered-v1"
+_MEMORY_CLOSEOUT_TOOL_NAME = "complete_memory_review"
 
 
 class RunnerRecordingError(RuntimeError):
@@ -81,6 +92,7 @@ class Runner:
         artifacts: ArtifactStore | None = None,
         brief: ResearchBriefStore | None = None,
         recorder: RunnerRecorder | None = None,
+        memory_closeout: MemoryCloseoutState | None = None,
     ) -> None:
         if client is not None and complete is not None:
             raise ValueError("Pass client= or complete=, not both.")
@@ -111,10 +123,12 @@ class Runner:
             log=self.log,
             brief=self.brief,
             artifact_recorder=self._turn_artifacts,
+            memory_closeout=memory_closeout,
         )
         self.registry.set_context(self.tool_context)
         self._procedure_message_idx: int | None = None
         self._submitted = False
+        self._memory_closeout = memory_closeout
 
         if log_path is not None:
             self.log.start_streaming(log_path)
@@ -141,9 +155,17 @@ class Runner:
         turn = 0
 
         try:
-            while turn < self.config.max_turns and not self._submitted:
+            while self._can_start_turn(turn):
                 turn += 1
-                self._record_progress(turn, self.procedures.active or "running")
+                if self._memory_closeout is not None:
+                    self._memory_closeout.begin_turn()
+                stage = (
+                    "memory_closeout"
+                    if self._memory_closeout is not None
+                    and self._memory_closeout.article_submitted
+                    else self.procedures.active or "running"
+                )
+                self._record_progress(turn, stage)
                 response = await self._client.complete(
                     turn_number=turn,
                     messages=list(messages),
@@ -157,6 +179,12 @@ class Runner:
                     previous_stage = self.procedures.active
                     results = await self._execute_tool_batch(calls, turn)
                     self._flush_artifact_turn(turn)
+                    if any(
+                        call.name == "submit_artifact"
+                        and self._is_successful_submit(result)
+                        for call, result in zip(calls, results)
+                    ):
+                        self._activate_submission(turn)
                     if (
                         self.procedures.active is not None
                         and self.procedures.active != previous_stage
@@ -164,7 +192,11 @@ class Runner:
                         self._record_progress(turn, self.procedures.active)
                     for call, result_content in zip(calls, results):
                         if call.name == "load_procedure":
-                            self._append_procedure_message(messages, call, result_content)
+                            self._append_procedure_message(
+                                messages,
+                                call,
+                                result_content,
+                            )
                         else:
                             messages.append(tool_result_message(call, result_content))
 
@@ -174,8 +206,12 @@ class Runner:
                 if text:
                     self.log.add_model_text(text, turn=turn)
                     messages.append({"role": "assistant", "content": text})
+                    if self._closeout_is_active():
+                        continue
                     break
 
+                if self._closeout_is_active():
+                    continue
                 break
 
             self.log.add_completion(
@@ -204,6 +240,7 @@ class Runner:
                         for procedure in self.log.procedure_history
                     ],
                     "submitted": self._submitted,
+                    "memory_closeout": self._closeout_summary(),
                     "brief": self._build_brief_summary(),
                 },
                 run_log_entries=[
@@ -260,13 +297,26 @@ class Runner:
         calls: list[ToolCall],
         turn: int,
     ) -> list[str]:
-        executed = await asyncio.gather(
-            *[
-                self._execute_tool(call, turn, ordinal)
-                for ordinal, call in enumerate(calls)
-            ]
-        )
-        return list(executed)
+        results: list[str | None] = [None] * len(calls)
+        regular = [
+            (ordinal, call)
+            for ordinal, call in enumerate(calls)
+            if call.name != _MEMORY_CLOSEOUT_TOOL_NAME
+        ]
+        if regular:
+            executed = await asyncio.gather(
+                *[
+                    self._execute_tool(call, turn, ordinal)
+                    for ordinal, call in regular
+                ]
+            )
+            for (ordinal, _), result in zip(regular, executed):
+                results[ordinal] = result
+
+        for ordinal, call in enumerate(calls):
+            if call.name == _MEMORY_CLOSEOUT_TOOL_NAME:
+                results[ordinal] = await self._execute_tool(call, turn, ordinal)
+        return [cast(str, result) for result in results]
 
     async def _execute_tool(
         self,
@@ -374,10 +424,51 @@ class Runner:
                 "Could not record durable artifact mutation"
             ) from artifact_recording_error
 
-        if call.name == "submit_artifact" and self._is_successful_submit(result_content):
-            self._submitted = True
-
         return result_content
+
+    def _can_start_turn(self, turn: int) -> bool:
+        state = self._memory_closeout
+        if state is not None:
+            if state.memory_review_completed:
+                return False
+            if state.article_submitted:
+                if state.closeout_turns_used >= MEMORY_CLOSEOUT_TURN_ALLOWANCE:
+                    state.mark_exhausted()
+                    self.log.add_memory_closeout(
+                        "limit_exhausted",
+                        turn=turn,
+                        turns_used=state.closeout_turns_used,
+                        turn_allowance=MEMORY_CLOSEOUT_TURN_ALLOWANCE,
+                    )
+                    self._record_progress(turn, "memory_closeout_exhausted")
+                    raise MemoryCloseoutIncompleteError(
+                        "Memory review was not completed within the six-turn "
+                        "closeout allowance."
+                    )
+                return True
+        return turn < self.config.max_turns and not self._submitted
+
+    def _activate_submission(self, turn: int) -> None:
+        self._submitted = True
+        state = self._memory_closeout
+        if state is None or state.article_submitted:
+            return
+        state.activate(turn=turn)
+        self.log.add_memory_closeout(
+            "closeout_activated",
+            turn=turn,
+            turn_allowance=MEMORY_CLOSEOUT_TURN_ALLOWANCE,
+            memory_writes_enabled=state.memory_writes_enabled,
+        )
+        self._record_progress(turn, "memory_closeout")
+
+    def _closeout_is_active(self) -> bool:
+        return self._memory_closeout is not None and self._memory_closeout.active
+
+    def _closeout_summary(self) -> dict[str, Any]:
+        if self._memory_closeout is None:
+            return {"enabled": False, "status": "not_applicable"}
+        return self._memory_closeout.summary()
 
     def _begin_tool_execution(self, execution: ToolExecutionStart) -> UUID | None:
         if self._recorder is None:

--- a/backend/services/reporter/runner/tools/__init__.py
+++ b/backend/services/reporter/runner/tools/__init__.py
@@ -23,6 +23,11 @@ from backend.services.reporter.runner.tools.datalayer_tools import (
     DATALAYER_TOOL_SPECS,
     register_datalayer_tools,
 )
+from backend.services.reporter.runner.tools.memory_closeout_tools import (
+    MEMORY_CLOSEOUT_TOOL_SPECS,
+    complete_memory_review,
+    register_memory_closeout_tools,
+)
 from backend.services.reporter.runner.tools.memory_tools import (
     MEMORY_TOOL_SPECS,
     register_memory_tools,
@@ -38,10 +43,12 @@ __all__ = [
     "BRIEF_TOOL_SPECS",
     "ARTIFACT_TOOL_SPECS",
     "DATALAYER_TOOL_SPECS",
+    "MEMORY_CLOSEOUT_TOOL_SPECS",
     "MEMORY_TOOL_SPECS",
     "PROCEDURE_TOOL_SPECS",
     "ToolContext",
     "ToolRegistry",
+    "complete_memory_review",
     "create_artifact",
     "edit_artifact",
     "list_artifacts",
@@ -51,6 +58,7 @@ __all__ = [
     "register_artifact_tools",
     "register_brief_tools",
     "register_datalayer_tools",
+    "register_memory_closeout_tools",
     "register_memory_tools",
     "register_procedure_tools",
     "submit_artifact",

--- a/backend/services/reporter/runner/tools/artifact_tools.py
+++ b/backend/services/reporter/runner/tools/artifact_tools.py
@@ -13,7 +13,7 @@ from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.registry import ToolRegistry
 
 
-ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "4"
+ARTIFACT_TOOL_IMPLEMENTATION_VERSION = "5"
 
 
 ARTIFACT_TOOL_SPECS: list[ToolDef] = [
@@ -268,15 +268,29 @@ def submit_artifact(
             artifact.revision,
             turn=ctx.turn,
         )
-        ctx.log.add_completion(stats, turn=ctx.turn)
-        return _success(
-            {
-                "artifact": artifact.model_dump(),
-                "finalized_revision": artifact.revision,
-                "stats": stats,
-                "brief_readiness": readiness.model_dump(mode="json"),
-            }
+        ctx.log.add_memory_closeout(
+            "article_submitted",
+            turn=ctx.turn,
+            submitted_path=artifact.path,
+            revision=artifact.revision,
         )
+        result: dict[str, Any] = {
+            "artifact": artifact.model_dump(),
+            "finalized_revision": artifact.revision,
+            "stats": stats,
+            "brief_readiness": readiness.model_dump(mode="json"),
+        }
+        if ctx.memory_closeout is not None:
+            result["next_action"] = {
+                "type": "mandatory_procedure",
+                "name": "memory_closeout",
+                "content": ctx.memory_closeout.procedure,
+                "completion_tool": "complete_memory_review",
+                "memory_writes_enabled": (
+                    ctx.memory_closeout.memory_writes_enabled
+                ),
+            }
+        return _success(result)
 
     return _execute(operation)
 

--- a/backend/services/reporter/runner/tools/context.py
+++ b/backend/services/reporter/runner/tools/context.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from backend.services.reporter.runner.recording import (
@@ -23,6 +24,9 @@ from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.schemas import ArtifactSnapshot
 from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
 
+if TYPE_CHECKING:
+    from backend.services.reporter.runner.memory_closeout import MemoryCloseoutState
+
 
 @dataclass
 class ToolContext:
@@ -32,6 +36,7 @@ class ToolContext:
     brief: ResearchBriefStore = field(default_factory=ResearchBriefStore)
     turn: int = 0
     artifact_recorder: ArtifactRecorder | None = None
+    memory_closeout: MemoryCloseoutState | None = None
 
     def __post_init__(self) -> None:
         self._source_tool_call_id: ContextVar[UUID | None] = ContextVar(

--- a/backend/services/reporter/runner/tools/memory_closeout_tools.py
+++ b/backend/services/reporter/runner/tools/memory_closeout_tools.py
@@ -1,0 +1,75 @@
+"""Terminal tool for mandatory same-agent memory review."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.services.reporter.runner.models import ToolDef
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.registry import ToolRegistry
+
+
+MEMORY_CLOSEOUT_TOOL_IMPLEMENTATION_VERSION = "1"
+
+MEMORY_CLOSEOUT_TOOL_SPECS: list[ToolDef] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "complete_memory_review",
+            "description": (
+                "Complete the mandatory post-submission memory review after saving "
+                "durable continuity or deliberately choosing a no-op."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def register_memory_closeout_tools(registry: ToolRegistry) -> None:
+    registry.register_context_tool(
+        "complete_memory_review",
+        complete_memory_review,
+        MEMORY_CLOSEOUT_TOOL_SPECS[0],
+        MEMORY_CLOSEOUT_TOOL_IMPLEMENTATION_VERSION,
+    )
+
+
+def complete_memory_review(ctx: ToolContext) -> dict[str, Any]:
+    state = ctx.memory_closeout
+    if state is None:
+        return {
+            "ok": False,
+            "error": {
+                "code": "memory_closeout_unavailable",
+                "message": "Memory closeout is not enabled for this run.",
+            },
+        }
+
+    result = state.complete(turn=ctx.turn)
+    if result.get("ok") is True and result.get("already_completed") is False:
+        ctx.log.add_memory_closeout(
+            "memory_review_completed",
+            turn=ctx.turn,
+            outcome=result["outcome"],
+            proposal_counts=result["proposal_counts"],
+        )
+        if result["outcome"] == "no_op":
+            ctx.log.add_memory_closeout(
+                "memory_review_noop",
+                turn=ctx.turn,
+                memory_writes_enabled=state.memory_writes_enabled,
+            )
+    return result
+
+
+__all__ = [
+    "MEMORY_CLOSEOUT_TOOL_IMPLEMENTATION_VERSION",
+    "MEMORY_CLOSEOUT_TOOL_SPECS",
+    "complete_memory_review",
+    "register_memory_closeout_tools",
+]

--- a/backend/tests/services/generations/test_manifest.py
+++ b/backend/tests/services/generations/test_manifest.py
@@ -130,7 +130,7 @@ def test_manifest_has_a_locked_schema_and_hash() -> None:
     assert built.schema_version == 1
     assert built.manifest["schema_version"] == 1
     assert built.manifest_hash == (
-        "7afb1bd111b65a26970558ce223b5a74166112c949140f9dc463b9e69b3bb359"
+        "8f81bc1c86321ea63b245dcf4459bb8e6e900894682ed9028f14c2345fff0ba0"
     )
     assert built.canonical_bytes.decode("utf-8").startswith(
         '{"assets":{"procedures":[{"content_sha256":"'

--- a/backend/tests/services/generations/test_service.py
+++ b/backend/tests/services/generations/test_service.py
@@ -28,6 +28,9 @@ from backend.services.generations import (
 from backend.services.memory import MemoryMutationResult
 from backend.services.reporter import ReporterOutput
 from backend.services.reporter.runner.completion import ProviderConfigurationError
+from backend.services.reporter.runner.memory_closeout import (
+    MemoryCloseoutIncompleteError,
+)
 from backend.services.reporter.runner.recording import ArtifactMutation
 from backend.services.reporter.runner.schemas import ArtifactSnapshot
 
@@ -604,7 +607,14 @@ async def test_backtest_without_eligible_or_root_memory_never_starts(tmp_path) -
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("error", [RuntimeError("provider"), asyncio.CancelledError()])
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("provider"),
+        MemoryCloseoutIncompleteError("closeout exhausted"),
+        asyncio.CancelledError(),
+    ],
+)
 async def test_reporter_failure_or_cancellation_closes_and_discards_context(
     tmp_path,
     error,

--- a/backend/tests/services/memory/test_generation_context.py
+++ b/backend/tests/services/memory/test_generation_context.py
@@ -124,3 +124,23 @@ def test_discard_closes_an_abandoned_proposal_buffer() -> None:
 
     with pytest.raises(GenerationMemoryContextClosedError):
         context.take_completed_bundle()
+
+
+def test_proposal_snapshot_is_read_only_and_does_not_close_context() -> None:
+    context = GenerationMemoryContext(
+        competition_id=uuid4(),
+        generation_id=uuid4(),
+        pinned_revision_id=uuid4(),
+        retrieval=RecordingRetrieval(),
+    )
+    event_reference = context.propose_event(_event())
+    reference = context.propose_fact(_fact(event_reference.version_id))
+
+    snapshot = context.proposal_snapshot()
+    bundle = context.take_completed_bundle()
+
+    assert tuple(proposal.proposed_ref() for proposal in snapshot) == (
+        event_reference,
+        reference,
+    )
+    assert bundle.proposals == snapshot

--- a/backend/tests/services/reporter/test_artifact_tools.py
+++ b/backend/tests/services/reporter/test_artifact_tools.py
@@ -11,6 +11,7 @@ from backend.services.reporter.runner.recording import (
     ArtifactMutation,
     ArtifactRecordingError,
 )
+from backend.services.reporter.runner.memory_closeout import MemoryCloseoutState
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
 from backend.services.reporter.runner.tools.artifact_tools import (
@@ -38,6 +39,8 @@ class ArtifactRecordingProbe:
 
 def make_ctx(
     recorder: ArtifactRecordingProbe | None = None,
+    *,
+    memory_closeout: MemoryCloseoutState | None = None,
 ) -> ToolContext:
     ctx = ToolContext(
         artifacts=ArtifactStore(),
@@ -45,6 +48,7 @@ def make_ctx(
         log=RunLog(session_id="testlog"),
         turn=3,
         artifact_recorder=recorder,
+        memory_closeout=memory_closeout,
     )
     mutation = ctx.brief.prepare_fact(
         id="fact_submission_fixture",
@@ -310,7 +314,31 @@ def test_submit_pins_existing_snapshot_and_final_artifact_is_immutable() -> None
     assert repeated["error"]["code"] == "artifact_finalized"
     assert rejected_edit["error"]["code"] == "artifact_finalized"
     assert ctx.log.entries[-2].data["operation"] == "submit_artifact"
-    assert ctx.log.entries[-1].event_type == "completion"
+    assert ctx.log.entries[-1].event_type == "memory_closeout"
+    assert ctx.log.entries[-1].data["event"] == "article_submitted"
+
+
+def test_submit_returns_exact_mandatory_memory_closeout_procedure() -> None:
+    closeout = MemoryCloseoutState(
+        procedure="# Exact closeout\n\nCall the terminal tool.\n",
+        memory_writes_enabled=False,
+        proposal_snapshot=lambda: (),
+    )
+    ctx = make_ctx(memory_closeout=closeout)
+    create_artifact(ctx, path="article.md", content="# Final")
+
+    submitted = decode(
+        submit_artifact(ctx, path="article.md", expected_revision=1)
+    )
+
+    assert submitted["next_action"] == {
+        "type": "mandatory_procedure",
+        "name": "memory_closeout",
+        "content": "# Exact closeout\n\nCall the terminal tool.\n",
+        "completion_tool": "complete_memory_review",
+        "memory_writes_enabled": False,
+    }
+    assert closeout.article_submitted is False
 
 
 def test_only_changed_mutations_are_recorded_with_bound_tool_provenance() -> None:

--- a/backend/tests/services/reporter/test_definition.py
+++ b/backend/tests/services/reporter/test_definition.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from backend.services.reporter import prepare_reporter_definition
 from backend.services.reporter.runner.run_log import RunLog
 from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
@@ -27,6 +29,9 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
     from backend.services.reporter.runner.tools.memory_tools import (
         register_memory_tools,
     )
+    from backend.services.reporter.runner.tools.memory_closeout_tools import (
+        register_memory_closeout_tools,
+    )
 
     data = object()
     memory = object()
@@ -39,6 +44,7 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
         memory,  # type: ignore[arg-type]
         data,  # type: ignore[arg-type]
     )
+    register_memory_closeout_tools(registry)
 
     assert registry.tool_specs == [tool.definition for tool in definition.tools]
     assert registry.tool_implementation_versions == [
@@ -50,6 +56,7 @@ def test_prepared_definition_matches_registered_execution_bundle() -> None:
         "research",
         "storyline",
         "verification",
+        "memory_closeout",
     }
 
 
@@ -64,10 +71,17 @@ def test_definition_without_memory_omits_only_memory_tools() -> None:
         "save_storyline_trigger",
         "save_team_context",
         "save_league_note",
+        "complete_memory_review",
     }
     assert {tool.name for tool in with_memory.tools} - {
         tool.name for tool in without_memory.tools
     } == memory_names
+    assert {procedure.name for procedure in without_memory.procedures} == {
+        "drafting",
+        "research",
+        "storyline",
+        "verification",
+    }
 
 
 def test_registered_procedure_uses_prepared_content() -> None:
@@ -85,3 +99,22 @@ def test_registered_procedure_uses_prepared_content() -> None:
 
     assert handler is not None
     assert handler(name="research") == "frozen research"
+
+
+def test_memory_closeout_procedure_cannot_be_loaded_before_submission() -> None:
+    definition = prepare_reporter_definition(memory_enabled=True)
+    registry = ToolRegistry()
+    register_procedure_tools(registry, definition.procedure_contents)
+    registry.set_context(
+        ToolContext(
+            artifacts=ArtifactStore(),
+            procedures=ProcedureState(),
+            log=RunLog(),
+        )
+    )
+
+    handler = registry.get_handler("load_procedure")
+
+    assert handler is not None
+    result = json.loads(handler(name="memory_closeout"))
+    assert result["error"].startswith("Unknown procedure: memory_closeout")

--- a/backend/tests/services/reporter/test_integration.py
+++ b/backend/tests/services/reporter/test_integration.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
 
+import pytest
+
 from backend.services.datalayer import FrozenRosterIdentity, ResolvedRosterIdentity
 from backend.services.memory import (
     GenerationMemoryContext,
@@ -15,6 +17,7 @@ from backend.services.memory import (
     MemoryRetrievalResult,
 )
 from backend.services.reporter.config import ReportConfig, TimeRange
+from backend.services.reporter.definition import prepare_reporter_definition
 from backend.services.reporter.generator import generate_article
 from backend.services.reporter.runner.completion import CompletionSettings
 from backend.services.reporter.runner.models import ToolCall
@@ -480,6 +483,15 @@ def test_generate_article_automatically_bridges_final_brief_storyline_facts() ->
                     )
                 ]
             ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "complete_memory_review",
+                        {},
+                        "bridge-closeout-call",
+                    )
+                ]
+            ),
         ]
     )
 
@@ -495,6 +507,25 @@ def test_generate_article_automatically_bridges_final_brief_storyline_facts() ->
     )
 
     assert output.submitted_path == "article.md"
+    prepared = prepare_reporter_definition(memory_enabled=True)
+    submit_result = next(
+        json.loads(message["content"])
+        for message in complete.requests[-1]["messages"]
+        if message.get("tool_call_id") == "submit-call"
+    )
+    assert submit_result["next_action"] == {
+        "type": "mandatory_procedure",
+        "name": "memory_closeout",
+        "content": prepared.procedure_contents["memory_closeout"],
+        "completion_tool": "complete_memory_review",
+        "memory_writes_enabled": True,
+    }
+    assert all(
+        request["tools"] == complete.requests[0]["tools"]
+        for request in complete.requests
+    )
+    assert output.run_log_summary["memory_closeout"]["status"] == "completed"
+    assert output.run_log_summary["memory_closeout"]["no_op"] is True
     bundle = memory_context.take_completed_bundle()
     assert [proposal.kind.value for proposal in bundle.proposals] == ["fact"]
     fact = bundle.proposals[0]
@@ -507,6 +538,121 @@ def test_generate_article_automatically_bridges_final_brief_storyline_facts() ->
         "data_refs": ["league_snapshot:week=8"],
     }
     assert fact.metadata.creating_tool_call_id is None
+
+
+@pytest.mark.parametrize(
+    ("allow_memory_writes", "expected_proposals"),
+    [(True, 1), (False, 0)],
+)
+def test_generation_closeout_buffers_live_writes_and_backtest_noop(
+    allow_memory_writes: bool,
+    expected_proposals: int,
+) -> None:
+    memory_context = GenerationMemoryContext(
+        competition_id=UUID(int=1),
+        generation_id=uuid4(),
+        pinned_revision_id=uuid4(),
+        retrieval=EmptyMemoryRetrieval(),
+        competition_season_id=UUID(int=2),
+        week=8,
+    )
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "save_fact",
+                        {
+                            "id": "fact_closeout_fixture",
+                            "claim_text": "Week 8 supplied a verified fact.",
+                            "data_refs": ["league_snapshot:week=8"],
+                        },
+                        "fact-call",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "create_artifact",
+                        {"path": "article.md", "content": "# Week 8\n\nVerified."},
+                        "create-call",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "submit_artifact",
+                        {"path": "article.md", "expected_revision": 1},
+                        "submit-call",
+                    )
+                ]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call(
+                        "complete_memory_review",
+                        {},
+                        "complete-call",
+                    ),
+                    tool_call(
+                        "save_league_note",
+                        {
+                            "key": "closeout_note",
+                            "value": "A durable league-wide closeout note.",
+                        },
+                        "memory-call",
+                    ),
+                    tool_call(
+                        "edit_artifact",
+                        {
+                            "path": "article.md",
+                            "old_text": "Verified.",
+                            "new_text": "Changed after submission.",
+                            "expected_revision": 1,
+                        },
+                        "immutable-call",
+                    ),
+                ]
+            ),
+        ]
+    )
+
+    output = run(
+        generate_article(
+            FakeFrozenLeagueData(),  # type: ignore[arg-type]
+            ReportConfig.for_week(8),
+            memory_context=memory_context,
+            completion=CompletionSettings(model="test-model"),
+            complete=complete,
+            allow_memory_writes=allow_memory_writes,
+        )
+    )
+
+    summary = output.run_log_summary["memory_closeout"]
+    bundle = memory_context.take_completed_bundle()
+    assert summary["status"] == "completed"
+    assert summary["proposal_counts"]["total"] == expected_proposals
+    assert summary["no_op"] is (expected_proposals == 0)
+    assert len(bundle.proposals) == expected_proposals
+    events = [
+        entry["data"]["event"]
+        for entry in output.run_log_entries
+        if entry["event_type"] == "memory_closeout"
+    ]
+    assert events[:3] == [
+        "article_submitted",
+        "closeout_activated",
+        "memory_review_completed",
+    ]
+    assert ("memory_review_noop" in events) is (expected_proposals == 0)
+    assert output.submitted_artifact is not None
+    assert output.submitted_artifact.content == "# Week 8\n\nVerified."
+    assert output.submitted_artifact.revision == 1
+    if allow_memory_writes:
+        assert bundle.proposals[0].kind.value == "context_note"
+        assert bundle.proposals[0].operation == "create"
 
 
 def test_generation_starts_with_exact_recorded_automatic_recall_context() -> None:

--- a/backend/tests/services/reporter/test_memory_closeout.py
+++ b/backend/tests/services/reporter/test_memory_closeout.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from backend.services.reporter.runner.memory_closeout import MemoryCloseoutState
+from backend.services.reporter.runner.run_log import RunLog
+from backend.services.reporter.runner.state import ArtifactStore, ProcedureState
+from backend.services.reporter.runner.tools.context import ToolContext
+from backend.services.reporter.runner.tools.memory_closeout_tools import (
+    MEMORY_CLOSEOUT_TOOL_SPECS,
+    complete_memory_review,
+)
+
+
+def _context(
+    state: MemoryCloseoutState | None,
+) -> ToolContext:
+    return ToolContext(
+        artifacts=ArtifactStore(),
+        procedures=ProcedureState(),
+        log=RunLog(),
+        turn=4,
+        memory_closeout=state,
+    )
+
+
+def test_completion_tool_has_empty_model_bookkeeping_schema() -> None:
+    spec = MEMORY_CLOSEOUT_TOOL_SPECS[0]["function"]
+
+    assert spec["name"] == "complete_memory_review"
+    assert spec["parameters"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+
+
+def test_completion_requires_submission_and_unavailable_runs_are_bounded() -> None:
+    state = MemoryCloseoutState(
+        procedure="# Closeout",
+        memory_writes_enabled=True,
+        proposal_snapshot=lambda: (),
+    )
+
+    early = complete_memory_review(_context(state))
+    unavailable = complete_memory_review(_context(None))
+
+    assert early == {
+        "ok": False,
+        "error": {
+            "code": "article_not_submitted",
+            "message": "Submit the final article before completing memory review.",
+        },
+    }
+    assert unavailable["error"]["code"] == "memory_closeout_unavailable"
+
+
+def test_completion_derives_delta_counts_and_is_idempotent() -> None:
+    proposals = [
+        SimpleNamespace(
+            proposal_id=uuid4(),
+            kind=SimpleNamespace(value="fact"),
+            operation="create",
+        )
+    ]
+    state = MemoryCloseoutState(
+        procedure="# Closeout",
+        memory_writes_enabled=True,
+        proposal_snapshot=lambda: tuple(proposals),  # type: ignore[arg-type]
+    )
+    state.activate(turn=3)
+    proposals.extend(
+        [
+            SimpleNamespace(
+                proposal_id=uuid4(),
+                kind=SimpleNamespace(value="storyline"),
+                operation="create",
+            ),
+            SimpleNamespace(
+                proposal_id=uuid4(),
+                kind=SimpleNamespace(value="storyline"),
+                operation="replace",
+            ),
+        ]
+    )
+    ctx = _context(state)
+
+    completed = complete_memory_review(ctx)
+    repeated = complete_memory_review(ctx)
+
+    expected_counts = {
+        "total": 2,
+        "by_kind": {"storyline": 2},
+        "by_operation": {"create": 1, "replace": 1},
+    }
+    assert completed == {
+        "ok": True,
+        "memory_review_completed": True,
+        "already_completed": False,
+        "outcome": "proposals_saved",
+        "proposal_counts": expected_counts,
+    }
+    assert repeated == {
+        **completed,
+        "already_completed": True,
+    }
+    events = [entry.data["event"] for entry in ctx.log.entries]
+    assert events == ["memory_review_completed"]
+
+
+def test_completion_records_explicit_noop_for_write_disabled_run() -> None:
+    state = MemoryCloseoutState(
+        procedure="# Closeout",
+        memory_writes_enabled=False,
+        proposal_snapshot=lambda: (),
+    )
+    state.activate(turn=2)
+    ctx = _context(state)
+
+    result = complete_memory_review(ctx)
+
+    assert result["outcome"] == "no_op"
+    assert result["proposal_counts"] == {
+        "total": 0,
+        "by_kind": {},
+        "by_operation": {},
+    }
+    assert [entry.data for entry in ctx.log.entries] == [
+        {
+            "event": "memory_review_completed",
+            "outcome": "no_op",
+            "proposal_counts": result["proposal_counts"],
+        },
+        {
+            "event": "memory_review_noop",
+            "memory_writes_enabled": False,
+        },
+    ]

--- a/backend/tests/services/reporter/test_run_log.py
+++ b/backend/tests/services/reporter/test_run_log.py
@@ -55,6 +55,11 @@ def test_streaming(tmp_path) -> None:
     log.add_artifact_write("brief", "save_fact", "fact_001", revision=1, turn=3)
     log.add_model_text("Drafting a lead from the standings.", turn=4)
     log.add_guardrail("tool_limit", 40, 50, turn=5)
+    log.add_memory_closeout(
+        "closeout_activated",
+        turn=6,
+        turn_allowance=6,
+    )
     log.add_completion({"status": "done"}, turn=6)
     log.stop_streaming()
 
@@ -65,6 +70,7 @@ def test_streaming(tmp_path) -> None:
     assert "save_fact(fact_001) -> brief rev 1" in content
     assert "Model: Drafting a lead from the standings." in content
     assert "GUARDRAIL: tool_limit (40/50)" in content
+    assert 'MEMORY CLOSEOUT: {"event": "closeout_activated"' in content
     assert 'COMPLETE: {"status": "done"}' in content
     assert "Completed:" in content
     assert "Total tool calls: 1" in content

--- a/backend/tests/services/reporter/test_runner.py
+++ b/backend/tests/services/reporter/test_runner.py
@@ -14,6 +14,10 @@ import pytest
 from backend.resources.memory.search_documents import SearchDocumentQuery
 from backend.services.memory import MemoryRetrievalResult
 from backend.services.reporter.runner.completion import CompletionClient, CompletionSettings
+from backend.services.reporter.runner.memory_closeout import (
+    MemoryCloseoutIncompleteError,
+    MemoryCloseoutState,
+)
 from backend.services.reporter.runner.models import ToolCall, ToolExecutionResult
 from backend.services.reporter.runner.recording import (
     ArtifactMutation,
@@ -36,6 +40,9 @@ from backend.services.reporter.runner.tools.brief_tools import (
 from backend.services.reporter.runner.tools.context import ToolContext
 from backend.services.reporter.runner.tools.memory_presentation import (
     MemoryPresentationAdapter,
+)
+from backend.services.reporter.runner.tools.memory_closeout_tools import (
+    register_memory_closeout_tools,
 )
 from backend.services.reporter.runner.tools.procedure_tools import (
     register_procedure_tools,
@@ -149,6 +156,57 @@ def registry_with(
     registry = ToolRegistry()
     registry.register(name, handler, tool_def(name, description), "test-v1")
     return registry
+
+
+def closeout_runner(
+    complete: FakeCompletion,
+    *,
+    max_turns: int = 60,
+    proposals: list[Any] | None = None,
+    register_write: bool = False,
+    recorder: RecordingProbe | None = None,
+) -> tuple[Runner, MemoryCloseoutState]:
+    buffered = proposals if proposals is not None else []
+    registry = ToolRegistry()
+    registry.register(
+        "submit_artifact",
+        lambda **_: '{"ok": true}',
+        tool_def("submit_artifact"),
+        "test-v1",
+    )
+    if register_write:
+        def save_memory_event() -> dict[str, Any]:
+            buffered.append(
+                SimpleNamespace(
+                    proposal_id=uuid4(),
+                    kind=SimpleNamespace(value="event"),
+                    operation="create",
+                )
+            )
+            return {"ok": True, "saved": True}
+
+        registry.register(
+            "save_memory_event",
+            save_memory_event,
+            tool_def("save_memory_event"),
+            "test-v1",
+        )
+    register_memory_closeout_tools(registry)
+    state = MemoryCloseoutState(
+        procedure="# Closeout",
+        memory_writes_enabled=True,
+        proposal_snapshot=lambda: tuple(buffered),  # type: ignore[arg-type]
+    )
+    return (
+        Runner(
+            registry,
+            complete=complete,
+            config=RunnerConfig(max_turns=max_turns),
+            memory_closeout=state,
+            recorder=recorder,
+        ),
+        state,
+    )
 
 
 def tool_call(
@@ -890,6 +948,206 @@ def test_runner_failed_submit_artifact_does_not_break_loop() -> None:
     assert output.run_log_summary["submitted"] is False
     assert output.run_log_summary["total_turns"] == 2
     assert len(complete.requests) == 2
+
+
+def test_memory_closeout_rejects_completion_before_submission() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("complete_memory_review", call_id="early")]
+            ),
+            make_response(
+                tool_calls=[tool_call("submit_artifact", call_id="submit")]
+            ),
+            make_response(
+                tool_calls=[tool_call("complete_memory_review", call_id="complete")]
+            ),
+        ]
+    )
+    runner, state = closeout_runner(complete)
+
+    output = run(runner.run("system", "user"))
+
+    early_result = next(
+        json.loads(message["content"])
+        for message in complete.requests[1]["messages"]
+        if message.get("tool_call_id") == "early"
+    )
+    assert early_result["error"]["code"] == "article_not_submitted"
+    assert state.memory_review_completed is True
+    assert output.run_log_summary["memory_closeout"]["status"] == "completed"
+    assert output.run_log_summary["memory_closeout"]["no_op"] is True
+
+
+def test_submit_and_complete_in_same_batch_cannot_skip_closeout() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[
+                    tool_call("submit_artifact", call_id="submit"),
+                    tool_call("complete_memory_review", call_id="too-soon"),
+                ]
+            ),
+            make_response(
+                tool_calls=[tool_call("complete_memory_review", call_id="complete")]
+            ),
+        ]
+    )
+    runner, state = closeout_runner(complete)
+
+    output = run(runner.run("system", "user"))
+
+    first_batch_results = {
+        message["tool_call_id"]: json.loads(message["content"])
+        for message in complete.requests[1]["messages"]
+        if message["role"] == "tool"
+    }
+    assert first_batch_results["too-soon"]["error"]["code"] == (
+        "article_not_submitted"
+    )
+    assert state.closeout_turns_used == 1
+    assert output.run_log_summary["memory_closeout"]["status"] == "completed"
+
+
+def test_closeout_continues_after_model_text_with_stable_tool_definitions() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("submit_artifact", call_id="submit")]
+            ),
+            make_response(text="I reviewed the final article."),
+            make_response(
+                tool_calls=[tool_call("complete_memory_review", call_id="complete")]
+            ),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner, _ = closeout_runner(complete, recorder=recorder)
+
+    output = run(runner.run("system", "user"))
+
+    assert output.run_log_summary["total_turns"] == 3
+    assert output.run_log_summary["memory_closeout"]["turns_used"] == 2
+    assert all(
+        request["tools"] == complete.requests[0]["tools"]
+        for request in complete.requests
+    )
+    assert GenerationProgress(
+        current_turn=1,
+        current_stage="memory_closeout",
+    ) in recorder.progress
+    assert recorder.progress[-1] == GenerationProgress(
+        current_turn=3,
+        current_stage="memory_closeout",
+    )
+
+
+def test_closeout_counts_parallel_write_before_completion() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("submit_artifact", call_id="submit")]
+            ),
+            make_response(
+                tool_calls=[
+                    tool_call("complete_memory_review", call_id="complete"),
+                    tool_call("save_memory_event", call_id="save"),
+                ]
+            ),
+        ]
+    )
+    recorder = RecordingProbe()
+    runner, _ = closeout_runner(
+        complete,
+        register_write=True,
+        recorder=recorder,
+    )
+
+    output = run(runner.run("system", "user"))
+
+    summary = output.run_log_summary["memory_closeout"]
+    assert summary["no_op"] is False
+    assert summary["proposal_counts"] == {
+        "total": 1,
+        "by_kind": {"event": 1},
+        "by_operation": {"create": 1},
+    }
+    completion_entry = next(
+        entry
+        for entry in output.run_log_entries
+        if entry["event_type"] == "memory_closeout"
+        and entry["data"]["event"] == "memory_review_completed"
+    )
+    assert completion_entry["data"]["outcome"] == "proposals_saved"
+    completion_execution_id = next(
+        execution_id
+        for execution_id, started in recorder.started
+        if started.tool_name == "complete_memory_review"
+    )
+    recorded = next(
+        result
+        for execution_id, result in recorder.finished
+        if execution_id == completion_execution_id
+    )
+    assert recorded.result == {
+        "ok": True,
+        "memory_review_completed": True,
+        "already_completed": False,
+        "outcome": "proposals_saved",
+        "proposal_counts": summary["proposal_counts"],
+    }
+    assert recorded.result_text == json.dumps(recorded.result)
+    assert recorded.metadata == {}
+
+
+def test_last_normal_turn_submission_gets_six_closeout_turns() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("submit_artifact", call_id="submit")]
+            ),
+            *[make_response(text=f"Review note {index}") for index in range(5)],
+            make_response(
+                tool_calls=[tool_call("complete_memory_review", call_id="complete")]
+            ),
+        ]
+    )
+    runner, _ = closeout_runner(complete, max_turns=1)
+
+    output = run(runner.run("system", "user"))
+
+    assert len(complete.requests) == 7
+    assert output.run_log_summary["total_turns"] == 7
+    assert output.run_log_summary["memory_closeout"]["turns_used"] == 6
+    assert output.run_log_summary["memory_closeout"]["completion_turn"] == 7
+
+
+def test_closeout_exhaustion_is_fatal_and_records_progress() -> None:
+    complete = FakeCompletion(
+        [
+            make_response(
+                tool_calls=[tool_call("submit_artifact", call_id="submit")]
+            ),
+            *[make_response(text=f"Incomplete {index}") for index in range(6)],
+        ]
+    )
+    recorder = RecordingProbe()
+    runner, state = closeout_runner(
+        complete,
+        max_turns=1,
+        recorder=recorder,
+    )
+
+    with pytest.raises(MemoryCloseoutIncompleteError, match="six-turn"):
+        run(runner.run("system", "user"))
+
+    assert len(complete.requests) == 7
+    assert state.exhausted is True
+    assert recorder.progress[-1] == GenerationProgress(
+        current_turn=7,
+        current_stage="memory_closeout_exhausted",
+    )
+    assert runner.log.entries[-1].data["event"] == "limit_exhausted"
 
 
 def test_runner_parallel_edits_with_same_revision_allow_exactly_one_success() -> None:

--- a/docs/reporter-memory-refactor/README.md
+++ b/docs/reporter-memory-refactor/README.md
@@ -45,6 +45,7 @@ Related upstream contracts:
 - The same reporter agent owns research, article writing, and memory closeout. Submission freezes the selected article revision and supplies the mandatory closeout procedure instead of terminating the runner.
 - The tool list remains unchanged for the entire conversation. Procedures guide behavior; they do not grant or revoke tools.
 - `complete_memory_review` terminates the run after the agent has saved useful memory or deliberately chosen a no-op.
+- Submission grants six additional model turns for closeout. Exhausting them without explicit completion fails the generation and discards its buffered memory proposals.
 - Live generation commits the closeout's buffered memory proposals through the existing generation finalization path. Backtests keep memory writes disabled.
 - The automatic structured-brief fact bridge is retired once memory closeout is proven.
 

--- a/docs/reporter-memory-refactor/application-contracts.md
+++ b/docs/reporter-memory-refactor/application-contracts.md
@@ -174,7 +174,7 @@ The runner tracks two lifecycle facts:
 
 A memory-enabled run begins with both false. A successful `submit_artifact` sets `article_submitted`, freezes the selected artifact revision, activates the closeout procedure in the returned result, and keeps the loop running. A successful `complete_memory_review` requires `article_submitted`, sets `memory_review_completed`, and terminates the loop.
 
-The runner terminates normally only when both facts are true. The tool definitions and their ordering remain constant on every completion request. A bounded closeout allowance guarantees the reporter receives an opportunity to act even when submission occurs at the normal writing-turn limit.
+The runner terminates normally only when both facts are true. The tool definitions and their ordering remain constant on every completion request. Six additional closeout turns guarantee the reporter receives an opportunity to act even when submission occurs at the normal writing-turn limit; the submission turn does not consume this allowance.
 
 Live finalization consumes the existing generation memory proposal bundle. Backtest mode continues returning blocked results for memory writes and completes closeout as a no-op.
 
@@ -198,7 +198,7 @@ Live finalization consumes the existing generation memory proposal bundle. Backt
 - Presentation or serialization failure fails the tool call and records diagnostics in metadata and error fields.
 - `complete_memory_review` before successful submission returns a bounded lifecycle error and does not terminate the runner.
 - Attempts to edit the submitted article retain the existing `artifact_finalized` error.
-- Reaching the closeout turn allowance without completion is recorded distinctly from successful or no-op closeout.
+- Reaching six closeout turns without completion is recorded distinctly, fails reporter execution, and causes generation failure to discard the proposal buffer.
 - Invalid memory proposals retain existing tool and generation-finalization error behavior.
 
 ## Compatibility and Transition

--- a/docs/reporter-memory-refactor/architecture.md
+++ b/docs/reporter-memory-refactor/architecture.md
@@ -42,8 +42,8 @@ The runner always sends the same ordered tool definitions to the model. It does 
 - Presentation failures fail that tool call because the exact model-visible result cannot be trusted.
 - `result`, `result_text`, and `metadata` for a tool execution are recorded coherently under the same call identity.
 - `complete_memory_review` returns an error before successful article submission and does not terminate the runner.
-- A successful `submit_artifact` does not terminate the runner. The runner guarantees a bounded closeout opportunity even when submission consumes the normal writing-turn budget.
-- If the reporter reaches the closeout limit without completing review, the run reports that explicit condition; it does not invent memory operations.
+- A successful `submit_artifact` does not terminate the runner. The runner guarantees six additional closeout turns even when submission consumes the normal writing-turn budget; the submission turn itself does not consume that allowance.
+- If the reporter reaches the six-turn closeout limit without completing review, reporter execution fails and the generation memory context is discarded. The run records exhaustion distinctly and does not invent memory operations.
 - Trigger state changes only through a valid buffered memory proposal. Merely recalling or mentioning a trigger does not fire or resolve it.
 - Canonical revision conflicts continue to use the generation finalizer's existing failure behavior; this feature does not add a second retry or transaction layer.
 
@@ -80,5 +80,4 @@ Hiding identifiers is a context-quality and trust-boundary improvement, not an a
 ## Deferred Decisions
 
 - Initial recall budgets per memory kind.
-- Whether closeout needs more than the initial bounded turn allowance.
 - Whether measured closeout quality eventually warrants a separate curator workflow.


### PR DESCRIPTION
Stack: PR #220 → PR #222 → PR #224 → PR #225 → PR #226

Base: codex/reporter-memory-refactor-3-automatic-recall (PR #225)

## Summary

- Keep the same reporter conversation running after a successful memory-enabled article submission.
- Return the sealed mandatory memory-closeout procedure and require complete_memory_review with an unchanged ordered tool surface.
- Grant six post-submit turns, count live proposal deltas by kind and operation, support explicit no-op closeout, and fail/discard on exhaustion.
- Preserve immediate termination for memory-disabled runs, write blocking for backtests, and the structured-brief fact bridge for PR5.

## Verification

- 134 affected backend tests passed with .venv\\Scripts\\python.exe.
- Python compileall passed for changed runtime and test modules.
- git diff --cached --check passed.
- No migration, OpenAPI, or frontend changes.